### PR TITLE
Parse and resolve num consts

### DIFF
--- a/flux-syntax/src/grammar.lalrpop
+++ b/flux-syntax/src/grammar.lalrpop
@@ -221,20 +221,6 @@ Path: surface::Path = {
     }
 }
 
-Refinement: surface::Expr = {
-    <lo:@L> <lit:Lit> <hi:@R> => {
-        surface::Expr {
-            kind: surface::ExprKind::Literal(lit),
-            span: mk_span(lo, hi),
-        }
-    },
-    <lo:@L> <var:Ident> <hi:@R> => surface::Expr {
-        kind: surface::ExprKind::Var(var),
-        span: mk_span(lo, hi),
-    },
-    "{" <Expr> "}" => <>
-};
-
 Indices: surface::Indices = {
     <lo:@L> <indices:Comma<RefineArg>> <hi:@R> => surface::Indices { indices, span: mk_span(lo, hi) }
 };
@@ -280,10 +266,9 @@ Level10: surface::Expr = {
             span: mk_span(lo, hi),
         }
     },
-    <lo:@L> <var:Ident> "." <fld:Ident> <hi:@R> => {
-        let expr = surface::Expr { kind: surface::ExprKind::Var(var), span: var.span};
+    <lo:@L> <qpath:QPathExpr> "." <fld:Ident> <hi:@R> => {
         surface::Expr {
-            kind: surface::ExprKind::Dot(var, fld),
+            kind: surface::ExprKind::Dot(qpath, fld),
             span: mk_span(lo, hi),
         }
     },
@@ -293,12 +278,13 @@ Level10: surface::Expr = {
             span: mk_span(lo, hi),
         }
     },
-    <lo:@L> <var:Ident> <hi:@R> => surface::Expr {
-        kind: surface::ExprKind::Var(var),
+    <lo:@L> <qpath:QPathExpr> <hi:@R> => surface::Expr {
+        kind: surface::ExprKind::QPath(qpath),
         span: mk_span(lo, hi),
     },
     "(" <Level1> ")"
 }
