### PR TITLE
Support extern specs for functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "flux-attrs"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "flux-attrs-proc-macros"
+version = "0.1.0"
+dependencies = [
+ "flux-attrs",
+ "proc-macro2",
+]
+
+[[package]]
 name = "flux-bin"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 
 members = [
     "flux",
+    "flux-attrs",
+    "flux-attrs-proc-macros",
     "flux-bin",
     "flux-common",
     "flux-config",

--- a/flux-attrs-proc-macros/Cargo.toml
+++ b/flux-attrs-proc-macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "flux-attrs-proc-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+flux-attrs= { path = "../flux-attrs", version = "0.1.0", optional = true }
+proc-macro2 = { version = "1.0", optional = true }
+
+[features]
+# Design taken from Prusti - we enable the 'flux-attributes-proc-macros/enabled'
+# feature when checking with flux which indicates that we should pull in these
+# deps.
+enabled = ["dep:flux-attrs", "dep:proc-macro2"]

--- a/flux-attrs-proc-macros/src/lib.rs
+++ b/flux-attrs-proc-macros/src/lib.rs
@@ -1,0 +1,15 @@
+// When running without flux, all macros are pass-through
+#![cfg_attr(not(feature = "enabled"), no_std)]
+use proc_macro::TokenStream;
+
+#[cfg(not(feature = "enabled"))]
+#[proc_macro_attribute]
+pub fn extern_spec(_: TokenStream, tokens: TokenStream) -> TokenStream {
+    tokens
+}
+
+#[cfg(feature = "enabled")]
+#[proc_macro_attribute]
+pub fn extern_spec(attrs: TokenStream, tokens: TokenStream) -> TokenStream {
+    flux_attrs::extern_spec(attrs.into(), tokens.into()).into()
+}

--- a/flux-attrs/Cargo.toml
+++ b/flux-attrs/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+edition = "2021"
+name = "flux-attrs"
+version = "0.1.0"
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["full"] }

