### PR TITLE
Implement type holes

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -499,6 +499,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 let ty = self.desugar_ty(None, ty, binders)?;
                 fhir::TyKind::Array(Box::new(ty), fhir::ArrayLen { val: len.val, span: len.span })
             }
+            surface::TyKind::Hole => fhir::TyKind::Hole,
         };
         Ok(fhir::Ty { kind, fhir_id: self.next_fhir_id(), span })
     }
@@ -1084,6 +1085,7 @@ impl Binders {
                 // allow it if we resolve the weird behavior by detecting shadowing.
                 self.gather_params_ty(early_cx, None, ty, TypePos::Other)
             }
+            surface::TyKind::Hole => Ok(()),
         }
     }
 

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -229,7 +229,7 @@ pub fn desugar_fn_sig(
         None => {
             let kind = fhir::TyKind::Tuple(vec![]);
             let span = fn_sig.span.with_lo(fn_sig.span.hi());
-            Ok(fhir::Ty { kind, span })
+            Ok(fhir::Ty { kind, fhir_id: cx.next_fhir_id(), span })
         }
     };
     let ensures = fn_sig
@@ -376,14 +376,22 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 let pred = self.as_expr_ctxt().desugar_expr(binders, pred)?;
 
                 let ty = if let Some(idx) = self.ident_into_refine_arg(*bind, binders)? {
-                    fhir::Ty { kind: fhir::TyKind::Indexed(bty, idx), span: path.span }
+                    fhir::Ty {
+                        kind: fhir::TyKind::Indexed(bty, idx),
+                        fhir_id: self.next_fhir_id(),
+                        span: path.span,
+                    }
                 } else {
-                    fhir::Ty { kind: fhir::TyKind::BaseTy(bty), span: path.span }
+                    fhir::Ty {
+                        kind: fhir::TyKind::BaseTy(bty),
+                        fhir_id: self.next_fhir_id(),
+                        span: path.span,
+                    }
                 };
 
                 let span = path.span.to(pred.span);
                 let kind = fhir::TyKind::Constr(pred, Box::new(ty));
-                Ok(fhir::Ty { kind, span })
+                Ok(fhir::Ty { kind, fhir_id: self.next_fhir_id(), span })
             }
             surface::Arg::StrgRef(loc, ty) => {
                 let span = loc.span;
@@ -391,7 +399,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 let ty = self.desugar_ty(None, ty, binders)?;
                 self.requires.push(fhir::Constraint::Type(loc, ty));
                 let kind = fhir::TyKind::Ptr(loc);
-                Ok(fhir::Ty { kind, span })
+                Ok(fhir::Ty { kind, fhir_id: self.next_fhir_id(), span })
             }
             surface::Arg::Ty(bind, ty) => self.desugar_ty(*bind, ty, binders),
         }
@@ -436,9 +444,16 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                     },
                     is_binder: false,
                 };
-                let indexed = fhir::Ty { kind: fhir::TyKind::Indexed(bty, idx), span: bty_span };
-                let constr =
-                    fhir::Ty { kind: fhir::TyKind::Constr(pred, Box::new(indexed)), span: ty_span };
+                let indexed = fhir::Ty {
+                    kind: fhir::TyKind::Indexed(bty, idx),
+                    fhir_id: self.next_fhir_id(),
+                    span: bty_span,
+                };
+                let constr = fhir::Ty {
+                    kind: fhir::TyKind::Constr(pred, Box::new(indexed)),
+                    fhir_id: self.next_fhir_id(),
+                    span: ty_span,
+                };
                 fhir::TyKind::Exists(params, Box::new(constr))
             }
             surface::TyKind::GeneralExists { params, ty, pred } => {
@@ -455,7 +470,11 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 if let Some(pred) = pred {
                     let pred = self.as_expr_ctxt().desugar_expr(binders, pred)?;
                     let span = ty.span.to(pred.span);
-                    ty = fhir::Ty { kind: fhir::TyKind::Constr(pred, Box::new(ty)), span };
+                    ty = fhir::Ty {
+                        kind: fhir::TyKind::Constr(pred, Box::new(ty)),
+                        fhir_id: self.next_fhir_id(),
+                        span,
+                    };
                 }
                 let params = binders.pop_layer().into_params(self);
 
@@ -481,7 +500,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 fhir::TyKind::Array(Box::new(ty), fhir::ArrayLen { val: len.val, span: len.span })
             }
         };
