### PR TITLE
Desugar the items in the same context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ name = "flux-desugar"
 version = "0.1.0"
 dependencies = [
  "flux-common",
+ "flux-config",
  "flux-errors",
  "flux-macros",
  "flux-middle",

--- a/flux-desugar/Cargo.toml
+++ b/flux-desugar/Cargo.toml
@@ -11,6 +11,7 @@ test = false
 
 [dependencies]
 flux-common = { path = "../flux-common" }
+flux-config = { path = "../flux-config" }
 flux-errors = { path = "../flux-errors" }
 flux-macros = { path = "../flux-macros" }
 flux-middle = { path = "../flux-middle" }

--- a/flux-desugar/src/desugar.rs
+++ b/flux-desugar/src/desugar.rs
@@ -1,4 +1,6 @@
 //! Desugaring from types in [`flux_syntax::surface`] to types in [`flux_middle::fhir`]
+//!
+
 use std::{borrow::Borrow, iter, slice};
 
 use flux_common::{bug, index::IndexGen, iter::IterExt, span_bug};

--- a/flux-desugar/src/lib.rs
+++ b/flux-desugar/src/lib.rs
@@ -8,6 +8,9 @@ extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;
 
+use desugar::{Binders, DesugarCtxt};
+use flux_common::dbg;
+use flux_config as config;
 use flux_macros::fluent_messages;
 use rustc_errors::{DiagnosticMessage, SubdiagnosticMessage};
 
@@ -19,9 +22,13 @@ mod table_resolver;
 pub use desugar::{
     desugar_defn, desugar_generics, desugar_qualifier, desugar_refined_by, func_def_to_func_decl,
 };
-use flux_middle::{fhir, global_env::GlobalEnv};
+use flux_middle::{
+    fhir::{self, lift},
+    global_env::GlobalEnv,
+};
 use flux_syntax::surface;
 use rustc_errors::ErrorGuaranteed;
+use rustc_hash::FxHashMap;
 use rustc_hir::OwnerId;
 
 pub fn desugar_struct_def(
@@ -45,13 +52,47 @@ pub fn desugar_enum_def(
 }
 
 pub fn desugar_fn_sig(
-    genv: &GlobalEnv,
+    genv: &mut GlobalEnv,
     owner_id: OwnerId,
-    fn_sig: surface::FnSig,
-) -> Result<fhir::FnInfo, ErrorGuaranteed> {
-    let resolver = table_resolver::Resolver::new(genv.tcx, genv.sess, owner_id.def_id)?;
-    let fn_sig = resolver.resolve_fn_sig(fn_sig)?;
-    desugar::desugar_fn_sig(genv, owner_id, &fn_sig)
+    fn_sig: Option<surface::FnSig>,
+) -> Result<(), ErrorGuaranteed> {
+    let def_id = owner_id.def_id;
+    if let Some(fn_sig) = fn_sig {
+        let resolver = table_resolver::Resolver::new(genv.tcx, genv.sess, def_id)?;
+        let fn_sig = resolver.resolve_fn_sig(fn_sig)?;
+
+        let mut opaque_tys = FxHashMap::default();
+        let mut cx = DesugarCtxt::new(genv, owner_id, Some(&mut opaque_tys));
+
+        let generics = if let Some(generics) = &fn_sig.generics {
+            cx.desugar_generics(generics)?
+        } else {
+            cx.as_lift_cx().lift_generics()?
+        };
+        genv.map().insert_generics(def_id, generics);
+
+        let (generic_preds, fn_sig) = cx.desugar_fn_sig(&fn_sig, &mut Binders::new())?;
+
+        if config::dump_fhir() {
+            dbg::dump_item_info(genv.tcx, def_id, "fhir", &fn_sig).unwrap();
+        }
+
+        genv.map_mut()
+            .insert_generic_predicates(def_id, generic_preds);
+        genv.map_mut().insert_fn_sig(def_id, fn_sig);
+        genv.map_mut().insert_opaque_tys(opaque_tys);
+    } else {
+        let (generics, fn_info) = lift::lift_fn(genv.tcx, genv.sess, owner_id)?;
+        if config::dump_fhir() {
+            dbg::dump_item_info(genv.tcx, def_id, "fhir", &fn_info.fn_sig).unwrap();
+        }
+        genv.map().insert_generics(def_id, generics);
+        genv.map_mut()
+            .insert_generic_predicates(def_id, fn_info.predicates);
+        genv.map_mut().insert_fn_sig(def_id, fn_info.fn_sig);
+        genv.map_mut().insert_opaque_tys(fn_info.opaque_tys);
+    }
+    Ok(())
 }
 
 pub fn desugar_sort_decl(sort_decl: surface::SortDecl) -> fhir::SortDecl {

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -5,7 +5,10 @@ use flux_desugar as desugar;
 use flux_errors::{FluxSession, ResultExt};
 use flux_metadata::CStore;
 use flux_middle::{
-    fhir::{lift, ConstInfo},
+    fhir::{
+        lift::{self, LiftCtxt},
+        ConstInfo,
+    },
     global_env::GlobalEnv,
 };
 use flux_refineck as refineck;
@@ -236,43 +239,26 @@ fn desugar_item(
             desugar_fn_sig(genv, specs, owner_id)?;
         }
         hir::ItemKind::TyAlias(..) => {
-            lift_generics(genv, owner_id)?;
-
             let ty_alias = specs.ty_aliases.remove(&owner_id).unwrap();
-            let ty_alias = if let Some(ty_alias) = ty_alias {
-                desugar::desugar_type_alias(genv, owner_id, ty_alias)?
-            } else {
-                lift::lift_type_alias(genv.tcx, genv.sess, owner_id)?
-            };
-            genv.map_mut().insert_type_alias(owner_id.def_id, ty_alias);
+            desugar::desugar_type_alias(genv, owner_id, ty_alias)?;
         }
-        hir::ItemKind::OpaqueTy(_) => lift_generics(genv, owner_id)?,
+        hir::ItemKind::OpaqueTy(_) => desugar::desugar_generics_and_predicates(genv, owner_id)?,
         hir::ItemKind::Enum(..) => {
-            lift_generics(genv, owner_id)?;
             let enum_def = specs.enums.remove(&owner_id).unwrap();
-            let enum_def = desugar::desugar_enum_def(genv, owner_id, enum_def)?;
-            if config::dump_fhir() {
-                dbg::dump_item_info(genv.tcx, owner_id.to_def_id(), "fhir", &enum_def).unwrap();
-            }
-            genv.map_mut().insert_enum(owner_id.def_id, enum_def);
+            desugar::desugar_enum_def(genv, owner_id, enum_def)?;
         }
         hir::ItemKind::Struct(..) => {
-            lift_generics(genv, owner_id)?;
             let struct_def = specs.structs.remove(&owner_id).unwrap();
-            let struct_def = desugar::desugar_struct_def(genv, owner_id, struct_def)?;
-            if config::dump_fhir() {
-                dbg::dump_item_info(genv.tcx, owner_id, "fhir", &struct_def).unwrap();
-            }
-            genv.map_mut().insert_struct(owner_id.def_id, struct_def);
+            desugar::desugar_struct_def(genv, owner_id, struct_def)?;
         }
         hir::ItemKind::Trait(.., items) => {
-            lift_generics(genv, owner_id)?;
+            desugar::desugar_generics_and_predicates(genv, owner_id)?;
             items
                 .iter()
                 .try_for_each_exhaust(|trait_item| desugar_trait_item(genv, specs, trait_item))?;
         }
         hir::ItemKind::Impl(impl_) => {
-            lift_generics(genv, owner_id)?;
+            desugar::desugar_generics_and_predicates(genv, owner_id)?;
             impl_
                 .items
                 .iter()
@@ -321,15 +307,6 @@ fn desugar_fn_sig(
     if let Some(quals) = spec.qual_names {
         genv.map_mut().insert_fn_quals(def_id, quals.names);
     }
-    Ok(())
-}
-
-fn lift_generics(genv: &mut GlobalEnv, owner_id: OwnerId) -> Result<(), ErrorGuaranteed> {
-    let def_id = owner_id.def_id;
-    let generics = lift::lift_generics(genv.tcx, genv.sess, owner_id)?;
-    let predicates = lift::lift_generic_predicates(genv.tcx, genv.sess, owner_id)?;
-    genv.map_mut().insert_generics(def_id, generics);
-    genv.map_mut().insert_generic_predicates(def_id, predicates);
     Ok(())
 }
 

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -5,10 +5,7 @@ use flux_desugar as desugar;
 use flux_errors::{FluxSession, ResultExt};
 use flux_metadata::CStore;
 use flux_middle::{
-    fhir::{
-        lift::{self, LiftCtxt},
-        ConstInfo,
-    },
+    fhir::{lift, ConstInfo},
     global_env::GlobalEnv,
 };
 use flux_refineck as refineck;

--- a/flux-driver/src/callbacks.rs
+++ b/flux-driver/src/callbacks.rs
@@ -316,28 +316,10 @@ fn desugar_fn_sig(
         genv.map_mut().add_trusted(def_id);
     }
 
-    let generics = if let Some(fn_sig) = &spec.fn_sig && let Some(generics) = &fn_sig.generics {
-        desugar::desugar_generics(genv.tcx, genv.sess, owner_id, generics)?
-    } else {
-        lift::lift_generics(genv.tcx, genv.sess, owner_id)?
-    };
-    genv.map_mut().insert_generics(def_id, generics);
+    desugar::desugar_fn_sig(genv, owner_id, spec.fn_sig)?;
 
-    let info = if let Some(fn_sig) = spec.fn_sig {
-        desugar::desugar_fn_sig(genv, owner_id, fn_sig)?
-    } else {
-        lift::lift_fn(genv.tcx, genv.sess, owner_id)?
-    };
-    if config::dump_fhir() {
-        dbg::dump_item_info(genv.tcx, def_id, "fhir", &info.fn_sig).unwrap();
-    }
-
-    let map = genv.map_mut();
-    map.insert_fn_sig(def_id, info.fn_sig);
-    map.insert_generic_predicates(def_id, info.fn_preds);
-    map.insert_opaque_tys(info.opaque_tys);
     if let Some(quals) = spec.qual_names {
-        map.insert_fn_quals(def_id, quals.names);
+        genv.map_mut().insert_fn_quals(def_id, quals.names);
     }
     Ok(())
 }

--- a/flux-fhir-analysis/src/annot_check.rs
+++ b/flux-fhir-analysis/src/annot_check.rs
@@ -29,7 +29,7 @@ pub fn check_fn_sig(
         return Ok(());
     }
     let self_ty = lift::lift_self_ty(tcx, sess, owner_id)?;
-    let expected_fn_sig = &lift::lift_fn(tcx, sess, owner_id)?.fn_sig;
+    let expected_fn_sig = &lift::lift_fn(tcx, sess, owner_id)?.1.fn_sig;
     Zipper::new(sess, wfckresults, self_ty.as_ref()).zip_fn_sig(fn_sig, expected_fn_sig)
 }
 

--- a/flux-fhir-analysis/src/annot_check.rs
+++ b/flux-fhir-analysis/src/annot_check.rs
@@ -42,8 +42,8 @@ pub fn check_alias(
     if ty_alias.lifted {
         return Ok(());
     }
-    Zipper::new(sess, wfckresults, None)
-        .zip_ty(&ty_alias.ty, &lift::lift_type_alias(tcx, sess, ty_alias.owner_id)?.ty)
+    let (.., expected_ty_alias) = lift::lift_type_alias(tcx, sess, ty_alias.owner_id)?;
+    Zipper::new(sess, wfckresults, None).zip_ty(&ty_alias.ty, &expected_ty_alias.ty)
 }
 
 pub fn check_struct_def(

--- a/flux-middle/src/lib.rs
+++ b/flux-middle/src/lib.rs
@@ -13,6 +13,7 @@
 
 //! This crate contains common type definitions that are used by other crates.
 
+extern crate elsa;
 extern crate rustc_abi;
 extern crate rustc_ast;
 extern crate rustc_borrowck;


### PR DESCRIPTION
Make sure that when desugaring/lifting an item we use the same DesugarCtxt/LiftCtxt such that `FhirId`s are properly generated. This also makes the scope of names clearer when desugaring.