### PR TITLE
Early Binder

### DIFF
--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -473,7 +473,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                 return Ok(self
                     .genv
                     .type_of(*def_id)?
-                    .replace_generics(&self.conv_generic_args(*def_id, &path.generics)?)
+                    .subst(&self.conv_generic_args(*def_id, &path.generics)?)
                     .replace_bvar(&rty::Expr::tuple(args)));
             }
         };
@@ -501,6 +501,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                             let ty = self
                                 .genv
                                 .type_of(param.def_id)?
+                                .subst(&[])
                                 .replace_bvar(&rty::Expr::unit());
                             Ok(rty::GenericArg::Ty(ty))
                         }
@@ -726,12 +727,12 @@ impl LookupResultKind<'_> {
     fn to_expr(&self, level: u32) -> rty::Expr {
         match self {
             Self::List(ListEntry::Sort { idx, conv, .. }) => {
-                rty::Expr::tuple_proj(rty::Expr::bvar(DebruijnIndex::new(level)), *idx)
+                rty::Expr::tuple_proj(rty::Expr::early_bvar(DebruijnIndex::new(level)), *idx)
                     .eta_expand_tuple(conv)
             }
             Self::List(ListEntry::Unit) => rty::Expr::unit(),
             Self::Single(_, conv) => {
-                rty::Expr::bvar(DebruijnIndex::new(level)).eta_expand_tuple(conv)
+                rty::Expr::early_bvar(DebruijnIndex::new(level)).eta_expand_tuple(conv)
             }
         }
     }

--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -51,13 +51,10 @@ enum ListEntry {
         sort: fhir::Sort,
         infer_mode: rty::InferMode,
         conv: rty::Sort,
-        /// The index of the entry in the layer skipping all [`unit`] entries.
-        ///
-        /// [`unit`]: ListEntry::Unit
+        /// The index of the entry in the layer skipping all [`ListEntry::Unit`].
         idx: u32,
     },
-    /// We track parameters of sort unit separately because we avoid creating bound variables
-    /// for them in [`rty`].
+    /// We track parameters of unit sort separately because we avoid creating bound variables for them.
     Unit,
 }
 
