### PR TITLE
Remove Binder from Clause

### DIFF
--- a/flux-fhir-analysis/src/conv.rs
+++ b/flux-fhir-analysis/src/conv.rs
@@ -331,7 +331,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
             output: self.conv_ty(env, &trait_ref.bindings[0].term)?,
             kind,
         };
-        clauses.push(rty::Clause::new(rty::ClauseKind::FnTrait(pred), List::empty()));
+        clauses.push(rty::Clause::new(rty::ClauseKind::FnTrait(pred)));
         Ok(())
     }
 
@@ -357,7 +357,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                 alias_ty,
                 term: self.conv_ty(env, &binding.term)?,
             });
-            clauses.push(rty::Clause::new(kind, List::empty()));
+            clauses.push(rty::Clause::new(kind));
         }
         Ok(())
     }

--- a/flux-middle/src/fhir/lift.rs
+++ b/flux-middle/src/fhir/lift.rs
@@ -214,7 +214,8 @@ impl<'a, 'tcx> LiftCtxt<'a, 'tcx> {
     ) -> Result<fhir::WhereBoundPredicate, ErrorGuaranteed> {
         if let hir::WherePredicate::BoundPredicate(bound) = pred {
             if !bound.bound_generic_params.is_empty() {
-                return self.emit_unsupported(&format!("unsupported where predicate: `{bound:?}`"));
+                return self
+                    .emit_unsupported(&format!("higher-rank trait bounds are not supported"));
             }
             let bounded_ty = self.lift_ty(bound.bounded_ty)?;
             let bounds = bound

--- a/flux-middle/src/rty/projections.rs
+++ b/flux-middle/src/rty/projections.rs
@@ -60,12 +60,10 @@ impl<'sess, 'tcx> ProjectionTable<'sess, 'tcx> {
 
         for clauses in vec {
             for pred in &clauses {
-                if pred.kind.vars().is_empty() {
-                    if let ClauseKind::Projection(proj_pred) = pred.kind.clone().skip_binder() {
-                        match preds.insert(proj_pred.alias_ty.key(), proj_pred.term) {
-                            None => (),
-                            Some(_) => bug!("duplicate projection predicate"),
-                        }
+                if let ClauseKind::Projection(proj_pred) = pred.kind() {
+                    match preds.insert(proj_pred.alias_ty.key(), proj_pred.term) {
+                        None => (),
+                        Some(_) => bug!("duplicate projection predicate"),
                     }
                 }
             }

--- a/flux-middle/src/rty/refining.rs
+++ b/flux-middle/src/rty/refining.rs
@@ -91,8 +91,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
         let clauses = clauses
             .iter()
             .map(|clause| -> QueryResult<rty::Clause> {
-                let vars = refine_bound_variables(clause.kind.vars());
-                let kind = match clause.kind.as_ref().skip_binder() {
+                let kind = match &clause.kind {
                     rustc::ty::ClauseKind::FnTrait { bounded_ty, tupled_args, output, kind } => {
                         let pred = rty::FnTraitPredicate {
                             self_ty: self.refine_ty(bounded_ty)?,
@@ -100,14 +99,14 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
                             output: self.refine_ty(output)?,
                             kind: *kind,
                         };
-                        rty::Binder::new(rty::ClauseKind::FnTrait(pred), vars)
+                        rty::ClauseKind::FnTrait(pred)
                     }
                     rustc::ty::ClauseKind::Projection(proj_pred) => {
                         let proj_pred = rty::ProjectionPredicate {
                             alias_ty: self.refine_alias_ty(&proj_pred.projection_ty)?,
                             term: self.as_default().refine_ty(&proj_pred.term)?,
                         };
-                        rty::Binder::new(rty::ClauseKind::Projection(proj_pred), vars)
+                        rty::ClauseKind::Projection(proj_pred)
                     }
                 };
                 Ok(rty::Clause { kind })

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -72,7 +72,7 @@ pub struct GenericPredicates {
 
 #[derive(PartialEq, Eq, Hash, Debug)]
 pub struct Clause {
-    pub kind: Binder<ClauseKind>,
+    pub kind: ClauseKind,
 }
 
 #[derive(PartialEq, Eq, Hash, Debug)]
@@ -273,7 +273,7 @@ pub struct BoundRegion {
 }
 
 impl Clause {
-    pub(crate) fn new(kind: Binder<ClauseKind>) -> Clause {
+    pub(crate) fn new(kind: ClauseKind) -> Clause {
         Clause { kind }
     }
 }

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -528,14 +528,14 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
         &mut self,
         rcx: &mut RefineCtxt,
         snapshot: &Snapshot,
-        gen_pred: Binder<GeneratorObligPredicate>,
+        gen_pred: GeneratorObligPredicate,
     ) -> Result<(), CheckerError> {
         let poly_sig = gen_pred.to_closure_sig();
         let refine_tree = rcx.subtree_at(snapshot).unwrap();
         Checker::run(
             self.genv,
             refine_tree,
-            gen_pred.skip_binder().def_id,
+            gen_pred.def_id,
             self.ghost_stmts,
             self.mode,
             poly_sig,
@@ -547,12 +547,10 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
         &mut self,
         rcx: &mut RefineCtxt,
         snapshot: &Snapshot,
-        fn_trait_pred: Binder<FnTraitPredicate>,
+        fn_trait_pred: FnTraitPredicate,
     ) -> Result<(), CheckerError> {
-        if let Some(BaseTy::Closure(def_id, tys)) = fn_trait_pred
-            .self_ty()
-            .skip_binder()
-            .as_bty_skipping_existentials()
+        if let Some(BaseTy::Closure(def_id, tys)) =
+            fn_trait_pred.self_ty.as_bty_skipping_existentials()
         {
             let refine_tree = rcx.subtree_at(snapshot).unwrap();
             Checker::run(
@@ -565,7 +563,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
                 self.config,
             )?;
         } else {
-            panic!("check_oblig_fn_trait_pred: unexpected self_ty {:?}", fn_trait_pred.self_ty());
+            panic!("check_oblig_fn_trait_pred: unexpected self_ty {:?}", fn_trait_pred.self_ty);
         }
         Ok(())
     }
@@ -577,15 +575,11 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
         obligs: Obligations,
     ) -> Result<(), CheckerError> {
         for pred in &obligs.predicates {
-            let kind = pred.kind();
-            let vars = kind.vars().clone();
-            match kind.skip_binder() {
+            match pred.kind() {
                 rty::ClauseKind::FnTrait(fn_trait_pred) => {
-                    let fn_trait_pred = Binder::new(fn_trait_pred, vars);
                     self.check_oblig_fn_trait_pred(rcx, &obligs.snapshot, fn_trait_pred)?;
                 }
                 rty::ClauseKind::GeneratorOblig(gen_pred) => {
-                    let gen_pred = Binder::new(gen_pred, vars);
                     self.check_oblig_generator_pred(rcx, &obligs.snapshot, gen_pred)?;
                 }
                 rty::ClauseKind::Projection(_) => (),

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -247,7 +247,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
         // check (non-closure) obligations -- the closure ones are handled in `checker` since
         // as we have to recursively walk over their def_id bodies.
         for pred in &obligs {
-            if let rty::ClauseKind::Projection(projection_pred) = pred.kind().skip_binder() {
+            if let rty::ClauseKind::Projection(projection_pred) = pred.kind() {
                 let proj_ty = Ty::projection(projection_pred.alias_ty);
                 let impl_elem =
                     rty::projections::normalize(infcx.genv, callsite_def_id, &proj_ty, span)?;
@@ -617,7 +617,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 .item_bounds(alias_ty.def_id, self.span())?
                 .skip_binder();
             for clause in &bounds {
-                if let rty::ClauseKind::Projection(pred) = clause.kind().skip_binder() {
+                if let rty::ClauseKind::Projection(pred) = clause.kind() {
                     let ty1 = self.project_bty(ty, pred.alias_ty.def_id);
                     let ty2 = pred.term;
                     self.subtyping(rcx, &ty1, &ty2)?;
@@ -733,14 +733,13 @@ fn mk_generator_obligations(
     span: Span,
 ) -> Result<Vec<rty::Clause>, CheckerErrKind> {
     let bounds = genv.item_bounds(*opaque_def_id, span)?;
-    let pred =
-        if let rty::ClauseKind::Projection(proj) = bounds.skip_binder()[0].kind().skip_binder() {
-            let output = proj.term;
-            GeneratorObligPredicate { def_id: *generator_did, args: generator_args.clone(), output }
-        } else {
-            panic!("mk_generator_obligations: unexpected bounds")
-        };
-    let clause = rty::Clause::new(rty::ClauseKind::GeneratorOblig(pred), List::empty());
+    let pred = if let rty::ClauseKind::Projection(proj) = bounds.skip_binder()[0].kind() {
+        let output = proj.term;
+        GeneratorObligPredicate { def_id: *generator_did, args: generator_args.clone(), output }
+    } else {
+        panic!("mk_generator_obligations: unexpected bounds")
+    };
+    let clause = rty::Clause::new(rty::ClauseKind::GeneratorOblig(pred));
     Ok(vec![clause])
 }
 


### PR DESCRIPTION
We were using `skip_binder` everywhere so better if we add it back once we add proper support for higher-rank trait bounds (for example, to be able to support closures taking references as arguments `F: FnOnce(&i32) -> i32` which desugar to a higher-rank trait bound)