--- a/flux-attrs/src/lib.rs
+++ b/flux-attrs/src/lib.rs
@@ -1,0 +1,137 @@
+#![feature(proc_macro_diagnostic)]
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote_spanned};
+use syn::{
+    parse_quote_spanned, punctuated::Punctuated, spanned::Spanned, Expr, FnArg, GenericArgument,
+    GenericParam, Token,
+};
+
+pub fn extern_spec(attr: TokenStream, tokens: TokenStream) -> TokenStream {
+    transform_extern_spec(attr, tokens).unwrap_or_else(|err| err.to_compile_error())
+}
+
+fn transform_extern_spec(attr: TokenStream, tokens: TokenStream) -> syn::Result<TokenStream> {
+    let mod_path: Option<syn::Path> =
+        if !attr.is_empty() { Some(syn::parse2(attr)?) } else { None };
+    let (sig, attrs) = extract_sig_from_stub(tokens)?;
+    create_dummy_fn(mod_path, sig, attrs)
+}
+
+/// Takes a function stub, i.e. something that looks like
+/// ```ignore
+///     pub fn swap(a: &mut i32, b: &mut i32) -> ();
+/// ```
+/// and extracts its signature and any attributes.
+///
+/// This function actually tries to parse the stub as a `syn::TraitItemMethod`
+/// and requires that it not have a default implementation.
+fn extract_sig_from_stub(
+    tokens: TokenStream,
+) -> syn::Result<(syn::Signature, Vec<syn::Attribute>)> {
+    let span = tokens.span();
+    match syn::parse2::<syn::TraitItemMethod>(tokens) {
+        // Parse must succeed and it must not have a default implementation (i.e. it must end with a ';')
+        Err(_) | Ok(syn::TraitItemMethod { default: Some(_), .. }) => Err(syn::Error::new(
+            span,
+            "Invalid function stub: extern specs expect a function stub like: fn swap(a: &mut i32, b: &mut i32);"
+        )),
+        Ok(trait_item_method) => {
+            Ok((trait_item_method.sig, trait_item_method.attrs))
+        }
+    }
+}
+
+/// Creates a dummy function whose inner body is just a pass-through call to the
+/// extern function. Takes the signature and attributes
+/// ```ignore
+/// swap(a: &mut i32, b: &mut i32) -> ()
+/// ```
+/// and produces a function that looks like.
+/// ```ignore
+///     pub fn flux_extern_spec_swap(a: &mut i32, b: &mut i32) -> () {
+///         swap(a,b)
+///     }
+/// ```
+///
+/// The big idea:
+/// 1. Mangle the name of the function into flux_extern_spec_{fn_ident} so that it doesn't
+///    conflict with an existing function. TODO: add some random number to ensure it.
+/// 2. Create a new function with the mangled name and same signature.
+/// 3. Replace its body with a single expression that is a function call.
+/// 4. The function call is of the form mod_path::fn_ident<generic_args>(params)
+///    where the generic args and params have been modified so that they function as
+///    arguments to the call instead of being a part of the function signature.
+/// 5. Finally, we suppress dead_code/unused warnings and add the flux::extern_spec
+///    so that flux knows this is the generated dummy function for the external function
+///    that is being called.
+fn create_dummy_fn(
+    mod_path: Option<syn::Path>,
+    sig: syn::Signature,
+    attrs: Vec<syn::Attribute>,
+) -> syn::Result<TokenStream> {
+    let span = sig.span();
+    let mut mangled_sig = sig.clone();
+    let ident = sig.ident;
+    mangled_sig.ident = format_ident!("flux_extern_spec_{}", ident);
+    let generic_call_args = transform_generic_params_to_call_args(sig.generics.params);
+    let call_args = transform_params_to_call_args(sig.inputs);
+    let fn_path: syn::Path = if let Some(mod_path) = mod_path {
+        parse_quote_spanned!( ident.span() => #mod_path :: #ident)
+    } else {
+        parse_quote_spanned!( ident.span() => #ident )
+    };
+    Ok(quote_spanned! { span =>
+                        #[flux::extern_spec]
+                        #(#attrs)*
+                        #[allow(unused, dead_code)]
+                        #mangled_sig {
+                            #fn_path :: < #generic_call_args > ( #call_args )
+                        }
+    })
+}
+// Cribbed from Prusti's extern_spec_rewriter
+fn transform_generic_params_to_call_args(
+    generic_params: Punctuated<GenericParam, Token!(,)>,
+) -> Punctuated<GenericArgument, Token!(,)> {
+    Punctuated::from_iter(
+        generic_params
+            .iter()
+            .flat_map(|param| -> Option<GenericArgument> {
+                let span = param.span();
+                match param {
+                    GenericParam::Type(syn::TypeParam { ident, .. }) => {
+                        Some(parse_quote_spanned! { span => #ident })
+                    }
+                    GenericParam::Lifetime(_) => None,
+                    GenericParam::Const(syn::ConstParam { ident, .. }) => {
+                        Some(parse_quote_spanned! {span => #ident })
+                    }
+                }
+            }),
+    )
+}
+
+// Cribbed from Prusti's extern_spec_rewriter
+fn transform_params_to_call_args(
+    params: Punctuated<FnArg, Token!(,)>,
+) -> Punctuated<Expr, Token!(,)> {
+    Punctuated::from_iter(params.iter().map(|param| -> Expr {
+        let span = param.span();
+        match param {
+            FnArg::Typed(pat_type) => {
+                match pat_type.pat.as_ref() {
+                    syn::Pat::Ident(ident) => {
+                        parse_quote_spanned! {span => #ident }
+                    }
+                    _ => {
+                        unimplemented!(
+                            "extern specs don't support patterns other than simple identifiers"
+                        )
+                    }
+                }
+            }
+            FnArg::Receiver(_) => parse_quote_spanned! {span => self},
+        }
+    }))
+}

--- a/flux-attrs/src/lib.rs
+++ b/flux-attrs/src/lib.rs
@@ -90,6 +90,7 @@ fn create_dummy_fn(
                         }
     })
 }
+
 // Cribbed from Prusti's extern_spec_rewriter
 fn transform_generic_params_to_call_args(
     generic_params: Punctuated<GenericParam, Token!(,)>,

--- a/flux-bin/src/bin/cargo-flux.rs
+++ b/flux-bin/src/bin/cargo-flux.rs
@@ -30,9 +30,12 @@ fn run() -> Result<i32> {
     let cargo_target = env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
     let cargo_target = PathBuf::from_iter([cargo_target, "flux".to_string()]);
 
+    let features = ["--features", "flux-attrs-proc-macros/enabled"].iter();
+
     let exit_code = Command::new("cargo")
         // Skip the invocation of cargo-flux itself
         .args(env::args().skip(1))
+        .args(features)
         .env(LIB_PATH, extended_lib_path)
         .env("RUST_TOOLCHAIN", rust_toolchain.clone())
         .env("RUSTUP_TOOLCHAIN", rust_toolchain)

--- a/flux-driver/locales/en-US.ftl
+++ b/flux-driver/locales/en-US.ftl
@@ -24,3 +24,9 @@ driver_missing_variant =
     missing variant annotation
     .label = this variant doesn't have a refinement annotation
     .note = all variants in a refined enum must be annotated
+
+driver_malformed_extern_spec =
+    malformed extern_spec, expecting a function definition with a call to the external method as the body
+
+driver_missing_fn_sig_for_extern_spec =
+    missing flux::sig attribute (functions declared as flux::extern_spec require a flux::sig)

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -378,6 +378,13 @@ fn build_fhir_map(early_cx: &mut EarlyCtxt, specs: &mut Specs) -> Result<(), Err
         .err()
         .or(err);
 
+    // Extern Fns
+    std::mem::take(&mut specs.extern_fns)
+        .into_iter()
+        .for_each(|(extern_def_id, local_def_id)| {
+            early_cx.map.insert_extern_fn(extern_def_id, local_def_id);
+        });
+
     if let Some(err) = err {
         Err(err)
     } else {

--- a/flux-driver/src/collector.rs
+++ b/flux-driver/src/collector.rs
@@ -392,7 +392,8 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
             && let ExprKind::Block(b, _) = e.kind
             && let Some(e) = b.expr
             && let ExprKind::Call(callee, _) = e.kind
-            && let ExprKind::Path(ref qself) = callee.kind {
+            && let ExprKind::Path(ref qself) = callee.kind
+        {
                 let typeck_result = self.tcx.typeck(def_id);
                 if let def::Res::Def(_, def_id) = typeck_result.qpath_res(qself, callee.hir_id)
                 {

--- a/flux-macros/src/lib.rs
+++ b/flux-macros/src/lib.rs
@@ -2,7 +2,6 @@
 
 mod diagnostics;
 
-use proc_macro::TokenStream;
 use synstructure::decl_derive;
 
 decl_derive!(
@@ -46,6 +45,6 @@ decl_derive!(
 );
 
 #[proc_macro]
-pub fn fluent_messages(input: TokenStream) -> TokenStream {
+pub fn fluent_messages(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     diagnostics::fluent_messages(input)
 }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -98,6 +98,7 @@ pub struct Map {
     fns: FxHashMap<LocalDefId, FnSig>,
     fn_quals: FxHashMap<LocalDefId, Vec<SurfaceIdent>>,
     trusted: FxHashSet<LocalDefId>,
+    extern_fns: FxHashMap<DefId, LocalDefId>,
 }
 
 #[derive(Debug)]
@@ -626,6 +627,14 @@ impl Map {
 
     pub fn is_trusted(&self, def_id: LocalDefId) -> bool {
         self.trusted.contains(&def_id)
+    }
+
+    pub fn insert_extern_fn(&mut self, extern_def_id: DefId, local_def_id: LocalDefId) {
+        self.extern_fns.insert(extern_def_id, local_def_id);
+    }
+
+    pub fn extern_fns(&self) -> &FxHashMap<DefId, LocalDefId> {
+        &self.extern_fns
     }
 
     // ADT

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -25,6 +25,8 @@ pub struct GlobalEnv<'sess, 'tcx> {
     fn_quals: FxHashMap<DefId, FxHashSet<String>>,
     early_cx: EarlyCtxt<'sess, 'tcx>,
     queries: Queries<'tcx>,
+    queries: Queries,
+    extern_fns: FxHashMap<DefId, DefId>,
 }
 
 impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
@@ -38,6 +40,12 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             let names = names.iter().map(|ident| ident.name.to_string()).collect();
             fn_quals.insert(def_id.to_def_id(), names);
         }
+        let extern_fns = early_cx
+            .map
+            .extern_fns()
+            .iter()
+            .map(|(extern_def_id, local_def_id)| (*extern_def_id, local_def_id.to_def_id()))
+            .collect();
         GlobalEnv {
             tcx: early_cx.tcx,
             sess: early_cx.sess,
@@ -45,6 +53,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             uifs,
             fn_quals,
             queries: Queries::new(providers),
+            extern_fns,
         }
     }
 
@@ -193,5 +202,9 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
 
     pub fn hir(&self) -> rustc_middle::hir::map::Map<'tcx> {
         self.tcx.hir()
+    }
+
+    pub fn extern_fns(&self) -> &FxHashMap<DefId, DefId> {
+        &self.extern_fns
     }
 }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -203,7 +203,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         self.tcx.hir()
     }
 
-    pub fn extern_fns(&self) -> &FxHashMap<DefId, DefId> {
-        &self.extern_fns
+    pub fn lookup_extern_fn(&self, def_id: &DefId) -> Option<&DefId> {
+        self.extern_fns.get(def_id)
     }
 }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -25,7 +25,6 @@ pub struct GlobalEnv<'sess, 'tcx> {
     fn_quals: FxHashMap<DefId, FxHashSet<String>>,
     early_cx: EarlyCtxt<'sess, 'tcx>,
     queries: Queries<'tcx>,
-    queries: Queries,
     extern_fns: FxHashMap<DefId, DefId>,
 }
 

--- a/flux-middle/src/queries.rs
+++ b/flux-middle/src/queries.rs
@@ -200,18 +200,18 @@ impl<'tcx> Queries<'tcx> {
 
     pub(crate) fn fn_sig(&self, genv: &GlobalEnv, def_id: DefId) -> QueryResult<rty::PolySig> {
         run_with_cache(&self.fn_sig, def_id, || {
-            // If it's an extern_fn, resolve it to its local fn_sig's def_id
-            let did =
-                if let Some(entry) = genv.extern_fns().get(&def_id) { *entry } else { def_id };
-            if let Some(local_id) = did.as_local() {
+            // If it's an extern_fn, resolve it to its local fn_sig's def_id,
+            // otherwise don't change it.
+            let def_id = *genv.lookup_extern_fn(&def_id).unwrap_or(&def_id);
+            if let Some(local_id) = def_id.as_local() {
                 (self.providers.fn_sig)(genv, local_id)
-            } else if let Some(fn_sig) = genv.early_cx().cstore.fn_sig(did) {
+            } else if let Some(fn_sig) = genv.early_cx().cstore.fn_sig(def_id) {
                 Ok(fn_sig)
             } else {
-                let fn_sig = lowering::lower_fn_sig_of(genv.tcx, did)
-                    .map_err(|err| QueryErr::unsupported(genv.tcx, did, err))?
+                let fn_sig = lowering::lower_fn_sig_of(genv.tcx, def_id)
+                    .map_err(|err| QueryErr::unsupported(genv.tcx, def_id, err))?
                     .skip_binder();
-                Refiner::default(genv, &genv.generics_of(did)?).refine_fn_sig(&fn_sig)
+                Refiner::default(genv, &genv.generics_of(def_id)?).refine_fn_sig(&fn_sig)
             }
         })
     }

--- a/flux-middle/src/queries.rs
+++ b/flux-middle/src/queries.rs
@@ -200,15 +200,18 @@ impl<'tcx> Queries<'tcx> {
 
     pub(crate) fn fn_sig(&self, genv: &GlobalEnv, def_id: DefId) -> QueryResult<rty::PolySig> {
         run_with_cache(&self.fn_sig, def_id, || {
-            if let Some(local_id) = def_id.as_local() {
+            // If it's an extern_fn, resolve it to its local fn_sig's def_id
+            let did =
+                if let Some(entry) = genv.extern_fns().get(&def_id) { *entry } else { def_id };
+            if let Some(local_id) = did.as_local() {
                 (self.providers.fn_sig)(genv, local_id)
-            } else if let Some(fn_sig) = genv.early_cx().cstore.fn_sig(def_id) {
+            } else if let Some(fn_sig) = genv.early_cx().cstore.fn_sig(did) {
                 Ok(fn_sig)
             } else {
-                let fn_sig = lowering::lower_fn_sig_of(genv.tcx, def_id)
-                    .map_err(|err| QueryErr::unsupported(genv.tcx, def_id, err))?
+                let fn_sig = lowering::lower_fn_sig_of(genv.tcx, did)
+                    .map_err(|err| QueryErr::unsupported(genv.tcx, did, err))?
                     .skip_binder();
-                Refiner::default(genv, &genv.generics_of(def_id)?).refine_fn_sig(&fn_sig)
+                Refiner::default(genv, &genv.generics_of(did)?).refine_fn_sig(&fn_sig)
             }
         })
     }

--- a/flux-tests/tests/neg/surface/extern_spec_internal.rs
+++ b/flux-tests/tests/neg/surface/extern_spec_internal.rs
@@ -1,0 +1,23 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+use std::vec::Vec;
+
+#[flux::alias(type Lb(n: int) = usize{v: n <= v})]
+type Lb = usize;
+
+#[flux::trusted]
+fn make_vec() -> Vec<i32> {
+    vec!(1,2,3)
+}
+
+#[flux::extern_spec]
+#[flux::sig(fn(v: &Vec<i32>) -> Lb(9))]
+fn extern_len(v: &Vec<i32>) -> Lb {
+    Vec::len(&v)
+}
+
+#[flux::sig(fn() -> Lb(10))]
+pub fn test() -> Lb {
+    Vec::len(&make_vec())
+} //~ ERROR postcondition

--- a/flux-tests/tests/neg/surface/extern_spec_macro.rs
+++ b/flux-tests/tests/neg/surface/extern_spec_macro.rs
@@ -1,0 +1,16 @@
+// ignore-test
+// Need to add macros to test
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+use std::mem::swap;
+
+#[extern_spec]
+#[flux::sig(fn(&mut i32[@a], &mut i32{v : a < v }) -> ())]
+fn swap(a: &mut i32, b: &mut i32);
+
+pub fn test() {
+  let mut x = 1;
+  let mut y = 2;
+  swap(&mut y, &mut x); //~ ERROR postcondition
+}

--- a/flux-tests/tests/pos/surface/extern_spec_internal.rs
+++ b/flux-tests/tests/pos/surface/extern_spec_internal.rs
@@ -1,0 +1,23 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+use std::vec::Vec;
+
+#[flux::alias(type Lb(n: int) = usize{v: n <= v})]
+type Lb = usize;
+
+#[flux::trusted]
+fn make_vec() -> Vec<i32> {
+    vec!(1,2,3)
+}
+
+#[flux::extern_spec]
+#[flux::sig(fn(v: &Vec<i32>) -> Lb(10))]
+fn extern_len(v: &Vec<i32>) -> Lb {
+    Vec::len(v)
+}
+
+#[flux::sig(fn() -> Lb(10))]
+pub fn test() -> Lb {
+    Vec::len(&make_vec())
+}

--- a/flux-tests/tests/pos/surface/extern_spec_macro.rs
+++ b/flux-tests/tests/pos/surface/extern_spec_macro.rs
@@ -1,0 +1,16 @@
+// ignore-test
+// Need to add macros to test
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+use std::mem::swap;
+
+#[extern_spec]
+#[flux::sig(fn(&mut i32[@a], &mut i32{v : a < v }) -> ())]
+fn swap(a: &mut i32, b: &mut i32);
+
+pub fn test() {
+  let mut x = 1;
+  let mut y = 2;
+  swap(&mut x, &mut y);
+}


### PR DESCRIPTION
## Current work

- [x] Macro to generate dummy functions from stubs (like Prusti's)
- [ ] WONTDO (Nico and I talked about this) Hack to make macro available in `(rustc|cargo)-flux`
- [x] Replace the `DefId` of a function marked `extern` with that of a dummy function with an assumed spec
- [x] Address review comments (most notably move the macro to a new crate)

## Overview

Here's my understanding of how extern specs are implemented in Prusti, which I am using as a guide for our own implementation.

### Invocation stage

[Prusti adds the compilation flag `--extern prusti_contracts=path/to/libprusti_contracts.rlib`](https://github.com/viperproject/prusti-dev/blob/d1d4dccb179e8be4769045cd3956e1d98be69c52/prusti-launch/src/bin/prusti-rustc.rs#L85-L105) so that macros are available whenever you check with it.

### Macro stage

The user writes code like

```rust
use prusti_contracts::*;

#[extern_spec(std::mem)]
#[ensures(*a == old(*b) && *b == old(*a))]
pub fn swap(a: &mut i32, b: &mut i32);
```

The `extern_spec` macro expands it to something like

```rust
#[prusti::extern_spec]
#[ensures(*a == old(*b) && *b == old(*a))]
pub fn prusti_extern_spec_swap(a: &mut i32, b: &mut i32) {
    std::mem::swap(a, b)
}
```

### Type checking stage

When Prusti sees the `prusti::extern_spec` annotation, it traverses the body of its associated function until it finds a function call expression. It then extracts the `DefId` of the function (in this case `std::mem::swap`). It then registers this `DefId` as having the same spec as `prusti_extern_spec_swap`.

### Why does Prusti do this?

This is very janky, but after discussing with Nico and thinking about it myself it unfortunately seems like the easiest solution.

There are several explanations for the jank:

* Passing an `--extern` flag to `cargo`/`rustc` makes it so that you can check things without introducing an additional dep, most notably standalone files.
* Going through the whole rigamarole of having a macro expand the spec is the best way to get typing information about the external function. There doesn't seem any particularly good way to take a string like `std::mem::swap` and resolve it to the right `DefId` without running the whole compiler.*
* However, there doesn't seem to be a straightforward way of writing out a path and telling Rust "hey, get the `DefId` of this but otherwise ignore it." So that's why they make a whole dummy function and traverse it to extract the path.
* Finally, there are some advantages to having a dummy function, most notably that they can just pretend as if the external spec was a trusted local definition - this prevents some duplication of logic.

\* I'd be interested in seeing if it's possible to generate a new top-level AST node to extend the `TyCtx` with and run the typechecking/namespace resolution algorithm on it. This essentially would do the macro expansion as part of the flux driver callback. However I don't have high hopes for this method since I'm guessing that flux is operating after these resolutions have finished.

## What I've added

See [Current work](#current-work) for the checklist.

[See the tests for examples of the syntax](https://github.com/flux-rs/flux/pull/394/files#diff-cc7bc02cac0f0f5f5805f12a4778af6acabdbc02c5526e5f148cb459075e7b25).

### Invocation stage

`cargo-flux` passes the feature `flux-attrs-proc-macros/enabled` which pulls in the deps of `flux-attrs-proc-macros` (without this feature, the `extern_spec` proc macro is just a pass-through function and therefore does not require any dependency on `flux-attrs`).

We do _not_ pass the `--extern` flag. Nico and I talked about this and it's too much of a hack and only is beneficial for invocations of `rustc-flux`.

### Macro

Here's how it works. We start with an empty function definition.

```rust
use flux_macros::extern_spec;

#[extern_spec(std::mem)]
#[flux::sig(fn(&mut i32[@a], &mut i32{v : a < v }) -> ())]
fn swap(a: &mut i32, b: &mut i32);
```

The macro parses the `std::mem` into a module path and then transforms the function into

```rust
#[flux::extern_spec]
#[flux::sig(fn(&mut i32[@a], &mut i32{v : a < v }) -> ())]
#[allow(unused, dead_code)]
fn swap(a: &mut i32, b: &mut i32) {
    std::mem::swap(a, b)
}
```

Note that `extern_spec` and `flux::extern_spec` are not the same - the latter is an "internal" attribute that expects the function to be defined in a particular way.

### Type checking

I've added an attribute `#[flux::extern_spec]`. This attribute requires an associated `#[flux::sig]` attribute and that the dummy function it's an attribute of is in the exact form of the function Prusti's `extern_spec` macro generates. The attribute makes the associated dummy function trusted.

I added an `extern_fns` attribute to the various contexts. It maps the `DefId` of an external function to the `DefId` of its local dummy function. Now when we resolve a function `DefId` during type checking, we first check if it's an external spec, returning the associated dummy function's signature if it is.

The nice thing about having the dummy function is that well-formedness checks and identifier resolution are handled just like they would be for a normal function, so we don't need to do any extra work.

## Limitations

When we add support for `extern_spec` macros, users will have to import the macro from `flux_macros` unqualified. Perhaps there is a way to change the import so that they can call it `flux::extern_spec` - I'm not too sure about how name resolution works.

Extern specs are only implemented for functions right now.

## Acknowledgements

[Prusti](https://github.com/viperproject/prusti-dev/)'s handling of extern specs was instrumental in helping me figure out what code I needed to write. For every line of code I wrote, I probably read 10 lines of their code.