### PR TITLE
Check refinement parameters can be fully determined

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -1030,7 +1030,7 @@ impl Binders {
         path: &surface::Path<Res>,
         pos: TypePos,
     ) -> Result<(), ErrorGuaranteed> {
-        let pos = if is_box(early_cx, path.res) { pos } else { TypePos::Other };
+        let pos = if early_cx.is_box(path.res) { pos } else { TypePos::Other };
         path.generics
             .iter()
             .try_for_each_exhaust(|ty| self.gather_params_ty(early_cx, None, ty, pos))
@@ -1092,14 +1092,6 @@ fn infer_mode(implicit: bool, sort: &fhir::Sort) -> fhir::InferMode {
         fhir::InferMode::KVar
     } else {
         fhir::InferMode::EVar
-    }
-}
-
-fn is_box(early_cx: &EarlyCtxt, res: fhir::Res) -> bool {
-    if let Res::Struct(def_id) = res {
-        early_cx.tcx.adt_def(def_id).is_box()
-    } else {
-        false
     }
 }
 

--- a/flux-fhir-analysis/locales/en-US.ftl
+++ b/flux-fhir-analysis/locales/en-US.ftl
@@ -80,6 +80,11 @@ fhir_analysis_expected_numeric =
 fhir_analysis_no_equality =
     values of sort `{$sort}` cannot be compared for equality
 
+fhir_analysis_param_not_determined =
+    parameter `{$sym}` cannot be determined
+    .label = undetermined parameter
+    .help = try indexing a type with `{$sym}` in a position that fully determines its value
+
 # Annot check
 
 fhir_analysis_invalid_refinement =

--- a/flux-fhir-analysis/src/lib.rs
+++ b/flux-fhir-analysis/src/lib.rs
@@ -189,7 +189,7 @@ fn check_wf(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<fhir::WfckResul
     match genv.tcx.def_kind(def_id) {
         DefKind::TyAlias => {
             let alias = genv.map().get_type_alias(def_id);
-            let wfckresults = wf::check_alias(genv.early_cx(), alias)?;
+            let wfckresults = wf::check_ty_alias(genv.early_cx(), alias)?;
             annot_check::check_alias(genv.early_cx(), alias)?;
             Ok(wfckresults)
         }

--- a/flux-fhir-analysis/src/wf/errors.rs
+++ b/flux-fhir-analysis/src/wf/errors.rs
@@ -209,3 +209,19 @@ impl<'a> NoEquality<'a> {
         Self { span, sort }
     }
 }
+
+#[derive(Diagnostic)]
+#[diag(fhir_analysis_param_not_determined, code = "FLUX")]
+#[help]
+pub(super) struct ParamNotDetermined {
+    #[primary_span]
+    #[label]
+    span: Span,
+    sym: Symbol,
+}
+
+impl ParamNotDetermined {
+    pub(super) fn new(ident: fhir::Ident) -> Self {
+        Self { span: ident.span(), sym: ident.sym() }
+    }
+}

--- a/flux-fhir-analysis/src/wf/mod.rs
+++ b/flux-fhir-analysis/src/wf/mod.rs
@@ -26,6 +26,14 @@ struct Wf<'a, 'tcx> {
     xi: XiCtxt,
 }
 
+/// Keeps track of all refinement parameters that were used as an index such that their value is fully
+/// determined. The context is called Xi because in the paper [Focusing on Liquid Refinement Typing], the
+/// well-formedness judgment uses an uppercase Xi (Ξ) for a context that is similar in purpose.
+///
+/// This is basically a set of [`fhir::Name`] implemented with a snapshot map such that elements
+/// can be removed in batch when there's a change in polarity.
+///
+/// [Focusing on Liquid Refinement Typing]: https://arxiv.org/pdf/2209.13000.pdf
 #[derive(Default)]
 struct XiCtxt(SnapshotMap<fhir::Name, ()>);
 

--- a/flux-middle/src/early_ctxt.rs
+++ b/flux-middle/src/early_ctxt.rs
@@ -159,4 +159,12 @@ impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
         let owner = self.hir().ty_param_owner(def_id);
         self.map.get_generics(owner).unwrap().get_param(def_id)
     }
+
+    pub fn is_box(&self, res: fhir::Res) -> bool {
+        if let fhir::Res::Struct(def_id) = res {
+            self.tcx.adt_def(def_id).is_box()
+        } else {
+            false
+        }
+    }
 }

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -579,6 +579,14 @@ impl Sort {
     pub fn is_pred(&self) -> bool {
         matches!(self, Sort::Func(fsort) if fsort.output().is_bool())
     }
+
+    pub fn default_infer_mode(&self) -> InferMode {
+        if self.is_pred() {
+            InferMode::KVar
+        } else {
+            InferMode::EVar
+        }
+    }
 }
 
 impl From<FuncSort> for Sort {
@@ -1066,7 +1074,7 @@ impl fmt::Display for FuncSort {
                 write!(f, "{} -> {}", input, self.output())
             }
             inputs => {
-                write!(f, "{} -> {}", inputs.iter().join(","), self.output())
+                write!(f, "({}) -> {}", inputs.iter().join(", "), self.output())
             }
         }
     }

--- a/flux-tests/tests/neg/error_messages/wf/undetermined_indices.rs
+++ b/flux-tests/tests/neg/error_messages/wf/undetermined_indices.rs
@@ -1,0 +1,18 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+// Unused parameter
+#[flux::refined_by(n: int)] //~ ERROR parameter `n` cannot be determined
+struct S1 {
+    x: Vec<i32>,
+}
+
+// Used but not determined
+#[flux::refined_by(n: int)] //~ ERROR parameter `n` cannot be determined
+struct S2 {
+    #[flux::field(Vec<i32[n]>)]
+    x: Vec<i32>,
+}
+
+#[flux::alias(type A[n: int] = i32{v: v > n})] //~ ERROR parameter `n` cannot be determined
+type A = i32;


### PR DESCRIPTION
Check that every refinement parameter is used in a position that fully determines its value. This is so we can guarantee that parameters can be solved via unification during subtyping. For more details see https://arxiv.org/pdf/2209.13000.pdf


Fixes https://github.com/flux-rs/flux/issues/212