### PR TITLE
Update toolchain

### DIFF
--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -805,7 +805,7 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
         let mut args = vec![];
         let mut bindings = vec![];
         if let Res::Def(
-            DefKind::TyAlias | DefKind::Struct | DefKind::Enum | DefKind::OpaqueTy,
+            DefKind::TyAlias { .. } | DefKind::Struct | DefKind::Enum | DefKind::OpaqueTy,
             def_id,
         ) = res
         {

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -352,7 +352,11 @@ impl<'a, 'genv, 'tcx> CrateChecker<'a, 'genv, 'tcx> {
     /// `is_ignored` transitively follows the `def_id`'s parent-chain to check if
     /// any enclosing mod has been marked as `ignore`
     fn is_ignored(&self, def_id: LocalDefId) -> bool {
-        let parent_def_id = self.genv.tcx.parent_module_from_def_id(def_id);
+        let parent_def_id = self
+            .genv
+            .tcx
+            .parent_module_from_def_id(def_id)
+            .to_local_def_id();
         if parent_def_id == def_id {
             false
         } else {
@@ -467,7 +471,7 @@ fn defs_with_generics(tcx: TyCtxt) -> impl Iterator<Item = OwnerId> + '_ {
                 DefKind::Struct
                 | DefKind::Enum
                 | DefKind::Impl { .. }
-                | DefKind::TyAlias
+                | DefKind::TyAlias { .. }
                 | DefKind::OpaqueTy
                 | DefKind::AssocTy => Some(OwnerId { def_id }),
                 _ => None,

--- a/flux-errors/src/lib.rs
+++ b/flux-errors/src/lib.rs
@@ -38,7 +38,7 @@ impl FluxSession {
         fallback_bundle: LazyFallbackBundle,
     ) -> Self {
         let emitter = emitter(opts, source_map.clone(), fallback_bundle);
-        let handler = rustc_errors::Handler::with_emitter(true, None, emitter, None);
+        let handler = rustc_errors::Handler::with_emitter(emitter);
         Self { parse_sess: ParseSess::with_span_handler(handler, source_map) }
     }
 
@@ -72,7 +72,7 @@ fn emitter(
     opts: &config::Options,
     source_map: Rc<SourceMap>,
     fallback_bundle: LazyFallbackBundle,
-) -> Box<dyn Emitter + sync::Send> {
+) -> Box<dyn Emitter + sync::DynSend> {
     let bundle = None;
     let track_diagnostics = opts.unstable_opts.track_diagnostics;
 
@@ -89,18 +89,19 @@ fn emitter(
                 );
                 Box::new(emitter)
             } else {
-                let emitter = EmitterWriter::stderr(
-                    color_config,
-                    Some(source_map),
-                    bundle,
-                    fallback_bundle,
-                    short,
-                    false,
-                    None,
-                    false,
-                    track_diagnostics,
-                    opts.unstable_opts.terminal_urls,
-                );
+                // let emitter = EmitterWriter::stderr(
+                //     color_config,
+                //     Some(source_map),
+                //     bundle,
+                //     fallback_bundle,
+                //     short,
+                //     false,
+                //     None,
+                //     false,
+                //     track_diagnostics,
+                //     opts.unstable_opts.terminal_urls,
+                // );
+                let emitter = EmitterWriter::stderr(color_config, fallback_bundle);
                 Box::new(emitter)
             }
         }

--- a/flux-errors/src/lib.rs
+++ b/flux-errors/src/lib.rs
@@ -89,19 +89,11 @@ fn emitter(
                 );
                 Box::new(emitter)
             } else {
-                // let emitter = EmitterWriter::stderr(
-                //     color_config,
-                //     Some(source_map),
-                //     bundle,
-                //     fallback_bundle,
-                //     short,
-                //     false,
-                //     None,
-                //     false,
-                //     track_diagnostics,
-                //     opts.unstable_opts.terminal_urls,
-                // );
-                let emitter = EmitterWriter::stderr(color_config, fallback_bundle);
+                let emitter = EmitterWriter::stderr(color_config, fallback_bundle)
+                    .sm(Some(source_map))
+                    .short_message(short)
+                    .track_diagnostics(track_diagnostics)
+                    .terminal_url(opts.unstable_opts.terminal_urls);
                 Box::new(emitter)
             }
         }

--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -675,7 +675,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                     .instantiate_identity()
                     .replace_bound_expr(&idx.expr));
             }
