### PR TITLE
Refactor asyncness in surface and desugaring

### DIFF
--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -22,7 +22,7 @@ pub struct ResKey {
 
 struct NameResTable<'sess> {
     res: FxHashMap<ResKey, ResEntry>,
-    opaque: Option<(LocalDefId, usize)>, // TODO: HACK! need to generalize to multiple opaque types/impls in a signature.
+    opaque: Option<LocalDefId>, // TODO: HACK! need to generalize to multiple opaque types/impls in a signature.
     sess: &'sess FluxSession,
 }
 
@@ -147,6 +147,8 @@ impl<'sess> Resolver<'sess> {
         &self,
         fn_sig: surface::FnSig,
     ) -> Result<surface::FnSig<Res>, ErrorGuaranteed> {
+        let asyncness = self.resolve_asyncness(fn_sig.asyncness);
+
         let args = fn_sig
             .args
             .into_iter()
@@ -171,6 +173,7 @@ impl<'sess> Resolver<'sess> {
         let returns = fn_sig.returns.map(|ty| self.resolve_ty(ty)).transpose();
 
         Ok(surface::FnSig {
+            asyncness: asyncness?,
             params: fn_sig.params,
             requires: fn_sig.requires,
             args: args?,
@@ -179,6 +182,19 @@ impl<'sess> Resolver<'sess> {
             predicates: predicates?,
             span: fn_sig.span,
         })
+    }
+
+    fn resolve_asyncness(
+        &self,
+        asyncness: surface::Async,
+    ) -> Result<surface::Async<Res>, ErrorGuaranteed> {
+        match asyncness {
+            surface::Async::Yes { span, .. } => {
+                let res = self.resolve_opaque_impl(span)?;
+                Ok(surface::Async::Yes { res, span })
+            }
+            surface::Async::No => Ok(surface::Async::No),
+        }
     }
 
     fn resolve_arg(&self, arg: surface::Arg) -> Result<surface::Arg<Res>, ErrorGuaranteed> {
@@ -234,11 +250,11 @@ impl<'sess> Resolver<'sess> {
             surface::TyKind::Hole => surface::TyKind::Hole,
             surface::TyKind::ImplTrait(_, bounds) => {
                 let bounds = self.resolve_bounds(bounds)?;
-                let res = self.resolve_opaque_impl(ty.span)?.0;
+                let res = self.resolve_opaque_impl(ty.span)?;
                 surface::TyKind::ImplTrait(res, bounds)
             },
             surface::TyKind::Async(_, ty) => {
-                let res = self.resolve_opaque_impl(ty.span)?.0;
+                let res = self.resolve_opaque_impl(ty.span)?;
                 let ty = self.resolve_ty(*ty)?;
                 surface::TyKind::Async(res, Box::new(ty))
             },
@@ -246,9 +262,9 @@ impl<'sess> Resolver<'sess> {
         Ok(surface::Ty { kind, span: ty.span })
     }
 
-    fn resolve_opaque_impl(&self, span: Span) -> Result<(Res, usize), ErrorGuaranteed> {
-        if let Some((opaque, arity)) = self.table.opaque {
-            Ok((Res::OpaqueTy(opaque.to_def_id()), arity))
+    fn resolve_opaque_impl(&self, span: Span) -> Result<Res, ErrorGuaranteed> {
+        if let Some(opaque) = self.table.opaque {
+            Ok(Res::OpaqueTy(opaque.to_def_id()))
         } else {
             Err(self
                 .sess
@@ -432,7 +448,7 @@ impl<'sess> NameResTable<'sess> {
     }
 
     fn collect_from_opaque_impls(&mut self, tcx: TyCtxt) -> Result<(), ErrorGuaranteed> {
-        if let Some((did, _arity)) = self.opaque {
+        if let Some(did) = self.opaque {
             let owner_id = OwnerId { def_id: did };
             let item_id = hir::ItemId { owner_id };
             let item_kind = tcx.hir().item(item_id).kind;
@@ -490,7 +506,7 @@ impl<'sess> NameResTable<'sess> {
                 };
                 self.collect_from_path(path)
             }
-            hir::TyKind::OpaqueDef(item_id, args, _) => {
+            hir::TyKind::OpaqueDef(item_id, ..) => {
                 assert!(self.opaque.is_none());
                 if self.opaque.is_some() {
                     Err(self.sess.emit_err(errors::UnsupportedSignature::new(
@@ -498,7 +514,7 @@ impl<'sess> NameResTable<'sess> {
                         "duplicate opaque types in signature",
                     )))
                 } else {
-                    self.opaque = Some((item_id.owner_id.def_id, args.len()));
+                    self.opaque = Some(item_id.owner_id.def_id);
                     Ok(())
                 }
             }

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -253,11 +253,6 @@ impl<'sess> Resolver<'sess> {
                 let res = self.resolve_opaque_impl(ty.span)?;
                 surface::TyKind::ImplTrait(res, bounds)
             },
-            surface::TyKind::Async(_, ty) => {
-                let res = self.resolve_opaque_impl(ty.span)?;
-                let ty = self.resolve_ty(*ty)?;
-                surface::TyKind::Async(res, Box::new(ty))
-            },
         };
         Ok(surface::Ty { kind, span: ty.span })
     }

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -294,7 +294,7 @@ fn build_stage2_fhir_map<'sess, 'tcx>(
             if let Some((fn_preds, fn_impls)) = preds {
                 early_cx.map.insert_predicates(def_id, fn_preds);
                 for (def_id, predicates) in fn_impls {
-                    early_cx.map.insert_item_bounds(def_id, predicates)
+                    early_cx.map.insert_item_bounds(def_id, predicates);
                 }
             }
             if let Some(quals) = spec.qual_names {

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -413,7 +413,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
                 if let Some(resume_ty) = self.resume_ty.clone() {
                     self.check_assign_ty(rcx, env, resume_arg, resume_ty, source_info)?;
                 } else {
-                    bug!("yield in non-generator function")
+                    bug!("yield in non-generator function");
                 }
                 Ok(vec![(*resume, Guard::None)])
             }
@@ -582,11 +582,11 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
             match kind.skip_binder() {
                 rty::ClauseKind::FnTrait(fn_trait_pred) => {
                     let fn_trait_pred = Binder::new(fn_trait_pred, vars);
-                    self.check_oblig_fn_trait_pred(rcx, &obligs.snapshot, fn_trait_pred)?
+                    self.check_oblig_fn_trait_pred(rcx, &obligs.snapshot, fn_trait_pred)?;
                 }
                 rty::ClauseKind::GeneratorOblig(gen_pred) => {
                     let gen_pred = Binder::new(gen_pred, vars);
-                    self.check_oblig_generator_pred(rcx, &obligs.snapshot, gen_pred)?
+                    self.check_oblig_generator_pred(rcx, &obligs.snapshot, gen_pred)?;
                 }
                 rty::ClauseKind::Projection(_) => (),
             }

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -239,7 +239,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
                 }
                 (TyKind::Ptr(PtrKind::Shr(_), path), Ref!(_, bound, Mutability::Not)) => {
                     let ty = env.get(path).unblocked();
-                    infcx.subtyping(rcx, &ty, bound)?
+                    infcx.subtyping(rcx, &ty, bound)?;
                 }
                 _ => infcx.subtyping(rcx, actual, &formal)?,
             }
@@ -350,12 +350,12 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
             match (ty.kind(), arr_ty.kind()) {
                 (TyKind::Ptr(PtrKind::Mut(_), path), Ref!(_, bound, Mutability::Mut)) => {
                     let ty = env.block_with(path, bound.clone());
-                    infcx.subtyping(rcx, &ty, bound)?
+                    infcx.subtyping(rcx, &ty, bound)?;
                 }
                 (TyKind::Ptr(PtrKind::Shr(_), path), Ref!(_, bound, Mutability::Not)) => {
                     // TODO(pack-closure): why is this not put into `infcx.subtyping`?
                     let ty = env.get(path);
-                    infcx.subtyping(rcx, &ty, bound)?
+                    infcx.subtyping(rcx, &ty, bound)?;
                 }
                 _ => infcx.subtyping(rcx, ty, &arr_ty)?,
             }

--- a/flux-syntax/src/grammar.lalrpop
+++ b/flux-syntax/src/grammar.lalrpop
@@ -109,6 +109,7 @@ Sort: surface::Sort = {
 
 pub FnSig: surface::FnSig = {
     <lo:@L>
+    <asyncness:Async>
     "fn"
     <params:("<" <RefineParams<"!">> ">")?>
     "(" <args:Args> ")"
@@ -121,25 +122,28 @@ pub FnSig: surface::FnSig = {
         let ensures = ensures.unwrap_or_default();
         let params = params.unwrap_or_default();
         let predicates = predicates.unwrap_or_default();
-        surface::FnSig { params, args, returns, ensures, requires, predicates, span: mk_span(lo, hi) }
+        surface::FnSig {
+            asyncness,
+            params,
+            args,
+            returns,
+            ensures,
+            requires,
+            predicates,
+            span: mk_span(lo, hi)
+        }
     },
-     <lo:@L>
-    "async" "fn"
-    <params:("<" <RefineParams<"!">> ">")?>
-    "(" <args:Args> ")"
-    <returns:("->" <Ty>)>
-    <requires:("requires" <Expr>)?>
-    <ensures:("ensures" <Ensures>)?>
-    <predicates:("where" <Predicates>)?>
-    <hi:@R>
-    => {
-        let ensures = ensures.unwrap_or_default();
-        let params = params.unwrap_or_default();
-        let predicates = predicates.unwrap_or_default();
-        let return_span = returns.span;
-        let returns = Some(surface::Ty { kind: surface::TyKind::Async((), Box::new(returns)), span: return_span });
-        surface::FnSig { params, args, returns, ensures, requires, predicates, span: mk_span(lo, hi) }
-    },
+
+}
+
+Async: surface::Async = {
+    <lo:@L> <asyncness:"async"?> <hi:@R> => {
+        if asyncness.is_some() {
+            surface::Async::Yes { res: (), span: mk_span(lo, hi) }
+        } else {
+            surface::Async::No
+        }
+    }
 
 }
 

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -126,6 +126,7 @@ pub struct ConstSig {
 
 #[derive(Debug)]
 pub struct FnSig<R = ()> {
+    pub asyncness: Async<R>,
     /// List of explicit refinement parameters
     pub params: Vec<RefineParam>,
     /// example: `requires n > 0`
@@ -140,6 +141,12 @@ pub struct FnSig<R = ()> {
     pub predicates: Vec<WhereBoundPredicate<R>>,
     /// source span
     pub span: Span,
+}
+
+#[derive(Debug)]
+pub enum Async<R = ()> {
+    Yes { res: R, span: Span },
+    No,
 }
 
 #[derive(Debug)]

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -143,7 +143,7 @@ pub struct FnSig<R = ()> {
     pub span: Span,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum Async<R = ()> {
     Yes { res: R, span: Span },
     No,
@@ -203,7 +203,6 @@ pub enum TyKind<R = ()> {
     Array(Box<Ty<R>>, ArrayLen),
     /// The first `R` parameter is for the `DefId` corresponding to the hir OpaqueTy
     ImplTrait(R, Bounds<R>),
-    Async(R, Box<Ty<R>>),
     Hole,
 }
 
@@ -379,10 +378,4 @@ impl fmt::Debug for BinOp {
             BinOp::Div => write!(f, "/"),
         }
     }
-}
-
-pub fn async_return_ty(ty: Ty) -> Ty {
-    let span = ty.span;
-    let kind = TyKind::Async((), Box::new(ty));
-    Ty { kind, span }
 }

--- a/flux-tests/tests/pos/surface/async00.rs
+++ b/flux-tests/tests/pos/surface/async00.rs
@@ -1,0 +1,17 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(bool[true]))]
+pub fn assert(_: bool) {}
+
+// Test that we support async function returning unit
+#[flux::sig(async fn())]
+pub async fn test() {
+    let x = make_nat().await;
+    assert(x >= 0);
+}
+
+#[flux::sig(async fn() -> i32{v: v >= 0})]
+pub async fn make_nat() -> i32 {
+    0
+}


### PR DESCRIPTION
* Make asyncness a field of `FnSig` instead of a type in `surface`.
* Get the `DefId` of `Future::Ouptut` using diagnostic items.
* Remove unused arity in table resolver
* For free: support for async functions returning unit.