-        Ok(fhir::Ty { kind, span })
+        Ok(fhir::Ty { kind, fhir_id: self.next_fhir_id(), span })
     }
 
     fn desugar_indices(
@@ -604,7 +623,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
         } else {
             fhir::TyKind::BaseTy(bty)
         };
-        Ok(fhir::Ty { kind, span })
+        Ok(fhir::Ty { kind, fhir_id: self.next_fhir_id(), span })
     }
 
     fn desugar_variant_ret(

--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -399,7 +399,15 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                     rty::Expr::unit(),
                 ))
             }
-            fhir::TyKind::Hole => span_bug!(ty.span, "unfilled hole"),
+            fhir::TyKind::Hole => {
+                self.conv_ty(
+                    env,
+                    self.wfckresults
+                        .holes()
+                        .get(ty.fhir_id)
+                        .unwrap_or_else(|| span_bug!(ty.span, "unfilled hole")),
+                )
+            }
         }
     }
 

--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -399,6 +399,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                     rty::Expr::unit(),
                 ))
             }
+            fhir::TyKind::Hole => span_bug!(ty.span, "unfilled hole"),
         }
     }
 

--- a/flux-fhir-analysis/src/lib.rs
+++ b/flux-fhir-analysis/src/lib.rs
@@ -210,20 +210,20 @@ fn check_wf_rust_item(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<fhir:
     match genv.tcx.def_kind(def_id) {
         DefKind::TyAlias => {
             let alias = genv.map().get_type_alias(def_id);
-            let wfckresults = wf::check_ty_alias(genv.early_cx(), alias)?;
-            annot_check::check_alias(genv.early_cx(), alias)?;
+            let mut wfckresults = wf::check_ty_alias(genv.early_cx(), alias)?;
+            annot_check::check_alias(genv.early_cx(), &mut wfckresults, alias)?;
             Ok(wfckresults)
         }
         DefKind::Struct => {
             let struct_def = genv.map().get_struct(def_id);
-            let wfckresults = wf::check_struct_def(genv.early_cx(), struct_def)?;
-            annot_check::check_struct_def(genv.early_cx(), struct_def)?;
+            let mut wfckresults = wf::check_struct_def(genv.early_cx(), struct_def)?;
+            annot_check::check_struct_def(genv.early_cx(), &mut wfckresults, struct_def)?;
             Ok(wfckresults)
         }
         DefKind::Enum => {
             let enum_def = genv.map().get_enum(def_id);
-            let wfckresults = wf::check_enum_def(genv.early_cx(), enum_def)?;
-            annot_check::check_enum_def(genv.early_cx(), enum_def)?;
+            let mut wfckresults = wf::check_enum_def(genv.early_cx(), enum_def)?;
+            annot_check::check_enum_def(genv.early_cx(), &mut wfckresults, enum_def)?;
             Ok(wfckresults)
         }
         DefKind::TyParam => {
@@ -243,9 +243,9 @@ fn check_wf_rust_item(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<fhir:
         DefKind::Fn | DefKind::AssocFn => {
             let fn_sig = genv.map().get_fn_sig(def_id);
             let owner_id = OwnerId { def_id };
-            let wf = wf::check_fn_sig(genv.early_cx(), fn_sig, owner_id)?;
-            annot_check::check_fn_sig(genv.early_cx(), owner_id, fn_sig)?;
-            Ok(wf)
+            let mut wfckresults = wf::check_fn_sig(genv.early_cx(), fn_sig, owner_id)?;
+            annot_check::check_fn_sig(genv.early_cx(), &mut wfckresults, owner_id, fn_sig)?;
+            Ok(wfckresults)
         }
         kind => bug!("unexpected def kind `{kind:?}`"),
     }

--- a/flux-fhir-analysis/src/wf/mod.rs
+++ b/flux-fhir-analysis/src/wf/mod.rs
@@ -305,7 +305,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                 self.check_pred(infcx, pred)
             }
             fhir::TyKind::RawPtr(ty, _) => self.check_type(infcx, ty),
-            fhir::TyKind::Never => Ok(()),
+            fhir::TyKind::Hole | fhir::TyKind::Never => Ok(()),
         }
     }
 

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -205,6 +205,7 @@ pub enum Constraint {
 
 pub struct Ty {
     pub kind: TyKind,
+    pub fhir_id: FhirId,
     pub span: Span,
 }
 
@@ -223,6 +224,7 @@ pub enum TyKind {
     Array(Box<Ty>, ArrayLen),
     RawPtr(Box<Ty>, Mutability),
     Never,
+    Hole,
 }
 
 pub struct ArrayLen {
@@ -260,13 +262,6 @@ pub struct LocalTableInContext<'a, T> {
 pub struct LocalTableInContextMut<'a, T> {
     owner: FluxOwnerId,
     data: &'a mut ItemLocalMap<T>,
-}
-
-impl From<BaseTy> for Ty {
-    fn from(bty: BaseTy) -> Ty {
-        let span = bty.span;
-        Ty { kind: TyKind::BaseTy(bty), span }
-    }
 }
 
 impl From<Mutability> for WeakKind {
@@ -1065,6 +1060,7 @@ impl fmt::Debug for Ty {
             TyKind::Constr(pred, ty) => write!(f, "{{{ty:?} | {pred:?}}}"),
             TyKind::RawPtr(ty, Mutability::Not) => write!(f, "*const {ty:?}"),
             TyKind::RawPtr(ty, Mutability::Mut) => write!(f, "*mut {ty:?}"),
+            TyKind::Hole => write!(f, "_"),
         }
     }
 }

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -8,7 +8,7 @@ pub use rustc_hir::PrimTy;
 use rustc_hir::{def_id::LocalDefId, OwnerId};
 pub use rustc_middle::ty::{FloatTy, IntTy, ParamTy, TyCtxt, UintTy};
 pub use rustc_span::symbol::Ident;
