### PR TITLE
Support specifying type parameter kind in the surface

### DIFF
--- a/flux-desugar/locales/en-US.ftl
+++ b/flux-desugar/locales/en-US.ftl
@@ -76,3 +76,7 @@ desugar_unsupported_signature =
 desugar_unresolved_path =
     cannot resolve `{$path}`
     .help = flux can only resolve a path if it is present in the definition being refined
+
+desugar_unresolved_generic_param =
+    cannot resolve generic param
+    .note = generic parameters in refined signature must much rust signature

--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -16,7 +16,9 @@ fluent_messages! { "../locales/en-US.ftl" }
 mod desugar;
 mod table_resolver;
 
-pub use desugar::{desugar_defn, desugar_qualifier, desugar_refined_by, func_def_to_func_decl};
+pub use desugar::{
+    desugar_defn, desugar_generics, desugar_qualifier, desugar_refined_by, func_def_to_func_decl,
+};
 use flux_middle::{early_ctxt::EarlyCtxt, fhir};
 use flux_syntax::surface;
 use rustc_errors::ErrorGuaranteed;

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -175,7 +175,6 @@ impl<'sess> Resolver<'sess> {
         Ok(surface::FnSig {
             asyncness: asyncness?,
             generics: fn_sig.generics,
-            params: fn_sig.params,
             requires: fn_sig.requires,
             args: args?,
             returns: returns?,

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -320,6 +320,10 @@ impl<'sess> Resolver<'sess> {
 }
 
 impl<'sess> NameResTable<'sess> {
+    fn new(sess: &'sess FluxSession) -> NameResTable<'sess> {
+        NameResTable { sess, opaque: None, res: FxHashMap::default() }
+    }
+
     fn from_item(
         tcx: TyCtxt,
         sess: &'sess FluxSession,
@@ -357,10 +361,6 @@ impl<'sess> NameResTable<'sess> {
         Ok(table)
     }
 
-    fn insert(&mut self, key: ResKey, res: impl Into<ResEntry>) {
-        self.res.insert(key, res.into());
-    }
-
     fn from_impl_item(
         tcx: TyCtxt,
         sess: &'sess FluxSession,
@@ -389,8 +389,8 @@ impl<'sess> NameResTable<'sess> {
         Ok(table)
     }
 
-    fn new(sess: &'sess FluxSession) -> NameResTable<'sess> {
-        NameResTable { sess, opaque: None, res: FxHashMap::default() }
+    fn insert(&mut self, key: ResKey, res: impl Into<ResEntry>) {
+        self.res.insert(key, res.into());
     }
 
     fn get(&self, key: &ResKey) -> Option<&ResEntry> {

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -174,6 +174,7 @@ impl<'sess> Resolver<'sess> {
 
         Ok(surface::FnSig {
             asyncness: asyncness?,
+            generics: fn_sig.generics,
             params: fn_sig.params,
             requires: fn_sig.requires,
             args: args?,

--- a/flux-driver/src/collector.rs
+++ b/flux-driver/src/collector.rs
@@ -53,6 +53,7 @@ pub(crate) struct Specs {
     pub extern_specs: FxHashMap<DefId, LocalDefId>,
 }
 
+#[derive(Debug)]
 pub(crate) struct FnSpec {
     pub fn_sig: Option<surface::FnSig>,
     pub trusted: bool,

--- a/flux-middle/src/fhir/lift.rs
+++ b/flux-middle/src/fhir/lift.rs
@@ -37,7 +37,7 @@ pub fn lift_generics(
         .map(|param| {
             let kind = match param.kind {
                 hir::GenericParamKind::Lifetime { .. } => fhir::GenericParamDefKind::Lifetime,
-                hir::GenericParamKind::Type { default, .. } => {
+                hir::GenericParamKind::Type { default, synthetic: false } => {
                     match def_kind {
                         DefKind::AssocFn | DefKind::Fn | DefKind::Impl { .. } => {
                             debug_assert!(default.is_none());
@@ -49,6 +49,13 @@ pub fn lift_generics(
                             }
                         }
                     }
+                }
+                hir::GenericParamKind::Type { synthetic: true, .. } => {
+                    return Err(sess.emit_err(errors::UnsupportedHir::new(
+                        tcx,
+                        param.def_id,
+                        "`impl Trait` in argument position not supported",
+                    )))
                 }
                 hir::GenericParamKind::Const { .. } => {
                     return Err(sess.emit_err(errors::UnsupportedHir::new(

--- a/flux-syntax/src/grammar.lalrpop
+++ b/flux-syntax/src/grammar.lalrpop
@@ -8,6 +8,18 @@ use lalrpop_util::ParseError;
 
 grammar<F>(mk_span: &F) where F: Fn(Location, Location) -> Span;
 
+GenericParam: surface::GenericParam = {
+    <name:Ident> => surface::GenericParam { name, kind: surface::GenericParamKind::Type },
+    <name:Ident> "as" <lo:@L> <kind:Ident> <hi:@R> =>? {
+        let kind = match kind.as_str() {
+            "type" => surface::GenericParamKind::Type,
+            "base" => surface::GenericParamKind::Base,
+            _ => return Err(ParseError::User { error: UserParseError::UnexpectedToken(lo, hi) })
+        };
+        Ok(surface::GenericParam { name, kind })
+    }
+}
+
 pub TyAlias: surface::TyAlias = {
     <lo:@L>
     "type"
@@ -113,17 +125,19 @@ pub FnSig: surface::FnSig = {
     "fn"
     <params:("<" <RefineParams<"!">> ">")?>
     "(" <args:Args> ")"
-    <returns:("->" <Ty>)?>
+    <mut returns:("->" <Ty>)?>
     <requires:("requires" <Expr>)?>
     <ensures:("ensures" <Ensures>)?>
     <predicates:("where" <Predicates>)?>
     <hi:@R>
     => {
+        let generics = None;
         let ensures = ensures.unwrap_or_default();
         let params = params.unwrap_or_default();
         let predicates = predicates.unwrap_or_default();
         surface::FnSig {
             asyncness,
+            generics,
             params,
             args,
             returns,
@@ -478,6 +492,7 @@ extern {
         "async" => Token::Async,
         "type" => Token::Type,
         "ref" => Token::Ref,
+        "as" => Token::As,
         "@"  => Token::At,
         "#"  => Token::Pound,
         "==" => Token::EqEq,
@@ -513,6 +528,6 @@ extern {
         "%"  => Token::Percent,
         "if"   => Token::If,
         "else" => Token::Else,
-        "::" => Token::ModSep
+        "::" => Token::ModSep,
     }
 }

--- a/flux-syntax/src/grammar.lalrpop
+++ b/flux-syntax/src/grammar.lalrpop
@@ -8,6 +8,15 @@ use lalrpop_util::ParseError;
 
 grammar<F>(mk_span: &F) where F: Fn(Location, Location) -> Span;
 
+Generics: surface::Generics = {
+    <lo:@L> "<" <params:Comma<GenericParam>> ">" <hi:@R> => {
+        surface::Generics {
+            params,
+            span: mk_span(lo, hi),
+        }
+    }
+}
+
 GenericParam: surface::GenericParam = {
     <name:Ident> => surface::GenericParam { name, kind: surface::GenericParamKind::Type },
     <name:Ident> "as" <lo:@L> <kind:Ident> <hi:@R> =>? {
@@ -123,7 +132,8 @@ pub FnSig: surface::FnSig = {
     <lo:@L>
     <asyncness:Async>
     "fn"
-    <params:("<" <RefineParams<"!">> ">")?>
+    <generics:Generics?>
+    <params:("[" <RefineParams<"!">> "]")?>
     "(" <args:Args> ")"
     <mut returns:("->" <Ty>)?>
     <requires:("requires" <Expr>)?>

--- a/flux-syntax/src/grammar.lalrpop
+++ b/flux-syntax/src/grammar.lalrpop
@@ -141,7 +141,6 @@ pub FnSig: surface::FnSig = {
     <predicates:("where" <Predicates>)?>
     <hi:@R>
     => {
-        let generics = None;
         let ensures = ensures.unwrap_or_default();
         let params = params.unwrap_or_default();
         let predicates = predicates.unwrap_or_default();

--- a/flux-syntax/src/grammar.lalrpop
+++ b/flux-syntax/src/grammar.lalrpop
@@ -26,7 +26,10 @@ GenericParam: surface::GenericParam = {
             _ => return Err(ParseError::User { error: UserParseError::UnexpectedToken(lo, hi) })
         };
         Ok(surface::GenericParam { name, kind })
-    }
+    },
+    "refine" <name:Ident> ":" <sort:Sort> => {
+        surface::GenericParam { name, kind: surface::GenericParamKind::Refine{ sort } }
+    },
 }
 
 pub TyAlias: surface::TyAlias = {
@@ -133,7 +136,6 @@ pub FnSig: surface::FnSig = {
     <asyncness:Async>
     "fn"
     <generics:Generics?>
-    <params:("[" <RefineParams<"!">> "]")?>
     "(" <args:Args> ")"
     <mut returns:("->" <Ty>)?>
     <requires:("requires" <Expr>)?>
@@ -142,12 +144,10 @@ pub FnSig: surface::FnSig = {
     <hi:@R>
     => {
         let ensures = ensures.unwrap_or_default();
-        let params = params.unwrap_or_default();
         let predicates = predicates.unwrap_or_default();
         surface::FnSig {
             asyncness,
             generics,
-            params,
             args,
             returns,
             ensures,
@@ -501,6 +501,7 @@ extern {
         "async" => Token::Async,
         "type" => Token::Type,
         "ref" => Token::Ref,
+        "refine" => Token::Refine,
         "as" => Token::As,
         "@"  => Token::At,
         "#"  => Token::Pound,

--- a/flux-syntax/src/lexer.rs
+++ b/flux-syntax/src/lexer.rs
@@ -62,6 +62,7 @@ pub enum Token {
     Opaque,
     Local,
     BitVec,
+    As,
 }
 
 pub(crate) struct Cursor {
@@ -156,6 +157,7 @@ impl Cursor {
             TokenKind::Ident(symb, _) if symb == kw::If => Token::If,
             TokenKind::Ident(symb, _) if symb == kw::Else => Token::Else,
             TokenKind::Ident(symb, _) if symb == kw::Async => Token::Async,
+            TokenKind::Ident(symb, _) if symb == kw::As => Token::As,
             TokenKind::Ident(symb, _) => Token::Ident(symb),
             TokenKind::BinOp(BinOpToken::Or) => Token::Caret,
             TokenKind::BinOp(BinOpToken::Plus) => Token::Plus,

--- a/flux-syntax/src/lexer.rs
+++ b/flux-syntax/src/lexer.rs
@@ -63,6 +63,7 @@ pub enum Token {
     Local,
     BitVec,
     As,
+    Refine,
 }
 
 pub(crate) struct Cursor {
@@ -83,6 +84,7 @@ struct Symbols {
     opaque: Symbol,
     local: Symbol,
     bitvec: Symbol,
+    refine: Symbol,
 }
 
 struct Frame {
@@ -110,6 +112,7 @@ impl Cursor {
                 bitvec: Symbol::intern("bitvec"),
                 opaque: Symbol::intern("opaque"),
                 local: Symbol::intern("local"),
+                refine: Symbol::intern("refine"),
             },
         }
     }
@@ -150,6 +153,7 @@ impl Cursor {
             TokenKind::Ident(symb, _) if symb == self.symbs.opaque => Token::Opaque,
             TokenKind::Ident(symb, _) if symb == self.symbs.local => Token::Local,
             TokenKind::Ident(symb, _) if symb == self.symbs.bitvec => Token::BitVec,
+            TokenKind::Ident(symb, _) if symb == self.symbs.refine => Token::Refine,
             TokenKind::Ident(symb, _) if symb == kw::Mut => Token::Mut,
             TokenKind::Ident(symb, _) if symb == kw::Where => Token::Where,
             TokenKind::Ident(symb, _) if symb == kw::Impl => Token::Impl,

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -40,6 +40,24 @@ pub struct FuncDef {
 }
 
 #[derive(Debug)]
+pub struct Generics {
+    pub params: Vec<GenericParam>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct GenericParam {
+    pub name: Ident,
+    pub kind: GenericParamKind,
+}
+
+#[derive(Debug)]
+pub enum GenericParamKind {
+    Type,
+    Base,
+}
+
+#[derive(Debug)]
 pub struct TyAlias<R = ()> {
     pub ident: Ident,
     pub generics: Vec<Ty>,
@@ -127,6 +145,7 @@ pub struct ConstSig {
 #[derive(Debug)]
 pub struct FnSig<R = ()> {
     pub asyncness: Async<R>,
+    pub generics: Option<Generics>,
     /// List of explicit refinement parameters
     pub params: Vec<RefineParam>,
     /// example: `requires n > 0`

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -55,6 +55,7 @@ pub struct GenericParam {
 pub enum GenericParamKind {
     Type,
     Base,
+    Refine { sort: Sort },
 }
 
 #[derive(Debug)]
@@ -146,8 +147,6 @@ pub struct ConstSig {
 pub struct FnSig<R = ()> {
     pub asyncness: Async<R>,
     pub generics: Option<Generics>,
-    /// List of explicit refinement parameters
-    pub params: Vec<RefineParam>,
     /// example: `requires n > 0`
     pub requires: Option<Expr>,
     /// example: `i32<@n>`

--- a/flux-tests/tests/neg/abstract_refinements/test00.rs
+++ b/flux-tests/tests/neg/abstract_refinements/test00.rs
@@ -2,7 +2,7 @@
 #![register_tool(flux)]
 
 #[flux::sig(
-    fn<p: int -> bool>(x: i32, y: i32) -> i32{v: p(v) && v >= x && v >= y}
+    fn[p: int -> bool](x: i32, y: i32) -> i32{v: p(v) && v >= x && v >= y}
     requires p(x) && p(y)
 )]
 fn max(x: i32, y: i32) -> i32 {

--- a/flux-tests/tests/neg/abstract_refinements/test00.rs
+++ b/flux-tests/tests/neg/abstract_refinements/test00.rs
@@ -2,7 +2,7 @@
 #![register_tool(flux)]
 
 #[flux::sig(
-    fn[p: int -> bool](x: i32, y: i32) -> i32{v: p(v) && v >= x && v >= y}
+    fn<refine p: int -> bool>(x: i32, y: i32) -> i32{v: p(v) && v >= x && v >= y}
     requires p(x) && p(y)
 )]
 fn max(x: i32, y: i32) -> i32 {

--- a/flux-tests/tests/neg/error_messages/desugar/index_errors00.rs
+++ b/flux-tests/tests/neg/error_messages/desugar/index_errors00.rs
@@ -42,3 +42,8 @@ pub struct Chair {
 pub fn mk_chair() -> Chair {
     Chair { x: 0 }
 }
+
+#[flux::sig(fn(x: T) -> i32[x])] //~ ERROR invalid use of refinement parameter
+fn generic<T>(x: T) -> i32 {
+    0
+}

--- a/flux-tests/tests/neg/error_messages/wf/abstract_refinements.rs
+++ b/flux-tests/tests/neg/error_messages/wf/abstract_refinements.rs
@@ -2,7 +2,7 @@
 #![register_tool(flux)]
 
 #[flux::sig(
-    fn[p: int -> bool](x: i32) -> i32{v: p(v)}
+    fn<refine p: int -> bool>(x: i32) -> i32{v: p(v)}
     requires x > 0 || p(x) //~ ERROR illegal use of refinement parameter
 )]
 fn test00(x: i32) -> i32 {
@@ -10,7 +10,7 @@ fn test00(x: i32) -> i32 {
 }
 
 #[flux::sig(
-    fn[p: int -> bool](x: i32) -> i32{v: p(v)}
+    fn<refine p: int -> bool>(x: i32) -> i32{v: p(v)}
     requires p == p //~ ERROR values of sort `int -> bool` cannot be compared for equality
 )]
 fn test01(x: i32) -> i32 {
@@ -29,14 +29,14 @@ fn test03(x: S) {}
 #[flux::sig(fn(S[|a| a]))] //~ ERROR mismatched sorts
 fn test04(x: S) {}
 
-#[flux::sig(fn[p: int -> bool]() -> S[|x| p(x) || x == 0])] //~ ERROR illegal use of refinement parameter
+#[flux::sig(fn<refine p: int -> bool>() -> S[|x| p(x) || x == 0])] //~ ERROR illegal use of refinement parameter
 fn test05() -> S {
     todo!()
 }
 
 // It should be possible to accept `p` in `bool[p(0)]` but it requires some refactoring.
 // In the meantime we explicitly test against it.
-#[flux::sig(fn[p: int -> bool]() -> bool[p(0)])] //~ ERROR illegal use of refinement parameter
+#[flux::sig(fn<refine p: int -> bool>() -> bool[p(0)])] //~ ERROR illegal use of refinement parameter
 fn test06() -> bool {
     todo!()
 }

--- a/flux-tests/tests/neg/error_messages/wf/abstract_refinements.rs
+++ b/flux-tests/tests/neg/error_messages/wf/abstract_refinements.rs
@@ -2,7 +2,7 @@
 #![register_tool(flux)]
 
 #[flux::sig(
-    fn<p: int -> bool>(x: i32) -> i32{v: p(v)}
+    fn[p: int -> bool](x: i32) -> i32{v: p(v)}
     requires x > 0 || p(x) //~ ERROR illegal use of refinement parameter
 )]
 fn test00(x: i32) -> i32 {
@@ -10,7 +10,7 @@ fn test00(x: i32) -> i32 {
 }
 
 #[flux::sig(
-    fn<p: int -> bool>(x: i32) -> i32{v: p(v)}
+    fn[p: int -> bool](x: i32) -> i32{v: p(v)}
     requires p == p //~ ERROR values of sort `int -> bool` cannot be compared for equality
 )]
 fn test01(x: i32) -> i32 {
@@ -29,14 +29,14 @@ fn test03(x: S) {}
 #[flux::sig(fn(S[|a| a]))] //~ ERROR mismatched sorts
 fn test04(x: S) {}
 
-#[flux::sig(fn<p: int -> bool>() -> S[|x| p(x) || x == 0])] //~ ERROR illegal use of refinement parameter
+#[flux::sig(fn[p: int -> bool]() -> S[|x| p(x) || x == 0])] //~ ERROR illegal use of refinement parameter
 fn test05() -> S {
     todo!()
 }
 
 // It should be possible to accept `p` in `bool[p(0)]` but it requires some refactoring.
 // In the meantime we explicitly test against it.
-#[flux::sig(fn<p: int -> bool>() -> bool[p(0)])] //~ ERROR illegal use of refinement parameter
+#[flux::sig(fn[p: int -> bool]() -> bool[p(0)])] //~ ERROR illegal use of refinement parameter
 fn test06() -> bool {
     todo!()
 }

--- a/flux-tests/tests/neg/error_messages/wf/index_errors.rs
+++ b/flux-tests/tests/neg/error_messages/wf/index_errors.rs
@@ -44,8 +44,3 @@ pub fn use_chair(c: Chair) -> i32 {
 fn ira(f: f32) -> i32 {
     0
 }
-
-#[flux::sig(fn(x: T) -> i32[x])] //~ ERROR mismatched sorts
-fn generic<T>(x: T) -> i32 {
-    0
-}

--- a/flux-tests/tests/neg/surface/refined_type_var00.rs
+++ b/flux-tests/tests/neg/surface/refined_type_var00.rs
@@ -6,7 +6,7 @@ fn assert(_: bool) {}
 
 #[flux::trusted]
 #[flux::sig(
-    fn(x: &strg T[@n], y: &strg T[@m])
+    fn<T as base>(x: &strg T[@n], y: &strg T[@m])
     ensures x: T[m], y: T[n]
 )]
 fn swap<T>(x: &mut T, y: &mut T) {
@@ -21,7 +21,7 @@ fn test00() {
     assert(y == 1); //~ ERROR refinement type error
 }
 
-#[flux::sig(fn(b: bool, x: T[@n], y: T[@m]) -> T[if b { n } else { m }])]
+#[flux::sig(fn<T as base>(b: bool, x: T[@n], y: T[@m]) -> T[if b { n } else { m }])]
 fn choose<T>(b: bool, x: T, y: T) -> T {
     if b {
         x

--- a/flux-tests/tests/pos/abstract_refinements/test00.rs
+++ b/flux-tests/tests/pos/abstract_refinements/test00.rs
@@ -2,7 +2,7 @@
 #![register_tool(flux)]
 
 #[flux::sig(
-    fn<p: int -> bool>(x: i32, y: i32) -> i32{v: p(v) && v >= x && v >= y}
+    fn[p: int -> bool](x: i32, y: i32) -> i32{v: p(v) && v >= x && v >= y}
     requires p(x) && p(y)
 )]
 fn max(x: i32, y: i32) -> i32 {

--- a/flux-tests/tests/pos/abstract_refinements/test00.rs
+++ b/flux-tests/tests/pos/abstract_refinements/test00.rs
@@ -2,7 +2,7 @@
 #![register_tool(flux)]
 
 #[flux::sig(
-    fn[p: int -> bool](x: i32, y: i32) -> i32{v: p(v) && v >= x && v >= y}
+    fn<refine p: int -> bool>(x: i32, y: i32) -> i32{v: p(v) && v >= x && v >= y}
     requires p(x) && p(y)
 )]
 fn max(x: i32, y: i32) -> i32 {

--- a/flux-tests/tests/pos/abstract_refinements/test02.rs
+++ b/flux-tests/tests/pos/abstract_refinements/test02.rs
@@ -9,5 +9,5 @@ fn ipa(x: S) -> S {
     x
 }
 
-#[flux::sig(fn[p: int -> bool](S[|x| p(x) && x != 0]))]
+#[flux::sig(fn<refine p: int -> bool>(S[|x| p(x) && x != 0]))]
 fn ris(x: S) {}

--- a/flux-tests/tests/pos/abstract_refinements/test02.rs
+++ b/flux-tests/tests/pos/abstract_refinements/test02.rs
@@ -9,5 +9,5 @@ fn ipa(x: S) -> S {
     x
 }
 
-#[flux::sig(fn<p: int -> bool>(S[|x| p(x) && x != 0]))]
+#[flux::sig(fn[p: int -> bool](S[|x| p(x) && x != 0]))]
 fn ris(x: S) {}

--- a/flux-tests/tests/pos/surface/refined_type_var00.rs
+++ b/flux-tests/tests/pos/surface/refined_type_var00.rs
@@ -6,7 +6,7 @@ fn assert(_: bool) {}
 
 #[flux::trusted]
 #[flux::sig(
-    fn(x: &strg T[@n], y: &strg T[@m])
+    fn<T as base>(x: &strg T[@n], y: &strg T[@m])
     ensures x: T[m], y: T[n]
 )]
 fn swap<T>(x: &mut T, y: &mut T) {
@@ -21,7 +21,7 @@ fn test00() {
     assert(y == 0);
 }
 
-#[flux::sig(fn(b: bool, x: T[@n], y: T[@m]) -> T[if b { n } else { m }])]
+#[flux::sig(fn<T as base>(b: bool, x: T[@n], y: T[@m]) -> T[if b { n } else { m }])]
 fn choose<T>(b: bool, x: T, y: T) -> T {
     if b {
         x


### PR DESCRIPTION
Extend surface syntax to include a list of generic type parameters that can be annotated with a kind (either `T as type` or `T as base`). This lets us avoid picking a default kind when lifting generics from `hir`. For backward compatibility, the list can be omitted in which case it will be lifted from `hir`. Since generics types and refinement parameters have to be parsed in the same list (within `<>`), disambiguate refinement parameters by prefixing them with `refine`, similar to what `rust` does for const generics which have to be prefixed with `const`.

This is to be able to move `BaseTy::Alias` to `Ty`