### PR TITLE
Enable proc macros in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "flux-attrs-proc-macros-build"
+version = "0.1.0"
+dependencies = [
+ "flux-attrs-proc-macros",
+]
+
+[[package]]
 name = "flux-bin"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "flux",
     "flux-attrs",
     "flux-attrs-proc-macros",
+    "flux-attrs-proc-macros-build",
     "flux-bin",
     "flux-common",
     "flux-config",

--- a/flux-attrs-proc-macros-build/Cargo.toml
+++ b/flux-attrs-proc-macros-build/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+edition = "2021"
+name = "flux-attrs-proc-macros-build"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies.flux-attrs-proc-macros]
+features = ["enabled"]
+path = "../flux-attrs-proc-macros"

--- a/flux-attrs-proc-macros-build/src/lib.rs
+++ b/flux-attrs-proc-macros-build/src/lib.rs
@@ -1,0 +1,1 @@
+//! This is a dummy crate to pre-build the `flux-attrs-proc-macros` crate.

--- a/flux-attrs-proc-macros/Cargo.toml
+++ b/flux-attrs-proc-macros/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
+edition = "2021"
 name = "flux-attrs-proc-macros"
 version = "0.1.0"
-edition = "2021"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-flux-attrs= { path = "../flux-attrs", version = "0.1.0", optional = true }
+flux-attrs = { path = "../flux-attrs", version = "0.1.0", optional = true }
 proc-macro2 = { version = "1.0", optional = true }
 
 [features]

--- a/flux-attrs-proc-macros/src/lib.rs
+++ b/flux-attrs-proc-macros/src/lib.rs
@@ -4,8 +4,8 @@ use proc_macro::TokenStream;
 
 #[cfg(not(feature = "enabled"))]
 #[proc_macro_attribute]
