### PR TITLE
Implement syntax for existentials with multiple parameters

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -421,7 +421,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 let constr =
                     fhir::Ty { kind: fhir::TyKind::Constr(pred, Box::new(indexed)), span: ty_span };
                 binders.pop_layer();
-                fhir::TyKind::Exists(bind, sort, Box::new(constr))
+                fhir::TyKind::Exists(vec![(bind, sort)], Box::new(constr))
             }
             surface::TyKind::GeneralExists { bind: ex_bind, sort, ty, pred } => {
                 binders.push_layer();
@@ -438,7 +438,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 }
                 binders.pop_layer();
 
-                fhir::TyKind::Exists(fhir::Ident::new(fresh, *ex_bind), sort, Box::new(ty))
+                fhir::TyKind::Exists(vec![(fhir::Ident::new(fresh, *ex_bind), sort)], Box::new(ty))
             }
             surface::TyKind::Constr(pred, ty) => {
                 let pred = self.as_expr_ctxt(binders).desugar_expr(pred)?;

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -181,9 +181,9 @@ impl<'sess> Resolver<'sess> {
                 let bty = self.resolve_bty(bty)?;
                 surface::TyKind::Exists { bind, bty, pred }
             }
-            surface::TyKind::GeneralExists { bind, sort, ty, pred } => {
+            surface::TyKind::GeneralExists { params, ty, pred } => {
                 let ty = self.resolve_ty(*ty)?;
-                surface::TyKind::GeneralExists { bind, sort, ty: Box::new(ty), pred }
+                surface::TyKind::GeneralExists { params, ty: Box::new(ty), pred }
             }
             surface::TyKind::Ref(rk, ty) => {
                 let ty = self.resolve_ty(*ty)?;

--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -344,9 +344,13 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                 let idxs = rty::Index::from(self.conv_refine_arg(idx));
                 self.conv_base_ty(bty, idxs)
             }
-            fhir::TyKind::Exists(bind, sort, ty) => {
-                self.env
-                    .push_layer(Layer::single(self.early_cx(), *bind, sort.clone()));
+            fhir::TyKind::Exists(params, ty) => {
+                let layer = if let [(ident, sort)] = &params[..] {
+                    Layer::single(self.early_cx(), *ident, sort.clone())
+                } else {
+                    Layer::from_params(self.early_cx(), params)
+                };
+                self.env.push_layer(layer);
                 let ty = self.conv_ty(ty)?;
                 let sort = self.env.pop_layer().into_sort();
                 if sort.is_unit() {

--- a/flux-fhir-analysis/src/wf/sortck.rs
+++ b/flux-fhir-analysis/src/wf/sortck.rs
@@ -56,9 +56,10 @@ impl<'a, 'tcx> SortChecker<'a, 'tcx> {
                             params.len(),
                         ));
                     }
-                    let params = iter::zip(params, fsort.inputs())
-                        .map(|((name, _), sort)| (&name.name, sort));
-                    env.push_layer(params);
+                    env.push_layer(
+                        iter::zip(params, fsort.inputs())
+                            .map(|((name, _), sort)| (*name, sort.clone())),
+                    );
                     self.check_expr(env, body, fsort.output())
                 } else {
                     self.emit_err(errors::UnexpectedFun::new(*span, expected))
@@ -312,12 +313,12 @@ impl<'a, 'tcx> SortChecker<'a, 'tcx> {
 
 impl Env {
     /// Push a layer of binders. We assume all names are fresh so we don't care about shadowing
-    pub(super) fn push_layer<'a>(
+    pub(super) fn push_layer(
         &mut self,
-        binders: impl IntoIterator<Item = (&'a fhir::Name, &'a fhir::Sort)>,
+        binders: impl IntoIterator<Item = (fhir::Ident, fhir::Sort)>,
     ) {
-        for (binder, sort) in binders {
-            self.sorts.insert(*binder, sort.clone());
+        for (ident, sort) in binders {
+            self.sorts.insert(ident.name, sort);
         }
     }
 }

--- a/flux-syntax/src/grammar.lalrpop
+++ b/flux-syntax/src/grammar.lalrpop
@@ -163,8 +163,8 @@ TyKind: surface::TyKind = {
     <bty:BaseTy> "[" <indices:Indices> "]"            => surface::TyKind::Indexed { <> },
     <bty:BaseTy> "{" <bind:Ident> ":" <pred:Expr> "}" => surface::TyKind::Exists { <> },
     "{" <ty:Ty> "|" <pred:Expr> "}"                   => surface::TyKind::Constr(pred, Box::new(ty)),
-    "{" <bind:Ident> ":" <sort:Sort> "." <ty:Ty> <pred:("|" <Expr>)?> "}" => {
-        surface::TyKind::GeneralExists { bind, sort, ty: Box::new(ty), pred }
+    "{" <params:Comma1<RefineParam>> "." <ty:Ty> <pred:("|" <Expr>)?> "}" => {
+        surface::TyKind::GeneralExists { params, ty: Box::new(ty), pred }
     },
     "(" <tys:Comma<Ty>> ")"         => surface::TyKind::Tuple(tys),
 
@@ -404,6 +404,7 @@ Sep1<S, T>: Vec<T> = {
 }
 
 Comma<T> = Sep<",", T>;
+Comma1<T> = Sep1<",", T>;
 
 Binding<A, B>: (A, B) = <A> ":" <B>;
 

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -187,8 +187,7 @@ pub enum TyKind<R = ()> {
         pred: Expr,
     },
     GeneralExists {
-        bind: Ident,
-        sort: Sort,
+        params: Vec<RefineParam>,
         ty: Box<Ty<R>>,
         pred: Option<Expr>,
     },

--- a/flux-tests/tests/neg/error_messages/wf/undetermined_indices.rs
+++ b/flux-tests/tests/neg/error_messages/wf/undetermined_indices.rs
@@ -19,4 +19,8 @@ type A = i32;
 
 // Undetermined parameter in general existential
 #[flux::sig(fn({a:int. {i32 | a > 0}}))] //~ ERROR parameter `a` cannot be determined
-fn test(x: i32) {}
+fn test01(x: i32) {}
+
+// Undetermined parameter in multi param existential
+#[flux::sig(fn({a:int,b:int. i32[a]}))] //~ ERROR parameter `b` cannot be determined
+fn test02(x: i32) {}

--- a/flux-tests/tests/neg/surface/general_exists00.rs
+++ b/flux-tests/tests/neg/surface/general_exists00.rs
@@ -46,3 +46,12 @@ fn test04() {
 
     f((0, 0)); //~ ERROR precondition
 }
+
+// Multi param existential
+fn test05() {
+    #[flux::sig(fn({ a:int,b:int. (i32[a], i32[b]) | b > a }) -> i32{v: v > 10})]
+    fn f(x: (i32, i32)) -> i32 {
+        x.1 - x.0 //~ ERROR postcondition
+    }
+    f((0, 0)); //~ ERROR precondition
+}

--- a/flux-tests/tests/pos/surface/general_exists00.rs
+++ b/flux-tests/tests/pos/surface/general_exists00.rs
@@ -46,3 +46,12 @@ fn test04() {
 
     f((0, 1));
 }
+
+// Multi param existential
+fn test05() {
+    #[flux::sig(fn({ a:int,b:int. (i32[a], i32[b]) | b > a }) -> i32{v: v > 0})]
+    fn f(x: (i32, i32)) -> i32 {
+        x.1 - x.0
+    }
+    f((0, 1));
+}


### PR DESCRIPTION
E.g. `{a:int,b:int. (i32[a], i32[b]) | b > a}`