@@ -167,7 +164,7 @@ pub(crate) fn conv_fn_sig(
     genv: &GlobalEnv,
     fn_sig: &fhir::FnSig,
     wfckresults: &fhir::WfckResults,
-) -> QueryResult<rty::PolySig> {
+) -> QueryResult<rty::PolyFnSig> {
     let mut env = Env::new(genv.early_cx(), []);
     env.push_layer(Layer::from_fun_params(genv.early_cx(), &fn_sig.params));
     let mut cx = ConvCtxt::new(genv, env, wfckresults);
@@ -185,7 +182,7 @@ pub(crate) fn conv_fn_sig(
     let output = cx.conv_fn_output(&fn_sig.output)?;
 
     let params = cx.env.pop_layer().into_fun_params();
-    Ok(rty::PolySig::new(params, rty::FnSig::new(requires, args, output)))
+    Ok(rty::PolyFnSig::new(params, rty::FnSig::new(requires, args, output)))
 }
 
 pub(crate) fn conv_ty(

--- a/flux-fhir-analysis/src/lib.rs
+++ b/flux-fhir-analysis/src/lib.rs
@@ -154,7 +154,7 @@ fn variants_of(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::PolyVar
     Ok(variants)
 }
 
-fn fn_sig(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<rty::PolySig>> {
+fn fn_sig(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
     let fn_sig = genv.map().get_fn_sig(def_id);
     let wfckresults = genv.check_wf(def_id)?;
     let fn_sig = conv::conv_fn_sig(genv, fn_sig, &wfckresults)?.normalize(genv.defns()?);

--- a/flux-fhir-analysis/src/wf.rs
+++ b/flux-fhir-analysis/src/wf.rs
@@ -59,6 +59,17 @@ impl From<&[(fhir::Ident, fhir::Sort)]> for Env {
     }
 }
 
+impl<'a> FromIterator<&'a (fhir::Ident, fhir::Sort)> for Env {
+    fn from_iter<T: IntoIterator<Item = &'a (fhir::Ident, fhir::Sort)>>(iter: T) -> Self {
+        Env {
+            sorts: iter
+                .into_iter()
+                .map(|(ident, sort)| (ident.name, sort.clone()))
+                .collect(),
+        }
+    }
+}
+
 impl<T: Borrow<fhir::Name>> std::ops::Index<T> for Env {
     type Output = fhir::Sort;
 
@@ -114,7 +125,7 @@ pub(crate) fn check_alias(
     alias: &fhir::TyAlias,
 ) -> Result<WfckResults, ErrorGuaranteed> {
     let mut wf = Wf::new(early_cx);
-    let mut env = Env::from(&alias.params[..]);
+    let mut env = Env::from_iter(alias.all_params());
     wf.check_type(&mut env, &alias.ty)?;
     Ok(wf.into_results())
 }

--- a/flux-metadata/src/lib.rs
+++ b/flux-metadata/src/lib.rs
@@ -44,7 +44,7 @@ pub struct CStore {
 
 #[derive(TyEncodable, TyDecodable)]
 pub struct CrateMetadata {
-    fn_sigs: FxHashMap<DefIndex, rty::EarlyBinder<rty::PolySig>>,
+    fn_sigs: FxHashMap<DefIndex, rty::EarlyBinder<rty::PolyFnSig>>,
     refined_bys: FxHashMap<DefIndex, fhir::RefinedBy>,
     adts: FxHashMap<DefIndex, AdtMetadata>,
     /// For now it only store type of aliases
@@ -77,7 +77,7 @@ impl CStore {
 }
 
 impl CrateStore for CStore {
-    fn fn_sig(&self, def_id: DefId) -> Option<rty::EarlyBinder<rty::PolySig>> {
+    fn fn_sig(&self, def_id: DefId) -> Option<rty::EarlyBinder<rty::PolyFnSig>> {
         self.meta
             .get(&def_id.krate)?
             .fn_sigs

--- a/flux-metadata/src/lib.rs
+++ b/flux-metadata/src/lib.rs
@@ -44,11 +44,11 @@ pub struct CStore {
 
 #[derive(TyEncodable, TyDecodable)]
 pub struct CrateMetadata {
-    fn_sigs: FxHashMap<DefIndex, rty::PolySig>,
+    fn_sigs: FxHashMap<DefIndex, rty::EarlyBinder<rty::PolySig>>,
     refined_bys: FxHashMap<DefIndex, fhir::RefinedBy>,
     adts: FxHashMap<DefIndex, AdtMetadata>,
     /// For now it only store type of aliases
-    type_of: FxHashMap<DefIndex, rty::Binder<rty::Ty>>,
+    type_of: FxHashMap<DefIndex, rty::EarlyBinder<rty::PolyTy>>,
 }
 
 #[derive(TyEncodable, TyDecodable)]
@@ -77,7 +77,7 @@ impl CStore {
 }
 
 impl CrateStore for CStore {
-    fn fn_sig(&self, def_id: DefId) -> Option<rty::PolySig> {
+    fn fn_sig(&self, def_id: DefId) -> Option<rty::EarlyBinder<rty::PolySig>> {
         self.meta
             .get(&def_id.krate)?
             .fn_sigs
@@ -97,7 +97,7 @@ impl CrateStore for CStore {
         self.adt(def_id).map(|adt| adt.variants.as_deref())
     }
 
-    fn type_of(&self, def_id: DefId) -> Option<&rty::Binder<rty::Ty>> {
+    fn type_of(&self, def_id: DefId) -> Option<&rty::EarlyBinder<rty::PolyTy>> {
         self.meta.get(&def_id.krate)?.type_of.get(&def_id.index)
     }
 }

--- a/flux-middle/src/cstore.rs
+++ b/flux-middle/src/cstore.rs
@@ -3,7 +3,7 @@ use rustc_span::def_id::DefId;
 use crate::{fhir, rty};
 
 pub trait CrateStore {
-    fn fn_sig(&self, def_id: DefId) -> Option<rty::EarlyBinder<rty::PolySig>>;
+    fn fn_sig(&self, def_id: DefId) -> Option<rty::EarlyBinder<rty::PolyFnSig>>;
     fn refined_by(&self, def_id: DefId) -> Option<&fhir::RefinedBy>;
     fn adt_def(&self, def_id: DefId) -> Option<&rty::AdtDef>;
     fn variants(&self, def_id: DefId) -> Option<rty::Opaqueness<&[rty::PolyVariant]>>;

--- a/flux-middle/src/cstore.rs
+++ b/flux-middle/src/cstore.rs
@@ -3,11 +3,11 @@ use rustc_span::def_id::DefId;
 use crate::{fhir, rty};
 
 pub trait CrateStore {
-    fn fn_sig(&self, def_id: DefId) -> Option<rty::PolySig>;
+    fn fn_sig(&self, def_id: DefId) -> Option<rty::EarlyBinder<rty::PolySig>>;
     fn refined_by(&self, def_id: DefId) -> Option<&fhir::RefinedBy>;
     fn adt_def(&self, def_id: DefId) -> Option<&rty::AdtDef>;
     fn variants(&self, def_id: DefId) -> Option<rty::Opaqueness<&[rty::PolyVariant]>>;
-    fn type_of(&self, def_id: DefId) -> Option<&rty::Binder<rty::Ty>>;
+    fn type_of(&self, def_id: DefId) -> Option<&rty::EarlyBinder<rty::PolyTy>>;
 }
 
 pub type CrateStoreDyn = dyn CrateStore;

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -103,9 +103,10 @@ pub struct Map {
 #[derive(Debug)]
 pub struct TyAlias {
     pub def_id: LocalDefId,
-    pub params: Vec<(Ident, Sort)>,
     pub ty: Ty,
     pub span: Span,
+    pub early_bound_params: Vec<(Ident, Sort)>,
+    pub index_params: Vec<(Ident, Sort)>,
     /// Whether this alias was [lifted] from a `hir` alias
     ///
     /// [lifted]: lift::lift_type_alias
@@ -760,6 +761,12 @@ impl Map {
 
     pub fn sort_decl(&self, name: impl Borrow<Symbol>) -> Option<&SortDecl> {
         self.sort_decls.get(name.borrow())
+    }
+}
+
+impl TyAlias {
+    pub fn all_params(&self) -> impl Iterator<Item = &(Ident, Sort)> {
+        self.early_bound_params.iter().chain(&self.index_params)
     }
 }
 

--- a/flux-middle/src/fhir/lift.rs
+++ b/flux-middle/src/fhir/lift.rs
@@ -80,7 +80,14 @@ pub fn lift_type_alias(
     };
     let cx = LiftCtxt::new(early_cx, def_id);
     let ty = cx.lift_ty(ty)?;
-    Ok(fhir::TyAlias { def_id, params: vec![], ty, span: item.span, lifted: true })
+    Ok(fhir::TyAlias {
+        def_id,
+        early_bound_params: vec![],
+        index_params: vec![],
+        ty,
+        span: item.span,
+        lifted: true,
+    })
 }
 
 pub fn lift_field_def(

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -122,7 +122,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         self.queries.type_of(self, def_id)
     }
 
-    pub fn fn_sig(&self, def_id: DefId) -> QueryResult<rty::EarlyBinder<rty::PolySig>> {
+    pub fn fn_sig(&self, def_id: DefId) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
         self.queries.fn_sig(self, def_id)
     }
 

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -111,7 +111,10 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         self.queries.generics_of(self, def_id.into())
     }
 
-    pub fn predicates_of(&self, def_id: DefId) -> QueryResult<rty::GenericPredicates> {
+    pub fn predicates_of(
+        &self,
+        def_id: DefId,
+    ) -> QueryResult<rty::EarlyBinder<rty::GenericPredicates>> {
         self.queries.predicates_of(self, def_id)
     }
 
@@ -131,10 +134,10 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         &self,
         def_id: DefId,
         variant_idx: VariantIdx,
-    ) -> QueryResult<rty::Opaqueness<rty::PolyVariant>> {
+    ) -> QueryResult<rty::Opaqueness<rty::EarlyBinder<rty::PolyVariant>>> {
         Ok(self
             .variants_of(def_id)?
-            .map(|variants| variants[variant_idx.as_usize()].clone()))
+            .map(|variants| rty::EarlyBinder(variants[variant_idx.as_usize()].clone())))
     }
 
     pub fn index_sorts_of(&self, def_id: DefId) -> &[fhir::Sort] {

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -115,11 +115,11 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         self.queries.predicates_of(self, def_id)
     }
 
-    pub fn type_of(&self, def_id: DefId) -> QueryResult<rty::Binder<rty::Ty>> {
+    pub fn type_of(&self, def_id: DefId) -> QueryResult<rty::EarlyBinder<rty::PolyTy>> {
         self.queries.type_of(self, def_id)
     }
 
-    pub fn fn_sig(&self, def_id: DefId) -> QueryResult<rty::PolySig> {
+    pub fn fn_sig(&self, def_id: DefId) -> QueryResult<rty::EarlyBinder<rty::PolySig>> {
         self.queries.fn_sig(self, def_id)
     }
 

--- a/flux-middle/src/queries.rs
+++ b/flux-middle/src/queries.rs
@@ -42,7 +42,7 @@ pub struct Providers {
     pub adt_def: fn(&GlobalEnv, LocalDefId) -> rty::AdtDef,
     pub type_of: fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::EarlyBinder<rty::PolyTy>>,
     pub variants_of: fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::PolyVariants>,
-    pub fn_sig: fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::EarlyBinder<rty::PolySig>>,
+    pub fn_sig: fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>>,
     pub generics_of: fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::Generics>,
 }
 
@@ -57,7 +57,7 @@ pub struct Queries<'tcx> {
     predicates_of: Cache<DefId, QueryResult<rty::EarlyBinder<rty::GenericPredicates>>>,
     type_of: Cache<DefId, QueryResult<rty::EarlyBinder<rty::PolyTy>>>,
     variants_of: Cache<DefId, QueryResult<rty::PolyVariants>>,
-    fn_sig: Cache<DefId, QueryResult<rty::EarlyBinder<rty::PolySig>>>,
+    fn_sig: Cache<DefId, QueryResult<rty::EarlyBinder<rty::PolyFnSig>>>,
 }
 
 impl<'tcx> Queries<'tcx> {
@@ -211,7 +211,7 @@ impl<'tcx> Queries<'tcx> {
         &self,
         genv: &GlobalEnv,
         def_id: DefId,
-    ) -> QueryResult<rty::EarlyBinder<rty::PolySig>> {
+    ) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
         run_with_cache(&self.fn_sig, def_id, || {
             if let Some(local_id) = def_id.as_local() {
                 (self.providers.fn_sig)(genv, local_id)

--- a/flux-middle/src/rty/evars.rs
+++ b/flux-middle/src/rty/evars.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 use rustc_index::newtype_index;
 use rustc_macros::{Decodable, Encodable};
 
-use super::{Expr, ExprKind};
+use super::{Expr, ExprKind, Var};
 
 static NEXT_CTXT_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -112,7 +112,7 @@ impl EVarSol {
         let vec = self
             .iter()
             .flat_map(|(evar, arg)| {
-                if let ExprKind::EVar(evar2) = arg.kind() {
+                if let ExprKind::Var(Var::EVar(evar2)) = arg.kind() {
                     Some((evar, self.get(*evar2).unwrap().clone()))
                 } else {
                     None

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -29,7 +29,7 @@ pub enum ExprKind {
     FreeVar(Name),
     EVar(EVar),
     LateBoundVar(DebruijnIndex),
-    EarlyBoundVar(u32, Symbol),
+    EarlyBoundVar(u32),
     Local(Local),
     Constant(Constant),
     ConstDefId(DefId),
@@ -160,7 +160,7 @@ impl Expr {
     }
 
     pub fn nu() -> Expr {
-        Expr::early_bvar(INNERMOST)
+        Expr::late_bvar(INNERMOST)
     }
 
     pub fn as_tuple(&self) -> &[Expr] {
@@ -199,12 +199,12 @@ impl Expr {
         ExprKind::EVar(evar).intern()
     }
 
-    pub fn early_bvar(bvar: DebruijnIndex) -> Expr {
+    pub fn late_bvar(bvar: DebruijnIndex) -> Expr {
         ExprKind::LateBoundVar(bvar).intern()
     }
 
-    pub fn late_bvar(idx: u32, sym: Symbol) -> Expr {
-        ExprKind::EarlyBoundVar(idx, sym).intern()
+    pub fn early_bvar(idx: u32) -> Expr {
+        ExprKind::EarlyBoundVar(idx).intern()
     }
 
     pub fn local(local: Local) -> Expr {
@@ -533,7 +533,7 @@ impl KVar {
 impl Var {
     pub fn to_expr(&self) -> Expr {
         match self {
-            Var::Bound(bvar) => Expr::early_bvar(*bvar),
+            Var::Bound(bvar) => Expr::late_bvar(*bvar),
             Var::Free(name) => Expr::fvar(*name),
             Var::EVar(evar) => Expr::evar(*evar),
         }
@@ -690,7 +690,7 @@ impl From<Name> for Expr {
 
 impl From<DebruijnIndex> for Expr {
     fn from(bvar: DebruijnIndex) -> Self {
-        Expr::early_bvar(bvar)
+        Expr::late_bvar(bvar)
     }
 }
 
@@ -764,7 +764,7 @@ mod pretty {
             let e = if cx.simplify_exprs { self.simplify() } else { self.clone() };
             match e.kind() {
                 ExprKind::LateBoundVar(bvar) => w!("{:?}", ^bvar),
-                ExprKind::EarlyBoundVar(_, symb) => w!("{}", ^symb),
+                ExprKind::EarlyBoundVar(idx) => w!("#{}", ^idx),
                 ExprKind::FreeVar(name) => w!("{:?}", ^name),
                 ExprKind::EVar(evar) => w!("{:?}", evar),
                 ExprKind::Local(local) => w!("{:?}", ^local),

--- a/flux-middle/src/rty/expr.rs
+++ b/flux-middle/src/rty/expr.rs
@@ -813,7 +813,7 @@ mod pretty {
                 ExprKind::Abs(body) => {
                     w!("{:?}", body)
                 }
-                ExprKind::Func(func) => w!("{:?}", ^func),
+                ExprKind::Func(func) => w!("{}", ^func),
             }
         }
     }

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -185,7 +185,7 @@ pub trait TypeFoldable: Sized {
                 if let ExprKind::LateBoundVar(debruijn) = expr.kind()
                     && *debruijn >= self.current_index
                 {
-                    Expr::early_bvar(debruijn.shifted_in(self.amount))
+                    Expr::late_bvar(debruijn.shifted_in(self.amount))
                 } else {
                     expr.super_fold_with(self)
                 }
@@ -202,7 +202,7 @@ pub trait TypeFoldable: Sized {
         impl TypeFolder for Shifter {
             fn fold_expr(&mut self, expr: &Expr) -> Expr {
                 if let ExprKind::LateBoundVar(debruijn) = expr.kind() {
-                    Expr::early_bvar(debruijn.shifted_out(self.amount))
+                    Expr::late_bvar(debruijn.shifted_out(self.amount))
                 } else {
                     expr.super_fold_with(self)
                 }
@@ -559,8 +559,8 @@ impl TypeFoldable for Expr {
     fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
         match self.kind() {
             ExprKind::FreeVar(name) => Expr::fvar(name.fold_with(folder)),
-            ExprKind::LateBoundVar(bvar) => Expr::early_bvar(*bvar),
-            ExprKind::EarlyBoundVar(idx, sym) => Expr::late_bvar(*idx, *sym),
+            ExprKind::LateBoundVar(bvar) => Expr::late_bvar(*bvar),
+            ExprKind::EarlyBoundVar(idx) => Expr::early_bvar(*idx),
             ExprKind::EVar(evar) => Expr::evar(*evar),
             ExprKind::Local(local) => Expr::local(*local),
             ExprKind::Constant(c) => Expr::constant(*c),

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -10,8 +10,8 @@ use super::{
     normalize::{Defns, Normalizer},
     subst::EVarSubstFolder,
     BaseTy, Binder, Constraint, DebruijnIndex, Expr, ExprKind, FnOutput, FnSig, FnTraitPredicate,
-    FuncSort, GenericArg, Index, Invariant, KVar, Name, Opaqueness, PolySig, Predicate, Qualifier,
-    Sort, Ty, TyKind, INNERMOST,
+    FuncSort, GenericArg, Index, Invariant, KVar, Name, Opaqueness, PolyFnSig, Predicate,
+    Qualifier, Sort, Ty, TyKind, INNERMOST,
 };
 use crate::{
     intern::{Internable, List},
@@ -319,9 +319,9 @@ where
     }
 }
 
-impl TypeFoldable for PolySig {
+impl TypeFoldable for PolyFnSig {
     fn super_fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
-        PolySig { fn_sig: self.fn_sig.fold_with(folder), modes: self.modes.clone() }
+        PolyFnSig { fn_sig: self.fn_sig.fold_with(folder), modes: self.modes.clone() }
     }
 
     fn super_visit_with<V: TypeVisitor>(&self, visitor: &mut V) {

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -39,7 +39,7 @@ pub trait TypeVisitor: Sized {
 }
 
 pub trait TypeFolder: Sized {
-    fn fold_binders<T: TypeFoldable>(&mut self, t: &Binder<T>) -> Binder<T> {
+    fn fold_binder<T: TypeFoldable>(&mut self, t: &Binder<T>) -> Binder<T> {
         t.super_fold_with(self)
     }
 
@@ -106,7 +106,7 @@ pub trait TypeFoldable: Sized {
         where
             F: FnMut(&[Sort]) -> Expr,
         {
-            fn fold_binders<T: TypeFoldable>(&mut self, t: &Binder<T>) -> Binder<T> {
+            fn fold_binder<T: TypeFoldable>(&mut self, t: &Binder<T>) -> Binder<T> {
                 self.1.push(t.sort().clone());
                 let t = t.super_fold_with(self);
                 self.1.pop();
@@ -169,7 +169,7 @@ pub trait TypeFoldable: Sized {
         }
 
         impl TypeFolder for Shifter {
-            fn fold_binders<T>(&mut self, t: &Binder<T>) -> Binder<T>
+            fn fold_binder<T>(&mut self, t: &Binder<T>) -> Binder<T>
             where
                 T: TypeFoldable,
             {
@@ -311,7 +311,7 @@ where
     }
 
     fn fold_with<F: TypeFolder>(&self, folder: &mut F) -> Self {
-        folder.fold_binders(self)
+        folder.fold_binder(self)
     }
 
     fn visit_with<V: TypeVisitor>(&self, visitor: &mut V) {

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -15,7 +15,7 @@ use super::{
 };
 use crate::{
     intern::{Internable, List},
-    rty::{subst::GenericsSubstFolder, Var, VariantDef},
+    rty::{Var, VariantDef},
 };
 
 pub trait TypeVisitor: Sized {
@@ -157,10 +157,6 @@ pub trait TypeFoldable: Sized {
         }
 
         self.fold_with(&mut WithHoles { in_exists: false })
-    }
-
-    fn replace_generics(&self, substs: &[GenericArg]) -> Self {
-        self.fold_with(&mut GenericsSubstFolder { substs })
     }
 
     fn replace_evars(&self, evars: &EVarSol) -> Self {

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -457,9 +457,13 @@ where
 }
 
 impl<T: TypeFoldable> EarlyBinder<T> {
-    pub fn subst(self, generics: &[GenericArg]) -> T {
+    pub fn subst(self, generics: &[GenericArg], refine: &[Expr]) -> T {
         self.0
-            .fold_with(&mut subst::GenericsSubstFolder::new(generics, &[]))
+            .fold_with(&mut subst::GenericsSubstFolder::new(generics, refine))
+    }
+
+    pub fn subst_generics(self, generics: &[GenericArg]) -> T {
+        self.subst(generics, &[])
     }
 
     pub fn subst_identity(self) -> T {

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -459,7 +459,7 @@ where
 impl<T: TypeFoldable> EarlyBinder<T> {
     pub fn subst(self, generics: &[GenericArg]) -> T {
         self.0
-            .fold_with(&mut subst::GenericsSubstFolder { substs: generics })
+            .fold_with(&mut subst::GenericsSubstFolder::new(generics, &[]))
     }
 
     pub fn subst_identity(self) -> T {

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -467,6 +467,12 @@ impl<T: TypeFoldable> EarlyBinder<T> {
     }
 }
 
+impl EarlyBinder<GenericPredicates> {
+    pub fn predicates(&self) -> EarlyBinder<List<Predicate>> {
+        EarlyBinder(self.0.predicates.clone())
+    }
+}
+
 impl VariantDef {
     pub fn new(fields: Vec<Ty>, ret: Ty) -> Self {
         VariantDef { fields: List::from_vec(fields), ret }
@@ -679,9 +685,10 @@ impl<T, E> Opaqueness<Result<T, E>> {
     }
 }
 
-impl PolyVariant {
+impl EarlyBinder<PolyVariant> {
     pub fn to_fn_sig(&self) -> EarlyBinder<PolySig> {
         let fn_sig = self
+            .0
             .as_ref()
             .map(|variant| {
                 let ret = variant.ret.shift_in_bvars(1);
@@ -690,6 +697,7 @@ impl PolyVariant {
             })
             .skip_binder();
         let params = self
+            .0
             .sort
             .expect_tuple()
             .iter()

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -457,12 +457,18 @@ where
 }
 
 impl<T: TypeFoldable> EarlyBinder<T> {
-    pub fn subst(self, generics: &[GenericArg], refine: &[Expr]) -> T {
+    pub fn subst(self, generics: &[GenericArg], refine: &[Expr]) -> T
+    where
+        T: std::fmt::Debug,
+    {
         self.0
             .fold_with(&mut subst::GenericsSubstFolder::new(generics, refine))
     }
 
-    pub fn subst_generics(self, generics: &[GenericArg]) -> T {
+    pub fn subst_generics(self, generics: &[GenericArg]) -> T
+    where
+        T: std::fmt::Debug,
+    {
         self.subst(generics, &[])
     }
 

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -1280,18 +1280,6 @@ mod pretty {
         }
     }
 
-    impl Pretty for Var {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            define_scoped!(cx, f);
-
-            match self {
-                Var::Bound(bvar) => w!("{:?}", ^bvar),
-                Var::Free(name) => w!("{:?}", ^name),
-                Var::EVar(evar) => w!("{:?}", evar),
-            }
-        }
-    }
-
     impl Pretty for VariantDef {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);

--- a/flux-middle/src/rty/refining.rs
+++ b/flux-middle/src/rty/refining.rs
@@ -110,7 +110,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
         Ok(rty::Binder::new(value, rty::Sort::unit()))
     }
 
-    pub(crate) fn refine_fn_sig(&self, fn_sig: &rustc::ty::FnSig) -> QueryResult<rty::PolySig> {
+    pub(crate) fn refine_fn_sig(&self, fn_sig: &rustc::ty::FnSig) -> QueryResult<rty::PolyFnSig> {
         let args = fn_sig
             .inputs()
             .iter()
@@ -118,7 +118,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
             .try_collect_vec()?;
         let ret = self.refine_ty(&fn_sig.output())?;
         let output = rty::Binder::new(rty::FnOutput::new(ret, vec![]), rty::Sort::unit());
-        Ok(rty::PolySig::new([], rty::FnSig::new(vec![], args, output)))
+        Ok(rty::PolyFnSig::new([], rty::FnSig::new(vec![], args, output)))
     }
 
     pub(crate) fn refine_generic_arg(

--- a/flux-middle/src/rty/refining.rs
+++ b/flux-middle/src/rty/refining.rs
@@ -131,7 +131,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
                 Ok(rty::GenericArg::Ty(self.refine_ty(ty)?))
             }
             (rty::GenericParamDefKind::BaseTy, rustc::ty::GenericArg::Ty(ty)) => {
-                Ok(rty::GenericArg::BaseTy(self.refine_bound_ty(ty)?))
+                Ok(rty::GenericArg::BaseTy(self.refine_poly_ty(ty)?))
             }
             (rty::GenericParamDefKind::Lifetime, rustc::ty::GenericArg::Lifetime(_)) => {
                 Ok(rty::GenericArg::Lifetime)
@@ -141,7 +141,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
     }
 
     pub(crate) fn refine_ty(&self, ty: &rustc::ty::Ty) -> QueryResult<rty::Ty> {
-        let ty = self.refine_bound_ty(ty)?;
+        let ty = self.refine_poly_ty(ty)?;
         if ty.sort().is_unit() {
             Ok(ty.replace_bvar(&rty::Expr::unit()))
         } else {
@@ -149,7 +149,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
         }
     }
 
-    fn refine_bound_ty(&self, ty: &rustc::ty::Ty) -> QueryResult<rty::Binder<rty::Ty>> {
+    fn refine_poly_ty(&self, ty: &rustc::ty::Ty) -> QueryResult<rty::PolyTy> {
         let bty = match ty.kind() {
             rustc::ty::TyKind::Closure(did, _substs) => rty::BaseTy::Closure(*did),
             rustc::ty::TyKind::Never => rty::BaseTy::Never,

--- a/flux-middle/src/rty/subst.rs
+++ b/flux-middle/src/rty/subst.rs
@@ -111,7 +111,7 @@ impl TypeFolder for BVarSubstFolder<'_> {
     }
 
     fn fold_expr(&mut self, e: &Expr) -> Expr {
-        if let ExprKind::BoundVar(debruijn) = e.kind() && *debruijn == self.current_index {
+        if let ExprKind::LateBoundVar(debruijn) = e.kind() && *debruijn == self.current_index {
             self.expr.shift_in_bvars(self.current_index.as_u32())
         } else {
             e.super_fold_with(self)

--- a/flux-middle/src/rty/subst.rs
+++ b/flux-middle/src/rty/subst.rs
@@ -172,7 +172,7 @@ impl TypeFolder for GenericsSubstFolder<'_> {
     }
 
     fn fold_expr(&mut self, expr: &Expr) -> Expr {
-        if let ExprKind::EarlyBoundVar(idx, _) = expr.kind() {
+        if let ExprKind::EarlyBoundVar(idx) = expr.kind() {
             self.expr_for_param(*idx)
         } else {
             expr.super_fold_with(self)

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -9,8 +9,8 @@ use flux_middle::{
     global_env::GlobalEnv,
     rty::{
         self, BaseTy, BinOp, Binder, Bool, Constraint, EarlyBinder, Expr, Float, FnOutput, FnSig,
-        GenericArg, Generics, Index, Int, IntTy, PolySig, RefKind, Sort, Ty, TyKind, Uint, UintTy,
-        VariantIdx,
+        GenericArg, Generics, Index, Int, IntTy, PolyFnSig, RefKind, Sort, Ty, TyKind, Uint,
+        UintTy, VariantIdx,
     },
     rustc::{
         self,
@@ -175,7 +175,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
         mut refine_tree: RefineSubtree<'a>,
         def_id: DefId,
         mode: &'a mut M,
-        fn_sig: PolySig,
+        fn_sig: PolyFnSig,
     ) -> Result<(), CheckerError> {
         let body = genv
             .mir(def_id.expect_local())
@@ -426,7 +426,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
         env: &mut TypeEnv,
         terminator_span: Span,
         did: Option<DefId>,
-        fn_sig: EarlyBinder<PolySig>,
+        fn_sig: EarlyBinder<PolyFnSig>,
         substs: &[GenericArg],
         args: &[Operand],
     ) -> Result<Ty, CheckerError> {

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -459,7 +459,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
         rcx: &mut RefineCtxt,
         obligs: Obligations,
     ) -> Result<(), CheckerError> {
-        for predicate in obligs.predicates {
+        for predicate in &obligs.predicates {
             match predicate {
                 rty::Predicate::FnTrait(fn_pred) => {
                     if let Some(BaseTy::Closure(def_id)) =

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -9,8 +9,8 @@ use flux_middle::{
         evars::{EVarCxId, EVarSol, UnsolvedEvar},
         fold::TypeFoldable,
         BaseTy, BinOp, Binder, Const, Constraint, EVarGen, EarlyBinder, Expr, ExprKind, FnOutput,
-        GenericArg, InferMode, Path, PolySig, PolyVariant, PtrKind, Ref, RefKind, Sort, TupleTree,
-        Ty, TyKind, Var,
+        GenericArg, InferMode, Path, PolyFnSig, PolyVariant, PtrKind, Ref, RefKind, Sort,
+        TupleTree, Ty, TyKind, Var,
     },
     rustc::mir::{BasicBlock, Place},
 };
@@ -112,7 +112,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
         rcx: &mut RefineCtxt,
         env: &mut TypeEnv,
         did: Option<DefId>,
-        fn_sig: EarlyBinder<PolySig>,
+        fn_sig: EarlyBinder<PolyFnSig>,
         substs: &[GenericArg],
         actuals: &[Ty],
     ) -> Result<(Binder<FnOutput>, Obligations), CheckerErrKind> {

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -10,7 +10,7 @@ use flux_middle::{
         fold::TypeFoldable,
         BaseTy, BinOp, Binder, Const, Constraint, EVarGen, EarlyBinder, Expr, ExprKind, FnOutput,
         GenericArg, InferMode, Path, PolySig, PolyVariant, PtrKind, Ref, RefKind, Sort, TupleTree,
-        Ty, TyKind,
+        Ty, TyKind, Var,
     },
     rustc::mir::{BasicBlock, Place},
 };
@@ -553,7 +553,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 
     fn unify_exprs(&mut self, e1: &Expr, e2: &Expr, replace: bool) {
-        if let ExprKind::EVar(evar) = e2.kind()
+        if let ExprKind::Var(Var::EVar(evar)) = e2.kind()
            && let scope = &self.scopes[&evar.cx()]
            && !scope.has_free_vars(e1)
         {

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -153,7 +153,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
 
         // Generate fresh evars and kvars for refinement parameters
         let inst_fn_sig = fn_sig
-            .subst(&substs)
+            .subst_generics(&substs)
             .replace_bvars_with(|sort, kind| infcx.fresh_evars_or_kvar(sort, kind));
 
         // Check closure obligations
@@ -253,7 +253,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
 
         // Generate fresh evars and kvars for refinement parameters
         let variant = variant
-            .subst(&substs)
+            .subst_generics(&substs)
             .replace_bvar_with(|sort| infcx.fresh_evars_or_kvar(sort, sort.default_infer_mode()));
 
         // Check arguments
@@ -577,7 +577,7 @@ fn mk_obligations(
     did: DefId,
     substs: &[GenericArg],
 ) -> Result<List<rty::Predicate>, CheckerErrKind> {
-    Ok(genv.predicates_of(did)?.predicates().subst(substs))
+    Ok(genv.predicates_of(did)?.predicates().subst_generics(substs))
 }
 
 impl<F> KVarGen for F

--- a/flux-refineck/src/fixpoint_encoding.rs
+++ b/flux-refineck/src/fixpoint_encoding.rs
@@ -346,7 +346,7 @@ where
                     span_bug!(self.def_span(), "no entry found for key: `{name:?}`")
                 })
             }
-            rty::ExprKind::BoundVar(_) => {
+            rty::ExprKind::LateBoundVar(_) => {
                 span_bug!(self.def_span(), "unexpected escaping variable")
             }
             _ => {
@@ -571,7 +571,8 @@ impl<'a> ExprCtxt<'a> {
             | rty::ExprKind::Hole
             | rty::ExprKind::KVar(_)
             | rty::ExprKind::Local(_)
-            | rty::ExprKind::BoundVar(_)
+            | rty::ExprKind::LateBoundVar(_)
+            | rty::ExprKind::EarlyBoundVar(..)
             | rty::ExprKind::Abs(_)
             | rty::ExprKind::Func(_)
             | rty::ExprKind::PathProj(..) => {

--- a/flux-refineck/src/invariants.rs
+++ b/flux-refineck/src/invariants.rs
@@ -41,6 +41,7 @@ fn check_invariant(
             .variant(adt_def.def_id(), variant_idx)
             .emit(genv.sess)?
             .expect("cannot check opaque structs")
+            .subst_identity()
             .replace_bvar_with(|sort| rcx.define_vars(sort));
 
         for ty in variant.fields() {

--- a/flux-refineck/src/refine_tree.rs
+++ b/flux-refineck/src/refine_tree.rs
@@ -428,7 +428,7 @@ impl Node {
             child.borrow_mut().simplify();
         }
 
-        match &self.kind {
+        match &mut self.kind {
             NodeKind::Head(pred, tag) => {
                 let pred = pred.simplify();
                 if pred.is_trivially_true() {
@@ -439,6 +439,7 @@ impl Node {
             }
             NodeKind::True => {}
             NodeKind::Guard(pred) => {
+                *pred = pred.simplify();
                 self.children.drain_filter(|child| {
                     matches!(child.borrow().kind, NodeKind::True)
                         || matches!(&child.borrow().kind, NodeKind::Head(head, _) if head == pred)

--- a/flux-refineck/src/type_env.rs
+++ b/flux-refineck/src/type_env.rs
@@ -628,7 +628,7 @@ impl BasicBlockEnvShape {
                     e1.clone()
                 } else {
                     bound_sorts.push(sort.clone());
-                    Expr::tuple_proj(Expr::early_bvar(INNERMOST), (bound_sorts.len() - 1) as u32)
+                    Expr::tuple_proj(Expr::late_bvar(INNERMOST), (bound_sorts.len() - 1) as u32)
                 }
             }
         }

--- a/flux-refineck/src/type_env.rs
+++ b/flux-refineck/src/type_env.rs
@@ -581,8 +581,8 @@ impl BasicBlockEnvShape {
     fn join_ty(&self, ty1: &Ty, ty2: &Ty) -> Ty {
         match (ty1.kind(), ty2.kind()) {
             (TyKind::Uninit, _) | (_, TyKind::Uninit) => Ty::uninit(),
-            (TyKind::Exists(ty1), _) => self.join_ty(ty1.as_ref().skip_binders(), ty2),
-            (_, TyKind::Exists(ty2)) => self.join_ty(ty1, ty2.as_ref().skip_binders()),
+            (TyKind::Exists(ty1), _) => self.join_ty(ty1.as_ref().skip_binder(), ty2),
+            (_, TyKind::Exists(ty2)) => self.join_ty(ty1, ty2.as_ref().skip_binder()),
             (TyKind::Constr(_, ty1), _) => self.join_ty(ty1, ty2),
             (_, TyKind::Constr(_, ty2)) => self.join_ty(ty1, ty2),
             (TyKind::Indexed(bty1, idx1), TyKind::Indexed(bty2, idx2)) => {
@@ -628,7 +628,7 @@ impl BasicBlockEnvShape {
                     e1.clone()
                 } else {
                     bound_sorts.push(sort.clone());
-                    Expr::tuple_proj(Expr::bvar(INNERMOST), (bound_sorts.len() - 1) as u32)
+                    Expr::tuple_proj(Expr::early_bvar(INNERMOST), (bound_sorts.len() - 1) as u32)
                 }
             }
         }

--- a/flux-refineck/src/type_env/paths_tree.rs
+++ b/flux-refineck/src/type_env/paths_tree.rs
@@ -849,7 +849,7 @@ fn downcast_struct(
     Ok(genv
         .variant(def_id, variant_idx)?
         .ok_or_else(|| CheckerErrKind::OpaqueStruct(def_id))?
-        .subst(substs)
+        .subst_generics(substs)
         .replace_bvar(&idx.expr)
         .fields
         .to_vec())
@@ -874,7 +874,7 @@ fn downcast_enum(
     let variant_def = genv
         .variant(def_id, variant_idx)?
         .expect("enums cannot be opaque")
-        .subst(substs)
+        .subst_generics(substs)
         .replace_bvar_with(|sort| rcx.define_vars(sort));
 
     let (.., idx2) = variant_def.ret.expect_adt();

--- a/flux-refineck/src/type_env/paths_tree.rs
+++ b/flux-refineck/src/type_env/paths_tree.rs
@@ -370,7 +370,7 @@ impl PathsTree {
             let mut node = ptr.borrow_mut();
             if let Node::Leaf(Binding::Owned(ty)) = &mut *node
                 && let TyKind::Ptr(_, path) = ty.kind()
-                && let Some(Loc::Var(Var::Free(name), proj)) = path.to_loc()
+                && let Some(Loc::TupleProj(Var::Free(name), proj)) = path.to_loc()
                 && !scope.contains(name)
             {
                 debug_assert!(proj.is_empty());

--- a/flux-refineck/src/type_env/paths_tree.rs
+++ b/flux-refineck/src/type_env/paths_tree.rs
@@ -697,7 +697,7 @@ impl Node {
                 let ty = if partially_moved {
                     Ty::uninit()
                 } else {
-                    gen.check_constructor(rcx, &variant, substs, &fields)
+                    gen.check_constructor(rcx, variant, substs, &fields)
                         .unwrap_or_else(|err| tracked_span_bug!("{err:?}"))
                 };
                 *self = Node::owned(ty.clone());
@@ -849,8 +849,8 @@ fn downcast_struct(
     Ok(genv
         .variant(def_id, variant_idx)?
         .ok_or_else(|| CheckerErrKind::OpaqueStruct(def_id))?
+        .subst(substs)
         .replace_bvar(&idx.expr)
-        .replace_generics(substs)
         .fields
         .to_vec())
 }
@@ -874,7 +874,7 @@ fn downcast_enum(
     let variant_def = genv
         .variant(def_id, variant_idx)?
         .expect("enums cannot be opaque")
-        .replace_generics(substs)
+        .subst(substs)
         .replace_bvar_with(|sort| rcx.define_vars(sort));
 
     let (.., idx2) = variant_def.ret.expect_adt();

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -311,18 +311,8 @@ impl RefinedBy {
     pub const DUMMY: &RefinedBy =
         &RefinedBy { index_params: vec![], early_bound_params: vec![], span: rustc_span::DUMMY_SP };
 
-    pub fn iter(&self) -> impl Iterator<Item = &RefineParam> {
+    pub fn all_params(&self) -> impl Iterator<Item = &RefineParam> {
         self.early_bound_params.iter().chain(&self.index_params)
-    }
-}
-
-impl<'a> IntoIterator for &'a RefinedBy {
-    type Item = &'a RefineParam;
-
-    type IntoIter = impl Iterator<Item = &'a RefineParam>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
     }
 }
 


### PR DESCRIPTION
* Introduce `EarlyBinder` as in `rustc` to mark explicitly when generics need to be replaced.
* Introduce the notion of early bound refinement variables and implement parenthetical parameters for types aliases as early bound parameters.