### PR TITLE
Unify user opaque sorts and sort constructors

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -925,7 +925,8 @@ fn resolve_base_sort_ident(
     } else if ident.name == SORTS.real {
         Ok(fhir::Sort::Real)
     } else if sort_decls.get(&ident.name).is_some() {
-        Ok(fhir::Sort::User(ident.name))
+        let ctor = fhir::SortCtor::User { name: ident.name, arity: 0 };
+        Ok(fhir::Sort::App(ctor, List::empty()))
     } else {
         Err(sess.emit_err(errors::UnresolvedSort::new(*ident)))
     }

--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -894,7 +894,6 @@ fn conv_sort(early_cx: &EarlyCtxt, sort: &fhir::Sort) -> rty::Sort {
         fhir::Sort::BitVec(w) => rty::Sort::BitVec(*w),
         fhir::Sort::Loc => rty::Sort::Loc,
         fhir::Sort::Unit => rty::Sort::unit(),
-        fhir::Sort::User(name) => rty::Sort::User(*name),
         fhir::Sort::Func(fsort) => rty::Sort::Func(conv_func_sort(early_cx, fsort)),
         fhir::Sort::Record(def_id) => {
             rty::Sort::tuple(conv_sorts(early_cx, early_cx.index_sorts_of(*def_id)))

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -32,7 +32,7 @@ pub enum Sort {
 #[derive(Clone, Hash)]
 pub enum SortCtor {
     Set,
-    User { name: Symbol, arity: usize },
+    // User { name: Symbol, arity: usize },
 }
 
 #[derive(Clone, Hash)]
@@ -280,7 +280,7 @@ impl fmt::Display for SortCtor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SortCtor::Set => write!(f, "Set_Set"),
-            SortCtor::User { name, .. } => write!(f, "{}", name),
+            // SortCtor::User { name, .. } => write!(f, "{}", name),
         }
     }
 }

--- a/flux-middle/src/early_ctxt.rs
+++ b/flux-middle/src/early_ctxt.rs
@@ -121,20 +121,25 @@ impl<'a, 'tcx> EarlyCtxt<'a, 'tcx> {
             | fhir::Sort::Bool
             | fhir::Sort::Real
             | fhir::Sort::Unit
-            | fhir::Sort::User(_)
             | fhir::Sort::BitVec(_) => true,
             fhir::Sort::Record(def_id) => {
                 self.index_sorts_of(*def_id)
                     .iter()
                     .all(|sort| self.has_equality(sort))
             }
-            fhir::Sort::App(_, sorts) => sorts.iter().all(|sort| self.has_equality(sort)),
+            fhir::Sort::App(ctor, sorts) => self.ctor_has_equality(ctor, sorts),
             fhir::Sort::Loc
             | fhir::Sort::Func(_)
             | fhir::Sort::Param(_)
             | fhir::Sort::Wildcard
             | fhir::Sort::Infer(_) => false,
         }
