### PR TITLE
Expose the full power of existentials in the surface syntax

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -1008,7 +1008,10 @@ impl Binders {
                 if let Some(bind) = bind {
                     self.insert_binder(early_cx.sess, bind, Binder::Unrefined)?;
                 }
-                self.gather_params_ty(early_cx, None, ty, pos)
+                // Declaring parameters with @ inside and existential has weird behavior if names
+                // are being shadowed. Thus, we don't allow it to keep things simple. We could eventually
+                // allow it if we resolve the weird behavior by detecting shadowing.
+                self.gather_params_ty(early_cx, None, ty, TypePos::Other)
             }
         }
     }

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -423,6 +423,23 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 binders.pop_layer();
                 fhir::TyKind::Exists(bind, sort, Box::new(constr))
             }
+            surface::TyKind::GeneralExists { bind: ex_bind, sort, ty, pred } => {
+                binders.push_layer();
+                let fresh = binders.fresh();
+                let sort = resolve_sort(self.sess(), self.early_cx.map.sort_decls(), sort)?;
+                let binder = Binder::Refined(fresh, sort.clone(), false);
+                binders.insert_binder(self.sess(), *ex_bind, binder)?;
+
+                let mut ty = self.desugar_ty(None, ty, binders)?;
+                if let Some(pred) = pred {
+                    let pred = self.as_expr_ctxt(binders).desugar_expr(pred)?;
+                    let span = ty.span.to(pred.span);
+                    ty = fhir::Ty { kind: fhir::TyKind::Constr(pred, Box::new(ty)), span };
+                }
+                binders.pop_layer();
+
+                fhir::TyKind::Exists(fhir::Ident::new(fresh, *ex_bind), sort, Box::new(ty))
+            }
             surface::TyKind::Constr(pred, ty) => {
                 let pred = self.as_expr_ctxt(binders).desugar_expr(pred)?;
                 let ty = self.desugar_ty(None, ty, binders)?;
@@ -986,6 +1003,12 @@ impl Binders {
                     self.insert_binder(early_cx.sess, bind, Binder::Unrefined)?;
                 }
                 self.gather_params_bty(early_cx, bty, pos)
+            }
+            surface::TyKind::GeneralExists { ty, .. } => {
+                if let Some(bind) = bind {
+                    self.insert_binder(early_cx.sess, bind, Binder::Unrefined)?;
+                }
+                self.gather_params_ty(early_cx, None, ty, pos)
             }
         }
     }

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -181,6 +181,10 @@ impl<'sess> Resolver<'sess> {
                 let bty = self.resolve_bty(bty)?;
                 surface::TyKind::Exists { bind, bty, pred }
             }
