### PR TITLE
Basic `struct` and `impl` extern specs

### DIFF
--- a/flux-attrs/Cargo.toml
+++ b/flux-attrs/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["full"] }
+syn = { version = "1", features = ["full", "extra-traits"] }

--- a/flux-attrs/src/lib.rs
+++ b/flux-attrs/src/lib.rs
@@ -144,7 +144,7 @@ fn create_dummy_ident(dummy_prefix: &mut String, ty: &syn::Type) -> syn::Result<
 /// Example:
 ///
 /// ```ignore
-/// #[extern_spec(mod_path = alloc::vec)]
+/// #[extern_spec(std::vec)]
 /// #[flux::refined_by(n: int)]
 /// struct Vec<T>;
 ///
@@ -153,7 +153,7 @@ fn create_dummy_ident(dummy_prefix: &mut String, ty: &syn::Type) -> syn::Result<
 /// #[flux::extern_spec]
 /// #[allow(unused, dead_code)]
 /// #[flux::refined_by(n: int)]
-/// struct FluxExternStructVec(alloc::vec::Vec<T>);
+/// struct FluxExternStructVec<T>(std::vec::Vec<T>);
 /// ```
 fn create_dummy_struct(
     mod_path: Option<syn::Path>,
@@ -167,8 +167,14 @@ fn create_dummy_struct(
         let generics = item_struct.generics;
         dummy_struct.ident = format_ident!("FluxExternStruct{}", ident);
         dummy_struct.semi_token = None;
-        let dummy_field: syn::FieldsUnnamed = parse_quote_spanned! {item_struct_span =>
-            ( #mod_path :: #ident #generics )
+        let dummy_field: syn::FieldsUnnamed = if let Some(mod_path) = mod_path {
+            parse_quote_spanned! {item_struct_span =>
+                ( #mod_path :: #ident #generics )
+            }
+        } else {
+            parse_quote_spanned! {item_struct_span =>
+                ( #ident #generics )
+            }
         };
         dummy_struct.fields = syn::Fields::Unnamed(dummy_field);
         let dummy_struct_with_attrs: syn::ItemStruct = parse_quote_spanned! { item_struct_span =>

--- a/flux-attrs/src/lib.rs
+++ b/flux-attrs/src/lib.rs
@@ -1,21 +1,189 @@
 #![feature(proc_macro_diagnostic)]
 
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote_spanned};
+use proc_macro2::{Ident, TokenStream, TokenTree};
+use quote::{format_ident, quote_spanned, ToTokens};
 use syn::{
-    parse_quote_spanned, punctuated::Punctuated, spanned::Spanned, Expr, FnArg, GenericArgument,
-    GenericParam, Token,
+    parse::{Parse, ParseStream},
+    parse_quote_spanned,
+    punctuated::Punctuated,
+    spanned::Spanned,
+    Expr, FnArg, GenericArgument, GenericParam, Token,
 };
+
+/// Attributes on an extern spec.
+///
+/// Example:
+///
+/// ```ignore
+/// #[extern_spec(mod_path = std::vec, generics = <T>)]
+/// struct Vec<T>;
+/// ```
+#[derive(Default)]
+struct ExternSpecAttrs {
+    /// The path prefix of the extern spec.
+    ///
+    /// In the example, the mod_path is `std::vec` and the `Vec` gets expanded
+    /// to `std::vec::Vec`.
+    mod_path: Option<syn::Path>,
+    /// Any generics that the extern spec takes. A module path has to be
+    /// specified to take generics - an empty module path or `::` should suffice
+    /// if one is not necessary.
+    ///
+    /// In the example, the sole generic is the variable `T`. The dummy struct that
+    /// gets expanded has `T` as an argument on it. Without this generic,
+    /// we would get a compile error because the dummy struct would look like
+    ///
+    /// ```ignore
+    /// struct FluxExternStructVec(Vec<T>);
+    /// ```
+    ///
+    /// and the `T` would not be in scope.
+    generics: Option<syn::Generics>,
+}
+
+enum ExternSpecAttr {
+    ModPath(syn::Path),
+    Generics(syn::Generics),
+}
+
+impl Parse for ExternSpecAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        // Extract an ident, erroring if there isn't one.
+        let ident: Ident = input.step(|cursor| {
+            if let Some((tt, next)) = cursor.token_tree() {
+                match tt {
+                    TokenTree::Ident(ident) => {
+                        Ok((ident, next))
+                    }
+                    _ => {
+                        Err(cursor.error(format!("Bad token {}: expecting an extern spec identifier (mod_path or generics)", tt)))
+                    }
+                }
+            } else {
+                Err(cursor.error("Empty stream: expecting an extern spec attribute, ex: mod_path = mod::path::def or generics = < Generics, List >"))
+            }
+        })?;
+        let _equals_token: Token![=] = input.parse()?;
+        match &ident.to_string()[..] {
+            "mod_path" => input.parse().map(Self::ModPath),
+            "generics" => input.parse().map(Self::Generics),
+            _ => {
+                Err(input
+                    .error(format!("Unexpected ident {}, expecting mod_path or generics", ident)))
+            }
+        }
+    }
+}
+
+impl Parse for ExternSpecAttrs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let punctuated_attrs: Punctuated<ExternSpecAttr, Token![,]> =
+            input.parse_terminated(ExternSpecAttr::parse)?;
+        let mut attrs = ExternSpecAttrs::default();
+        for attr in punctuated_attrs {
+            match attr {
+                ExternSpecAttr::ModPath(mod_path) => {
+                    if attrs.mod_path.is_some() {
+                        return Err(
+                            input.error("Invalid extern_spec: duplicate mod_path attribute")
+                        );
+                    }
+                    attrs.mod_path = Some(mod_path);
+                }
+                ExternSpecAttr::Generics(generics) => {
+                    if attrs.generics.is_some() {
+                        return Err(
+                            input.error("Invalid extern_spec: duplicate generics attribute")
+                        );
+                    }
+                    attrs.generics = Some(generics);
+                }
+            }
+        }
+        Ok(attrs)
+    }
+}
 
 pub fn extern_spec(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     transform_extern_spec(attr, tokens).unwrap_or_else(|err| err.to_compile_error())
 }
 
 fn transform_extern_spec(attr: TokenStream, tokens: TokenStream) -> syn::Result<TokenStream> {
-    let mod_path: Option<syn::Path> =
-        if !attr.is_empty() { Some(syn::parse2(attr)?) } else { None };
-    let (sig, attrs) = extract_sig_from_stub(tokens)?;
-    create_dummy_fn(mod_path, sig, attrs)
+    let extern_spec_attrs: ExternSpecAttrs = syn::parse2(attr)?;
+    let span = tokens.span();
+    match syn::parse2::<syn::Item>(tokens) {
+        // TODO: impls
+        Ok(syn::Item::Impl(_item_impl)) => {
+            unimplemented!()
+        }
+        Ok(syn::Item::Struct(item_struct)) => create_dummy_struct(extern_spec_attrs, item_struct),
+        // Function stubs end up as Verbatim
+        Ok(syn::Item::Verbatim(tokens)) => {
+            let (sig, attrs) = extract_sig_from_stub(tokens)?;
+            create_dummy_fn(extern_spec_attrs, sig, attrs)
+        }
+        Ok(_) => Err(syn::Error::new(
+            span,
+            "Invalid extern_spec: the only items which are supported are impls and function stubs",
+        )),
+        Err(_) => {
+            Err(syn::Error::new(span, "Invalid extern_spec: could not parse associated item"))
+        }
+    }
+}
+
+/// Create a dummy struct with a single unnamed field that is the external struct.
+///
+/// Example:
+///
+/// ```ignore
+/// #[extern_spec(mod_path = alloc::vec)]
+/// #[flux::refined_by(n: int)]
+/// struct Vec<T>;
+///
+/// =>
+///
+/// #[flux::extern_spec]
+/// #[allow(unused, dead_code)]
+/// #[flux::refined_by(n: int)]
+/// struct FluxExternStructVec(alloc::vec::Vec<T>);
+/// ```
+fn create_dummy_struct(
+    attrs: ExternSpecAttrs,
+    item_struct: syn::ItemStruct,
+) -> syn::Result<TokenStream> {
+    let item_struct_span = item_struct.span();
+    let fields_span = item_struct.fields.span();
+    if let syn::Fields::Unit = item_struct.fields {
+        let mut dummy_struct = item_struct.clone();
+        let ident = item_struct.ident;
+        let generics = item_struct.generics;
+        dummy_struct.ident = format_ident!("FluxExternStruct{}", ident);
+        dummy_struct.semi_token = None;
+        let dummy_field: syn::FieldsUnnamed = if let Some(mod_path) = attrs.mod_path {
+            parse_quote_spanned! {item_struct_span =>
+                ( #mod_path :: #ident #generics )
+            }
+        } else {
+            parse_quote_spanned! {item_struct_span =>
+                ( #ident #generics )
+            }
+        };
+        dummy_struct.fields = syn::Fields::Unnamed(dummy_field);
+        dummy_struct.generics =
+            if let Some(generics) = attrs.generics { generics } else { syn::Generics::default() };
+        let dummy_struct_with_attrs: syn::ItemStruct = parse_quote_spanned! { item_struct_span =>
+            #[flux::extern_spec]
+            #[allow(unused, dead_code)]
+            #dummy_struct
+        };
+        Ok(dummy_struct_with_attrs.to_token_stream())
+    } else {
+        Err(syn::Error::new(
+            fields_span,
+            "Extern specs on structs cannot have fields, i.e. they must look like struct Vec<T>;",
+        ))
+    }
 }
 
 /// Takes a function stub, i.e. something that looks like
@@ -58,15 +226,16 @@ fn extract_sig_from_stub(
 /// 1. Mangle the name of the function into flux_extern_spec_{fn_ident} so that it doesn't
 ///    conflict with an existing function. TODO: add some random number to ensure it.
 /// 2. Create a new function with the mangled name and same signature.
-/// 3. Replace its body with a single expression that is a function call.
-/// 4. The function call is of the form mod_path::fn_ident<generic_args>(params)
+/// 3. Add any generic parameters in the extern spec to the generic params of the new function.
+/// 4. Replace its body with a single expression that is a function call.
+/// 5. The function call is of the form mod_path::fn_ident<generic_args>(params)
 ///    where the generic args and params have been modified so that they function as
 ///    arguments to the call instead of being a part of the function signature.
-/// 5. Finally, we suppress dead_code/unused warnings and add the flux::extern_spec
+/// 6. Finally, we suppress dead_code/unused warnings and add the flux::extern_spec
 ///    so that flux knows this is the generated dummy function for the external function
 ///    that is being called.
 fn create_dummy_fn(
-    mod_path: Option<syn::Path>,
+    extern_spec_attrs: ExternSpecAttrs,
     sig: syn::Signature,
     attrs: Vec<syn::Attribute>,
 ) -> syn::Result<TokenStream> {
@@ -74,9 +243,12 @@ fn create_dummy_fn(
     let mut mangled_sig = sig.clone();
     let ident = sig.ident;
     mangled_sig.ident = format_ident!("flux_extern_spec_{}", ident);
+    if let Some(generics) = extern_spec_attrs.generics {
+        mangled_sig.generics.params.extend(generics.params);
+    }
     let generic_call_args = transform_generic_params_to_call_args(sig.generics.params);
     let call_args = transform_params_to_call_args(sig.inputs);
-    let fn_path: syn::Path = if let Some(mod_path) = mod_path {
+    let fn_path: syn::Path = if let Some(mod_path) = extern_spec_attrs.mod_path {
         parse_quote_spanned!( ident.span() => #mod_path :: #ident)
     } else {
         parse_quote_spanned!( ident.span() => #ident )

--- a/flux-attrs/src/lib.rs
+++ b/flux-attrs/src/lib.rs
@@ -3,8 +3,8 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote_spanned, ToTokens};
 use syn::{
-    parse_quote_spanned, punctuated::Punctuated, spanned::Spanned, Expr, FnArg, GenericArgument,
-    GenericParam, Token,
+    parse_quote, parse_quote_spanned, punctuated::Punctuated, spanned::Spanned, Expr, FnArg,
+    GenericArgument, GenericParam, Token,
 };
 
 pub fn extern_spec(attr: TokenStream, tokens: TokenStream) -> TokenStream {
@@ -23,73 +23,7 @@ fn transform_extern_spec(attr: TokenStream, tokens: TokenStream) -> syn::Result<
             let (sig, attrs) = extract_sig_from_stub(tokens)?;
             create_dummy_fn(mod_path, None, sig, attrs)
         }
-        Ok(syn::Item::Impl(item_impl)) => {
-            let self_ty_span = item_impl.self_ty.as_ref().span();
-            let mod_path_clone = mod_path.clone();
-            // This field corresponds to the Self type. Reading the mod_path
-            // from the extern_spec attr is probably not strictly necessary, but
-            // we do it so our behavior is consistent.
-            let self_ty = item_impl.self_ty.as_ref();
-            let struct_field: syn::FieldsUnnamed = if let Some(mod_path) = mod_path {
-                parse_quote_spanned! { self_ty_span => ( #mod_path :: #self_ty ) }
-            } else {
-                parse_quote_spanned! { self_ty_span => ( #self_ty ) }
-            };
-            // The name of this struct is mangled to ensure that it doesn't
-            // conflict with an actual impl. Same with the name of the type.
-            let dummy_ident = create_dummy_ident(&mut "FluxExternImplStruct".to_string(), item_impl.self_ty.as_ref())?;
-            let mut dummy_self_ty_path = syn::TypePath {
-                qself: None,
-                path: syn::Path {
-                    leading_colon: None,
-                    segments: Punctuated::new(),
-                }
-            };
-            let generics_span = item_impl.generics.span();
-            let generics = item_impl.generics.clone();
-            let generic_arguments: syn::AngleBracketedGenericArguments = parse_quote_spanned! { generics_span => #generics };
-            dummy_self_ty_path.path.segments.push(syn::PathSegment {
-                ident: dummy_ident.clone(),
-                arguments: syn::PathArguments::AngleBracketed(generic_arguments),
-            });
-            let dummy_self_ty = syn::Type::Path(dummy_self_ty_path);
-            let mut dummy_impl = item_impl.clone();
-            let item_impl_span = item_impl.span();
-            let item_struct = syn::ItemStruct {
-                attrs: item_impl.attrs,
-                vis: syn::Visibility::Inherited,
-                struct_token: syn::token::Struct { span: item_impl.impl_token.span },
-                ident: dummy_ident,
-                generics: item_impl.generics.clone(),
-                fields: syn::Fields::Unnamed(struct_field),
-                semi_token: Some(syn::token::Semi { spans: [item_impl_span] }),
-            };
-            dummy_impl.self_ty = Box::new(dummy_self_ty);
-            dummy_impl.items = item_impl.items.into_iter().map(|impl_item| {
-                match impl_item {
-                    // For whatever reason, syn parses function stubs correctly
-                    // by assuming that the semicolon at their end is wrapped in
-                    // braces (functions require a brace-delimited list of Items
-                    // inside of them, the semicolon gets converted to a
-                    // Verbatim).
-                    //
-                    // This does however mean that we will silently discard the
-                    // contents of any "implementation" of an extern function.
-                    syn::ImplItem::Method(impl_item_method) => {
-                        let span = impl_item_method.span();
-                        let dummy_fn_tokens = create_dummy_fn(mod_path_clone.clone(), Some(self_ty.clone()), impl_item_method.sig, impl_item_method.attrs)?;
-                        Ok(parse_quote_spanned! { span => #dummy_fn_tokens })
-                    }
-                    _ => {
-                        Err(syn::Error::new(
-                            impl_item.span(),
-                            format!("Invalid extern_spec: invalid impl item: {:?}\n extern impls may only contain function stubs such as fn len(v: &Vec<T>) -> usize;", impl_item)
-                        ))
-                    }
-                }
-            }).collect::<syn::Result<Vec<syn::ImplItem>>>()?;
-            Ok(TokenStream::from_iter([item_struct.to_token_stream(), dummy_impl.to_token_stream()].into_iter()))
-        }
+        Ok(syn::Item::Impl(item_impl)) => create_dummy_impl(mod_path, item_impl),
         Ok(_) => Err(syn::Error::new(
             span,
             "Invalid extern_spec: the only items which are supported are structs, impls, and function stubs",
@@ -98,6 +32,118 @@ fn transform_extern_spec(attr: TokenStream, tokens: TokenStream) -> syn::Result<
             Err(syn::Error::new(span, "Invalid extern_spec: could not parse associated item"))
         }
     }
+}
+
+/// Creates a dummy impl and supporting struct.
+///
+/// Here's how it works at a high level.
+///
+/// 1. Mangle the Self type's name and create a struct similar to the one
+/// created from create_dummy_struct. We will make an impl on this struct that
+/// mirrors the extern impl.
+/// 2. Create an impl for the struct made in step 1. that follows the structure
+/// of the original impl.
+/// 3. Convert each method inside of the impl into a dummy function using
+/// create_dummy_fn. We pass both the mod_path and the original Self type so
+/// that create_dummy_fn can create the proper function call.
+///
+/// Example:
+///
+/// ```ignore
+/// #[extern_spec]
+/// impl<T> [T] {
+///     #[flux::sig(fn(&[T][@n]) -> usize[n])]
+///     fn len(v: &[T]) -> usize;
+/// }
+///
+/// =>
+///
+/// #[allow(unused, dead_code)]
+/// struct<T> FluxExternImplStructRefSliceT<T>(&[T]);
+/// #[allow(unused, dead_code)]
+/// impl<T> FluxExternImplStructRefSliceT<T> {
+///     #[flux::extern_spec]
+///     #[flux::sig(fn(&[T][@n]) -> usize[n])]
+///     #[allow(unused, dead_code)]
+///     fn len(v: &[T]) -> usize {
+///         <&[T]>::len(v)
+///     }
+/// }
+/// ```
+fn create_dummy_impl(
+    mod_path: Option<syn::Path>,
+    item_impl: syn::ItemImpl,
+) -> syn::Result<TokenStream> {
+    let self_ty_span = item_impl.self_ty.as_ref().span();
+    let mod_path_clone = mod_path.clone();
+    // This field corresponds to the Self type. Reading the mod_path
+    // from the extern_spec attr is probably not strictly necessary, but
+    // we do it so our behavior is consistent.
+    let self_ty = item_impl.self_ty.as_ref();
+    let struct_field: syn::FieldsUnnamed = if let Some(mod_path) = mod_path {
+        parse_quote_spanned! { self_ty_span => ( #mod_path :: #self_ty ) }
+    } else {
+        parse_quote_spanned! { self_ty_span => ( #self_ty ) }
+    };
+    // The name of this struct is mangled to ensure that it doesn't
+    // conflict with an actual impl. Same with the name of the type.
+    let dummy_ident =
+        create_dummy_ident(&mut "FluxExternImplStruct".to_string(), item_impl.self_ty.as_ref())?;
+    let mut dummy_self_ty_path = syn::TypePath {
+        qself: None,
+        path: syn::Path { leading_colon: None, segments: Punctuated::new() },
+    };
+    let generics_span = item_impl.generics.span();
+    let generics = item_impl.generics.clone();
+    let generic_arguments: syn::AngleBracketedGenericArguments =
+        parse_quote_spanned! { generics_span => #generics };
+    dummy_self_ty_path.path.segments.push(syn::PathSegment {
+        ident: dummy_ident.clone(),
+        arguments: syn::PathArguments::AngleBracketed(generic_arguments),
+    });
+    let dummy_self_ty = syn::Type::Path(dummy_self_ty_path);
+    let mut dummy_impl = item_impl.clone();
+    let item_impl_span = item_impl.span();
+    let mut item_struct = syn::ItemStruct {
+        attrs: item_impl.attrs,
+        vis: syn::Visibility::Inherited,
+        struct_token: syn::token::Struct { span: item_impl.impl_token.span },
+        ident: dummy_ident,
+        generics: item_impl.generics.clone(),
+        fields: syn::Fields::Unnamed(struct_field),
+        semi_token: Some(syn::token::Semi { spans: [item_impl_span] }),
+    };
+    // Both the struct and its impl end up unused so we add these attributes.
+    let allow_attr: syn::Attribute = parse_quote!(#[allow(unused, dead_code)]);
+    item_struct.attrs.push(allow_attr.clone());
+    dummy_impl.attrs.push(allow_attr);
+    dummy_impl.self_ty = Box::new(dummy_self_ty);
+    dummy_impl.items = item_impl.items.into_iter().map(|impl_item| {
+        match impl_item {
+            // For whatever reason, syn parses function stubs correctly
+            // by assuming that the semicolon at their end is wrapped in
+            // braces (functions require a brace-delimited list of Items
+            // inside of them, the semicolon gets converted to a
+            // Verbatim).
+            //
+            // This does however mean that we will silently discard the
+            // contents of any "implementation" of an extern function.
+            syn::ImplItem::Method(impl_item_method) => {
+                let span = impl_item_method.span();
+                let dummy_fn_tokens = create_dummy_fn(mod_path_clone.clone(), Some(self_ty.clone()), impl_item_method.sig, impl_item_method.attrs)?;
+                Ok(parse_quote_spanned! { span => #dummy_fn_tokens })
+            }
+            _ => {
+                Err(syn::Error::new(
+                    impl_item.span(),
+                    format!("Invalid extern_spec: invalid impl item: {:?}\n extern impls may only contain function stubs such as fn len(v: &Vec<T>) -> usize;", impl_item)
+                ))
+            }
+        }
+    }).collect::<syn::Result<Vec<syn::ImplItem>>>()?;
+    Ok(TokenStream::from_iter(
+        [item_struct.to_token_stream(), dummy_impl.to_token_stream()].into_iter(),
+    ))
 }
 
 fn create_dummy_ident(dummy_prefix: &mut String, ty: &syn::Type) -> syn::Result<syn::Ident> {
@@ -231,12 +277,11 @@ fn extract_sig_from_stub(
 /// 1. Mangle the name of the function into flux_extern_spec_{fn_ident} so that it doesn't
 ///    conflict with an existing function. TODO: add some random number to ensure it.
 /// 2. Create a new function with the mangled name and same signature.
-/// 3. Add any generic parameters in the extern spec to the generic params of the new function.
-/// 4. Replace its body with a single expression that is a function call.
-/// 5. The function call is of the form mod_path::fn_ident<generic_args>(params)
+/// 3. Replace its body with a single expression that is a function call.
+/// 4. The function call is of the form mod_path::fn_ident<generic_args>(params)
 ///    where the generic args and params have been modified so that they function as
 ///    arguments to the call instead of being a part of the function signature.
-/// 6. Finally, we suppress dead_code/unused warnings and add the flux::extern_spec
+/// 5. Finally, we suppress dead_code/unused warnings and add the flux::extern_spec
 ///    so that flux knows this is the generated dummy function for the external function
 ///    that is being called.
 fn create_dummy_fn(

--- a/flux-driver/locales/en-US.ftl
+++ b/flux-driver/locales/en-US.ftl
@@ -26,7 +26,7 @@ driver_missing_variant =
     .note = all variants in a refined enum must be annotated
 
 driver_malformed_extern_spec =
-    malformed extern_spec, expecting a function definition with a call to the external method as the body
+    malformed extern_spec, this should never happen if you are using the extern_spec macro. Did you accidentally use the internal flux::extern_spec attribute?
 
 driver_missing_fn_sig_for_extern_spec =
     missing flux::sig attribute (functions declared as flux::extern_spec require a flux::sig)

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -172,7 +172,7 @@ fn build_stage1_fhir_map(
         .or(err);
 
     // Externs
-    std::mem::take(&mut specs.externs)
+    std::mem::take(&mut specs.extern_specs)
         .into_iter()
         .for_each(|(extern_def_id, local_def_id)| {
             map.insert_extern(extern_def_id, local_def_id);

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -171,11 +171,11 @@ fn build_stage1_fhir_map(
         .err()
         .or(err);
 
-    // Extern Fns
-    std::mem::take(&mut specs.extern_fns)
+    // Externs
+    std::mem::take(&mut specs.externs)
         .into_iter()
         .for_each(|(extern_def_id, local_def_id)| {
-            map.insert_extern_fn(extern_def_id, local_def_id);
+            map.insert_extern(extern_def_id, local_def_id);
         });
 
     if let Some(err) = err {

--- a/flux-driver/src/collector.rs
+++ b/flux-driver/src/collector.rs
@@ -208,8 +208,9 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
             // extern_spec dummy structs are always opaque because they contain
             // one field: the external struct they are meant to represent.
             opaque = true;
-            let extern_def_id = self.extract_extern_def_id_from_extern_spec_struct(def_id, data)?;
-            self.specs.externs.insert(extern_def_id, def_id);
+            let extern_def_id =
+                self.extract_extern_def_id_from_extern_spec_struct(owner_id.def_id, data)?;
+            self.specs.externs.insert(extern_def_id, owner_id.def_id);
         }
 
         self.specs.structs.insert(

--- a/flux-driver/src/collector.rs
+++ b/flux-driver/src/collector.rs
@@ -50,7 +50,7 @@ pub(crate) struct Specs {
     pub ignores: Ignores,
     pub consts: FxHashMap<LocalDefId, ConstSig>,
     pub crate_config: Option<config::CrateConfig>,
-    pub externs: FxHashMap<DefId, LocalDefId>,
+    pub extern_specs: FxHashMap<DefId, LocalDefId>,
 }
 
 pub(crate) struct FnSpec {
@@ -210,7 +210,9 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
             opaque = true;
             let extern_def_id =
                 self.extract_extern_def_id_from_extern_spec_struct(owner_id.def_id, data)?;
-            self.specs.externs.insert(extern_def_id, owner_id.def_id);
+            self.specs
+                .extern_specs
+                .insert(extern_def_id, owner_id.def_id);
         }
 
         self.specs.structs.insert(
@@ -295,7 +297,9 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
                 }));
             }
             let extern_def_id = self.extract_extern_def_id_from_extern_spec_fn(owner_id.def_id)?;
-            self.specs.externs.insert(extern_def_id, owner_id.def_id);
+            self.specs
+                .extern_specs
+                .insert(extern_def_id, owner_id.def_id);
             // We should never check an extern spec (it will infinitely recurse)
             trusted = true;
         }
@@ -497,7 +501,7 @@ impl Specs {
             ignores: FxHashSet::default(),
             consts: FxHashMap::default(),
             crate_config: None,
-            externs: FxHashMap::default(),
+            extern_specs: FxHashMap::default(),
         }
     }
 

--- a/flux-middle/src/early_ctxt.rs
+++ b/flux-middle/src/early_ctxt.rs
@@ -40,7 +40,10 @@ impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
     }
 
     pub fn index_sorts_of(&self, def_id: DefId) -> &[fhir::Sort] {
-        if let Some(local_id) = def_id.as_local() {
+        if let Some(local_id) = def_id
+            .as_local()
+            .or_else(|| self.map.externs().get(&def_id).copied())
+        {
             self.map.refined_by(local_id).index_sorts()
         } else {
             self.cstore

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -108,7 +108,7 @@ pub struct Map {
     fns: FxHashMap<LocalDefId, FnSig>,
     fn_quals: FxHashMap<LocalDefId, Vec<SurfaceIdent>>,
     trusted: FxHashSet<LocalDefId>,
-    extern_fns: FxHashMap<DefId, LocalDefId>,
+    externs: FxHashMap<DefId, LocalDefId>,
 }
 
 #[derive(Debug)]
@@ -791,12 +791,12 @@ impl Map {
         self.trusted.contains(&def_id)
     }
 
-    pub fn insert_extern_fn(&mut self, extern_def_id: DefId, local_def_id: LocalDefId) {
-        self.extern_fns.insert(extern_def_id, local_def_id);
+    pub fn insert_extern(&mut self, extern_def_id: DefId, local_def_id: LocalDefId) {
+        self.externs.insert(extern_def_id, local_def_id);
     }
 
-    pub fn extern_fns(&self) -> &FxHashMap<DefId, LocalDefId> {
-        &self.extern_fns
+    pub fn externs(&self) -> &FxHashMap<DefId, LocalDefId> {
+        &self.externs
     }
 
     // ADT

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -25,7 +25,7 @@ pub struct GlobalEnv<'sess, 'tcx> {
     fn_quals: FxHashMap<DefId, FxHashSet<Symbol>>,
     early_cx: EarlyCtxt<'sess, 'tcx>,
     queries: Queries<'tcx>,
-    externs: FxHashMap<DefId, DefId>,
+    extern_specs: FxHashMap<DefId, DefId>,
 }
 
 impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
@@ -52,7 +52,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             func_decls,
             fn_quals,
             queries: Queries::new(providers),
-            externs,
+            extern_specs: externs,
         }
     }
 
@@ -210,6 +210,6 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
     }
 
     pub fn lookup_extern(&self, def_id: &DefId) -> Option<&DefId> {
-        self.externs.get(def_id)
+        self.extern_specs.get(def_id)
     }
 }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -25,7 +25,7 @@ pub struct GlobalEnv<'sess, 'tcx> {
     fn_quals: FxHashMap<DefId, FxHashSet<Symbol>>,
     early_cx: EarlyCtxt<'sess, 'tcx>,
     queries: Queries<'tcx>,
-    extern_fns: FxHashMap<DefId, DefId>,
+    externs: FxHashMap<DefId, DefId>,
 }
 
 impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
@@ -39,9 +39,9 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             let names = names.iter().map(|ident| ident.name).collect();
             fn_quals.insert(def_id.to_def_id(), names);
         }
-        let extern_fns = early_cx
+        let externs = early_cx
             .map
-            .extern_fns()
+            .externs()
             .iter()
             .map(|(extern_def_id, local_def_id)| (*extern_def_id, local_def_id.to_def_id()))
             .collect();
@@ -52,7 +52,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             func_decls,
             fn_quals,
             queries: Queries::new(providers),
-            extern_fns,
+            externs,
         }
     }
 
@@ -209,7 +209,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         self.tcx.hir()
     }
 
-    pub fn lookup_extern_fn(&self, def_id: &DefId) -> Option<&DefId> {
-        self.extern_fns.get(def_id)
+    pub fn lookup_extern(&self, def_id: &DefId) -> Option<&DefId> {
+        self.externs.get(def_id)
     }
 }

--- a/flux-middle/src/queries.rs
+++ b/flux-middle/src/queries.rs
@@ -133,7 +133,7 @@ impl<'tcx> Queries<'tcx> {
         def_id: DefId,
     ) -> QueryResult<rty::Generics> {
         run_with_cache(&self.generics_of, def_id, || {
-            let def_id = *genv.lookup_extern_fn(&def_id).unwrap_or(&def_id);
+            let def_id = *genv.lookup_extern(&def_id).unwrap_or(&def_id);
             if let Some(local_id) = def_id.as_local() {
                 (self.providers.generics_of)(genv, local_id)
             } else {

--- a/flux-middle/src/queries.rs
+++ b/flux-middle/src/queries.rs
@@ -116,6 +116,7 @@ impl<'tcx> Queries<'tcx> {
 
     pub(crate) fn adt_def(&self, genv: &GlobalEnv, def_id: DefId) -> QueryResult<rty::AdtDef> {
         run_with_cache(&self.adt_def, def_id, || {
+            let def_id = *genv.lookup_extern(&def_id).unwrap_or(&def_id);
             if let Some(local_id) = def_id.as_local() {
                 (self.providers.adt_def)(genv, local_id)
             } else if let Some(adt_def) = genv.early_cx().cstore.adt_def(def_id) {
@@ -216,7 +217,7 @@ impl<'tcx> Queries<'tcx> {
         run_with_cache(&self.fn_sig, def_id, || {
             // If it's an extern_fn, resolve it to its local fn_sig's def_id,
             // otherwise don't change it.
-            let def_id = *genv.lookup_extern_fn(&def_id).unwrap_or(&def_id);
+            let def_id = *genv.lookup_extern(&def_id).unwrap_or(&def_id);
             if let Some(local_id) = def_id.as_local() {
                 (self.providers.fn_sig)(genv, local_id)
             } else if let Some(fn_sig) = genv.early_cx().cstore.fn_sig(def_id) {

--- a/flux-tests/tests/neg/surface/extern_spec_impl.rs
+++ b/flux-tests/tests/neg/surface/extern_spec_impl.rs
@@ -1,0 +1,56 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+use flux_attrs_proc_macros::extern_spec;
+
+#[extern_spec]
+#[flux::refined_by(len: int)]
+struct String;
+
+#[extern_spec]
+impl String {
+    #[flux::sig(fn() -> String[0])]
+    fn new() -> String;
+
+    #[flux::sig(fn(&String[@n]) -> usize[n])]
+    fn len(s: &String) -> usize;
+
+    #[flux::sig(fn(&String[@n]) -> bool[n == 0])]
+    fn is_empty(s: &String) -> bool;
+
+    #[flux::sig(fn(s: &strg String[@n], char) ensures s: String[n+1])]
+    fn push(s: &mut String, c: char);
+
+    #[flux::sig(fn(s: &strg String[@n]) -> Option<char>
+                requires n > 0
+                ensures s: String[n-1])]
+    fn pop(s: &mut String) -> Option<char>;
+
+    #[flux::sig(fn(&String[@n]) -> &[u8][n])]
+    fn as_bytes(s: &String) -> &[u8];
+}
+
+
+#[extern_spec]
+impl<T> [T] {
+    #[flux::sig(fn(&[T][@n]) -> usize[n])]
+    fn len(v: &[T]) -> usize;
+
+    #[flux::sig(fn(&[T][@n]) -> bool[n == 0])]
+    fn is_empty(v: &[T]) -> bool;
+}
+
+#[flux::sig(fn(bool[@b]) requires b)]
+fn assert_true(_: bool) {
+}
+
+fn test_string() {
+    let mut s = String::new();
+    s.push('h');
+    s.push('i');
+    s.pop();
+    s.pop();
+    assert_true(s.as_bytes().is_empty());
+    assert_true(!s.as_bytes().is_empty()); //~ ERROR precondition
+    s.pop(); //~ ERROR precondition
+}

--- a/flux-tests/tests/neg/surface/extern_spec_struct.rs
+++ b/flux-tests/tests/neg/surface/extern_spec_struct.rs
@@ -1,0 +1,18 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+use flux_attrs_proc_macros::extern_spec;
+
+#[extern_spec(std::string)]
+#[flux::refined_by(len: int)]
+struct String;
+
+#[flux::sig(fn(String[@n]) requires n == 3)]
+fn expect_string_len_3(s: String) {
+
+}
+
+#[flux::sig(fn(String[2]))]
+fn test_string_len_2(s: String) {
+    expect_string_len_3(s); //~ ERROR precondition
+}

--- a/flux-tests/tests/pos/surface/extern_spec_impl.rs
+++ b/flux-tests/tests/pos/surface/extern_spec_impl.rs
@@ -1,0 +1,59 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+use flux_attrs_proc_macros::extern_spec;
+
+#[extern_spec]
+#[flux::refined_by(len: int)]
+struct String;
+
+#[extern_spec]
+impl String {
+    #[flux::sig(fn() -> String[0])]
+    fn new() -> String;
+
+    #[flux::sig(fn(&String[@n]) -> usize[n])]
+    fn len(s: &String) -> usize;
+
+    #[flux::sig(fn(&String[@n]) -> bool[n == 0])]
+    fn is_empty(s: &String) -> bool;
+
+    #[flux::sig(fn(s: &strg String[@n], char) ensures s: String[n+1])]
+    fn push(s: &mut String, c: char);
+
+    #[flux::sig(fn(s: &strg String[@n]) -> Option<char>
+                requires n > 0
+                ensures s: String[n-1])]
+    fn pop(s: &mut String) -> Option<char>;
+
+    #[flux::sig(fn(&String[@n]) -> &[u8][n])]
+    fn as_bytes(s: &String) -> &[u8];
+}
+
+
+#[extern_spec]
+impl<T> [T] {
+    #[flux::sig(fn(&[T][@n]) -> usize[n])]
+    fn len(v: &[T]) -> usize;
+
+    #[flux::sig(fn(&[T][@n]) -> bool[n == 0])]
+    fn is_empty(v: &[T]) -> bool;
+}
+
+#[flux::sig(fn(bool[@b]) requires b)]
+fn assert_true(_: bool) {
+}
+
+fn test_string() {
+    let mut s = String::new();
+    assert_true(s.is_empty());
+    assert_true(s.as_bytes().is_empty());
+    s.push('h');
+    s.push('i');
+    assert_true(s.len() == 2);
+    s.pop();
+    assert_true(s.len() == 1);
+    s.pop();
+    assert_true(s.is_empty());
+    assert_true(s.as_bytes().is_empty());
+}

--- a/flux-tests/tests/pos/surface/extern_spec_struct.rs
+++ b/flux-tests/tests/pos/surface/extern_spec_struct.rs
@@ -1,0 +1,18 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+use flux_attrs_proc_macros::extern_spec;
+
+#[extern_spec(std::string)]
+#[flux::refined_by(len: int)]
+struct String;
+
+#[flux::sig(fn(String[@n]) requires n == 3)]
+fn expect_string_len_3(s: String) {
+
+}
+
+#[flux::sig(fn(String[3]))]
+fn test_string_len_3(s: String) {
+    expect_string_len_3(s);
+}


### PR DESCRIPTION
PR #400 🎉 

# Extern `struct`

## Syntax

```rust
#[extern_spec(std::string)]
#[flux::refined_by(len: int)]
struct String;
```

expands to 

```rust
#[flux::extern_spec]
#[allow(unused, dead_code)]
#[flux::refined_by(len: int)]
struct __FluxExternSpecString(std::string::String);
```

## Typing

We extract the `std::string::String`'s `DefId` and add it to our `extern_specs` map that resolves the `DefId` of extern structs to their dummy local version. We add the dummy `__FluxExternSpecString` as an opaque struct.

# Extern `impl`

## Syntax

```rust
#[extern_spec]
impl<T> [T] {
    #[flux::sig(fn(&[T][@n]) -> usize[n])]
    fn len(v: &[T]) -> usize;

    #[flux::sig(fn(&[T][@n]) -> bool[n == 0])]
    fn is_empty(v: &[T]) -> bool;
}
```

expands to

```rust
#[allow(unused, dead_code)]
struct __FluxExternImplStructSliceT<T>([T]);

#[allow(unused, dead_code)]
impl<T> __FluxExternImplStructSliceT<T> {
    #[flux::extern_spec]
    #[flux::sig(fn(&[T][@n]) -> usize[n])]
    #[allow(unused, dead_code)]
    fn __flux_extern_spec_len(v: &[T]) -> usize {
        <[T]>::len::<>(v)
    }
    #[flux::extern_spec]
    #[flux::sig(fn(&[T][@n]) -> bool[n == 0])]
    #[allow(unused, dead_code)]
    fn __flux_extern_spec_is_empty(v: &[T]) -> bool {
        <[T]>::is_empty::<>(v)
    }
}
```

## Typing

We generate a dummy struct `__FluxExternImplStructSliceT` that wraps the extern type `[T]`. This allows us to make an `impl` for the dummy struct that mirrors the extern `impl` on `[T]`.

The methods inside of the `impl` on `__FluxExternImplStructSliceT<T>` are refined as if they were extern functions; however, they use the `Self` type of the original `impl` (in this case, `[T]`) to generate the extern call in the body of the function. This has the effect of mapping `<[T]>::is_empty` to the refined signature of `<__FluxExternImplStructSliceT<T>>::__flux_extern_spec_is_empty`, ditto for `<[T]>::len`.

The reason why we need the `impl` is to ensure that the method functions we refine have the same shape as the extern method functions; if we didn't do this, then we would run into issues when we get the generics of the dummy method function with refined signature.

# Limitations

## Extern `struct`

Extern `struct`s are opaque. `enum`s are not supported, although we do not reject code like

```rust
#[extern_spec(std::string)]
#[flux::refined_by(is_some: bool)]
struct Option<T>;
```

even though an `Option<T>` is neither a `struct` nor opaque.

## Extern `impl`

Self `impl`s are the only officially-supported `impl`s. In practice we think the only limitation to allowing extern impls on traits is that we generate the same name for the dummy struct for `impl`s on the same self type.

We presently do not allow the use of `self` in `impl` methods.