+    }
+
+    // For now all sort constructors have equality if all the generic arguments do. In the
+    // future we may have a more fine-grained notion of equality for sort constructors.
+    fn ctor_has_equality(&self, _: &fhir::SortCtor, args: &[fhir::Sort]) -> bool {
+        args.iter().all(|sort| self.has_equality(sort))
     }
 
     pub fn sort_of_bty(&self, bty: &fhir::BaseTy) -> Option<fhir::Sort> {

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -410,7 +410,11 @@ newtype_index! {
 #[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum SortCtor {
     Set,
-    User { name: Symbol, arity: usize },
+    /// User defined opaque sort
+    User {
+        name: Symbol,
+        arity: usize,
+    },
 }
 
 impl SortCtor {
@@ -430,13 +434,11 @@ pub enum Sort {
     Unit,
     BitVec(usize),
     /// Sort constructor application (e.g. `Set<int>`)
-    App(SortCtor, Vec<Sort>),
+    App(SortCtor, List<Sort>),
     Func(FuncSort),
     /// A record sort corresponds to the sort associated with a type alias or an adt (struct/enum).
     /// Values of a record sort can be projected using dot notation to extract their fields.
     Record(DefId),
-    /// User defined opaque sort
-    User(Symbol),
     /// The sort associated to a type variable
     Param(DefId),
     /// A sort that needs to be inferred
@@ -702,7 +704,7 @@ impl Sort {
     }
 
     pub fn set(t: Sort) -> Self {
-        Self::App(SortCtor::Set, vec![t])
+        Self::App(SortCtor::Set, List::singleton(t))
     }
 }
 
@@ -1357,7 +1359,6 @@ impl fmt::Debug for Sort {
             Sort::Func(sort) => write!(f, "{sort}"),
             Sort::Unit => write!(f, "()"),
             Sort::Record(def_id) => write!(f, "{}", pretty::def_id_to_string(*def_id)),
-            Sort::User(name) => write!(f, "{name}"),
             Sort::Param(def_id) => write!(f, "sortof({})", pretty::def_id_to_string(*def_id)),
             Sort::Wildcard => write!(f, "_"),
             Sort::Infer(vid) => write!(f, "{vid:?}"),

--- a/flux-middle/src/intern.rs
+++ b/flux-middle/src/intern.rs
@@ -280,6 +280,10 @@ where
         Self::from_vec(vec![])
     }
 
+    pub fn singleton(elem: T) -> List<T> {
+        Self::from_vec(vec![elem])
+    }
+
     pub fn from_vec(vec: Vec<T>) -> List<T> {
         match Interned::lookup(vec.as_slice()) {
             Ok(this) => this,

--- a/flux-middle/src/rty/fold.rs
+++ b/flux-middle/src/rty/fold.rs
@@ -321,13 +321,9 @@ impl TypeFoldable for Sort {
             Sort::Func(fsort) => {
                 Sort::Func(FuncSort { input_and_output: fsort.input_and_output.fold_with(folder) })
             }
-            Sort::Int
-            | Sort::Bool
-            | Sort::Real
-            | Sort::Loc
-            | Sort::BitVec(_)
-            | Sort::Param(_)
-            | Sort::User(_) => self.clone(),
+            Sort::Int | Sort::Bool | Sort::Real | Sort::Loc | Sort::BitVec(_) | Sort::Param(_) => {
+                self.clone()
+            }
         }
     }
 
@@ -335,13 +331,7 @@ impl TypeFoldable for Sort {
         match self {
             Sort::Tuple(sorts) | Sort::App(_, sorts) => sorts.visit_with(visitor),
             Sort::Func(fsort) => fsort.input_and_output.visit_with(visitor),
-            Sort::Int
-            | Sort::Bool
-            | Sort::Real
-            | Sort::BitVec(_)
-            | Sort::Loc
-            | Sort::Param(_)
-            | Sort::User(_) => {}
+            Sort::Int | Sort::Bool | Sort::Real | Sort::BitVec(_) | Sort::Loc | Sort::Param(_) => {}
         }
     }
 

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -111,7 +111,6 @@ pub enum Sort {
     Param(ParamTy),
     Tuple(List<Sort>),
     Func(FuncSort),
-    User(Symbol),
     App(SortCtor, List<Sort>),
 }
 
@@ -1271,7 +1270,6 @@ mod pretty {
                     }
                 }
                 Sort::Param(param_ty) => w!("sortof({})", ^param_ty),
-                Sort::User(name) => w!("{}", ^name),
             }
         }
     }

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -138,7 +138,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
                 }
                 _ => ty.clone(),
             };
-            res.push(packed_ty)
+            res.push(packed_ty);
         }
         Ok(res)
     }

--- a/flux-refineck/src/type_env/paths_tree.rs
+++ b/flux-refineck/src/type_env/paths_tree.rs
@@ -368,7 +368,9 @@ impl PathsTree {
                 (Index(_), TyKind::Indexed(BaseTy::Slice(slice_ty), _)) => ty = slice_ty.clone(),
 
                 _ => {
-                    tracked_span_bug!("unexpected type and projection elem = {elem:?}, ty = {ty:?}")
+                    tracked_span_bug!(
+                        "unexpected type and projection elem = {elem:?}, ty = {ty:?}"
+                    );
                 }
             }
         }


### PR DESCRIPTION
* Remove user opaque sort in favor of sort constructors
* Remove user-defined sorts from fixpoint because there's currently no way to declare user-defined sorts in the horn syntax