### PR TITLE
Refactor opaque type and associated types implementation

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -504,7 +504,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 if let Some(item_id) = mk_res_impl_item_id(&res) {
                     self.opaque_tys.insert(
                         item_id.owner_id.def_id,
-                        mk_opaque_ty_for_async(self.early_cx.tcx, output)?,
+                        mk_opaque_ty_for_async(self.early_cx.tcx, item_id.owner_id.def_id, output)?,
                     );
                     let (args, _) = self.desugar_generic_args(res, &[], binders)?;
                     let kind = fhir::TyKind::OpaqueDef(item_id, args, false);
@@ -621,8 +621,10 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
             surface::TyKind::ImplTrait(res, bounds) => {
                 if let Some(item_id) = mk_res_impl_item_id(res) {
                     let bounds = self.desugar_generic_bounds(bounds, binders)?;
-                    self.opaque_tys
-                        .insert(item_id.owner_id.def_id, fhir::OpaqueTy { bounds });
+                    self.opaque_tys.insert(
+                        item_id.owner_id.def_id,
+                        fhir::OpaqueTy { def_id: item_id.owner_id.def_id, bounds },
+                    );
 
                     let (args, _) = self.desugar_generic_args(*res, &[], binders)?;
                     fhir::TyKind::OpaqueDef(item_id, args, false)
@@ -1500,6 +1502,7 @@ fn as_tuple<'a>(early_cx: &'a EarlyCtxt, sort: &'a fhir::Sort) -> &'a [fhir::Sor
 
 fn mk_opaque_ty_for_async(
     tcx: TyCtxt,
+    def_id: LocalDefId,
     output: fhir::Ty,
 ) -> Result<fhir::OpaqueTy, ErrorGuaranteed> {
     let future_trait = tcx.lang_items().future_trait().unwrap();
@@ -1513,7 +1516,7 @@ fn mk_opaque_ty_for_async(
         refine: vec![],
         res: Res::Trait(future_trait),
     };
-    Ok(fhir::OpaqueTy { bounds: vec![bound] })
+    Ok(fhir::OpaqueTy { def_id, bounds: vec![bound] })
 }
 
 fn mk_res_impl_item_id(res: &Res) -> Option<hir::ItemId> {

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -502,7 +502,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 if let Some(item_id) = mk_res_impl_item_id(&res) {
                     self.opaque_tys.insert(
                         item_id.owner_id.def_id,
-                        mk_opaque_ty_for_async(self.early_cx.tcx, item_id.owner_id.def_id, output)?,
+                        mk_opaque_ty_for_async(self.early_cx.tcx, output)?,
                     );
                     let (args, _) = self.desugar_generic_args(res, &[], binders)?;
                     let kind = fhir::TyKind::OpaqueDef(item_id, args, false);
@@ -619,10 +619,8 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
             surface::TyKind::ImplTrait(res, bounds) => {
                 if let Some(item_id) = mk_res_impl_item_id(res) {
                     let bounds = self.desugar_generic_bounds(bounds, binders)?;
-                    self.opaque_tys.insert(
-                        item_id.owner_id.def_id,
-                        fhir::OpaqueTy { def_id: item_id.owner_id.def_id, bounds },
-                    );
+                    self.opaque_tys
+                        .insert(item_id.owner_id.def_id, fhir::OpaqueTy { bounds });
 
                     let (args, _) = self.desugar_generic_args(*res, &[], binders)?;
                     fhir::TyKind::OpaqueDef(item_id, args, false)
@@ -1500,7 +1498,6 @@ fn as_tuple<'a>(early_cx: &'a EarlyCtxt, sort: &'a fhir::Sort) -> &'a [fhir::Sor
 
 fn mk_opaque_ty_for_async(
     tcx: TyCtxt,
-    def_id: LocalDefId,
     output: fhir::Ty,
 ) -> Result<fhir::OpaqueTy, ErrorGuaranteed> {
     let future_trait = tcx.lang_items().future_trait().unwrap();
@@ -1514,7 +1511,7 @@ fn mk_opaque_ty_for_async(
         refine: vec![],
         res: Res::Def(DefKind::Trait, future_trait),
     };
-    Ok(fhir::OpaqueTy { def_id, bounds: vec![bound] })
+    Ok(fhir::OpaqueTy { bounds: vec![bound] })
 }
 
 fn mk_res_impl_item_id(res: &Res) -> Option<hir::ItemId> {

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -487,7 +487,12 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
     ) -> Result<fhir::GenericBounds, ErrorGuaranteed> {
         bounds
             .iter()
-            .map(|bound| Ok(fhir::GenericBound::Trait(self.desugar_path(bound, binders)?)))
+            .map(|bound| {
+                Ok(fhir::GenericBound::Trait(
+                    self.desugar_path(bound, binders)?,
+                    fhir::TraitBoundModifier::None,
+                ))
+            })
             .try_collect_exhaust()
     }
 

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -493,43 +493,6 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
             .try_collect_exhaust()
     }
 
-    // fn lookup_item_id(
-    //     &mut self,
-    //     trait_id: DefId,
-    //     ident: fhir::SurfaceIdent,
-    // ) -> Result<DefId, ErrorGuaranteed> {
-    //     let item = self
-    //         .early_cx
-    //         .tcx
-    //         .associated_items(trait_id)
-    //         .filter_by_name_unhygienic(ident.name)
-    //         .next();
-    //     match item {
-    //         Some(item) => Ok(item.def_id),
-    //         None => Err(self.emit_err(errors::UnresolvedVar::from_ident(ident))),
-    //     }
-    // }
-
-    // fn desugar_generic_bound(
-    //     &mut self,
-    //     args: &fhir::Ty,
-    //     path: &surface::Path<Res>,
-    //     binders: &mut Binders,
-    // ) -> Result<fhir::ClauseKind, ErrorGuaranteed> {
-    //     let Res::Trait(trait_def_id) = path.res else {
-    //         span_bug!(path.span, "unexpected trait {:?}", path.res);
-    //     };
-    //     if let [surface::GenericArg::Constraint(ident, ty)] = path.generics.as_slice() {
-    //         let item_id = self.lookup_item_id(trait_def_id, *ident)?;
-    //         let projection_ty = fhir::AliasTy { args: args.clone(), def_id: item_id };
-    //         let term = self.desugar_ty(None, ty, binders)?;
-    //         let proj = fhir::ProjectionPredicate { projection_ty, term };
-    //         Ok(fhir::ClauseKind::Projection(proj))
-    //     } else {
-    //         bug!("unexpected path in desugar_bound: {:?}", path.generics)
-    //     }
-    // }
-
     fn desugar_asyncness(
         &mut self,
         asyncness: surface::Async<Res>,

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -504,9 +504,11 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
     ) -> Result<fhir::Ty, ErrorGuaranteed> {
         match asyncness {
             surface::Async::Yes { res, span } => {
-                if let Some(item_id) = mk_res_impl_item_id(&res) {
+                if let Res::Def(DefKind::OpaqueTy, def_id) = res {
+                    let def_id = def_id.expect_local();
+                    let item_id = hir::ItemId { owner_id: hir::OwnerId { def_id } };
                     self.opaque_tys
-                        .insert(item_id.owner_id.def_id, mk_opaque_ty_for_async(output)?);
+                        .insert(def_id, mk_opaque_ty_for_async(output));
                     let (args, _) = self.desugar_generic_args(res, &[], binders)?;
                     let kind = fhir::TyKind::OpaqueDef(item_id, args, false);
                     Ok(fhir::Ty { kind, fhir_id: self.next_fhir_id(), span })
@@ -620,10 +622,11 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
             }
             surface::TyKind::Hole => fhir::TyKind::Hole,
             surface::TyKind::ImplTrait(res, bounds) => {
-                if let Some(item_id) = mk_res_impl_item_id(res) {
+                if let Res::Def(DefKind::OpaqueTy, def_id) = res {
+                    let def_id = def_id.expect_local();
+                    let item_id = hir::ItemId { owner_id: hir::OwnerId { def_id } };
                     let bounds = self.desugar_generic_bounds(bounds, binders)?;
-                    self.opaque_tys
-                        .insert(item_id.owner_id.def_id, fhir::OpaqueTy { bounds });
+                    self.opaque_tys.insert(def_id, fhir::OpaqueTy { bounds });
 
                     let (args, _) = self.desugar_generic_args(*res, &[], binders)?;
                     fhir::TyKind::OpaqueDef(item_id, args, false)
@@ -1499,7 +1502,7 @@ fn as_tuple<'a>(early_cx: &'a EarlyCtxt, sort: &'a fhir::Sort) -> &'a [fhir::Sor
     }
 }
 
-fn mk_opaque_ty_for_async(output: fhir::Ty) -> Result<fhir::OpaqueTy, ErrorGuaranteed> {
+fn mk_opaque_ty_for_async(output: fhir::Ty) -> fhir::OpaqueTy {
     let bound = fhir::GenericBound::LangItemTrait(
         hir::LangItem::Future,
         vec![],
@@ -1508,20 +1511,7 @@ fn mk_opaque_ty_for_async(output: fhir::Ty) -> Result<fhir::OpaqueTy, ErrorGuara
             term: output,
         }],
     );
-    Ok(fhir::OpaqueTy { bounds: vec![bound] })
-}
-
-fn mk_res_impl_item_id(res: &Res) -> Option<hir::ItemId> {
-    if let Res::Def(DefKind::OpaqueTy, def_id) = res
-        && let Some(local_def_id) = def_id.as_local()
-    {
-        let owner_id = OwnerId { def_id: local_def_id };
-        let item_id = hir::ItemId { owner_id };
-        Some(item_id)
-
-    } else {
-        None
-    }
+    fhir::OpaqueTy { bounds: vec![bound] }
 }
 
 trait DesugarContext<'a, 'tcx> {

--- a/flux-desugar/src/table_resolver.rs
+++ b/flux-desugar/src/table_resolver.rs
@@ -1,7 +1,7 @@
 use flux_common::{bug, iter::IterExt};
 use flux_errors::FluxSession;
 use flux_middle::fhir::Res;
-use flux_syntax::surface::{self, BaseTy, BaseTyKind, Bounds, Ident, Path, Ty};
+use flux_syntax::surface::{self, BaseTy, BaseTyKind, GenericBounds, Ident, Path, Ty};
 use hir::{ItemKind, OwnerId, PathSegment};
 use itertools::Itertools;
 use rustc_errors::ErrorGuaranteed;
@@ -134,7 +134,10 @@ impl<'sess> Resolver<'sess> {
         Ok(surface::WhereBoundPredicate { span: pred.span, bounded_ty, bounds })
     }
 
-    fn resolve_bounds(&self, bounds: surface::Bounds) -> Result<Bounds<Res>, ErrorGuaranteed> {
+    fn resolve_bounds(
+        &self,
+        bounds: surface::GenericBounds,
+    ) -> Result<GenericBounds<Res>, ErrorGuaranteed> {
         let bounds = bounds
             .into_iter()
             .map(|bound| self.resolve_path(bound))

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -296,9 +296,9 @@ fn build_stage2_fhir_map<'sess, 'tcx>(
                 early_cx.map.add_trusted(def_id);
             }
 
-            let (fn_sig, preds) = if let Some(fn_sig) = spec.fn_sig {
+            let (fn_sig, data) = if let Some(fn_sig) = spec.fn_sig {
                 let fn_info = desugar::desugar_fn_sig(&early_cx, owner_id, fn_sig)?;
-                (fn_info.fn_sig, Some((fn_info.fn_preds, fn_info.fn_impls)))
+                (fn_info.fn_sig, Some((fn_info.fn_preds, fn_info.opaque_tys)))
             } else {
                 (fhir::lift::lift_fn_sig(tcx, sess, owner_id)?, None)
             };
@@ -307,12 +307,11 @@ fn build_stage2_fhir_map<'sess, 'tcx>(
             }
 
             early_cx.map.insert_fn_sig(def_id, fn_sig);
-            if let Some((fn_preds, fn_impls)) = preds {
-                early_cx.map.insert_predicates(def_id, fn_preds);
-                for (def_id, predicates) in fn_impls {
-                    early_cx.map.insert_item_bounds(def_id, predicates);
-                }
+            if let Some((fn_preds, opaque_tys)) = data {
+                early_cx.map.insert_generic_predicates(def_id, fn_preds);
+                early_cx.map.insert_opaque_tys(opaque_tys);
             }
+
             if let Some(quals) = spec.qual_names {
                 early_cx.map.insert_fn_quals(def_id, quals.names);
             }

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -6,7 +6,7 @@ use flux_errors::{FluxSession, ResultExt};
 use flux_metadata::CStore;
 use flux_middle::{
     early_ctxt::EarlyCtxt,
-    fhir::{self, ConstInfo},
+    fhir::{self, lift, ConstInfo},
     global_env::GlobalEnv,
 };
 use flux_refineck as refineck;
@@ -144,7 +144,7 @@ fn build_stage1_fhir_map(
             let generics = if let Some(fn_sig) = &spec.fn_sig && let Some(generics) = &fn_sig.generics {
                 desugar::desugar_generics(tcx, sess, *owner_id, generics)?
             } else {
-                fhir::lift::lift_generics(tcx, sess, *owner_id)?
+                lift::lift_generics(tcx, sess, *owner_id)?
             };
             map.insert_generics(owner_id.def_id, generics);
             Ok(())
@@ -153,8 +153,10 @@ fn build_stage1_fhir_map(
         .or(err);
     err = defs_with_generics(tcx)
         .try_for_each_exhaust(|owner_id| {
-            let generics = fhir::lift::lift_generics(tcx, sess, owner_id)?;
+            let generics = lift::lift_generics(tcx, sess, owner_id)?;
+            let predicates = lift::lift_generic_predicates(tcx, sess, owner_id)?;
             map.insert_generics(owner_id.def_id, generics);
+            map.insert_generic_predicates(owner_id.def_id, predicates);
             Ok(())
         })
         .err()
@@ -187,7 +189,7 @@ fn build_stage1_fhir_map(
             let refined_by = if let Some(refined_by) = refined_by {
                 desugar::desugar_refined_by(sess, map.sort_decls(), owner_id, refined_by)?
             } else {
-                fhir::lift::lift_refined_by(tcx, owner_id)
+                lift::lift_refined_by(tcx, owner_id)
             };
             map.insert_refined_by(owner_id.def_id, refined_by);
             Ok(())
@@ -251,7 +253,7 @@ fn build_stage2_fhir_map<'sess, 'tcx>(
             let alias = if let Some(alias) = alias {
                 desugar::desugar_type_alias(&early_cx, owner_id, alias)?
             } else {
-                fhir::lift::lift_type_alias(tcx, sess, owner_id)?
+                lift::lift_type_alias(tcx, sess, owner_id)?
             };
             early_cx.map.insert_type_alias(owner_id.def_id, alias);
             Ok(())
@@ -296,24 +298,21 @@ fn build_stage2_fhir_map<'sess, 'tcx>(
                 early_cx.map.add_trusted(def_id);
             }
 
-            let (fn_sig, data) = if let Some(fn_sig) = spec.fn_sig {
-                let fn_info = desugar::desugar_fn_sig(&early_cx, owner_id, fn_sig)?;
-                (fn_info.fn_sig, Some((fn_info.fn_preds, fn_info.opaque_tys)))
+            let info = if let Some(fn_sig) = spec.fn_sig {
+                desugar::desugar_fn_sig(&early_cx, owner_id, fn_sig)?
             } else {
-                (fhir::lift::lift_fn_sig(tcx, sess, owner_id)?, None)
+                lift::lift_fn(tcx, sess, owner_id)?
             };
             if config::dump_fhir() {
-                dbg::dump_item_info(tcx, def_id, "fhir", &fn_sig).unwrap();
+                dbg::dump_item_info(tcx, def_id, "fhir", &info.fn_sig).unwrap();
             }
 
-            early_cx.map.insert_fn_sig(def_id, fn_sig);
-            if let Some((fn_preds, opaque_tys)) = data {
-                early_cx.map.insert_generic_predicates(def_id, fn_preds);
-                early_cx.map.insert_opaque_tys(opaque_tys);
-            }
-
+            let map = &mut early_cx.map;
+            map.insert_fn_sig(def_id, info.fn_sig);
+            map.insert_generic_predicates(def_id, info.fn_preds);
+            map.insert_opaque_tys(info.opaque_tys);
             if let Some(quals) = spec.qual_names {
-                early_cx.map.insert_fn_quals(def_id, quals.names);
+                map.insert_fn_quals(def_id, quals.names);
             }
             Ok(())
         })
@@ -473,12 +472,14 @@ fn is_tool_registered(tcx: TyCtxt) -> bool {
 fn defs_with_generics(tcx: TyCtxt) -> impl Iterator<Item = OwnerId> + '_ {
     tcx.hir_crate_items(())
         .definitions()
+        .chain(tcx.hir().body_owners())
         .flat_map(move |def_id| {
             match tcx.def_kind(def_id) {
                 DefKind::Struct
                 | DefKind::Enum
                 | DefKind::Impl { .. }
                 | DefKind::TyAlias
+                | DefKind::OpaqueTy
                 | DefKind::AssocTy => Some(OwnerId { def_id }),
                 _ => None,
             }

--- a/flux-fhir-analysis/locales/en-US.ftl
+++ b/flux-fhir-analysis/locales/en-US.ftl
@@ -146,3 +146,11 @@ fhir_analysis_field_count_mismatch =
 fhir_analysis_definition_cycle =
     cycle in definitions
     .label = {$msg}
+
+# Conv errors
+
+fhir_analysis_assoc_type_not_found =
+    associated type not found
+    .label = cannot resolve this associated type
+    .note = flux cannot resolved associated types if they are defined in a super trait
+

--- a/flux-fhir-analysis/src/annot_check.rs
+++ b/flux-fhir-analysis/src/annot_check.rs
@@ -26,8 +26,8 @@ pub fn check_fn_sig(
         return Ok(());
     }
     let self_ty = lift::lift_self_ty(early_cx.tcx, early_cx.sess, owner_id)?;
-    Zipper::new(early_cx.sess, wfckresults, self_ty.as_ref())
-        .zip_fn_sig(fn_sig, &lift::lift_fn_sig(early_cx.tcx, early_cx.sess, owner_id)?)
+    let expected_fn_sig = &lift::lift_fn(early_cx.tcx, early_cx.sess, owner_id)?.fn_sig;
+    Zipper::new(early_cx.sess, wfckresults, self_ty.as_ref()).zip_fn_sig(fn_sig, expected_fn_sig)
 }
 
 pub fn check_alias(

--- a/flux-fhir-analysis/src/annot_check.rs
+++ b/flux-fhir-analysis/src/annot_check.rs
@@ -306,11 +306,11 @@ impl<'zip> Zipper<'zip> {
         if path.res != expected_path.res {
             return Err(self.emit_err(errors::InvalidRefinement::from_paths(path, expected_path)));
         }
-        if path.generics.len() != expected_path.generics.len() {
+        if path.args.len() != expected_path.args.len() {
             return Err(self.emit_err(errors::GenericArgCountMismatch::new(path, expected_path)));
         }
 
-        iter::zip(&path.generics, &expected_path.generics)
+        iter::zip(&path.args, &expected_path.args)
             .try_for_each_exhaust(|(arg, expected)| self.zip_generic_arg(arg, expected))
     }
 
@@ -424,8 +424,8 @@ mod errors {
         pub(super) fn new(path: &fhir::Path, expected_path: &fhir::Path) -> Self {
             GenericArgCountMismatch {
                 span: path.span,
-                found: path.generics.len(),
-                expected: expected_path.generics.len(),
+                found: path.args.len(),
+                expected: expected_path.args.len(),
                 def_descr: path.res.descr(),
                 expected_span: expected_path.span,
             }

--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -113,13 +113,14 @@ pub(crate) fn conv_generic_predicates(
 
 pub(crate) fn conv_opaque_ty(
     genv: &GlobalEnv,
+    def_id: DefId,
     opaque_ty: &fhir::OpaqueTy,
     wfckresults: &fhir::WfckResults,
 ) -> QueryResult<List<rty::Clause>> {
     let cx = ConvCtxt::new(genv, wfckresults);
     let env = &mut Env::new(&[]);
-    let args = rty::GenericArgs::identity_for_item(genv, opaque_ty.def_id)?;
-    let self_ty = rty::Ty::opaque(opaque_ty.def_id, args);
+    let args = rty::GenericArgs::identity_for_item(genv, def_id)?;
+    let self_ty = rty::Ty::opaque(def_id, args);
     Ok(cx
         .conv_generic_bounds(env, self_ty, &opaque_ty.bounds)?
         .into_iter()

--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -294,7 +294,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
         clauses: &mut Vec<rty::Clause>,
     ) -> QueryResult<()> {
         match bound {
-            fhir::GenericBound::Trait(trait_ref) => {
+            fhir::GenericBound::Trait(trait_ref, fhir::TraitBoundModifier::None) => {
                 let fhir::Res::Def(DefKind::Trait, trait_def_id) = trait_ref.res else {
                     span_bug!(trait_ref.span, "unexpected resolution {:?}", trait_ref.res);
                 };
@@ -310,6 +310,9 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                     )
                 }
             }
+            // Maybe bounds are only supported for `?Sized`, and the effect is just to relax the
+            // default which is `Sized`, so we just skip it here.
+            fhir::GenericBound::Trait(_, fhir::TraitBoundModifier::Maybe) => Ok(()),
             fhir::GenericBound::LangItemTrait(lang_item, _, bindings) => {
                 let trait_def_id = self.genv.tcx.require_lang_item(*lang_item, None);
                 self.conv_type_bindings(env, bounded_ty, trait_def_id, bindings, clauses)

--- a/flux-fhir-analysis/src/lib.rs
+++ b/flux-fhir-analysis/src/lib.rs
@@ -134,7 +134,7 @@ fn item_bounds(
 ) -> QueryResult<Option<rty::EarlyBinder<rty::GenericPredicates>>> {
     let wfckresults = genv.check_wf(local_id)?;
     if let Some(opaque_ty) = genv.map().get_item_bounds(local_id) {
-        Ok(Some(rty::EarlyBinder(conv::conv_generic_predicates(genv, predicates, &wfckresults)?)))
+        Ok(Some(rty::EarlyBinder(conv::conv_opaque_ty(genv, opaque_ty, &wfckresults)?)))
     } else {
         Ok(None)
     }
@@ -283,8 +283,8 @@ fn check_wf_rust_item(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<fhir:
         DefKind::OpaqueTy => {
             let hir_id = genv.hir().local_def_id_to_hir_id(def_id);
             let owner = genv.hir().get_parent_item(hir_id);
-            if let Some(predicates) = genv.map().get_item_bounds(def_id) {
-                let wfckresults = wf::check_generic_predicates(genv.early_cx(), predicates, owner)?;
+            if let Some(opaque_ty) = genv.map().get_item_bounds(def_id) {
+                let wfckresults = wf::check_opaque_ty(genv.early_cx(), opaque_ty, owner)?;
                 Ok(wfckresults)
             } else {
                 Ok(fhir::WfckResults::new(fhir::FluxOwnerId::from(owner)))

--- a/flux-fhir-analysis/src/lib.rs
+++ b/flux-fhir-analysis/src/lib.rs
@@ -13,6 +13,8 @@ mod annot_check;
 mod conv;
 mod wf;
 
+use std::rc::Rc;
+
 use flux_common::{bug, dbg};
 use flux_config as config;
 use flux_errors::ResultExt;
@@ -120,14 +122,16 @@ fn predicates_of(
     genv: &GlobalEnv,
     local_id: LocalDefId,
 ) -> QueryResult<rty::EarlyBinder<rty::GenericPredicates>> {
-    let wfckresults = genv.check_wf(local_id)?;
-    let predicates = genv.map().get_predicates(local_id).unwrap();
-    Ok(rty::EarlyBinder(conv::conv_generic_predicates(
-        genv,
-        local_id.to_def_id(),
-        predicates,
-        &wfckresults,
-    )?))
+    let predicates = if let Some(predicates) = genv.map().get_generic_predicates(local_id) {
+        let wfckresults = genv.check_wf(local_id)?;
+        conv::conv_generic_predicates(genv, local_id.to_def_id(), predicates, &wfckresults)?
+    } else {
+        rty::GenericPredicates {
+            parent: genv.tcx.opt_parent(local_id.to_def_id()),
+            predicates: List::empty(),
+        }
+    };
+    Ok(rty::EarlyBinder(predicates))
 }
 
 fn item_bounds(
@@ -136,13 +140,14 @@ fn item_bounds(
 ) -> QueryResult<rty::EarlyBinder<List<rty::Clause>>> {
     let wfckresults = genv.check_wf(local_id)?;
     let opaque_ty = genv.map().get_opaque_ty(local_id).unwrap();
-    Ok(rty::EarlyBinder(conv::conv_opaque_ty(genv, opaque_ty, &wfckresults)?))
+    Ok(rty::EarlyBinder(conv::conv_opaque_ty(genv, local_id.to_def_id(), opaque_ty, &wfckresults)?))
 }
 
 fn generics_of(genv: &GlobalEnv, local_id: LocalDefId) -> QueryResult<rty::Generics> {
     let def_id = local_id.to_def_id();
     let rustc_generics = lowering::lower_generics(genv.tcx.generics_of(def_id))
         .map_err(|err| QueryErr::unsupported(genv.tcx, def_id, err))?;
+    // FIXME(nilehmann) we are returning the wrong generics for closures and generators
     let generics = genv.map().get_generics(local_id).unwrap_or_else(|| {
         genv.map()
             .get_generics(genv.tcx.local_parent(local_id))
@@ -221,48 +226,47 @@ fn fn_sig(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<
     Ok(rty::EarlyBinder(fn_sig))
 }
 
-fn check_wf(genv: &GlobalEnv, flux_id: FluxLocalDefId) -> QueryResult<fhir::WfckResults> {
+fn check_wf(genv: &GlobalEnv, flux_id: FluxLocalDefId) -> QueryResult<Rc<fhir::WfckResults>> {
     match flux_id {
         FluxLocalDefId::Flux(sym) => check_wf_flux_item(genv, sym),
         FluxLocalDefId::Rust(def_id) => check_wf_rust_item(genv, def_id),
     }
 }
 
-fn check_wf_flux_item(genv: &GlobalEnv, sym: Symbol) -> QueryResult<fhir::WfckResults> {
+fn check_wf_flux_item(genv: &GlobalEnv, sym: Symbol) -> QueryResult<Rc<fhir::WfckResults>> {
     let wfckresults = match genv.map().get_flux_item(sym).unwrap() {
         fhir::FluxItem::Qualifier(qualifier) => wf::check_qualifier(genv.early_cx(), qualifier)?,
         fhir::FluxItem::Defn(defn) => wf::check_defn(genv.early_cx(), defn)?,
     };
-    Ok(wfckresults)
+    Ok(Rc::new(wfckresults))
 }
 
-fn check_wf_rust_item(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<fhir::WfckResults> {
-    match genv.tcx.def_kind(def_id) {
+fn check_wf_rust_item(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<Rc<fhir::WfckResults>> {
+    let wfckresults = match genv.tcx.def_kind(def_id) {
         DefKind::TyAlias => {
             let alias = genv.map().get_type_alias(def_id);
             let mut wfckresults = wf::check_ty_alias(genv.early_cx(), alias)?;
             annot_check::check_alias(genv.early_cx(), &mut wfckresults, alias)?;
-            Ok(wfckresults)
+            wfckresults
         }
         DefKind::Struct => {
             let struct_def = genv.map().get_struct(def_id);
             let mut wfckresults = wf::check_struct_def(genv.early_cx(), struct_def)?;
             annot_check::check_struct_def(genv.early_cx(), &mut wfckresults, struct_def)?;
-            Ok(wfckresults)
+            wfckresults
         }
         DefKind::Enum => {
             let enum_def = genv.map().get_enum(def_id);
             let mut wfckresults = wf::check_enum_def(genv.early_cx(), enum_def)?;
             annot_check::check_enum_def(genv.early_cx(), &mut wfckresults, enum_def)?;
-            Ok(wfckresults)
+            wfckresults
         }
         DefKind::TyParam => {
             match &genv.early_cx().get_generic_param(def_id).kind {
                 fhir::GenericParamDefKind::Type { default: Some(ty) } => {
                     let hir_id = genv.hir().local_def_id_to_hir_id(def_id);
                     let owner = genv.hir().get_parent_item(hir_id);
-                    let wfckresults = wf::check_type(genv.early_cx(), ty, owner)?;
-                    Ok(wfckresults)
+                    wf::check_type(genv.early_cx(), ty, owner)?
                 }
                 fhir::GenericParamDefKind::Type { default: None } => {
                     bug!("type parameter without default")
@@ -273,29 +277,18 @@ fn check_wf_rust_item(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<fhir:
         DefKind::Fn | DefKind::AssocFn => {
             let owner_id = OwnerId { def_id };
 
-            // 1. check the actual FnSig
             let fn_sig = genv.map().get_fn_sig(def_id);
             let mut wfckresults = wf::check_fn_sig(genv.early_cx(), fn_sig, owner_id)?;
             annot_check::check_fn_sig(genv.early_cx(), &mut wfckresults, owner_id, fn_sig)?;
-
-            // 2. check the predicates (stashed in `where` clauses); we don't 'zip' these because the orders are jumbled :-(
-            if let Some(predicates) = genv.map().get_predicates(def_id) {
-                wf::check_generic_predicates(genv.early_cx(), predicates, owner_id)?;
-            }
-            Ok(wfckresults)
+            wfckresults
         }
-        DefKind::OpaqueTy => {
-            let hir_id = genv.hir().local_def_id_to_hir_id(def_id);
-            let owner = genv.hir().get_parent_item(hir_id);
-            if let Some(opaque_ty) = genv.map().get_opaque_ty(def_id) {
-                let wfckresults = wf::check_opaque_ty(genv.early_cx(), opaque_ty, owner)?;
-                Ok(wfckresults)
-            } else {
-                Ok(fhir::WfckResults::new(fhir::FluxOwnerId::from(owner)))
-            }
+        DefKind::OpaqueTy | DefKind::Closure | DefKind::Generator => {
+            let parent = genv.tcx.local_parent(def_id);
+            return genv.check_wf(parent);
         }
         kind => panic!("unexpected def kind `{kind:?}`"),
-    }
+    };
+    Ok(Rc::new(wfckresults))
 }
 
 pub fn check_crate_wf(genv: &GlobalEnv) -> Result<(), ErrorGuaranteed> {

--- a/flux-fhir-analysis/src/lib.rs
+++ b/flux-fhir-analysis/src/lib.rs
@@ -133,7 +133,7 @@ fn item_bounds(
     local_id: LocalDefId,
 ) -> QueryResult<Option<rty::EarlyBinder<rty::GenericPredicates>>> {
     let wfckresults = genv.check_wf(local_id)?;
-    if let Some(predicates) = genv.map().get_item_bounds(local_id) {
+    if let Some(opaque_ty) = genv.map().get_item_bounds(local_id) {
         Ok(Some(rty::EarlyBinder(conv::conv_generic_predicates(genv, predicates, &wfckresults)?)))
     } else {
         Ok(None)

--- a/flux-fhir-analysis/src/wf/mod.rs
+++ b/flux-fhir-analysis/src/wf/mod.rs
@@ -193,6 +193,20 @@ pub(crate) fn check_generic_predicates(
     Ok(infcx.into_results())
 }
 
+pub(crate) fn check_opaque_ty(
+    early_cx: &EarlyCtxt,
+    opaque_ty: &fhir::OpaqueTy,
+    owner_id: OwnerId,
+) -> Result<WfckResults, ErrorGuaranteed> {
+    let mut infcx = InferCtxt::new(early_cx, owner_id.into());
+    let mut wf = Wf::new(early_cx);
+    opaque_ty
+        .bounds
+        .iter()
+        .try_for_each_exhaust(|bound| wf.check_path(&mut infcx, bound))?;
+    Ok(infcx.into_results())
+}
+
 impl<'a, 'tcx> Wf<'a, 'tcx> {
     fn new(early_cx: &'a EarlyCtxt<'a, 'tcx>) -> Self {
         Wf { early_cx, modes: Default::default(), xi: Default::default() }

--- a/flux-fhir-analysis/src/wf/mod.rs
+++ b/flux-fhir-analysis/src/wf/mod.rs
@@ -27,9 +27,9 @@ struct Wf<'a, 'tcx> {
     xi: XiCtxt,
 }
 
-/// Keeps track of all refinement parameters that were used as an index such that their value is fully
-/// determined. The context is called Xi because in the paper [Focusing on Liquid Refinement Typing], the
-/// well-formedness judgment uses an uppercase Xi (Ξ) for a context that is similar in purpose.
+/// Keeps track of all refinement parameters that are used as an index such that their value is fully
+/// determined. The context is called Xi because in the paper [Focusing on Liquid Refinement Typing],
+/// the well-formedness judgment uses an uppercase Xi (Ξ) for a context that is similar in purpose.
 ///
 /// This is basically a set of [`fhir::Name`] implemented with a snapshot map such that elements
 /// can be removed in batch when there's a change in polarity.
@@ -151,9 +151,16 @@ pub(crate) fn check_fn_sig(
     let mut infcx = InferCtxt::new(early_cx, owner_id.into());
     let mut wf = Wf::new(early_cx);
 
-    for opaque_ty_id in early_cx.tcx.opaque_types_defined_by(owner_id.def_id) {
-        let opaque_ty = early_cx.map.get_opaque_ty(*opaque_ty_id).unwrap();
-        wf.check_opaque_ty(&mut infcx, opaque_ty)?;
+    // FIXME(nilehmann) we should move opaque types outside functions as they are their own item
+    if early_cx
+        .hir()
+        .maybe_body_owned_by(owner_id.def_id)
+        .is_some()
+    {
+        for opaque_ty_id in early_cx.tcx.opaque_types_defined_by(owner_id.def_id) {
+            let opaque_ty = early_cx.map.get_opaque_ty(*opaque_ty_id).unwrap();
+            wf.check_opaque_ty(&mut infcx, opaque_ty)?;
+        }
     }
 
     let predicates = early_cx

--- a/flux-fhir-analysis/src/wf/mod.rs
+++ b/flux-fhir-analysis/src/wf/mod.rs
@@ -227,7 +227,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         bound: &fhir::GenericBound,
     ) -> Result<(), ErrorGuaranteed> {
         match bound {
-            fhir::GenericBound::Trait(trait_ref) => self.check_path(infcx, trait_ref),
+            fhir::GenericBound::Trait(trait_ref, _) => self.check_path(infcx, trait_ref),
             fhir::GenericBound::LangItemTrait(_, args, bindings) => {
                 self.check_generic_args(infcx, args)?;
                 self.check_type_bindings(infcx, bindings)?;

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -110,6 +110,7 @@ pub type GenericBounds = Vec<Path>;
 
 #[derive(Debug)]
 pub struct OpaqueTy {
+    pub def_id: LocalDefId,
     pub bounds: GenericBounds,
 }
 
@@ -860,7 +861,7 @@ impl Map {
         self.predicates.get(&def_id)
     }
 
-    pub fn get_item_bounds(&self, def_id: LocalDefId) -> Option<&OpaqueTy> {
+    pub fn get_opaque_ty(&self, def_id: LocalDefId) -> Option<&OpaqueTy> {
         self.opaque_tys.get(&def_id)
     }
 

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -115,7 +115,7 @@ pub enum GenericBound {
     LangItemTrait(LangItem, Vec<GenericArg>, Vec<TypeBinding>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum TraitBoundModifier {
     None,
     Maybe,

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -31,7 +31,7 @@ pub use rustc_hir::PrimTy;
 use rustc_hir::{
     def::DefKind,
     def_id::{DefId, LocalDefId},
-    ItemId, OwnerId,
+    ItemId, LangItem, OwnerId,
 };
 use rustc_index::newtype_index;
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
@@ -106,7 +106,13 @@ pub struct WhereBoundPredicate {
     pub bounds: GenericBounds,
 }
 
-pub type GenericBounds = Vec<Path>;
+pub type GenericBounds = Vec<GenericBound>;
+
+#[derive(Debug)]
+pub enum GenericBound {
+    Trait(Path),
+    LangItemTrait(LangItem, Vec<GenericArg>, Vec<TypeBinding>),
+}
 
 #[derive(Debug)]
 pub struct OpaqueTy {
@@ -402,7 +408,7 @@ pub struct Path {
     pub span: Span,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TypeBinding {
     pub ident: SurfaceIdent,
     pub term: Ty,

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -95,7 +95,6 @@ pub type ItemPredicates = FxHashMap<LocalDefId, GenericPredicates>;
 
 #[derive(Debug)]
 pub struct GenericPredicates {
-    pub parent: Option<DefId>,
     pub predicates: Vec<WhereBoundPredicate>,
 }
 

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -111,8 +111,14 @@ pub type GenericBounds = Vec<GenericBound>;
 
 #[derive(Debug)]
 pub enum GenericBound {
-    Trait(Path),
+    Trait(Path, TraitBoundModifier),
     LangItemTrait(LangItem, Vec<GenericArg>, Vec<TypeBinding>),
+}
+
+#[derive(Debug)]
+pub enum TraitBoundModifier {
+    None,
+    Maybe,
 }
 
 #[derive(Debug)]

--- a/flux-middle/src/fhir.rs
+++ b/flux-middle/src/fhir.rs
@@ -110,7 +110,6 @@ pub type GenericBounds = Vec<Path>;
 
 #[derive(Debug)]
 pub struct OpaqueTy {
-    pub def_id: LocalDefId,
     pub bounds: GenericBounds,
 }
 
@@ -849,7 +848,7 @@ impl Map {
         self.generics.get(&def_id)
     }
 
-    pub fn get_predicates(&self, def_id: LocalDefId) -> Option<&GenericPredicates> {
+    pub fn get_generic_predicates(&self, def_id: LocalDefId) -> Option<&GenericPredicates> {
         self.predicates.get(&def_id)
     }
 

--- a/flux-middle/src/fhir/lift.rs
+++ b/flux-middle/src/fhir/lift.rs
@@ -2,7 +2,7 @@
 //!
 use flux_common::{bug, index::IndexGen, iter::IterExt};
 use flux_errors::{ErrorGuaranteed, FluxSession};
-use hir::{def::DefKind, OwnerId};
+use hir::{def::DefKind, LangItem, OwnerId};
 use itertools::Itertools;
 use rustc_ast::LitKind;
 use rustc_errors::IntoDiagnostic;
@@ -59,23 +59,6 @@ pub fn lift_generics(
         })
         .try_collect_exhaust()?;
     Ok(fhir::Generics { params })
-}
-
-pub fn lift_generic_predicates(
-    tcx: TyCtxt,
-    sess: &FluxSession,
-    owner_id: OwnerId,
-) -> Result<fhir::GenericPredicates, ErrorGuaranteed> {
-    let def_id = owner_id.def_id;
-    let hir_generics = tcx.hir().get_generics(def_id).unwrap();
-    let cx = LiftCtxt::new(tcx, sess, owner_id);
-
-    let predicates = hir_generics
-        .predicates
-        .iter()
-        .map(|pred| cx.lift_where_predicate(pred))
-        .try_collect_exhaust()?;
-    Ok(fhir::GenericPredicates { predicates })
 }
 
 pub fn lift_refined_by(tcx: TyCtxt, owner_id: OwnerId) -> fhir::RefinedBy {
@@ -166,41 +149,46 @@ pub fn lift_enum_variant_def(
     Ok(fhir::VariantDef { def_id, params: vec![], fields, ret, span: variant.span, lifted: true })
 }
 
-pub fn lift_fn_sig(
+// FIXME(nilehmann) this is wrong, we should lift generic predicates in the same `LiftCtxt` than
+// then owned item to generate appropriate `FluxOwnerId`s
+pub fn lift_generic_predicates(
     tcx: TyCtxt,
     sess: &FluxSession,
     owner_id: OwnerId,
-) -> Result<fhir::FnSig, ErrorGuaranteed> {
+) -> Result<fhir::GenericPredicates, ErrorGuaranteed> {
     let def_id = owner_id.def_id;
+    let generics = tcx.hir().get_generics(def_id).unwrap();
+    LiftCtxt::new(tcx, sess, owner_id).lift_generic_predicates(generics)
+}
+
+pub fn lift_fn(
+    tcx: TyCtxt,
+    sess: &FluxSession,
+    owner_id: OwnerId,
+) -> Result<fhir::FnInfo, ErrorGuaranteed> {
     let cx = LiftCtxt::new(tcx, sess, owner_id);
-    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
-    let fn_sig = tcx
-        .hir()
+
+    let def_id = owner_id.def_id;
+    let hir = tcx.hir();
+    let hir_id = hir.local_def_id_to_hir_id(def_id);
+    let fn_sig = hir
         .fn_sig_by_hir_id(hir_id)
         .expect("item does not have a `FnDecl`");
+    let generics = tcx.hir().get_generics(def_id).unwrap();
 
-    let args = fn_sig
-        .decl
-        .inputs
+    let fn_sig = cx.lift_fn_sig(fn_sig)?;
+    let fn_preds = cx.lift_generic_predicates(generics)?;
+    let opaque_tys = tcx
+        .opaque_types_defined_by(def_id)
         .iter()
-        .map(|ty| cx.lift_ty(ty))
-        .try_collect_exhaust()?;
-
-    let output = fhir::FnOutput {
-        params: vec![],
-        ensures: vec![],
-        ret: cx.lift_fn_ret_ty(&fn_sig.decl.output)?,
-    };
-
-    let fn_sig = fhir::FnSig {
-        params: vec![],
-        requires: vec![],
-        args,
-        output,
-        lifted: true,
-        span: fn_sig.span,
-    };
-    Ok(fn_sig)
+        .map(|opaque_ty_id| {
+            let hir::ItemKind::OpaqueTy(opaque_ty) = hir.expect_item(*opaque_ty_id).kind else {
+                bug!("expected opaque type")
+            };
+            Ok((*opaque_ty_id, cx.lift_opaque_ty(opaque_ty)?))
+        })
+        .try_collect()?;
+    Ok(fhir::FnInfo { fn_sig, fn_preds, opaque_tys })
 }
 
 pub fn lift_self_ty(
@@ -246,12 +234,24 @@ impl<'a, 'tcx> LiftCtxt<'a, 'tcx> {
         FhirId { owner: FluxOwnerId::Rust(self.owner), local_id: self.local_id_gen.fresh() }
     }
 
+    pub fn lift_generic_predicates(
+        &self,
+        generics: &hir::Generics,
+    ) -> Result<fhir::GenericPredicates, ErrorGuaranteed> {
+        let predicates = generics
+            .predicates
+            .iter()
+            .map(|pred| self.lift_where_predicate(pred))
+            .try_collect_exhaust()?;
+        Ok(fhir::GenericPredicates { predicates })
+    }
+
     fn lift_where_predicate(
         &self,
         pred: &hir::WherePredicate,
     ) -> Result<fhir::WhereBoundPredicate, ErrorGuaranteed> {
         if let hir::WherePredicate::BoundPredicate(bound) = pred {
-            if bound.bound_generic_params.is_empty() {
+            if !bound.bound_generic_params.is_empty() {
                 return self.emit_unsupported(&format!("unsupported where predicate: `{bound:?}`"));
             }
             let bounded_ty = self.lift_ty(bound.bounded_ty)?;
@@ -268,14 +268,52 @@ impl<'a, 'tcx> LiftCtxt<'a, 'tcx> {
     }
 
     fn lift_generic_bound(&self, bound: &hir::GenericBound) -> Result<fhir::Path, ErrorGuaranteed> {
-        if let hir::GenericBound::Trait(poly_trait_ref, hir::TraitBoundModifier::None) = bound
-            && poly_trait_ref.bound_generic_params.is_empty()
-        {
-            todo!()
-            // self.lift_path(None, &poly_trait_ref.trait_ref.path)
-        } else {
-            self.emit_unsupported(&format!("unsupported generic bound: `{bound:?}`"))
+        match bound {
+            hir::GenericBound::Trait(poly_trait_ref, hir::TraitBoundModifier::None)
+                if poly_trait_ref.bound_generic_params.is_empty() =>
+            {
+                self.lift_path(poly_trait_ref.trait_ref.path)
+            }
+            hir::GenericBound::LangItemTrait(LangItem::Future, .., args) => {
+                todo!("{args:?}");
+            }
+            _ => self.emit_unsupported(&format!("unsupported generic bound: `{bound:?}`")),
         }
+    }
+
+    fn lift_opaque_ty(&self, opaque_ty: &hir::OpaqueTy) -> Result<fhir::OpaqueTy, ErrorGuaranteed> {
+        Ok(fhir::OpaqueTy {
+            bounds: opaque_ty
+                .bounds
+                .iter()
+                .map(|bound| self.lift_generic_bound(bound))
+                .try_collect()?,
+        })
+    }
+
+    fn lift_fn_sig(&self, fn_sig: &hir::FnSig) -> Result<fhir::FnSig, ErrorGuaranteed> {
+        let args = fn_sig
+            .decl
+            .inputs
+            .iter()
+            .map(|ty| self.lift_ty(ty))
+            .try_collect_exhaust()?;
+
+        let output = fhir::FnOutput {
+            params: vec![],
+            ensures: vec![],
+            ret: self.lift_fn_ret_ty(&fn_sig.decl.output)?,
+        };
+
+        let fn_sig = fhir::FnSig {
+            params: vec![],
+            requires: vec![],
+            args,
+            output,
+            lifted: true,
+            span: fn_sig.span,
+        };
+        Ok(fn_sig)
     }
 
     fn lift_fn_ret_ty(&self, ret_ty: &hir::FnRetTy) -> Result<fhir::Ty, ErrorGuaranteed> {
@@ -351,7 +389,7 @@ impl<'a, 'tcx> LiftCtxt<'a, 'tcx> {
 
     fn lift_qpath(&self, qpath: &hir::QPath) -> Result<fhir::Ty, ErrorGuaranteed> {
         match qpath {
-            hir::QPath::Resolved(self_ty, path) => self.lift_path(*self_ty, path),
+            hir::QPath::Resolved(self_ty, path) => self.lift_path_to_ty(*self_ty, path),
             hir::QPath::TypeRelative(_, _) | hir::QPath::LangItem(_, _, _) => {
                 self.emit_unsupported(&format!(
                     "unsupported type: `{}`",
@@ -361,11 +399,7 @@ impl<'a, 'tcx> LiftCtxt<'a, 'tcx> {
         }
     }
 
-    fn lift_path(
-        &self,
-        self_ty: Option<&hir::Ty>,
-        path: &hir::Path,
-    ) -> Result<fhir::Ty, ErrorGuaranteed> {
+    fn lift_path(&self, path: &hir::Path) -> Result<fhir::Path, ErrorGuaranteed> {
         let res = match path.res {
             hir::def::Res::Def(kind, def_id) => fhir::Res::Def(kind, def_id),
             hir::def::Res::PrimTy(prim_ty) => fhir::Res::PrimTy(prim_ty),
@@ -387,7 +421,15 @@ impl<'a, 'tcx> LiftCtxt<'a, 'tcx> {
             None => (vec![], vec![]),
         };
 
-        let path = fhir::Path { res, args, bindings, refine: vec![], span: path.span };
+        Ok(fhir::Path { res, args, bindings, refine: vec![], span: path.span })
+    }
+
+    fn lift_path_to_ty(
+        &self,
+        self_ty: Option<&hir::Ty>,
+        path: &hir::Path,
+    ) -> Result<fhir::Ty, ErrorGuaranteed> {
+        let path = self.lift_path(path)?;
         let self_ty = self_ty
             .map(|ty| Ok(Box::new(self.lift_ty(ty)?)))
             .transpose()?;

--- a/flux-middle/src/fhir/lift.rs
+++ b/flux-middle/src/fhir/lift.rs
@@ -275,7 +275,18 @@ impl<'a, 'tcx> LiftCtxt<'a, 'tcx> {
             hir::GenericBound::Trait(poly_trait_ref, hir::TraitBoundModifier::None)
                 if poly_trait_ref.bound_generic_params.is_empty() =>
             {
-                Ok(fhir::GenericBound::Trait(self.lift_path(poly_trait_ref.trait_ref.path)?))
+                Ok(fhir::GenericBound::Trait(
+                    self.lift_path(poly_trait_ref.trait_ref.path)?,
+                    fhir::TraitBoundModifier::None,
+                ))
+            }
+            hir::GenericBound::Trait(poly_trait_ref, hir::TraitBoundModifier::Maybe)
+                if poly_trait_ref.bound_generic_params.is_empty() =>
+            {
+                Ok(fhir::GenericBound::Trait(
+                    self.lift_path(poly_trait_ref.trait_ref.path)?,
+                    fhir::TraitBoundModifier::Maybe,
+                ))
             }
             hir::GenericBound::LangItemTrait(lang_item, .., args) => {
                 Ok(fhir::GenericBound::LangItemTrait(

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -146,7 +146,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         &self,
         def_id: DefId,
         span: Span,
-    ) -> QueryResult<rty::EarlyBinder<rty::GenericPredicates>> {
+    ) -> QueryResult<rty::EarlyBinder<List<rty::Clause>>> {
         self.queries.item_bounds(self, def_id, span)
     }
 

--- a/flux-middle/src/queries.rs
+++ b/flux-middle/src/queries.rs
@@ -42,7 +42,7 @@ pub enum QueryErr {
 pub struct Providers {
     pub defns: fn(&GlobalEnv) -> QueryResult<rty::Defns>,
     pub qualifiers: fn(&GlobalEnv) -> QueryResult<Vec<rty::Qualifier>>,
-    pub check_wf: fn(&GlobalEnv, FluxLocalDefId) -> QueryResult<fhir::WfckResults>,
+    pub check_wf: fn(&GlobalEnv, FluxLocalDefId) -> QueryResult<Rc<fhir::WfckResults>>,
     pub adt_def: fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::AdtDef>,
     pub type_of: fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::EarlyBinder<rty::PolyTy>>,
     pub variants_of: fn(
@@ -165,10 +165,7 @@ impl<'tcx> Queries<'tcx> {
         genv: &GlobalEnv,
         flux_id: FluxLocalDefId,
     ) -> QueryResult<Rc<fhir::WfckResults>> {
-        run_with_cache(&self.check_wf, flux_id, || {
-            let wfckresults = (self.providers.check_wf)(genv, flux_id)?;
-            Ok(Rc::new(wfckresults))
-        })
+        run_with_cache(&self.check_wf, flux_id, || (self.providers.check_wf)(genv, flux_id))
     }
 
     pub(crate) fn adt_def(&self, genv: &GlobalEnv, def_id: DefId) -> QueryResult<rty::AdtDef> {

--- a/flux-middle/src/queries.rs
+++ b/flux-middle/src/queries.rs
@@ -52,9 +52,8 @@ pub struct Providers {
     pub fn_sig: fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>>,
     pub generics_of: fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::Generics>,
     pub predicates_of:
-        fn(&GlobalEnv, LocalDefId) -> QueryResult<Option<rty::EarlyBinder<rty::GenericPredicates>>>,
-    pub item_bounds:
-        fn(&GlobalEnv, LocalDefId) -> QueryResult<Option<rty::EarlyBinder<rty::GenericPredicates>>>,
+        fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::EarlyBinder<rty::GenericPredicates>>,
+    pub item_bounds: fn(&GlobalEnv, LocalDefId) -> QueryResult<rty::EarlyBinder<List<rty::Clause>>>,
 }
 
 macro_rules! empty_query {
@@ -92,7 +91,7 @@ pub struct Queries<'tcx> {
     adt_def: Cache<DefId, QueryResult<rty::AdtDef>>,
     generics_of: Cache<DefId, QueryResult<rty::Generics>>,
     predicates_of: Cache<DefId, QueryResult<rty::EarlyBinder<rty::GenericPredicates>>>,
-    item_bounds: Cache<DefId, QueryResult<rty::EarlyBinder<rty::GenericPredicates>>>,
+    item_bounds: Cache<DefId, QueryResult<rty::EarlyBinder<List<rty::Clause>>>>,
     type_of: Cache<DefId, QueryResult<rty::EarlyBinder<rty::PolyTy>>>,
     variants_of: Cache<DefId, QueryResult<rty::Opaqueness<rty::EarlyBinder<rty::PolyVariants>>>>,
     fn_sig: Cache<DefId, QueryResult<rty::EarlyBinder<rty::PolyFnSig>>>,
@@ -206,31 +205,36 @@ impl<'tcx> Queries<'tcx> {
             }
         })
     }
+
     pub(crate) fn item_bounds(
         &self,
         genv: &GlobalEnv,
         def_id: DefId,
         span: Span,
-    ) -> QueryResult<rty::EarlyBinder<rty::GenericPredicates>> {
+    ) -> QueryResult<rty::EarlyBinder<List<rty::Clause>>> {
         run_with_cache(&self.item_bounds, def_id, || {
             let def_id = *genv.lookup_extern(&def_id).unwrap_or(&def_id);
 
-            if !genv.tcx.is_closure(def_id) && // TODO(RJ) Hack to avoid check_wf_rust_item on closure
-               let Some(local_id) = def_id.as_local() &&
-               let Some(predicates) = (self.providers.item_bounds)(genv, local_id)? {
-                Ok(predicates)
+            if let Some(local_id) = def_id.as_local() {
+                (self.providers.item_bounds)(genv, local_id)
             } else {
-                let clauses = genv.tcx.item_bounds(def_id).skip_binder().iter().map(|clause| (clause, span)).collect_vec();
+                let clauses = genv
+                    .tcx
+                    .item_bounds(def_id)
+                    .skip_binder()
+                    .iter()
+                    .map(|clause| (clause, span))
+                    .collect_vec();
 
                 // FIXME(nilehmann) we should propagate this error through the query
-                let predicates =
-                    lowering::lower_generic_predicates_clauses(genv.tcx, genv.sess, None, &clauses)
+                let clauses =
+                    lowering::lower_generic_predicates_clauses(genv.tcx, genv.sess, &clauses)
                         .unwrap_or_else(|_| FatalError.raise());
 
-                let predicates = Refiner::default(genv, &genv.generics_of(def_id)?)
-                    .refine_generic_predicates(&predicates)?;
+                let clauses =
+                    Refiner::default(genv, &genv.generics_of(def_id)?).refine_clauses(&clauses)?;
 
-                Ok(rty::EarlyBinder(predicates))
+                Ok(rty::EarlyBinder(clauses))
             }
         })
     }
@@ -242,10 +246,8 @@ impl<'tcx> Queries<'tcx> {
         run_with_cache(&self.predicates_of, def_id, || {
             let def_id = *genv.lookup_extern(&def_id).unwrap_or(&def_id);
 
-            if !genv.tcx.is_closure(def_id) && // TODO(RJ) Hack to avoid check_wf_rust_item on closure
-               let Some(local_id) = def_id.as_local() &&
-               let Some(predicates) = (self.providers.predicates_of)(genv, local_id)? {
-                Ok(predicates)
+            if let Some(local_id) = def_id.as_local() {
+                (self.providers.predicates_of)(genv, local_id)
             } else {
                 let predicates = genv.tcx.predicates_of(def_id);
                 // FIXME(nilehmann) we should propagate this error through the query

--- a/flux-middle/src/rty/projections.rs
+++ b/flux-middle/src/rty/projections.rs
@@ -82,6 +82,8 @@ impl<'sess, 'tcx> ProjectionTable<'sess, 'tcx> {
     fn normalize_with_preds(&self, alias_ty: &AliasTy) -> Option<Ty> {
         let alias_ty = without_constrs(alias_ty);
         let key = alias_ty.key();
+        println!("{:#?}", self.preds);
+        println!("{:?}", alias_ty);
         let res = self.preds.get(&key).cloned();
         // TODO:ALIASKEYHACK (uncomment below to see the mysterious key that doesn't get found in impl_trait02.rs)
         res
@@ -93,6 +95,7 @@ impl<'sess, 'tcx> ProjectionTable<'sess, 'tcx> {
     }
 
     fn normalize_projection(&self, alias_ty: &AliasTy) -> Ty {
+        println!("\nnormalize");
         self.normalize_with_preds(alias_ty)
             .or_else(|| self.normalize_with_impl(alias_ty))
             .unwrap_or_else(|| {

--- a/flux-middle/src/rty/projections.rs
+++ b/flux-middle/src/rty/projections.rs
@@ -24,24 +24,18 @@ use crate::{
     rustc::{self},
 };
 
-// type AliasTyKey = (DefId, Vec<GenericArg>);
-// type AliasTyKey = AliasTy;
 type AliasTyKey = String;
 
 impl AliasTy {
     fn key(&self) -> AliasTyKey {
         // TODO:ALIASKEYHACK: super janky hack, Nico -- why is the plain hasher not working? Maybe List<GenericArg> is not *really* hashable?
         format!("{:?}", self)
-        // without_constrs(&self)
-        // let args = self.args.iter().map(|arg| arg.clone()).collect();
-        // (self.def_id, args)
     }
 }
 
 struct ProjectionTable<'sess, 'tcx> {
     genv: &'sess GlobalEnv<'sess, 'tcx>,
     def_id: DefId,
-    // preds: FxHashMap<AliasTy, Ty>,
     preds: FxHashMap<AliasTyKey, Ty>,
 }
 

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -10,7 +10,10 @@ use rustc_hash::FxHashMap;
 use rustc_hir::def_id::DefId;
 use rustc_middle::{
     mir as rustc_mir,
-    ty::{self as rustc_ty, adjustment as rustc_adjustment, GenericArgKind, ParamEnv, TyCtxt},
+    ty::{
+        self as rustc_ty, adjustment as rustc_adjustment, GenericArgKind, ParamConst, ParamEnv,
+        TyCtxt,
+    },
 };
 use rustc_span::Span;
 
@@ -23,8 +26,7 @@ use super::{
     ty::{
         AdtDef, AdtDefData, AliasKind, Binder, BoundRegion, BoundRegionKind, BoundVariableKind,
         Clause, ClauseKind, Const, FieldDef, FnSig, GenericArg, GenericParamDef,
-        GenericParamDefKind, GenericPredicates, Generics, ParamConst, PolyFnSig, Ty, ValueConst,
-        VariantDef,
+        GenericParamDefKind, GenericPredicates, Generics, PolyFnSig, Ty, ValueConst, VariantDef,
     },
 };
 use crate::{
@@ -877,9 +879,8 @@ pub(crate) fn lower_generic_predicates<'tcx>(
 pub(crate) fn lower_generic_predicates_clauses<'tcx>(
     tcx: TyCtxt<'tcx>,
     sess: &FluxSession,
-    parent: Option<DefId>,
     generic_predicates: &[(rustc_ty::Clause<'tcx>, Span)],
-) -> Result<GenericPredicates, ErrorGuaranteed> {
+) -> Result<List<Clause>, ErrorGuaranteed> {
     let mut fn_trait_refs = FxHashMap::default();
     let mut fn_output_proj = FxHashMap::default();
     let mut predicates = vec![];
@@ -951,7 +952,7 @@ pub(crate) fn lower_generic_predicates_clauses<'tcx>(
         let kind = ClauseKind::FnTrait { bounded_ty, tupled_args, output, kind };
         predicates.push(Clause::new(Binder::bind_with_vars(kind, vars)));
     }
-    Ok(GenericPredicates { parent, predicates: List::from_vec(predicates) })
+    Ok(predicates.into())
 }
 
 mod errors {

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -10,7 +10,7 @@ use rustc_abi::{FieldIdx, VariantIdx, FIRST_VARIANT};
 use rustc_hir::def_id::DefId;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
-use rustc_middle::ty::{AdtFlags, ClosureKind};
+use rustc_middle::ty::{AdtFlags, ClosureKind, ParamConst};
 pub use rustc_middle::{
     mir::Mutability,
     ty::{
@@ -164,13 +164,7 @@ pub struct ValueConst {
     pub val: usize,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
-pub struct ParamConst {
-    pub index: u32,
-    pub name: Symbol,
-}
-
-#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
+#[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum Const {
     Param(ParamConst),
     Value(ValueConst),

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -394,11 +394,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         self.obligs.clone()
     }
 
-    fn insert_obligations(&mut self, obligs: List<rty::Clause>) {
-        for oblig in obligs.into_iter() {
-            self.obligs.push(oblig.clone());
-        }
-        // self.obligs.extend(obligs.clone().into_iter());
+    fn insert_obligations(&mut self, obligs: Vec<rty::Clause>) {
+        self.obligs.extend(obligs);
     }
 
     fn push_scope(&mut self, rcx: &RefineCtxt) {
@@ -734,7 +731,7 @@ fn mk_generator_obligations(
     generator_args: &GenericArgs,
     opaque_def_id: &DefId,
     span: Span,
-) -> Result<List<rty::Clause>, CheckerErrKind> {
+) -> Result<Vec<rty::Clause>, CheckerErrKind> {
     let bounds = genv.item_bounds(*opaque_def_id, span)?;
     let pred = if let rty::ClauseKind::Projection(proj) =
         bounds.skip_binder().predicates[0].kind().skip_binder()
@@ -745,7 +742,7 @@ fn mk_generator_obligations(
         panic!("mk_generator_obligations: unexpected bounds")
     };
     let clause = rty::Clause::new(rty::ClauseKind::GeneratorOblig(pred), List::empty());
-    Ok(List::from_vec(vec![clause]))
+    Ok(vec![clause])
 }
 
 fn mk_obligations(

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -616,7 +616,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 .genv
                 .item_bounds(alias_ty.def_id, self.span())?
                 .skip_binder();
-            for clause in &bounds.predicates {
+            for clause in &bounds {
                 if let rty::ClauseKind::Projection(pred) = clause.kind().skip_binder() {
                     let ty1 = self.project_bty(ty, pred.alias_ty.def_id);
                     let ty2 = pred.term;
@@ -733,14 +733,13 @@ fn mk_generator_obligations(
     span: Span,
 ) -> Result<Vec<rty::Clause>, CheckerErrKind> {
     let bounds = genv.item_bounds(*opaque_def_id, span)?;
-    let pred = if let rty::ClauseKind::Projection(proj) =
-        bounds.skip_binder().predicates[0].kind().skip_binder()
-    {
-        let output = proj.term;
-        GeneratorObligPredicate { def_id: *generator_did, args: generator_args.clone(), output }
-    } else {
-        panic!("mk_generator_obligations: unexpected bounds")
-    };
+    let pred =
+        if let rty::ClauseKind::Projection(proj) = bounds.skip_binder()[0].kind().skip_binder() {
+            let output = proj.term;
+            GeneratorObligPredicate { def_id: *generator_did, args: generator_args.clone(), output }
+        } else {
+            panic!("mk_generator_obligations: unexpected bounds")
+        };
     let clause = rty::Clause::new(rty::ClauseKind::GeneratorOblig(pred), List::empty());
     Ok(vec![clause])
 }

--- a/flux-syntax/src/grammar.lalrpop
+++ b/flux-syntax/src/grammar.lalrpop
@@ -200,7 +200,7 @@ Ensures = <Comma<(<Ident> ":" <Ty>)>>;
 Predicates = <Comma<WhereBoundPredicate>>;
 
 WhereBoundPredicate: surface::WhereBoundPredicate = {
-    <lo:@L> <bounded_ty:Ty> ":" <bounds:Bounds>  <hi:@R> => {
+    <lo:@L> <bounded_ty:Ty> ":" <bounds:GenericBounds>  <hi:@R> => {
         surface::WhereBoundPredicate {
             span: mk_span(lo, hi),
             bounded_ty,
@@ -209,7 +209,7 @@ WhereBoundPredicate: surface::WhereBoundPredicate = {
     }
 }
 
-Bounds: surface::Bounds = {
+GenericBounds: surface::GenericBounds = {
     <bound:Path> => vec![bound]
 }
 
@@ -250,7 +250,7 @@ TyKind: surface::TyKind = {
         Err(ParseError::User { error: UserParseError::UnexpectedToken(lo, hi) })
     },
 
-    "impl" <bounds:Bounds> => surface::TyKind::ImplTrait((), bounds),
+    "impl" <bounds:GenericBounds> => surface::TyKind::ImplTrait((), bounds),
 }
 
 #[inline]

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -171,10 +171,10 @@ pub enum Async<R = ()> {
 pub struct WhereBoundPredicate<R = ()> {
     pub span: Span,
     pub bounded_ty: Ty<R>,
-    pub bounds: Bounds<R>,
+    pub bounds: GenericBounds<R>,
 }
 
-pub type Bounds<R = ()> = Vec<Path<R>>;
+pub type GenericBounds<R = ()> = Vec<Path<R>>;
 
 #[derive(Debug)]
 pub enum Arg<R = ()> {
@@ -220,7 +220,7 @@ pub enum TyKind<R = ()> {
     Tuple(Vec<Ty<R>>),
     Array(Box<Ty<R>>, ArrayLen),
     /// The first `R` parameter is for the `DefId` corresponding to the hir OpaqueTy
-    ImplTrait(R, Bounds<R>),
+    ImplTrait(R, GenericBounds<R>),
     Hole,
 }
 


### PR DESCRIPTION
Refactor opaque types and associated types implementation to match closer to rustc. This fixes a lot of bugs along the way.