+            surface::TyKind::GeneralExists { bind, sort, ty, pred } => {
+                let ty = self.resolve_ty(*ty)?;
+                surface::TyKind::GeneralExists { bind, sort, ty: Box::new(ty), pred }
+            }
             surface::TyKind::Ref(rk, ty) => {
                 let ty = self.resolve_ty(*ty)?;
                 surface::TyKind::Ref(rk, Box::new(ty))

--- a/flux-syntax/src/grammar.lalrpop
+++ b/flux-syntax/src/grammar.lalrpop
@@ -163,7 +163,9 @@ TyKind: surface::TyKind = {
     <bty:BaseTy> "[" <indices:Indices> "]"            => surface::TyKind::Indexed { <> },
     <bty:BaseTy> "{" <bind:Ident> ":" <pred:Expr> "}" => surface::TyKind::Exists { <> },
     "{" <ty:Ty> "|" <pred:Expr> "}"                   => surface::TyKind::Constr(pred, Box::new(ty)),
-
+    "{" <bind:Ident> ":" <sort:Sort> "." <ty:Ty> <pred:("|" <Expr>)?> "}" => {
+        surface::TyKind::GeneralExists { bind, sort, ty: Box::new(ty), pred }
+    },
     "(" <tys:Comma<Ty>> ")"         => surface::TyKind::Tuple(tys),
 
     "&" <ty:Ty>                     => surface::TyKind::Ref(surface::RefKind::Shr, Box::new(ty)),

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -175,16 +175,22 @@ pub struct Ty<R = ()> {
 pub enum TyKind<R = ()> {
     /// ty
     Base(BaseTy<R>),
-    /// `t[e]`
+    /// `B[r]`
     Indexed {
         bty: BaseTy<R>,
         indices: Indices,
     },
-    /// ty{b:e}
+    /// B{v: r}
     Exists {
         bind: Ident,
         bty: BaseTy<R>,
         pred: Expr,
+    },
+    GeneralExists {
+        bind: Ident,
+        sort: Sort,
+        ty: Box<Ty<R>>,
+        pred: Option<Expr>,
     },
     /// Mutable or shared reference
     Ref(RefKind, Box<Ty<R>>),

--- a/flux-tests/tests/neg/error_messages/wf/undetermined_indices.rs
+++ b/flux-tests/tests/neg/error_messages/wf/undetermined_indices.rs
@@ -16,3 +16,7 @@ struct S2 {
 
 #[flux::alias(type A[n: int] = i32{v: v > n})] //~ ERROR parameter `n` cannot be determined
 type A = i32;
+
+// Undetermined parameter in general existential
+#[flux::sig(fn({a:int. {i32 | a > 0}}))] //~ ERROR parameter `a` cannot be determined
+fn test(x: i32) {}

--- a/flux-tests/tests/neg/surface/general_exists00.rs
+++ b/flux-tests/tests/neg/surface/general_exists00.rs
@@ -1,0 +1,48 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+// Existential without a constraint
+fn test00() {
+    #[flux::sig(fn({a:int. i32[a]}))]
+    fn f(x: i32) {}
+
+    f(0);
+}
+
+// Existential nested with a constraint tpye
+fn test01() {
+    #[flux::sig(fn({a:int. {i32[a] | a > 0}}) -> i32{v: v >= 10})]
+    fn f(x: i32) -> i32 {
+        x //~ ERROR postcondition
+    }
+
+    f(0); //~ ERROR precondition
+}
+
+// Existential with constraint
+fn test02() {
+    #[flux::sig(fn({a:int. i32[a] | a > 0}) -> i32{v: v >= 10})]
+    fn f(x: i32) -> i32 {
+        x //~ ERROR postcondition
+    }
+    f(0); //~ ERROR precondition
+}
+
+// Nested existentials
+fn test03() {
+    #[flux::sig(fn({a:int. {b:int. (i32[a], i32[b]) | b > a } }) -> i32{v: v > 10})]
+    fn f(x: (i32, i32)) -> i32 {
+        x.1 - x.0 //~ ERROR postcondition
+    }
+    f((0, 0)); //~ ERROR precondition
+}
+
+// general existential nested with "limited" existential
+fn test04() {
+    #[flux::sig(fn({a:int. (i32[a], i32{b: b > a})}) -> i32{v: v > 10})]
+    fn f(x: (i32, i32)) -> i32 {
+        x.1 - x.0 //~ ERROR postcondition
+    }
+
+    f((0, 0)); //~ ERROR precondition
+}

--- a/flux-tests/tests/pos/surface/general_exists00.rs
+++ b/flux-tests/tests/pos/surface/general_exists00.rs
@@ -1,0 +1,48 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+// Existential without a constraint
+fn test00() {
+    #[flux::sig(fn({a:int. i32[a]}))]
+    fn f(x: i32) {}
+
+    f(0);
+}
+
+// Existential nested with a constraint tpye
+fn test01() {
+    #[flux::sig(fn({a:int. {i32[a] | a > 0}}) -> i32{v: v >= 0})]
+    fn f(x: i32) -> i32 {
+        x
+    }
+
+    f(1);
+}
+
+// Existential with constraint
+fn test02() {
+    #[flux::sig(fn({a:int. i32[a] | a > 0}) -> i32{v: v >= 0})]
+    fn f(x: i32) -> i32 {
+        x
+    }
+    f(1);
+}
+
+// Nested existentials
+fn test03() {
+    #[flux::sig(fn({a:int. {b:int. (i32[a], i32[b]) | b > a } }) -> i32{v: v > 0})]
+    fn f(x: (i32, i32)) -> i32 {
+        x.1 - x.0
+    }
+    f((0, 1));
+}
+
+// general existential nested with "limited" existential
+fn test04() {
+    #[flux::sig(fn({a:int. (i32[a], i32{b: b > a})}) -> i32{v: v > 0})]
+    fn f(x: (i32, i32)) -> i32 {
+        x.1 - x.0
+    }
+
+    f((0, 1));
+}


### PR DESCRIPTION
For a long time now we've supported a *generalized existential type* internally that's not exposed in the surface syntax.  I've been pretty printing it as `∃v:σ. T`, where `T` can be an arbitrary type (with some restrictions on how `v` can be used inside `T` #417).

We take advantage of them by desugaring types in the surface syntax as generalized existential
* The syntax `B{v: p}`, desugars to a constraint type nested in an existential `∃v:σ. {B[v] | p}`, e.g., `i32{v: v > 0}` desugars to `∃v:int. {i32[v] | v > 0}`. 
* A Rust base type `B` without any refinements is desugared into `∃v:σ. B[v]`, e.g., `i32` desugars to `∃v:int. i32[v]`.
* Given the type alias `type Range[n: int, m: int] = {(i32[a], i32[b] | b > a}`, when writing `Range` (omiting the indices) we expand it to `∃a:int,b:int. {(i32[a], i32[b]) | b > a}`.

This PR exposes the full power of existential on the surface using the syntax `{v:sort. T}`. Thus, we can write the types above directly on the surface:
* `{a:int. i32[a]}`
* `{a:int. {i32[a] | a > 0}}`
* `{a:int. {b:int. (i32[a], i32[b]) | b > a } }`

The pr also implements the syntax `{v: sort. T | p}` which is equivalent to a constraint type nested with an existential `{v:sort. {T | p}}`.

Generalized existential may be useful in some advanced use cases, but I don't think they will be too common as type aliases unlock most of their power. However, generalized existential had become an important part of Flux and I find it hard to explain some aspects of the system without exposing them. I believe that choosing a surface syntax for generalized existentials will help explain some aspects of flux.

(I would like to call them just existentials, but then we need a different name for the syntax `i32{v: v > 0}`)