### PR TITLE
Syntax: use `|` instead of `:` for constraint types

### DIFF
--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -910,7 +910,7 @@ impl fmt::Debug for Ty {
             TyKind::Tuple(tys) => write!(f, "({:?})", tys.iter().format(", ")),
             TyKind::Array(ty, len) => write!(f, "[{ty:?}; {len:?}]"),
             TyKind::Never => write!(f, "!"),
-            TyKind::Constr(pred, ty) => write!(f, "{{{ty:?} : {pred:?}}}"),
+            TyKind::Constr(pred, ty) => write!(f, "{{{ty:?} | {pred:?}}}"),
             TyKind::RawPtr(ty, Mutability::Not) => write!(f, "*const {ty:?}"),
             TyKind::RawPtr(ty, Mutability::Mut) => write!(f, "*mut {ty:?}"),
         }

--- a/flux-syntax/src/grammar.lalrpop
+++ b/flux-syntax/src/grammar.lalrpop
@@ -166,7 +166,7 @@ TyKind: surface::TyKind = {
     <bty:BaseTy>                                      => surface::TyKind::Base(<>),
     <bty:BaseTy> "[" <indices:Indices> "]"            => surface::TyKind::Indexed { <> },
     <bty:BaseTy> "{" <bind:Ident> ":" <pred:Expr> "}" => surface::TyKind::Exists { <> },
-    "{" <ty:Ty> ":" <pred:Expr> "}"                   => surface::TyKind::Constr(pred, Box::new(ty)),
+    "{" <ty:Ty> "|" <pred:Expr> "}"                   => surface::TyKind::Constr(pred, Box::new(ty)),
 
     "(" <tys:Comma<Ty>> ")"         => surface::TyKind::Tuple(tys),
 

--- a/flux-tests/tests/lib/range.rs
+++ b/flux-tests/tests/lib/range.rs
@@ -9,7 +9,7 @@ pub struct RngIter {
 }
 
 impl RngIter {
-    #[flux::sig(fn(lo:i32, hi:i32{lo <= hi}) -> RngIter[lo, hi])]
+    #[flux::sig(fn(lo: i32, hi: i32{lo <= hi}) -> RngIter[lo, hi])]
     pub fn new(lo: i32, hi: i32) -> RngIter {
         Self { _lo: lo, hi, cur: lo }
     }
@@ -19,7 +19,7 @@ impl RngIter {
 pub struct Rng {
     #[flux::field(i32[@lo])]
     lo: i32,
-    #[flux::field({i32[@hi] : lo <= hi})]
+    #[flux::field({i32[@hi] | lo <= hi})]
     hi: i32,
 }
 
@@ -33,7 +33,7 @@ impl Rng {
 impl Iterator for RngIter {
     type Item = i32;
 
-    #[flux::sig(fn(self: &mut RngIter[@lo, @hi]) -> Option<i32{v:lo <= v && v < hi}>)]
+    #[flux::sig(fn(self: &mut RngIter[@lo, @hi]) -> Option<i32{v: lo <= v && v < hi}>)]
     fn next(&mut self) -> Option<i32> {
         let cur = self.cur;
         let hi = self.hi;

--- a/flux-tests/tests/neg/abstract_refinements/test01.rs
+++ b/flux-tests/tests/neg/abstract_refinements/test01.rs
@@ -5,7 +5,7 @@
 struct Pair {
     #[flux::field(i32[@a])]
     fst: i32,
-    #[flux::field({i32[@b] : p(a, b)})]
+    #[flux::field({i32[@b] | p(a, b)})]
     snd: i32,
 }
 

--- a/flux-tests/tests/neg/enums/invariant00.rs
+++ b/flux-tests/tests/neg/enums/invariant00.rs
@@ -3,13 +3,13 @@
 
 #[flux::refined_by(n: int)]
 pub enum E {
-    #[flux::variant({{i32[@n] : n > 0}} -> E[n])]
+    #[flux::variant({{i32[@n] | n > 0}} -> E[n])]
     Pos(i32),
     #[flux::variant({i32[0]} -> E[0])]
     Zero(i32),
 }
 
-#[flux::sig(fn(E[@n], i32[n]) -> i32{v : v > 0})]
+#[flux::sig(fn(E[@n], i32[n]) -> i32{v: v > 0})]
 pub fn is_zero(_: E, x: i32) -> i32 {
     x + 1 //~ ERROR postcondition
 }

--- a/flux-tests/tests/neg/structs/fold-on-drop.rs
+++ b/flux-tests/tests/neg/structs/fold-on-drop.rs
@@ -3,7 +3,7 @@
 
 #[flux::refined_by(a: int)]
 pub struct S {
-    #[flux::field({i32[@a] : a >= 0})]
+    #[flux::field({i32[@a] | a >= 0})]
     f1: i32,
     _f2: Vec<i32>,
 }

--- a/flux-tests/tests/neg/structs/invariant00.rs
+++ b/flux-tests/tests/neg/structs/invariant00.rs
@@ -5,8 +5,8 @@
 #[flux::invariant(a > 0)]
 #[flux::invariant(b > 0)] //~ ERROR invariant
 pub struct S {
-    #[flux::field({i32[@a] : a > 0})]
+    #[flux::field({i32[@a] | a > 0})]
     fst: i32,
-    #[flux::field({i32[@b] : a >= b})]
+    #[flux::field({i32[@b] | a >= b})]
     snd: i32,
 }

--- a/flux-tests/tests/neg/structs/struct-join.rs
+++ b/flux-tests/tests/neg/structs/struct-join.rs
@@ -3,12 +3,12 @@
 
 #[flux::refined_by(a: int)]
 pub struct S<T> {
-    #[flux::field({i32[@a] : a >= 0})]
+    #[flux::field({i32[@a] | a >= 0})]
     f1: i32,
     f2: T,
 }
 
-#[flux::sig(fn(bool, S<i32>) -> i32{v : v >= 0})]
+#[flux::sig(fn(bool, S<i32>) -> i32{v: v >= 0})]
 pub fn test1(b: bool, mut s: S<i32>) -> i32 {
     if b {
         // we break the invariant
@@ -18,7 +18,7 @@ pub fn test1(b: bool, mut s: S<i32>) -> i32 {
     s.f1 //~ ERROR postcondition
 }
 
-#[flux::sig(fn(bool, S<i32>) -> i32{v : v > 0})]
+#[flux::sig(fn(bool, S<i32>) -> i32{v: v > 0})]
 pub fn test2(b: bool, s: S<i32>) -> i32 {
     let x = if b {
         drop(s);
@@ -30,7 +30,7 @@ pub fn test2(b: bool, s: S<i32>) -> i32 {
     x //~ ERROR postcondition
 }
 
-#[flux::sig(fn(bool, S<Vec<i32> >) -> i32{v : v > 0})]
+#[flux::sig(fn(bool, S<Vec<i32> >) -> i32{v: v > 0})]
 pub fn test3(b: bool, s: S<Vec<i32>>) -> i32 {
     let x = if b {
         drop(s.f2);

--- a/flux-tests/tests/neg/surface/const02.rs
+++ b/flux-tests/tests/neg/surface/const02.rs
@@ -8,7 +8,7 @@ pub const FORTY_TWO: usize = 21 + 21;
 
 #[flux::refined_by(a:int)]
 pub struct Silly {
-    #[flux::field({usize[@a] : a < FORTY_TWO})]
+    #[flux::field({usize[@a] | a < FORTY_TWO})]
     fld: usize,
 }
 

--- a/flux-tests/tests/neg/surface/const03.rs
+++ b/flux-tests/tests/neg/surface/const03.rs
@@ -8,7 +8,7 @@ pub const FORTY_TWO: usize = 21 + 21;
 
 #[flux::refined_by(a:int)]
 pub struct Silly {
-    #[flux::field({usize[@a] : a < FORTY_TWO})]
+    #[flux::field({usize[@a] | a < FORTY_TWO})]
     fld: usize,
 }
 

--- a/flux-tests/tests/neg/surface/constr00.rs
+++ b/flux-tests/tests/neg/surface/constr00.rs
@@ -4,7 +4,7 @@
 #[flux::sig(fn(bool[true]))]
 fn assert(_b: bool) {}
 
-#[flux::sig(fn(&i32[@a], { &i32[@b] : b <= a } ) -> i32[a-b])]
+#[flux::sig(fn(&i32[@a], { &i32[@b] | b <= a } ) -> i32[a-b])]
 fn sub(x: &i32, y: &i32) -> i32 {
     let res = *x - *y;
     assert(0 < res); //~ ERROR precondition

--- a/flux-tests/tests/neg/surface/constr01.rs
+++ b/flux-tests/tests/neg/surface/constr01.rs
@@ -3,18 +3,18 @@
 
 #[flux::refined_by(a: int, b: int)]
 struct Foo {
-    #[flux::field({i32[@a]: 0 <= a})]
+    #[flux::field({i32[@a] | 0 <= a})]
     x: i32,
-    #[flux::field({i32[@b]: a <= b})]
+    #[flux::field({i32[@b] | a <= b})]
     y: i32,
 }
 
 #[flux::sig(fn(&Foo) -> bool[true])]
 fn test1(foo: &Foo) -> bool {
-    foo.x < foo.y //~ ERROR postcondition 
+    foo.x < foo.y //~ ERROR postcondition
 }
 
-#[flux::sig(fn({&Foo[@a, @b] : b == 20}) -> i32[20])]
+#[flux::sig(fn({&Foo[@a, @b] | b == 20}) -> i32[20])]
 fn test2(foo: &Foo) -> i32 {
     foo.y
 }

--- a/flux-tests/tests/neg/surface/constr02.rs
+++ b/flux-tests/tests/neg/surface/constr02.rs
@@ -2,12 +2,12 @@
 #![register_tool(flux)]
 
 // Test for
-// Option<{i32[a] : a > 0}> <: Option<i32{v : v > 0 }>
+// Option<{i32[a] | a > 0}> <: Option<i32{v: v > 0 }>
 
 #[flux::sig(fn(Option<i32{v: 10 < v}>))]
 fn foo(_x: Option<i32>) {}
 
-#[flux::sig(fn(a:i32, Option<{i32[a] : 0 < a}>))]
+#[flux::sig(fn(a:i32, Option<{i32[a] | 0 < a}>))]
 pub fn bar(_a: i32, y: Option<i32>) {
     foo(y) //~ ERROR precondition
 }

--- a/flux-tests/tests/neg/surface/constr03.rs
+++ b/flux-tests/tests/neg/surface/constr03.rs
@@ -6,12 +6,12 @@ mod rvec;
 
 use rvec::RVec;
 
-#[flux::sig(fn(&mut {RVec<i32>[@n] : n > 0}))]
+#[flux::sig(fn(&mut {RVec<i32>[@n] | n > 0}))]
 pub fn test1(vec: &mut RVec<i32>) {
     vec[1] = 5; //~ ERROR precondition
 }
 
-#[flux::sig(fn({&mut RVec<i32>[@n] : n > 0}))]
+#[flux::sig(fn({&mut RVec<i32>[@n] | n > 0}))]
 pub fn test2(vec: &mut RVec<i32>) {
     vec[1] = 5; //~ ERROR precondition
 }

--- a/flux-tests/tests/neg/surface/date.rs
+++ b/flux-tests/tests/neg/surface/date.rs
@@ -16,11 +16,11 @@
 #[allow(dead_code)]
 #[flux::refined_by(d:int, m:int, y:int)]
 pub struct Date {
-    #[flux::field({ usize[@d] : ok_day(d) })]
+    #[flux::field({ usize[@d] | ok_day(d) })]
     day: usize,
-    #[flux::field({ usize[@m] : ok_month(d, m)})]
+    #[flux::field({ usize[@m] | ok_month(d, m)})]
     month: usize,
-    #[flux::field({ usize[@y] : ok_year(d, m, y)})]
+    #[flux::field({ usize[@y] | ok_year(d, m, y)})]
     year: usize,
 }
 

--- a/flux-tests/tests/neg/surface/issue-271.rs
+++ b/flux-tests/tests/neg/surface/issue-271.rs
@@ -3,7 +3,7 @@
 
 pub struct S;
 
-#[flux::sig(fn(x: u32) -> Result<{S: x < 100}, bool>)]
+#[flux::sig(fn(x: u32) -> Result<{S | x < 100}, bool>)]
 pub fn test01(x: u32) -> Result<S, bool> {
     if x > 100 {
         return Err(false);
@@ -11,7 +11,7 @@ pub fn test01(x: u32) -> Result<S, bool> {
     Ok(S) //~ ERROR postcondition
 }
 
-#[flux::sig(fn(x: u32) -> Option<{S: x < 100}>)]
+#[flux::sig(fn(x: u32) -> Option<{S | x < 100}>)]
 pub fn test02(x: u32) -> Option<S> {
     if x > 100 {
         return None;

--- a/flux-tests/tests/neg/surface/issue-299.rs
+++ b/flux-tests/tests/neg/surface/issue-299.rs
@@ -17,7 +17,7 @@ struct S2 {
     pub f1: i32,
     #[flux::field(i32[@a])]
     pub f2: i32,
-    #[flux::field({i32[@b] : b > 0})]
+    #[flux::field({i32[@b] | b > 0})]
     pub f3: i32,
     #[flux::field(i32{v: v > 0})]
     pub f4: i32,

--- a/flux-tests/tests/neg/surface/rslice00.rs
+++ b/flux-tests/tests/neg/surface/rslice00.rs
@@ -12,7 +12,7 @@ fn test00<T>(vec: &mut RVec<T>) {
     let s2 = s.subslice(2, 5); //~ ERROR precondition
 }
 
-#[flux::sig(fn(&mut {RVec<i32>[@n] : n % 2 == 0 && n > 0}))]
+#[flux::sig(fn(&mut {RVec<i32>[@n] | n % 2 == 0 && n > 0}))]
 fn test01(vec: &mut RVec<i32>) {
     let n = vec.len();
     let mut s = RSlice::from_vec(vec);

--- a/flux-tests/tests/pos/abstract_refinements/test01.rs
+++ b/flux-tests/tests/pos/abstract_refinements/test01.rs
@@ -5,7 +5,7 @@
 struct Pair {
     #[flux::field(i32[@a])]
     fst: i32,
-    #[flux::field({i32[@b] : p(a, b)})]
+    #[flux::field({i32[@b] | p(a, b)})]
     snd: i32,
 }
 

--- a/flux-tests/tests/pos/enums/invariant00.rs
+++ b/flux-tests/tests/pos/enums/invariant00.rs
@@ -4,13 +4,13 @@
 #[flux::refined_by(n: int)]
 #[flux::invariant(n >= 0)]
 pub enum E {
-    #[flux::variant({{i32[@n] : n > 0}} -> E[n])]
+    #[flux::variant({{i32[@n] | n > 0}} -> E[n])]
     Pos(i32),
     #[flux::variant({i32[0]} -> E[0])]
     Zero(i32),
 }
 
-#[flux::sig(fn(E[@n], i32[n]) -> i32{v : v > 0})]
+#[flux::sig(fn(E[@n], i32[n]) -> i32{v: v > 0})]
 pub fn is_zero(_: E, x: i32) -> i32 {
     x + 1
 }

--- a/flux-tests/tests/pos/enums/invariant01.rs
+++ b/flux-tests/tests/pos/enums/invariant01.rs
@@ -4,13 +4,13 @@
 #[flux::refined_by(n: int)]
 #[flux::invariant(n >= 0)]
 pub enum E {
-    #[flux::variant({{i32[@n] : n > 0}} -> E[n])]
+    #[flux::variant({{i32[@n] | n > 0}} -> E[n])]
     Pos(i32),
     #[flux::variant({i32[0]} -> E[0])]
     Zero(i32),
 }
 
-#[flux::sig(fn(E[@n], i32[n]) -> i32{v : v > 0})]
+#[flux::sig(fn(E[@n], i32[n]) -> i32{v: v > 0})]
 pub fn is_zero(_: E, x: i32) -> i32 {
     x + 1
 }

--- a/flux-tests/tests/pos/enums/list00.rs
+++ b/flux-tests/tests/pos/enums/list00.rs
@@ -1,8 +1,8 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-#[flux::sig(fn(i32{v:false}) -> T)]
-pub fn never<T>(_x: i32) -> T {
+#[flux::sig(fn(i32{v: false}) -> T)]
+pub fn never<T>(_: i32) -> T {
     loop {}
 }
 
@@ -31,7 +31,7 @@ pub fn len(l: &List) -> i32 {
     }
 }
 
-#[flux::sig(fn({&List[@n] : 0 < n}) -> i32)]
+#[flux::sig(fn({&List[@n] | 0 < n}) -> i32)]
 pub fn head(l: &List) -> i32 {
     match l {
         List::Nil => never(0),
@@ -39,7 +39,7 @@ pub fn head(l: &List) -> i32 {
     }
 }
 
-#[flux::sig(fn({&List[@n] : 0 < n}) -> &List)]
+#[flux::sig(fn({&List[@n] | 0 < n}) -> &List)]
 pub fn tail(l: &List) -> &List {
     match l {
         List::Nil => never(0),
@@ -47,7 +47,7 @@ pub fn tail(l: &List) -> &List {
     }
 }
 
-#[flux::sig(fn(i32, n:usize) -> List[n])]
+#[flux::sig(fn(i32, n: usize) -> List[n])]
 pub fn clone(val: i32, n: usize) -> List {
     if n == 0 {
         List::Nil

--- a/flux-tests/tests/pos/structs/fold-on-drop.rs
+++ b/flux-tests/tests/pos/structs/fold-on-drop.rs
@@ -3,7 +3,7 @@
 
 #[flux::refined_by(a: int)]
 pub struct S {
-    #[flux::field({i32[@a] : a >= 0})]
+    #[flux::field({i32[@a] | a >= 0})]
     f1: i32,
     _f2: Vec<i32>,
 }

--- a/flux-tests/tests/pos/structs/invariant00.rs
+++ b/flux-tests/tests/pos/structs/invariant00.rs
@@ -5,8 +5,8 @@
 #[flux::invariant(a > 0)]
 #[flux::invariant(b > 0)]
 pub struct S {
-    #[flux::field({i32[@a] : a > 0})]
+    #[flux::field({i32[@a] | a > 0})]
     fst: i32,
-    #[flux::field({i32[@b] : b >= a})]
+    #[flux::field({i32[@b] | b >= a})]
     snd: i32,
 }

--- a/flux-tests/tests/pos/structs/struct-join.rs
+++ b/flux-tests/tests/pos/structs/struct-join.rs
@@ -3,12 +3,12 @@
 
 #[flux::refined_by(a: int)]
 pub struct S<T> {
-    #[flux::field({i32[@a] : a >= 0})]
+    #[flux::field({i32[@a] | a >= 0})]
     f1: i32,
     f2: T,
 }
 
-#[flux::sig(fn(bool, S<i32>) -> i32{v : v >= 0})]
+#[flux::sig(fn(bool, S<i32>) -> i32{v: v >= 0})]
 pub fn test1(b: bool, mut s: S<i32>) -> i32 {
     if b {
         // we break the invariant
@@ -18,7 +18,7 @@ pub fn test1(b: bool, mut s: S<i32>) -> i32 {
     s.f1 + 1
 }
 
-#[flux::sig(fn(bool, S<i32>) -> i32{v : v > 0})]
+#[flux::sig(fn(bool, S<i32>) -> i32{v: v > 0})]
 pub fn test2(b: bool, s: S<i32>) -> i32 {
     let x = if b {
         drop(s);
@@ -30,7 +30,7 @@ pub fn test2(b: bool, s: S<i32>) -> i32 {
     x + 1
 }
 
-#[flux::sig(fn(bool, S<Vec<i32> >) -> i32{v : v > 0})]
+#[flux::sig(fn(bool, S<Vec<i32> >) -> i32{v: v > 0})]
 pub fn test3(b: bool, s: S<Vec<i32>>) -> i32 {
     let x = if b {
         drop(s.f2);

--- a/flux-tests/tests/pos/surface/const02.rs
+++ b/flux-tests/tests/pos/surface/const02.rs
@@ -8,7 +8,7 @@ pub const FORTY_TWO: usize = 21 + 21;
 
 #[flux::refined_by(a:int)]
 pub struct Silly {
-    #[flux::field({usize[@a] : a < FORTY_TWO})]
+    #[flux::field({usize[@a] | a < FORTY_TWO})]
     fld: usize,
 }
 

--- a/flux-tests/tests/pos/surface/constr00.rs
+++ b/flux-tests/tests/pos/surface/constr00.rs
@@ -4,7 +4,7 @@
 #[flux::sig(fn(bool[true]))]
 fn assert(_b: bool) {}
 
-#[flux::sig(fn(&i32[@a], { &i32[@b] : b <= a } ) -> i32[a-b])]
+#[flux::sig(fn(&i32[@a], { &i32[@b] | b <= a } ) -> i32[a-b])]
 fn sub(x: &i32, y: &i32) -> i32 {
     let res = *x - *y;
     assert(0 <= res);

--- a/flux-tests/tests/pos/surface/constr01.rs
+++ b/flux-tests/tests/pos/surface/constr01.rs
@@ -3,9 +3,9 @@
 
 #[flux::refined_by(a: int, b: int)]
 struct Foo {
-    #[flux::field({i32[@a]: 0 <= a})]
+    #[flux::field({i32[@a] | 0 <= a})]
     x: i32,
-    #[flux::field({i32[@b]: a < b})]
+    #[flux::field({i32[@b] | a < b})]
     y: i32,
 }
 
@@ -14,7 +14,7 @@ fn test1(foo: &Foo) -> bool {
     foo.x < foo.y && 0 < foo.y
 }
 
-#[flux::sig(fn({&Foo[@a, @b] : b == 20}) -> i32[20])]
+#[flux::sig(fn({&Foo[@a, @b] | b == 20}) -> i32[20])]
 fn test2(foo: &Foo) -> i32 {
     foo.y
 }

--- a/flux-tests/tests/pos/surface/constr02.rs
+++ b/flux-tests/tests/pos/surface/constr02.rs
@@ -2,12 +2,12 @@
 #![register_tool(flux)]
 
 // Test for
-// Option<{i32[a] : a > 0}> <: Option<i32{v : v > 0 }>
+// Option<{i32[a] | a > 0}> <: Option<i32{v: v > 0 }>
 
 #[flux::sig(fn(Option<i32{v: 0 < v}>))]
 fn foo(_x: Option<i32>) {}
 
-#[flux::sig(fn(a:i32, Option<{i32[a] : 0 < a}>))]
+#[flux::sig(fn(a:i32, Option<{i32[a] | 0 < a}>))]
 pub fn bar(_a: i32, y: Option<i32>) {
     foo(y)
 }

--- a/flux-tests/tests/pos/surface/constr03.rs
+++ b/flux-tests/tests/pos/surface/constr03.rs
@@ -6,12 +6,12 @@ mod rvec;
 
 use rvec::RVec;
 
-#[flux::sig(fn(&mut {RVec<i32>[@n] : n > 0}))]
+#[flux::sig(fn(&mut {RVec<i32>[@n] | n > 0}))]
 pub fn test1(vec: &mut RVec<i32>) {
     vec[0] = 5;
 }
 
-#[flux::sig(fn({&mut RVec<i32>[@n] : n > 0}))]
+#[flux::sig(fn({&mut RVec<i32>[@n] | n > 0}))]
 pub fn test2(vec: &mut RVec<i32>) {
     vec[0] = 5;
 }

--- a/flux-tests/tests/pos/surface/date.rs
+++ b/flux-tests/tests/pos/surface/date.rs
@@ -16,11 +16,11 @@
 #[allow(dead_code)]
 #[flux::refined_by(d:int, m:int, y:int)]
 pub struct Date {
-    #[flux::field({ usize[@d] : ok_day(d) })]
+    #[flux::field({ usize[@d] | ok_day(d) })]
     day: usize,
-    #[flux::field({ usize[@m] : ok_month(d, m)})]
+    #[flux::field({ usize[@m] | ok_month(d, m)})]
     month: usize,
-    #[flux::field({ usize[@y] : ok_year(d, m, y)})]
+    #[flux::field({ usize[@y] | ok_year(d, m, y)})]
     year: usize,
 }
 

--- a/flux-tests/tests/pos/surface/fft.rs
+++ b/flux-tests/tests/pos/surface/fft.rs
@@ -19,7 +19,7 @@ pub fn fft(px: &mut RVec<f32>, py: &mut RVec<f32>) -> i32 {
     0
 }
 
-#[flux::sig(fn({&mut RVec<f32>[@n] : n > 0}, &mut RVec<f32>[n]) -> i32)]
+#[flux::sig(fn({&mut RVec<f32>[@n] | n > 0}, &mut RVec<f32>[n]) -> i32)]
 fn loop_a(px: &mut RVec<f32>, py: &mut RVec<f32>) -> i32 {
     let n = px.len() - 1;
     let mut n2 = n;
@@ -88,7 +88,7 @@ fn loop_a(px: &mut RVec<f32>, py: &mut RVec<f32>) -> i32 {
     0
 }
 
-#[flux::sig(fn({&mut RVec<f32>[@n] : n > 0}, &mut RVec<f32>[n]) -> i32)]
+#[flux::sig(fn({&mut RVec<f32>[@n] | n > 0}, &mut RVec<f32>[n]) -> i32)]
 fn loop_b(px: &mut RVec<f32>, py: &mut RVec<f32>) -> i32 {
     let n = px.len() - 1;
     let mut is = 1;

--- a/flux-tests/tests/pos/surface/issue-271.rs
+++ b/flux-tests/tests/pos/surface/issue-271.rs
@@ -3,7 +3,7 @@
 
 pub struct S;
 
-#[flux::sig(fn(x:u32) -> Result<{S: x < 100}, bool>)]
+#[flux::sig(fn(x:u32) -> Result<{S | x < 100}, bool>)]
 pub fn test01(x: u32) -> Result<S, bool> {
     if x >= 100 {
         return Err(false);
@@ -11,7 +11,7 @@ pub fn test01(x: u32) -> Result<S, bool> {
     Ok(S)
 }
 
-#[flux::sig(fn(x:u32) -> Option<{S: x < 100}>)]
+#[flux::sig(fn(x:u32) -> Option<{S | x < 100}>)]
 pub fn test02(x: u32) -> Option<S> {
     if x >= 100 {
         return None;

--- a/flux-tests/tests/pos/surface/issue-299.rs
+++ b/flux-tests/tests/pos/surface/issue-299.rs
@@ -17,7 +17,7 @@ struct S2 {
     pub f1: i32,
     #[flux::field(i32[@a])]
     pub f2: i32,
-    #[flux::field({i32[@b] : b > 0})]
+    #[flux::field({i32[@b] | b > 0})]
     pub f3: i32,
     #[flux::field(i32{v: v > 0})]
     pub f4: i32,

--- a/flux-tests/tests/pos/surface/rslice00.rs
+++ b/flux-tests/tests/pos/surface/rslice00.rs
@@ -12,7 +12,7 @@ fn test00<T>(vec: &mut RVec<T>) {
     let s2 = s.subslice(4, 5);
 }
 
-#[flux::sig(fn(&mut {RVec<i32>[@n] : n % 2 == 0 && n > 0}))]
+#[flux::sig(fn(&mut {RVec<i32>[@n] | n % 2 == 0 && n > 0}))]
 fn test01(vec: &mut RVec<i32>) {
     let n = vec.len();
     let mut s = RSlice::from_vec(vec);


### PR DESCRIPTION
This is to make the distinction between an existential type (`i32{v: v > 0}`) and a constraint type (`{i32[n] | n > 0}`) a bit clearer.