-use rustc_span::Span;
+use rustc_span::{symbol::kw, Span};
 
 #[derive(Debug)]
 pub struct SortDecl {
@@ -192,6 +192,7 @@ pub enum TyKind<R = ()> {
     Constr(Expr, Box<Ty<R>>),
     Tuple(Vec<Ty<R>>),
     Array(Box<Ty<R>>, ArrayLen),
+    Hole,
 }
 
 #[derive(Debug)]
@@ -287,6 +288,16 @@ pub enum BinOp {
 pub enum UnOp {
     Not,
     Neg,
+}
+
+impl Path {
+    pub fn is_hole(&self) -> bool {
+        if let [segment] = &self.segments[..] && segment.name == kw::Underscore {
+            self.refine.is_empty() && self.generics.is_empty()
+        } else {
+            false
+        }
+    }
 }
 
 impl BindKind {

--- a/flux-tests/tests/pos/surface/trait00.rs
+++ b/flux-tests/tests/pos/surface/trait00.rs
@@ -1,4 +1,4 @@
-// ignore-test disabled until we implement type holes
+// ignore-test disabled until we implement type projections
 
 #![feature(register_tool)]
 #![register_tool(flux)]

--- a/flux-tests/tests/pos/surface/type_holes00.rs
+++ b/flux-tests/tests/pos/surface/type_holes00.rs
@@ -1,0 +1,17 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(_) -> Option<_>)]
+fn test00(x: i32) -> Option<i32> {
+    Some(x)
+}
+
+#[flux::sig(fn(x: &strg _) ensures x: i32[0])]
+fn test01(x: &mut i32) {
+    *x = 0;
+}
+
+#[flux::sig(fn(x: &strg i32) ensures x: _)]
+fn test02(x: &mut i32) {
+    *x = 0;
+}


### PR DESCRIPTION
Support for writing `_` in a signature signifying a hole. The hole is filled during `annot_check` when zipping against the default lifted `fhir`.