### PR TITLE
Add a flag for overflow check

### DIFF
--- a/flux-config/src/lib.rs
+++ b/flux-config/src/lib.rs
@@ -129,7 +129,7 @@ static CONFIG: LazyLock<Config> = LazyLock::new(|| {
             .set_default("check_def", "")?
             .set_default("cache", false)?
             .set_default("cache_file", "cache.json")?
-            .set_default("check_overflow", true)?;
+            .set_default("check_overflow", false)?;
         // Config comes first, enviroment settings override it.
         if let Some(config_path) = CONFIG_PATH.as_ref() {
             config_builder = config_builder.add_source(File::from(config_path.to_path_buf()));

--- a/flux-config/src/lib.rs
+++ b/flux-config/src/lib.rs
@@ -57,6 +57,10 @@ pub fn driver_path() -> Option<&'static PathBuf> {
     CONFIG.driver_path.as_ref()
 }
 
+pub fn check_overflow() -> bool {
+    CONFIG.check_overflow
+}
+
 #[derive(Debug)]
 pub struct CrateConfig {
     pub log_dir: PathBuf,
@@ -78,6 +82,7 @@ struct Config {
     check_def: String,
     cache: bool,
     cache_file: String,
+    check_overflow: bool,
 }
 
 #[derive(Copy, Clone, Deserialize)]
@@ -123,7 +128,8 @@ static CONFIG: LazyLock<Config> = LazyLock::new(|| {
             .set_default("pointer_width", "64")?
             .set_default("check_def", "")?
             .set_default("cache", false)?
-            .set_default("cache_file", "cache.json")?;
+            .set_default("cache_file", "cache.json")?
+            .set_default("check_overflow", true)?;
         // Config comes first, enviroment settings override it.
         if let Some(config_path) = CONFIG_PATH.as_ref() {
             config_builder = config_builder.add_source(File::from(config_path.to_path_buf()));

--- a/flux-docs/src/guide/run.md
+++ b/flux-docs/src/guide/run.md
@@ -139,6 +139,9 @@ You can set various `env` variables to customize the behavior of `flux`.
 * `FLUX_CHECK_DEF=name` only checks definitions containing `name` as a substring
 * `FLUX_CACHE=1"` switches on query caching and saves the cache in `FLUX_CACHE_FILE`
 * `FLUX_CACHE_FILE=file.json` customizes the cache file, default `FLUX_LOG_DIR/cache.json`
+* `FLUX_CHECK_OVERFLOW=1` checks for over and underflow on arithmetic integer
+  operations, default `0`. When set to `0`, it still checks for underflow on
+  unsigned integer subtraction.
 
 ### Config file
 

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -633,15 +633,22 @@ impl Constant {
         Some(Constant::Bool(n1 >= n2))
     }
 
-    pub fn int_min(bit_width: u128) -> Constant {
-        Constant::Int(Sign::Negative, 2 ^ (bit_width - 1))
+    /// Given the bit width of an integer type, produces the maximum integer for
+    /// that type.
+    pub fn int_min(bit_width: u32) -> Constant {
+        let abs_max: u128 = 2_u128.pow(bit_width);
+        Constant::Int(Sign::Negative, abs_max)
     }
 
-    pub fn int_max(bit_width: u128) -> Constant {
+    /// Given the bit width of an integer type, produces the minimum integer for
+    /// that type.
+    pub fn int_max(bit_width: u32) -> Constant {
         (i128::MAX >> (128 - bit_width)).into()
     }
 
-    pub fn uint_max(bit_width: u128) -> Constant {
+    /// Given the bit width of an unsigned integer type, produces the maximum
+    /// unsigned integer for that type.
+    pub fn uint_max(bit_width: u32) -> Constant {
         (u128::MAX >> (128 - bit_width)).into()
     }
 }
@@ -674,12 +681,6 @@ impl From<bool> for Constant {
 impl From<i128> for Expr {
     fn from(c: i128) -> Self {
         Expr::Constant(Constant::from(c))
-    }
-}
-
-impl From<u128> for Expr {
-    fn from(c: u128) -> Self {
-        Expr::Constant(c.into())
     }
 }
 

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -632,6 +632,18 @@ impl Constant {
         let n2 = other.to_int()?;
         Some(Constant::Bool(n1 >= n2))
     }
+
+    pub fn int_min(bit_width: u128) -> Constant {
+        Constant::Int(Sign::Negative, 2^(bit_width - 1))
+    }
+
+    pub fn int_max(bit_width: u128) -> Constant {
+        (i128::MAX >> (128 - bit_width)).into()
+    }
+
+    pub fn uint_max(bit_width: u128) -> Constant {
+        (u128::MAX >> (128 - bit_width)).into()
+    }
 }
 
 impl From<usize> for Constant {

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -634,7 +634,7 @@ impl Constant {
     }
 
     pub fn int_min(bit_width: u128) -> Constant {
-        Constant::Int(Sign::Negative, 2^(bit_width - 1))
+        Constant::Int(Sign::Negative, 2 ^ (bit_width - 1))
     }
 
     pub fn int_max(bit_width: u128) -> Constant {

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -677,6 +677,12 @@ impl From<i128> for Expr {
     }
 }
 
+impl From<u128> for Expr {
+    fn from(c: u128) -> Self {
+        Expr::Constant(c.into())
+    }
+}
+
 impl From<Name> for Expr {
     fn from(n: Name) -> Self {
         Expr::Var(n)

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -718,11 +718,11 @@ impl<'a, 'tcx, P: Phase> Checker<'a, 'tcx, P> {
             (TyKind::Indexed(bty1, idx1), TyKind::Indexed(bty2, idx2)) => {
                 let sig = sigs::get_bin_op_sig(bin_op, bty1, bty2);
                 let (e1, e2) = (idx1.expr.clone(), idx2.expr.clone());
-                if let sigs::Pre::Some(reason, constr) = sig.pre {
+                if let sigs::Pre::Some(reason, constr) = &sig.pre {
                     self.constr_gen(rcx, source_span).check_pred(
                         rcx,
                         constr([e1.clone(), e2.clone()]),
-                        reason,
+                        *reason,
                     );
                 }
 

--- a/flux-refineck/src/sigs.rs
+++ b/flux-refineck/src/sigs.rs
@@ -101,7 +101,7 @@ fn mk_unsigned_bin_ops() -> impl Iterator<Item = (mir::BinOp, Sig<2>)> {
                          requires E::ge(a - b, 0) => ConstrReason::Overflow)
                 )
             } else {
-                    (Sub, s!(fn(a: Uint, b: Uint) -> Uint[a - b]))
+                (Sub, s!(fn(a: Uint, b: Uint) -> Uint[a - b]))
             };
             [
                 // ARITH

--- a/flux-refineck/src/sigs.rs
+++ b/flux-refineck/src/sigs.rs
@@ -224,7 +224,7 @@ fn mk_signed_bin_ops_check_overflow() -> impl Iterator<Item = (mir::BinOp, Sig<2
                 let bool = BaseTy::Bool;
                 let Int = BaseTy::Int(int_ty);
             }
-            let bit_width: u64 = int_ty.bit_width().unwrap_or(flux_config::pointer_width().bits()).into();
+            let bit_width: u64 = int_ty.bit_width().unwrap_or(flux_config::pointer_width().bits());
             [
                 // ARITH
                 (Add, s!(fn(a: Int, b: Int) -> Int[a + b]

--- a/flux-refineck/src/sigs.rs
+++ b/flux-refineck/src/sigs.rs
@@ -93,7 +93,8 @@ fn uint_max(bit_width: u128) -> E {
     E::constant(flux_fixpoint::Constant::uint_max(bit_width))
 }
 
-/// This set of signatures does not check for overflow or underflow.
+/// This set of signatures does not check for overflow. They check for underflow
+/// in subtraction.
 #[rustfmt::skip]
 fn mk_unsigned_bin_ops() -> impl Iterator<Item = (mir::BinOp, Sig<2>)> {
     use mir::BinOp::*;
@@ -108,7 +109,9 @@ fn mk_unsigned_bin_ops() -> impl Iterator<Item = (mir::BinOp, Sig<2>)> {
                 // ARITH
                 (Add, s!(fn(a: Uint, b: Uint) -> Uint[a + b])),
                 (Mul, s!(fn(a: Uint, b: Uint) -> Uint[a * b])),
-                (Sub, s!(fn(a: Uint, b: Uint) -> Uint[a - b])),
+                (Sub, s!(fn(a: Uint, b: Uint) -> Uint[a - b]
+                         requires E::ge(a - b, 0) => ConstrReason::Overflow)
+                ),
                 (Div, s!(fn(a: Uint, b: Uint) -> Uint[a / b]
                          requires E::ne(b, 0) => ConstrReason::Div),
                 ),

--- a/flux-tests/tests/neg/surface/binop.rs
+++ b/flux-tests/tests/neg/surface/binop.rs
@@ -1,11 +1,8 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-// Bitwise BinOps
-//
-// We don't natively track any conditions on the bit-wise arithmetic operations,
-// so all that we know is the type of the resulting value (although we know that
-// it will unconditionally succeed).
+// Arithmetic BinOps
+// These check for over/underflow
 
 #[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a - b})]
 pub fn uint_sub(a: u32, b: u32) -> u32 {
@@ -16,6 +13,22 @@ pub fn uint_sub(a: u32, b: u32) -> u32 {
 pub fn uint_add(a: u32, b: u32) -> u32 {
     a + b //~ ERROR overflow
 }
+
+#[flux::sig(fn(a: i32{a > 0}, b: i32{b > 0}) -> i32{v: v == a + b})]
+pub fn uint_add_pos(a: i32, b: i32) -> i32 {
+    a + b //~ ERROR overflow
+}
+
+#[flux::sig(fn(a: i32{a < 0}, b: i32{b < 0}) -> i32{v: v == a + b})]
+pub fn uint_add_neg(a: i32, b: i32) -> i32 {
+    a + b //~ ERROR overflow
+}
+
+// Bitwise BinOps
+//
+// We don't natively track any conditions on the bit-wise arithmetic operations,
+// so all that we know is the type of the resulting value (although we know that
+// it will unconditionally succeed).
 
 #[flux::sig(fn(i32{v: v != 0}, i32) -> i32{v: v != 0})]
 pub fn bitwise_or(a: i32, b: i32) -> i32 {

--- a/flux-tests/tests/neg/surface/binop.rs
+++ b/flux-tests/tests/neg/surface/binop.rs
@@ -12,6 +12,11 @@ pub fn uint_sub(a: u32, b: u32) -> u32 {
     a - b //~ ERROR overflow
 }
 
+#[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a + b})]
+pub fn uint_add(a: u32, b: u32) -> u32 {
+    a + b //~ ERROR overflow
+}
+
 #[flux::sig(fn(i32{v: v != 0}, i32) -> i32{v: v != 0})]
 pub fn bitwise_or(a: i32, b: i32) -> i32 {
     a | b //~ ERROR postcondition

--- a/flux-tests/tests/neg/surface/binop.rs
+++ b/flux-tests/tests/neg/surface/binop.rs
@@ -7,6 +7,11 @@
 // so all that we know is the type of the resulting value (although we know that
 // it will unconditionally succeed).
 
+#[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a - b})]
+pub fn uint_sub(a: u32, b: u32) -> u32 {
+    a - b //~ ERROR overflow
+}
+
 #[flux::sig(fn(i32{v: v != 0}, i32) -> i32{v: v != 0})]
 pub fn bitwise_or(a: i32, b: i32) -> i32 {
     a | b //~ ERROR postcondition

--- a/flux-tests/tests/neg/surface/binop.rs
+++ b/flux-tests/tests/neg/surface/binop.rs
@@ -1,30 +1,12 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-// TODO: Uncomment when we can set flags on a per-test basis. Add the ERROR
-// overflow comment on the lines too.
-//
 // Arithmetic BinOps
-// These check for over/underflow
-// #[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a - b})]
-// pub fn uint_sub(a: u32, b: u32) -> u32 {
-//     a - b
-// }
-//
-// #[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a + b})]
-// pub fn uint_add(a: u32, b: u32) -> u32 {
-//     a + b
-// }
-//
-// #[flux::sig(fn(a: i32{a > 0}, b: i32{b > 0}) -> i32{v: v == a + b})]
-// pub fn uint_add_pos(a: i32, b: i32) -> i32 {
-//     a + b
-// }
-//
-// #[flux::sig(fn(a: i32{a < 0}, b: i32{b < 0}) -> i32{v: v == a + b})]
-// pub fn uint_add_neg(a: i32, b: i32) -> i32 {
-//     a + b
-// }
+// Checks for unsigned integer underflow
+#[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a - b})]
+pub fn uint_sub(a: u32, b: u32) -> u32 {
+    a - b //~ ERROR overflow
+}
 
 // Bitwise BinOps
 //

--- a/flux-tests/tests/neg/surface/binop.rs
+++ b/flux-tests/tests/neg/surface/binop.rs
@@ -1,28 +1,30 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
+// TODO: Uncomment when we can set flags on a per-test basis. Add the ERROR
+// overflow comment on the lines too.
+//
 // Arithmetic BinOps
 // These check for over/underflow
-
-#[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a - b})]
-pub fn uint_sub(a: u32, b: u32) -> u32 {
-    a - b //~ ERROR overflow
-}
-
-#[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a + b})]
-pub fn uint_add(a: u32, b: u32) -> u32 {
-    a + b //~ ERROR overflow
-}
-
-#[flux::sig(fn(a: i32{a > 0}, b: i32{b > 0}) -> i32{v: v == a + b})]
-pub fn uint_add_pos(a: i32, b: i32) -> i32 {
-    a + b //~ ERROR overflow
-}
-
-#[flux::sig(fn(a: i32{a < 0}, b: i32{b < 0}) -> i32{v: v == a + b})]
-pub fn uint_add_neg(a: i32, b: i32) -> i32 {
-    a + b //~ ERROR overflow
-}
+// #[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a - b})]
+// pub fn uint_sub(a: u32, b: u32) -> u32 {
+//     a - b
+// }
+//
+// #[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a + b})]
+// pub fn uint_add(a: u32, b: u32) -> u32 {
+//     a + b
+// }
+//
+// #[flux::sig(fn(a: i32{a > 0}, b: i32{b > 0}) -> i32{v: v == a + b})]
+// pub fn uint_add_pos(a: i32, b: i32) -> i32 {
+//     a + b
+// }
+//
+// #[flux::sig(fn(a: i32{a < 0}, b: i32{b < 0}) -> i32{v: v == a + b})]
+// pub fn uint_add_neg(a: i32, b: i32) -> i32 {
+//     a + b
+// }
 
 // Bitwise BinOps
 //

--- a/flux-tests/tests/neg/surface/binop_overflow.rs
+++ b/flux-tests/tests/neg/surface/binop_overflow.rs
@@ -1,0 +1,27 @@
+// ignore-test
+// TODO: Uncomment when we can set flags on a per-test basis. Add the ERROR
+// overflow comment on the lines too.
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+// Arithmetic BinOps
+// These check for over/underflow
+#[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a - b})]
+pub fn uint_sub(a: u32, b: u32) -> u32 {
+    a - b //~ ERROR overflow
+}
+
+#[flux::sig(fn(a: u32, b: u32) -> u32{v: v == a + b})]
+pub fn uint_add(a: u32, b: u32) -> u32 {
+    a + b //~ ERROR overflow
+}
+
+#[flux::sig(fn(a: i32{a > 0}, b: i32{b > 0}) -> i32{v: v == a + b})]
+pub fn uint_add_pos(a: i32, b: i32) -> i32 {
+    a + b //~ ERROR overflow
+}
+
+#[flux::sig(fn(a: i32{a < 0}, b: i32{b < 0}) -> i32{v: v == a + b})]
+pub fn uint_add_neg(a: i32, b: i32) -> i32 {
+    a + b //~ ERROR overflow
+}

--- a/flux-tests/tests/pos/surface/binop.rs
+++ b/flux-tests/tests/pos/surface/binop.rs
@@ -1,19 +1,20 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
+// TODO: Uncomment when we can set flags on a per-test basis
 // Arithmetic BinOps
 //
 // These require a guarantee that the operation will not over/underflow.
-
-#[flux::sig(fn(a:u32, b:u32{b < a}) -> u32{v: v == a - b})]
-pub fn uint_sub(a: u32, b: u32) -> u32 {
-    a - b
-}
-
-#[flux::sig(fn(a:i32, b:i32{b + a > 0 && b + a < 1000000000}) -> i32{v: v == a + b})]
-pub fn int_add(a: i32, b: i32) -> i32 {
-    a + b
-}
+//
+// #[flux::sig(fn(a:u32, b:u32{b < a}) -> u32{v: v == a - b})]
+// pub fn uint_sub(a: u32, b: u32) -> u32 {
+//     a - b
+// }
+//
+// #[flux::sig(fn(a:i32, b:i32{b + a > 0 && b + a < 1000000000}) -> i32{v: v == a + b})]
+// pub fn int_add(a: i32, b: i32) -> i32 {
+//     a + b
+// }
 
 // Bitwise BinOps
 //

--- a/flux-tests/tests/pos/surface/binop.rs
+++ b/flux-tests/tests/pos/surface/binop.rs
@@ -1,6 +1,20 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
+// Arithmetic BinOps
+//
+// These require a guarantee that the operation will not over/underflow.
+
+#[flux::sig(fn(a:u32, b:u32{b < a}) -> u32{v: v == a - b})]
+pub fn uint_sub(a: u32, b: u32) -> u32 {
+    a - b
+}
+
+#[flux::sig(fn(a:i32, b:i32{b + a > 0 && b + a < 1000000000}) -> i32{v: v == a + b})]
+pub fn int_add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
 // Bitwise BinOps
 //
 // We don't natively track any conditions on the bit-wise arithmetic operations,

--- a/flux-tests/tests/pos/surface/binop_overflow.rs
+++ b/flux-tests/tests/pos/surface/binop_overflow.rs
@@ -1,0 +1,18 @@
+// ignore-test
+// TODO: Uncomment when we can set flags on a per-test basis
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+// Arithmetic BinOps
+//
+// These require a guarantee that the operation will not over/underflow.
+//
+#[flux::sig(fn(a:u32, b:u32{b < a}) -> u32{v: v == a - b})]
+pub fn uint_sub(a: u32, b: u32) -> u32 {
+    a - b
+}
+
+#[flux::sig(fn(a:i32, b:i32{b + a > 0 && b + a < 1000000000}) -> i32{v: v == a + b})]
+pub fn int_add(a: i32, b: i32) -> i32 {
+    a + b
+}


### PR DESCRIPTION
### `FLUX_CHECK_OVERFLOW=0`

Behavior as previously (only check underflow on subtraction of unsigned integers).

### `FLUX_CHECK_OVERFLOW=1`

Checks overflow and underflow on arithmetic (plus/minus/times) operations for signed and unsigned integers.

### Tests

I added tests but left them commented because we can't configure the flag on a per-test level (see https://github.com/cole-k/flux-develop/blob/b8339c091f7aadf85306c843f95322daa5e9f3b0/flux-driver/src/collector.rs#L657-L663)