### PR TITLE
Fix cargo-flux

### DIFF
--- a/flux/src/main.rs
+++ b/flux/src/main.rs
@@ -24,7 +24,7 @@ fn main() -> io::Result<()> {
                 args.push("-C".to_string());
                 is_codegen = false;
             }
-            if arg == CMD_RUSTC {
+            if arg.ends_with(CMD_RUSTC) {
                 in_cargo = true;
             } else {
                 args.push(arg);


### PR DESCRIPTION
The latest toolchain update broke `cargo-flux` because `cargo` nows calls `rustc` passing and absolute path as the first argument.


fixes https://github.com/flux-rs/flux/issues/463