-pub fn extern_spec(_: TokenStream, tokens: TokenStream) -> TokenStream {
-    tokens
+pub fn extern_spec(_attrs: TokenStream, _tokens: TokenStream) -> TokenStream {
+    TokenStream::new()
 }
 
 #[cfg(feature = "enabled")]

--- a/flux-middle/src/queries.rs
+++ b/flux-middle/src/queries.rs
@@ -132,6 +132,7 @@ impl<'tcx> Queries<'tcx> {
         def_id: DefId,
     ) -> QueryResult<rty::Generics> {
         run_with_cache(&self.generics_of, def_id, || {
+            let def_id = *genv.lookup_extern_fn(&def_id).unwrap_or(&def_id);
             if let Some(local_id) = def_id.as_local() {
                 (self.providers.generics_of)(genv, local_id)
             } else {

--- a/flux-tests/tests/compiletest.rs
+++ b/flux-tests/tests/compiletest.rs
@@ -29,8 +29,10 @@ fn find_flux_path() -> PathBuf {
 fn find_attrs_proc_macro_lib_path() -> PathBuf {
     let attrs_proc_macros_lib = if cfg!(target_os = "linux") {
         "libflux_attrs_proc_macros.so"
+    } else if cfg!(target_os = "macos") {
+        "libflux_attrs_proc_macros.dylib"
     } else {
-        todo!("implement this for mac and windows")
+        todo!("implement for windows")
     };
     find_file_in_target_dir(attrs_proc_macros_lib)
 }

--- a/flux-tests/tests/compiletest.rs
+++ b/flux-tests/tests/compiletest.rs
@@ -6,25 +6,33 @@ use std::{env, path::PathBuf};
 use compiletest_rs::{common::Mode, Config};
 use itertools::Itertools;
 
-fn find_flux_path() -> PathBuf {
+fn find_file_in_target_dir(file: &str) -> PathBuf {
     let target_directory = if cfg!(debug_assertions) { "debug" } else { "release" };
+    let local_flux_driver_path: PathBuf = ["target", target_directory, file].into_iter().collect();
+    if local_flux_driver_path.exists() {
+        return local_flux_driver_path;
+    }
+    let workspace_flux_driver_path: PathBuf = ["..", "target", target_directory, file]
+        .into_iter()
+        .collect();
+    if workspace_flux_driver_path.exists() {
+        return workspace_flux_driver_path;
+    }
+    panic!("Could not find {file}");
+}
+
+fn find_flux_path() -> PathBuf {
     let executable_name = if cfg!(windows) { "flux-driver.exe" } else { "flux-driver" };
-    let local_prusti_rustc_path: PathBuf = ["target", target_directory, executable_name]
-        .iter()
-        .collect();
-    if local_prusti_rustc_path.exists() {
-        return local_prusti_rustc_path;
-    }
-    let workspace_prusti_rustc_path: PathBuf = ["..", "target", target_directory, executable_name]
-        .iter()
-        .collect();
-    if workspace_prusti_rustc_path.exists() {
-        return workspace_prusti_rustc_path;
-    }
-    panic!(
-        "Could not find the {target_directory:?} flux-driver binary to be used in tests. \
-        It might be that flux has not been compiled correctly."
-    );
+    find_file_in_target_dir(executable_name)
+}
+
+fn find_attrs_proc_macro_lib_path() -> PathBuf {
+    let attrs_proc_macros_lib = if cfg!(target_os = "linux") {
+        "libflux_attrs_proc_macros.so"
+    } else {
+        todo!("implement this for mac and windows")
+    };
+    find_file_in_target_dir(attrs_proc_macros_lib)
 }
 
 fn config() -> Config {
@@ -39,7 +47,10 @@ fn config() -> Config {
 fn test_runner(_: &[&()]) {
     let mut config = config();
 
-    config.target_rustcflags = Some("--crate-type=rlib".to_string());
+    config.target_rustcflags = Some(format!(
+        "--crate-type=rlib --extern flux_attrs_proc_macros={} --edition=2018",
+        find_attrs_proc_macro_lib_path().display()
+    ));
 
     let path: PathBuf = ["tests", "pos"].iter().collect();
     if path.exists() {

--- a/flux-tests/tests/neg/surface/extern_spec_internal.rs
+++ b/flux-tests/tests/neg/surface/extern_spec_internal.rs
@@ -1,23 +1,13 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-use std::vec::Vec;
-
-#[flux::alias(type Lb(n: int) = usize{v: n <= v})]
-type Lb = usize;
-
-#[flux::trusted]
-fn make_vec() -> Vec<i32> {
-    vec!(1,2,3)
-}
-
 #[flux::extern_spec]
-#[flux::sig(fn(v: &Vec<i32>) -> Lb(9))]
-fn extern_len(v: &Vec<i32>) -> Lb {
-    Vec::len(&v)
+#[flux::sig(fn(&T) -> &[T][1])]
+fn from_ref<T>(s: &T) -> &[T] {
+    std::slice::from_ref::<T>(s)
 }
 
-#[flux::sig(fn() -> Lb(10))]
-pub fn test() -> Lb {
-    Vec::len(&make_vec())
-} //~ ERROR postcondition
+#[flux::sig(fn(&i32) -> &[i32]{n: n > 1})]
+pub fn test(x: &i32) -> &[i32] {
+    from_ref(x) //~ ERROR postcondition
+}

--- a/flux-tests/tests/neg/surface/extern_spec_macro.rs
+++ b/flux-tests/tests/neg/surface/extern_spec_macro.rs
@@ -1,16 +1,15 @@
-// ignore-test
-// Need to add macros to test
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-use std::mem::swap;
+use std::slice::from_ref;
+
+use flux_attrs_proc_macros::extern_spec;
 
 #[extern_spec]
-#[flux::sig(fn(&mut i32[@a], &mut i32{v : a < v }) -> ())]
-fn swap(a: &mut i32, b: &mut i32);
+#[flux::sig(fn(&T) -> &[T][1])]
+fn from_ref<T>(s: &T) -> &[T];
 
-pub fn test() {
-  let mut x = 1;
-  let mut y = 2;
-  swap(&mut y, &mut x); //~ ERROR postcondition
+#[flux::sig(fn(&i32) -> &[i32]{n: n > 1})]
+pub fn test(x: &i32) -> &[i32] {
+    from_ref(x) //~ ERROR postcondition
 }

--- a/flux-tests/tests/pos/surface/extern_spec_internal.rs
+++ b/flux-tests/tests/pos/surface/extern_spec_internal.rs
@@ -1,23 +1,13 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-use std::vec::Vec;
-
-#[flux::alias(type Lb(n: int) = usize{v: n <= v})]
-type Lb = usize;
-
-#[flux::trusted]
-fn make_vec() -> Vec<i32> {
-    vec!(1,2,3)
-}
-
 #[flux::extern_spec]
-#[flux::sig(fn(v: &Vec<i32>) -> Lb(10))]
-fn extern_len(v: &Vec<i32>) -> Lb {
-    Vec::len(v)
+#[flux::sig(fn(&T) -> &[T][1])]
+fn from_ref<T>(s: &T) -> &[T] {
+    std::slice::from_ref::<T>(s)
 }
 
-#[flux::sig(fn() -> Lb(10))]
-pub fn test() -> Lb {
-    Vec::len(&make_vec())
+#[flux::sig(fn(&i32) -> &[i32][1])]
+pub fn test(x: &i32) -> &[i32] {
+    from_ref(x)
 }

--- a/flux-tests/tests/pos/surface/extern_spec_macro.rs
+++ b/flux-tests/tests/pos/surface/extern_spec_macro.rs
@@ -1,16 +1,15 @@
-// ignore-test
-// Need to add macros to test
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-use std::mem::swap;
+use std::slice::from_ref;
+
+use flux_attrs_proc_macros::extern_spec;
 
 #[extern_spec]
-#[flux::sig(fn(&mut i32[@a], &mut i32{v : a < v }) -> ())]
-fn swap(a: &mut i32, b: &mut i32);
+#[flux::sig(fn(&T) -> &[T][1])]
+fn from_ref<T>(s: &T) -> &[T];
 
-pub fn test() {
-  let mut x = 1;
-  let mut y = 2;
-  swap(&mut x, &mut y);
+#[flux::sig(fn(&i32) -> &[i32]{n: n > 0})]
+pub fn test(x: &i32) -> &[i32] {
+    from_ref(x)
 }


### PR DESCRIPTION
* Add dummy `flux-attrs-proc-macros-build` crate to pre-build the `flux_attrs-proc-macros` crate with the flux feature enabled
* Add a `--extern` flag in `compilete.rs` to make proc macros available in tests
* Fix extern specs tests to be valid refinements of functions
* Enable extern specs tests that use the `extern_spec` proc macro
* Fix the `extren_spec` proc macro to return an empty stream of tokens if the feature is disabled.

I need someone to fill this [`todo!`](https://github.com/flux-rs/flux/blob/e726bc3e657191124c0f0d0085fb260531f885f3/flux-tests/tests/compiletest.rs#L33) in mac. I believe the name of the shared library will be different.