### PR TITLE
Only shift out escaping bvars

### DIFF
--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -352,7 +352,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                 let sort = self.env.pop_layer().into_sort();
 
                 if sort.is_unit() {
-                    Ok(constr.shift_out_bvars(1))
+                    Ok(constr.shift_out_escaping(1))
                 } else {
                     Ok(rty::Ty::exists(rty::Binder::new(constr, sort)))
                 }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -903,7 +903,7 @@ impl fmt::Debug for Ty {
         match &self.kind {
             TyKind::BaseTy(bty) => write!(f, "{bty:?}"),
             TyKind::Indexed(bty, idx) => write!(f, "{bty:?}[{idx:?}]"),
-            TyKind::Exists(bty, bind, p) => write!(f, "{bty:?}{{{bind:?} : {p:?}}}"),
+            TyKind::Exists(bty, bind, p) => write!(f, "{bty:?}{{{bind:?}: {p:?}}}"),
             TyKind::Ptr(loc) => write!(f, "ref<{loc:?}>"),
             TyKind::Ref(RefKind::Mut, ty) => write!(f, "&mut {ty:?}"),
             TyKind::Ref(RefKind::Shr, ty) => write!(f, "&{ty:?}"),

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -162,7 +162,7 @@ pub trait TypeFoldable: Sized {
             .normalize(&Default::default())
     }
 
-    fn shift_in_bvars(&self, amount: u32) -> Self {
+    fn shift_in_escaping(&self, amount: u32) -> Self {
         struct Shifter {
             current_index: DebruijnIndex,
             amount: u32,
@@ -192,21 +192,31 @@ pub trait TypeFoldable: Sized {
         self.fold_with(&mut Shifter { amount, current_index: INNERMOST })
     }
 
-    fn shift_out_bvars(&self, amount: u32) -> Self {
+    fn shift_out_escaping(&self, amount: u32) -> Self {
         struct Shifter {
             amount: u32,
+            current_index: DebruijnIndex,
         }
 
         impl TypeFolder for Shifter {
+            fn fold_binder<T: TypeFoldable>(&mut self, t: &Binder<T>) -> Binder<T> {
+                self.current_index.shift_in(1);
+                let t = t.super_fold_with(self);
+                self.current_index.shift_out(1);
+                t
+            }
+
             fn fold_expr(&mut self, expr: &Expr) -> Expr {
-                if let ExprKind::Var(Var::LateBound(debruijn)) = expr.kind() {
+                if let ExprKind::Var(Var::LateBound(debruijn)) = expr.kind()
+                    && debruijn >= &self.current_index
+                {
                     Expr::late_bvar(debruijn.shifted_out(self.amount))
                 } else {
                     expr.super_fold_with(self)
                 }
             }
         }
-        self.fold_with(&mut Shifter { amount })
+        self.fold_with(&mut Shifter { amount, current_index: INNERMOST })
     }
 
     fn has_escaping_bvars(&self) -> bool {

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -705,7 +705,7 @@ impl EarlyBinder<PolyVariant> {
             .0
             .as_ref()
             .map(|variant| {
-                let ret = variant.ret.shift_in_bvars(1);
+                let ret = variant.ret.shift_in_escaping(1);
                 let output = Binder::new(FnOutput::new(ret, vec![]), Sort::unit());
                 FnSig::new(vec![], variant.fields.clone(), output)
             })

--- a/flux-middle/src/rty/subst.rs
+++ b/flux-middle/src/rty/subst.rs
@@ -116,7 +116,7 @@ impl TypeFolder for BVarSubstFolder<'_> {
         if let ExprKind::Var(Var::LateBound(debruijn)) = e.kind() {
             match debruijn.cmp(&self.current_index) {
                 Ordering::Less => Expr::late_bvar(*debruijn),
-                Ordering::Equal => self.expr.shift_in_bvars(self.current_index.as_u32()),
+                Ordering::Equal => self.expr.shift_in_escaping(self.current_index.as_u32()),
                 Ordering::Greater => Expr::late_bvar(debruijn.shifted_out(1)),
             }
         } else {
@@ -223,6 +223,6 @@ impl GenericsSubstFolder<'_> {
     }
 
     fn expr_for_param(&self, idx: u32) -> Expr {
-        self.refine[idx as usize].shift_in_bvars(self.current_index.as_u32())
+        self.refine[idx as usize].shift_in_escaping(self.current_index.as_u32())
     }
 }

--- a/flux-tests/tests/pos/surface/pldi23ae-reviewerb-bug.rs
+++ b/flux-tests/tests/pos/surface/pldi23ae-reviewerb-bug.rs
@@ -1,0 +1,9 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::alias(type Nat = i32{v: v >= 0})]
+type Nat = i32;
+
+// This should not crash
+#[flux::sig(fn(&mut Nat{v: true}))]
+fn test(x: &mut Nat) {}


### PR DESCRIPTION
Buf found by AE reviewer B

Also rename function as `shift_in_escaping` and `shift_out_escaping`