+
 ElseIf: surface::Expr = {
     "else" <lo:@L> "if" <p:Level1> "{" <e1:Level1> "}" <e2:ElseIf> <hi:@R> => {
         surface::Expr {
@@ -309,6 +295,12 @@ ElseIf: surface::Expr = {
     "else" "{" <Level1> "}"
 }
 
+QPathExpr: surface::QPathExpr = {
+    <lo:@L> <segments:Sep1<"::", Ident>> <hi:@R> => surface::QPathExpr {
+        segments,
+        span: mk_span(lo, hi),
+    }
+}
 
 NonAssoc<Op, NextLevel>: surface::Expr = {
     <lo:@L> <e1:NextLevel> <op:Op> <e2:NextLevel> <hi:@R> => surface::Expr {

--- a/flux-syntax/src/lib.rs
+++ b/flux-syntax/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(rustc_private, box_patterns, let_chains, type_alias_impl_trait)]
 
 extern crate rustc_ast;
+extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -258,13 +258,19 @@ pub struct Expr {
 
 #[derive(Debug, Clone)]
 pub enum ExprKind {
-    Var(Ident),
-    Dot(Ident, Ident),
+    QPath(QPathExpr),
+    Dot(QPathExpr, Ident),
     Literal(Lit),
     BinaryOp(BinOp, Box<[Expr; 2]>),
     UnaryOp(UnOp, Box<Expr>),
     App(Ident, Vec<Expr>),
     IfThenElse(Box<[Expr; 3]>),
+}
+
+#[derive(Debug, Clone)]
+pub struct QPathExpr {
+    pub segments: Vec<Ident>,
+    pub span: Span,
 }
 
 #[derive(Copy, Clone)]

--- a/flux-tests/tests/neg/surface/num_consts.rs
+++ b/flux-tests/tests/neg/surface/num_consts.rs
@@ -1,0 +1,52 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn() -> (i8[i8::MAX], i8[i8::MIN]))]
+fn test_i8() -> (i8, i8) {
+    (i8::MIN, i8::MAX) //~ ERROR postcondition might not hold
+}
+
+#[flux::sig(fn() -> (i16[i16::MAX], i16[i16::MIN]))]
+fn test_i16() -> (i16, i16) {
+    (i16::MIN, i16::MAX) //~ ERROR postcondition might not hold
+}
+
+#[flux::sig(fn() -> (i32[i32::MAX], i32[i32::MIN]))]
+fn test_i32() -> (i32, i32) {
+    (i32::MIN, i32::MAX) //~ ERROR postcondition might not hold
+}
+
+#[flux::sig(fn() -> (i64[i64::MAX], i64[i64::MIN]))]
+fn test_i64() -> (i64, i64) {
+    (i64::MIN, i64::MAX) //~ ERROR postcondition might not hold
+}
+
+#[flux::sig(fn() -> (isize[isize::MAX], isize[isize::MIN]))]
+fn test_isize() -> (isize, isize) {
+    (isize::MIN, isize::MAX) //~ ERROR postcondition might not hold
+}
+
+#[flux::sig(fn() -> (u8[u8::MAX], u8[u8::MIN]))]
+fn test_u8() -> (u8, u8) {
+    (u8::MIN, u8::MAX) //~ ERROR postcondition might not hold
+}
+
+#[flux::sig(fn() -> (u16[u16::MAX], u16[u16::MIN]))]
+fn test_u16() -> (u16, u16) {
+    (u16::MIN, u16::MAX) //~ ERROR postcondition might not hold
+}
+
+#[flux::sig(fn() -> (u32[u32::MAX], u32[u32::MIN]))]
+fn test_u32() -> (u32, u32) {
+    (u32::MIN, u32::MAX) //~ ERROR postcondition might not hold
+}
+
+#[flux::sig(fn() -> (u64[u64::MAX], u64[u64::MIN]))]
+fn test_u64() -> (u64, u64) {
+    (u64::MIN, u64::MAX) //~ ERROR postcondition might not hold
+}
+
+#[flux::sig(fn() -> (usize[usize::MAX], usize[usize::MIN]))]
+fn test_usize() -> (usize, usize) {
+    (usize::MIN, usize::MAX) //~ ERROR postcondition might not hold
+}

--- a/flux-tests/tests/pos/surface/num_consts.rs
+++ b/flux-tests/tests/pos/surface/num_consts.rs
@@ -1,0 +1,52 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn() -> (i8[i8::MIN], i8[i8::MAX]))]
+fn test_i8() -> (i8, i8) {
+    (i8::MIN, i8::MAX)
+}
+
+#[flux::sig(fn() -> (i16[i16::MIN], i16[i16::MAX]))]
+fn test_i16() -> (i16, i16) {
+    (i16::MIN, i16::MAX)
+}
+
+#[flux::sig(fn() -> (i32[i32::MIN], i32[i32::MAX]))]
+fn test_i32() -> (i32, i32) {
+    (i32::MIN, i32::MAX)
+}
+
+#[flux::sig(fn() -> (i64[i64::MIN], i64[i64::MAX]))]
+fn test_i64() -> (i64, i64) {
+    (i64::MIN, i64::MAX)
+}
+
+#[flux::sig(fn() -> (isize[isize::MIN], isize[isize::MAX]))]
+fn test_isize() -> (isize, isize) {
+    (isize::MIN, isize::MAX)
+}
+
+#[flux::sig(fn() -> (u8[u8::MIN], u8[u8::MAX]))]
+fn test_u8() -> (u8, u8) {
+    (u8::MIN, u8::MAX)
+}
+
+#[flux::sig(fn() -> (u16[u16::MIN], u16[u16::MAX]))]
+fn test_u16() -> (u16, u16) {
+    (u16::MIN, u16::MAX)
+}
+
+#[flux::sig(fn() -> (u32[u32::MIN], u32[u32::MAX]))]
+fn test_u32() -> (u32, u32) {
+    (u32::MIN, u32::MAX)
+}
+
+#[flux::sig(fn() -> (u64[u64::MIN], u64[u64::MAX]))]
+fn test_u64() -> (u64, u64) {
+    (u64::MIN, u64::MAX)
+}
+
+#[flux::sig(fn() -> (usize[usize::MIN], usize[usize::MAX]))]
+fn test_usize() -> (usize, usize) {
+    (usize::MIN, usize::MAX)
+}


### PR DESCRIPTION
Parse qualified paths (separated by `::`) in refinement expressions and resolve numeric constants `*::MAX` and `*::MIN`. This is to make it easier to demo overflow checking.