-            fhir::Res::Def(DefKind::TyAlias, def_id) => {
+            fhir::Res::Def(DefKind::TyAlias { .. }, def_id) => {
                 let generics = self.conv_generic_args(env, *def_id, &path.args)?;
                 let refine = path
                     .refine

--- a/flux-fhir-analysis/src/lib.rs
+++ b/flux-fhir-analysis/src/lib.rs
@@ -157,7 +157,7 @@ fn generics_of(genv: &GlobalEnv, local_id: LocalDefId) -> QueryResult<rty::Gener
 
 fn type_of(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<rty::PolyTy>> {
     let ty = match genv.tcx.def_kind(def_id) {
-        DefKind::TyAlias => {
+        DefKind::TyAlias { .. } => {
             let alias = genv.map().get_type_alias(def_id);
             let wfckresults = genv.check_wf(def_id)?;
             conv::expand_type_alias(genv, alias, &wfckresults)?
@@ -242,7 +242,7 @@ fn check_wf_flux_item(genv: &GlobalEnv, sym: Symbol) -> QueryResult<Rc<fhir::Wfc
 
 fn check_wf_rust_item(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<Rc<fhir::WfckResults>> {
     let wfckresults = match genv.tcx.def_kind(def_id) {
-        DefKind::TyAlias => {
+        DefKind::TyAlias { .. } => {
             let alias = genv.map().get_type_alias(def_id);
             let mut wfckresults = wf::check_ty_alias(genv, alias)?;
             annot_check::check_alias(genv.tcx, genv.sess, &mut wfckresults, alias)?;
@@ -300,7 +300,7 @@ pub fn check_crate_wf(genv: &GlobalEnv) -> Result<(), ErrorGuaranteed> {
 
     for def_id in genv.tcx.hir_crate_items(()).definitions() {
         match genv.tcx.def_kind(def_id) {
-            DefKind::TyAlias
+            DefKind::TyAlias { .. }
             | DefKind::Struct
             | DefKind::Enum
             | DefKind::Fn

--- a/flux-fhir-analysis/src/wf/mod.rs
+++ b/flux-fhir-analysis/src/wf/mod.rs
@@ -430,7 +430,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         path: &fhir::Path,
     ) -> Result<(), ErrorGuaranteed> {
         match &path.res {
-            fhir::Res::Def(DefKind::TyAlias, def_id) => {
+            fhir::Res::Def(DefKind::TyAlias { .. }, def_id) => {
                 let sorts = self.genv.early_bound_sorts_of(*def_id);
                 if path.refine.len() != sorts.len() {
                     return self.emit_err(errors::EarlyBoundArgCountMismatch::new(

--- a/flux-fixpoint/src/constraint.rs
+++ b/flux-fixpoint/src/constraint.rs
@@ -391,7 +391,9 @@ impl fmt::Display for Func {
 }
 
 pub(crate) static DEFAULT_QUALIFIERS: LazyLock<Vec<Qualifier>> = LazyLock::new(|| {
-    // Unary
+    // -----
+    // UNARY
+    // -----
 
     // (qualif EqZero ((v int)) (v == 0))
     let eqzero = Qualifier {
@@ -433,7 +435,9 @@ pub(crate) static DEFAULT_QUALIFIERS: LazyLock<Vec<Qualifier>> = LazyLock::new(|
         global: true,
     };
 
-    // Binary
+    // ------
+    // BINARY
+    // ------
 
     // (qualif Eq ((a int) (b int)) (a == b))
     let eq = Qualifier {

--- a/flux-metadata/src/lib.rs
+++ b/flux-metadata/src/lib.rs
@@ -133,7 +133,7 @@ impl CrateMetadata {
 
                     refined_bys.insert(def_id.index, genv.map().refined_by(local_id).clone());
                 }
-                DefKind::TyAlias => {
+                DefKind::TyAlias { .. } => {
                     type_of.insert(def_id.index, genv.type_of(def_id).unwrap());
                     refined_bys.insert(def_id.index, genv.map().refined_by(local_id).clone());
                 }

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -209,7 +209,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             fhir::Res::PrimTy(PrimTy::Int(_) | PrimTy::Uint(_)) => fhir::Sort::Int,
             fhir::Res::PrimTy(PrimTy::Bool) => fhir::Sort::Bool,
             fhir::Res::PrimTy(PrimTy::Float(..) | PrimTy::Str | PrimTy::Char) => fhir::Sort::Unit,
-            fhir::Res::Def(DefKind::TyAlias | DefKind::Enum | DefKind::Struct, def_id) => {
+            fhir::Res::Def(DefKind::TyAlias { .. } | DefKind::Enum | DefKind::Struct, def_id) => {
                 fhir::Sort::Record(def_id)
             }
             fhir::Res::SelfTyAlias { alias_to, .. } => {

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -288,8 +288,9 @@ impl<'sess, 'tcx> LoweringCtxt<'_, 'sess, 'tcx> {
                 }
             }
             rustc_mir::TerminatorKind::GeneratorDrop => TerminatorKind::GeneratorDrop,
-            rustc_mir::TerminatorKind::Resume => TerminatorKind::Resume,
-            rustc_mir::TerminatorKind::Terminate | rustc_mir::TerminatorKind::InlineAsm { .. } => {
+            rustc_mir::TerminatorKind::UnwindResume => TerminatorKind::UnwindResume,
+            rustc_mir::TerminatorKind::UnwindTerminate(..)
+            | rustc_mir::TerminatorKind::InlineAsm { .. } => {
                 return Err(errors::UnsupportedMir::from(terminator)).emit(self.sess);
             }
         };

--- a/flux-middle/src/rustc/mir.rs
+++ b/flux-middle/src/rustc/mir.rs
@@ -120,7 +120,7 @@ pub enum TerminatorKind<'tcx> {
         drop: Option<BasicBlock>,
     },
     GeneratorDrop,
-    Resume,
+    UnwindResume,
 }
 
 #[derive(Debug)]
@@ -526,7 +526,7 @@ impl<'tcx> fmt::Debug for Terminator<'tcx> {
             TerminatorKind::FalseUnwind { real_target, unwind } => {
                 write!(f, "falseUnwind -> [real: {real_target:?}, cleanup: {unwind:?}]")
             }
-            TerminatorKind::Resume => write!(f, "resume"),
+            TerminatorKind::UnwindResume => write!(f, "resume"),
             TerminatorKind::GeneratorDrop => write!(f, "generator_drop"),
             TerminatorKind::Yield { value, resume, drop, resume_arg } => {
                 write!(

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -485,7 +485,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
             TerminatorKind::FalseUnwind { real_target, .. } => {
                 Ok(vec![(*real_target, Guard::None)])
             }
-            TerminatorKind::Resume => todo!("implement checking of cleanup code"),
+            TerminatorKind::UnwindResume => todo!("implement checking of cleanup code"),
         }
     }
 

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -970,19 +970,19 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
                     }
                 }
             }
-            // See [NOTE:unsize]
+            // &mut [T; n] -> &mut [T][n] and &[T; n] -> &[T][n]
             CastKind::Pointer(mir::PointerCast::Unsize) => {
                 if // src is an array
-                   let TyKind::Indexed(BaseTy::Ref(_, src_ty, src_mut), _) = from.kind() &&
-                   let TyKind::Indexed(BaseTy::Array(src_arr_ty, Const::Value(src_n)), _src_ix) = src_ty.kind() &&
+                   let TyKind::Indexed(BaseTy::Ref(_, src_ty, src_mut), _) = from.kind()
+                   && let TyKind::Indexed(BaseTy::Array(src_arr_ty, Const::Value(src_n)), _) = src_ty.kind()
                    // dst is a slice
-                   let rustc::ty::TyKind::Ref(dst_reg, dst_ty, dst_mut) = to.kind() &&
-                   let rustc::ty::TyKind::Slice(_dst_slice_ty) = dst_ty.kind() &&
-                   src_mut == dst_mut
+                   && let rustc::ty::TyKind::Ref(dst_re, dst_ty, dst_mut) = to.kind()
+                   && let rustc::ty::TyKind::Slice(_) = dst_ty.kind()
+                   && src_mut == dst_mut
                 {
                     let dst_ix = Index::from(src_n.clone());
                     let dst_slice = Ty::indexed(BaseTy::Slice(src_arr_ty.clone()), dst_ix);
-                    Ty::mk_ref(*dst_reg, dst_slice, *dst_mut)
+                    Ty::mk_ref(*dst_re, dst_slice, *dst_mut)
                 } else {
                     tracked_span_bug!("unsupported Unsize cast")
                 }
@@ -997,18 +997,6 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
         };
         Ok(ty)
     }
-
-    /* [NOTE:unsize]  https://github.com/flux-rs/flux/pull/490#discussion_r1313923883
-
-    This is unsound for mir::PointerCast::Unsize. As implemented, you can use it to
-    coerce a &mut [i32{v: v > 0}; 10] to a &mut [i32]. We should make sure this is
-    only being applied for unsizing of arrays into slices (I think this is enough for panic)
-    and that the semantics is
-
-        &mut [T; n] -> &mut [T][n]
-        &[T;n] -> &[T][n]
-
-    */
 
     fn check_operands(
         &mut self,

--- a/flux-refineck/src/fold_unfold.rs
+++ b/flux-refineck/src/fold_unfold.rs
@@ -335,7 +335,7 @@ impl<'a, 'tcx, M: Mode> FoldUnfoldAnalysis<'a, 'tcx, M> {
                 self.goto(bb, *real_target, env)?;
             }
             TerminatorKind::Unreachable
-            | TerminatorKind::Resume
+            | TerminatorKind::UnwindResume
             | TerminatorKind::GeneratorDrop => {}
         }
         Ok(())

--- a/flux-syntax/src/lib.rs
+++ b/flux-syntax/src/lib.rs
@@ -31,35 +31,35 @@ macro_rules! parse {
     }};
 }
 
-pub fn parse_refined_by(tokens: TokenStream, span: Span) -> ParseResult<surface::RefinedBy> {
+pub fn parse_refined_by(tokens: &TokenStream, span: Span) -> ParseResult<surface::RefinedBy> {
     parse!(grammar::RefinedByParser, tokens, span)
 }
 
-pub fn parse_type_alias(tokens: TokenStream, span: Span) -> ParseResult<surface::TyAlias> {
+pub fn parse_type_alias(tokens: &TokenStream, span: Span) -> ParseResult<surface::TyAlias> {
     parse!(grammar::TyAliasParser, tokens, span)
 }
 
-pub fn parse_fn_surface_sig(tokens: TokenStream, span: Span) -> ParseResult<surface::FnSig> {
+pub fn parse_fn_surface_sig(tokens: &TokenStream, span: Span) -> ParseResult<surface::FnSig> {
     parse!(grammar::FnSigParser, tokens, span)
 }
 
-pub fn parse_qual_names(tokens: TokenStream, span: Span) -> ParseResult<surface::QualNames> {
+pub fn parse_qual_names(tokens: &TokenStream, span: Span) -> ParseResult<surface::QualNames> {
     parse!(grammar::QualNamesParser, tokens, span)
 }
 
-pub fn parse_flux_item(tokens: TokenStream, span: Span) -> ParseResult<Vec<surface::Item>> {
+pub fn parse_flux_item(tokens: &TokenStream, span: Span) -> ParseResult<Vec<surface::Item>> {
     parse!(grammar::ItemsParser, tokens, span)
 }
 
-pub fn parse_ty(tokens: TokenStream, span: Span) -> ParseResult<surface::Ty> {
+pub fn parse_ty(tokens: &TokenStream, span: Span) -> ParseResult<surface::Ty> {
     parse!(grammar::TyParser, tokens, span)
 }
 
-pub fn parse_variant(tokens: TokenStream, span: Span) -> ParseResult<surface::VariantDef> {
+pub fn parse_variant(tokens: &TokenStream, span: Span) -> ParseResult<surface::VariantDef> {
     parse!(grammar::VariantParser, tokens, span)
 }
 
-pub fn parse_expr(tokens: TokenStream, span: Span) -> ParseResult<surface::Expr> {
+pub fn parse_expr(tokens: &TokenStream, span: Span) -> ParseResult<surface::Expr> {
     parse!(grammar::ExprParser, tokens, span)
 }
 

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -374,8 +374,8 @@ impl BindKind {
 }
 
 impl RefinedBy {
-    pub const DUMMY: &RefinedBy =
-        &RefinedBy { index_params: vec![], early_bound_params: vec![], span: rustc_span::DUMMY_SP };
+    // pub const DUMMY: &'static RefinedBy =
+    //     &RefinedBy { index_params: vec![], early_bound_params: vec![], span: rustc_span::DUMMY_SP };
 
     pub fn all_params(&self) -> impl Iterator<Item = &RefineParam> {
         self.early_bound_params.iter().chain(&self.index_params)

--- a/flux-syntax/src/surface.rs
+++ b/flux-syntax/src/surface.rs
@@ -374,9 +374,6 @@ impl BindKind {
 }
 
 impl RefinedBy {
-    // pub const DUMMY: &'static RefinedBy =
-    //     &RefinedBy { index_params: vec![], early_bound_params: vec![], span: rustc_span::DUMMY_SP };
-
     pub fn all_params(&self) -> impl Iterator<Item = &RefineParam> {
         self.early_bound_params.iter().chain(&self.index_params)
     }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-24"
+channel = "nightly-2023-09-03"
 components = ["rust-src", "rustc-dev", "llvm-tools", "rustfmt"]


### PR DESCRIPTION
RustAnalyzer wasn't giving me go-to-definition for some stuff in `hir`, updating the toolchain fixed it. We were also overdue for an update.