### PR TITLE
Carry `ClauseKind::Trait` down to rty

### DIFF
--- a/flux-middle/src/fhir/lift.rs
+++ b/flux-middle/src/fhir/lift.rs
@@ -214,8 +214,7 @@ impl<'a, 'tcx> LiftCtxt<'a, 'tcx> {
     ) -> Result<fhir::WhereBoundPredicate, ErrorGuaranteed> {
         if let hir::WherePredicate::BoundPredicate(bound) = pred {
             if !bound.bound_generic_params.is_empty() {
-                return self
-                    .emit_unsupported(&format!("higher-rank trait bounds are not supported"));
+                return self.emit_unsupported("higher-rank trait bounds are not supported");
             }
             let bounded_ty = self.lift_ty(bound.bounded_ty)?;
             let bounds = bound
@@ -235,17 +234,19 @@ impl<'a, 'tcx> LiftCtxt<'a, 'tcx> {
         bound: &hir::GenericBound,
     ) -> Result<fhir::GenericBound, ErrorGuaranteed> {
         match bound {
-            hir::GenericBound::Trait(poly_trait_ref, hir::TraitBoundModifier::None)
-                if poly_trait_ref.bound_generic_params.is_empty() =>
-            {
+            hir::GenericBound::Trait(poly_trait_ref, hir::TraitBoundModifier::None) => {
+                if !poly_trait_ref.bound_generic_params.is_empty() {
+                    return self.emit_unsupported("higher-rank trait bounds are not supported");
+                }
                 Ok(fhir::GenericBound::Trait(
                     self.lift_path(poly_trait_ref.trait_ref.path)?,
                     fhir::TraitBoundModifier::None,
                 ))
             }
-            hir::GenericBound::Trait(poly_trait_ref, hir::TraitBoundModifier::Maybe)
-                if poly_trait_ref.bound_generic_params.is_empty() =>
-            {
+            hir::GenericBound::Trait(poly_trait_ref, hir::TraitBoundModifier::Maybe) => {
+                if !poly_trait_ref.bound_generic_params.is_empty() {
+                    return self.emit_unsupported("higher-rank trait bounds are not supported");
+                }
                 Ok(fhir::GenericBound::Trait(
                     self.lift_path(poly_trait_ref.trait_ref.path)?,
                     fhir::TraitBoundModifier::Maybe,

--- a/flux-middle/src/global_env.rs
+++ b/flux-middle/src/global_env.rs
@@ -356,7 +356,13 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         self.tcx.hir()
     }
 
-    pub fn lookup_extern(&self, def_id: DefId) -> Option<DefId> {
+    pub(crate) fn lookup_extern(&self, def_id: DefId) -> Option<DefId> {
         self.map().get_extern(def_id).map(LocalDefId::to_def_id)
+    }
+
+    pub(crate) fn is_fn_once_output(&self, def_id: DefId) -> bool {
+        self.tcx
+            .require_lang_item(rustc_hir::LangItem::FnOnceOutput, None)
+            == def_id
     }
 }

--- a/flux-middle/src/rty/mod.rs
+++ b/flux-middle/src/rty/mod.rs
@@ -93,13 +93,25 @@ pub struct Clause {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ClauseKind {
     FnTrait(FnTraitPredicate),
+    Trait(TraitPredicate),
     Projection(ProjectionPredicate),
     GeneratorOblig(GeneratorObligPredicate),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TraitPredicate {
+    pub trait_ref: TraitRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TraitRef {
+    pub def_id: DefId,
+    pub args: GenericArgs,
+}
+
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub struct ProjectionPredicate {
-    pub alias_ty: AliasTy,
+    pub projection_ty: AliasTy,
     pub term: Ty,
 }
 
@@ -1513,6 +1525,7 @@ mod pretty {
             define_scoped!(_cx, f);
             match self {
                 ClauseKind::FnTrait(pred) => w!("FnTrait ({pred:?})"),
+                ClauseKind::Trait(pred) => w!("Trait ({pred:?})"),
                 ClauseKind::Projection(pred) => w!("Projection ({pred:?})"),
                 ClauseKind::GeneratorOblig(pred) => w!("Projection ({pred:?})"),
             }

--- a/flux-middle/src/rty/projections.rs
+++ b/flux-middle/src/rty/projections.rs
@@ -61,7 +61,7 @@ impl<'sess, 'tcx> ProjectionTable<'sess, 'tcx> {
         for clauses in vec {
             for pred in &clauses {
                 if let ClauseKind::Projection(proj_pred) = pred.kind() {
-                    match preds.insert(proj_pred.alias_ty.key(), proj_pred.term) {
+                    match preds.insert(proj_pred.projection_ty.key(), proj_pred.term) {
                         None => (),
                         Some(_) => bug!("duplicate projection predicate"),
                     }

--- a/flux-middle/src/rty/refining.rs
+++ b/flux-middle/src/rty/refining.rs
@@ -129,6 +129,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
         for clause in clauses {
             if let rustc::ty::ClauseKind::Projection(trait_pred) = &clause.kind
                 && self.genv.is_fn_once_output(trait_pred.projection_ty.def_id)
+                && trait_pred.projection_ty.self_ty() == trait_ref.self_ty()
             {
                 candidates.push(trait_pred);
             }

--- a/flux-middle/src/rty/refining.rs
+++ b/flux-middle/src/rty/refining.rs
@@ -6,16 +6,10 @@ use std::iter;
 use flux_common::{bug, iter::IterExt};
 use itertools::Itertools;
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::ParamTy;
+use rustc_middle::ty::{ClosureKind, ParamTy};
 
 use super::fold::TypeFoldable;
-use crate::{
-    global_env::GlobalEnv,
-    intern::List,
-    queries::QueryResult,
-    rty,
-    rustc::{self, ty::GenericArgs},
-};
+use crate::{global_env::GlobalEnv, intern::List, queries::QueryResult, rty, rustc};
 
 pub(crate) fn refine_generics(generics: &rustc::ty::Generics) -> rty::Generics {
     let params = generics
@@ -90,30 +84,77 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
     ) -> QueryResult<List<rty::Clause>> {
         let clauses = clauses
             .iter()
-            .map(|clause| -> QueryResult<rty::Clause> {
-                let kind = match &clause.kind {
-                    rustc::ty::ClauseKind::FnTrait { bounded_ty, tupled_args, output, kind } => {
-                        let pred = rty::FnTraitPredicate {
-                            self_ty: self.refine_ty(bounded_ty)?,
-                            tupled_args: self.refine_ty(tupled_args)?,
-                            output: self.refine_ty(output)?,
-                            kind: *kind,
-                        };
-                        rty::ClauseKind::FnTrait(pred)
-                    }
-                    rustc::ty::ClauseKind::Projection(proj_pred) => {
-                        let proj_pred = rty::ProjectionPredicate {
-                            alias_ty: self.refine_alias_ty(&proj_pred.projection_ty)?,
-                            term: self.as_default().refine_ty(&proj_pred.term)?,
-                        };
-                        rty::ClauseKind::Projection(proj_pred)
-                    }
-                };
-                Ok(rty::Clause { kind })
-            })
+            .flat_map(|clause| self.refine_clause(clauses, clause).transpose())
             .try_collect()?;
 
         Ok(clauses)
+    }
+
+    fn refine_clause(
+        &self,
+        clauses: &[rustc::ty::Clause],
+        clause: &rustc::ty::Clause,
+    ) -> QueryResult<Option<rty::Clause>> {
+        let kind = match &clause.kind {
+            rustc::ty::ClauseKind::Trait(trait_pred) => {
+                let trait_ref = &trait_pred.trait_ref;
+                if let Some(kind) = self.genv.tcx.fn_trait_kind_from_def_id(trait_ref.def_id) {
+                    self.refine_fn_trait_pred(clauses, kind, trait_ref)?
+                } else {
+                    let pred = rty::TraitPredicate { trait_ref: self.refine_trait_ref(trait_ref)? };
+                    rty::ClauseKind::Trait(pred)
+                }
+            }
+            rustc::ty::ClauseKind::Projection(proj_pred) => {
+                if self.genv.is_fn_once_output(proj_pred.projection_ty.def_id) {
+                    return Ok(None);
+                }
+                let pred = rty::ProjectionPredicate {
+                    projection_ty: self.refine_alias_ty(&proj_pred.projection_ty)?,
+                    term: self.as_default().refine_ty(&proj_pred.term)?,
+                };
+                rty::ClauseKind::Projection(pred)
+            }
+        };
+        Ok(Some(rty::Clause { kind }))
+    }
+
+    fn refine_fn_trait_pred(
+        &self,
+        clauses: &[rustc::ty::Clause],
+        kind: ClosureKind,
+        trait_ref: &rustc::ty::TraitRef,
+    ) -> QueryResult<rty::ClauseKind> {
+        let mut candidates = vec![];
+        for clause in clauses {
+            if let rustc::ty::ClauseKind::Projection(trait_pred) = &clause.kind
+                && self.genv.is_fn_once_output(trait_pred.projection_ty.def_id)
+            {
+                candidates.push(trait_pred);
+            }
+        }
+        assert!(candidates.len() == 1);
+        let pred = candidates.first().unwrap();
+
+        let pred = rty::FnTraitPredicate {
+            kind,
+            self_ty: self.refine_ty(trait_ref.args[0].expect_type())?,
+            tupled_args: self.refine_ty(trait_ref.args[1].expect_type())?,
+            output: self.refine_ty(&pred.term)?,
+        };
+        Ok(rty::ClauseKind::FnTrait(pred))
+    }
+
+    fn refine_trait_ref(&self, trait_ref: &rustc::ty::TraitRef) -> QueryResult<rty::TraitRef> {
+        let trait_ref = rty::TraitRef {
+            def_id: trait_ref.def_id,
+            args: trait_ref
+                .args
+                .iter()
+                .map(|arg| self.refine_generic_arg_raw(arg))
+                .try_collect()?,
+        };
+        Ok(trait_ref)
     }
 
     pub(crate) fn refine_variant_def(
@@ -227,20 +268,16 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
         }
     }
 
-    fn refine_generic_args(&self, args: &GenericArgs) -> QueryResult<List<rty::Ty>> {
-        if let rustc::ty::GenericArg::Ty(ty) = &args[args.len() - 1] &&
-           let rustc::ty::TyKind::Tuple(tys) = ty.kind()
-        {
-          tys.iter().map(|ty| self.refine_ty(ty)).try_collect()
-        } else {
-            bug!()
-        }
-    }
-
     pub fn refine_poly_ty(&self, ty: &rustc::ty::Ty) -> QueryResult<rty::PolyTy> {
         let bty = match ty.kind() {
             rustc::ty::TyKind::Closure(did, args) => {
-                rty::BaseTy::Closure(*did, self.refine_generic_args(args)?)
+                let args = args.as_closure();
+                let upvar_tys = args
+                    .upvar_tys()
+                    .iter()
+                    .map(|ty| self.refine_ty(ty))
+                    .try_collect()?;
+                rty::BaseTy::Closure(*did, upvar_tys)
             }
             rustc::ty::TyKind::Generator(did, args) => {
                 let args = args

--- a/flux-middle/src/rustc/lowering.rs
+++ b/flux-middle/src/rustc/lowering.rs
@@ -1,12 +1,9 @@
-use std::collections::hash_map;
-
 use flux_common::index::IndexVec;
 use flux_errors::{FluxSession, ResultExt};
 use itertools::Itertools;
 use rustc_borrowck::consumers::BodyWithBorrowckFacts;
 use rustc_const_eval::interpret::ConstValue;
 use rustc_errors::ErrorGuaranteed;
-use rustc_hash::FxHashMap;
 use rustc_hir::def_id::DefId;
 use rustc_middle::{
     mir as rustc_mir,
@@ -26,7 +23,8 @@ use super::{
     ty::{
         AdtDef, AdtDefData, AliasKind, Binder, BoundRegion, BoundRegionKind, BoundVariableKind,
         Clause, ClauseKind, Const, FieldDef, FnSig, GenericArg, GenericParamDef,
-        GenericParamDefKind, GenericPredicates, Generics, PolyFnSig, Ty, ValueConst, VariantDef,
+        GenericParamDefKind, GenericPredicates, Generics, PolyFnSig, TraitPredicate, TraitRef, Ty,
+        ValueConst, VariantDef,
     },
 };
 use crate::{
@@ -809,7 +807,6 @@ fn lower_generic_param_def(
     Ok(GenericParamDef { def_id: generic.def_id, index: generic.index, name: generic.name, kind })
 }
 
-#[allow(clippy::mutable_key_type)] // False positive `List` is not mutable
 pub(crate) fn lower_generic_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     sess: &FluxSession,
@@ -819,82 +816,66 @@ pub(crate) fn lower_generic_predicates<'tcx>(
     Ok(GenericPredicates { parent: generics.parent, predicates })
 }
 
-#[allow(clippy::mutable_key_type)] // False positive `List` is not mutable
 pub(crate) fn lower_generic_predicates_clauses<'tcx>(
     tcx: TyCtxt<'tcx>,
     sess: &FluxSession,
     generic_predicates: &[(rustc_ty::Clause<'tcx>, Span)],
 ) -> Result<List<Clause>, ErrorGuaranteed> {
-    let mut fn_trait_refs = FxHashMap::default();
-    let mut fn_output_proj = FxHashMap::default();
-    let mut predicates = vec![];
+    generic_predicates
+        .iter()
+        .map(|(clause, span)| lower_clause(tcx, sess, clause, *span))
+        .try_collect()
+}
 
-    for (predicate, span) in generic_predicates {
-        let Some(kind) = predicate.kind().no_bound_vars() else {
-            return Err(sess.emit_err(errors::UnsupportedGenericBound::new(
-                *span,
-                "higher-rank trait bounds are not supported",
-            )));
-        };
-
-        match kind {
-            rustc_ty::ClauseKind::Trait(trait_pred) => {
-                let trait_ref = trait_pred.trait_ref;
-                let args = trait_ref.args;
-                if let Some(closure_kind) = tcx.fn_trait_kind_from_def_id(trait_ref.def_id) {
-                    match fn_trait_refs.entry(args) {
-                        hash_map::Entry::Occupied(_) => todo!(),
-                        hash_map::Entry::Vacant(entry) => {
-                            entry.insert((closure_kind, *span));
-                        }
-                    }
-                }
-            }
-            rustc_ty::ClauseKind::Projection(proj_pred) => {
-                let proj_ty = proj_pred.projection_ty;
-                let args = proj_ty.args;
-                if proj_ty.def_id == tcx.lang_items().fn_once_output().unwrap() {
-                    match fn_output_proj.entry(args) {
-                        hash_map::Entry::Occupied(_) => todo!(),
-                        hash_map::Entry::Vacant(entry) => {
-                            entry.insert(proj_pred.term.ty().unwrap());
-                        }
-                    };
-                } else if let Some(ty) = proj_pred.term.ty() {
-                    let args = lower_generic_args(tcx, args)
-                        .map_err(|err| errors::UnsupportedGenericBound::new(*span, err.descr))
-                        .emit(sess)?;
-
-                    let projection_ty = AliasTy { args, def_id: proj_ty.def_id };
-                    let term = lower_ty(tcx, ty)
-                        .map_err(|err| errors::UnsupportedGenericBound::new(*span, err.descr))
-                        .emit(sess)?;
-                    let kind = ClauseKind::Projection(ProjectionPredicate { projection_ty, term });
-                    predicates.push(Clause::new(kind));
-                }
-            }
-            _ => {}
+fn lower_clause<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    sess: &FluxSession,
+    clause: &rustc_ty::Clause<'tcx>,
+    span: Span,
+) -> Result<Clause, ErrorGuaranteed> {
+    let Some(kind) = clause.kind().no_bound_vars() else {
+        return Err(sess.emit_err(errors::UnsupportedGenericBound::new(
+            span,
+            "higher-rank trait bounds are not supported",
+        )));
+    };
+    let kind = match kind {
+        rustc_ty::ClauseKind::Trait(trait_pred) => {
+            ClauseKind::Trait(TraitPredicate {
+                trait_ref: TraitRef {
+                    def_id: trait_pred.trait_ref.def_id,
+                    args: lower_generic_args(tcx, trait_pred.trait_ref.args)
+                        .map_err(|err| errors::UnsupportedGenericBound::new(span, err.descr))
+                        .emit(sess)?,
+                },
+            })
         }
-    }
+        rustc_ty::ClauseKind::Projection(proj_pred) => {
+            let Some(term) = proj_pred.term.ty() else {
+                return Err(sess.emit_err(errors::UnsupportedGenericBound::new(
+                    span,
+                    format!("unsupported projection predicate `{proj_pred:?}`"),
+                )));
+            };
+            let proj_ty = proj_pred.projection_ty;
+            let args = lower_generic_args(tcx, proj_ty.args)
+                .map_err(|err| errors::UnsupportedGenericBound::new(span, err.descr))
+                .emit(sess)?;
 
-    for (args, (kind, span)) in fn_trait_refs {
-        let output = fn_output_proj.get(&args).unwrap();
-
-        let args = args.into_type_list(tcx);
-        let bounded_ty = lower_ty(tcx, args[0])
-            .map_err(|err| errors::UnsupportedGenericBound::new(span, err.descr))
-            .emit(sess)?;
-        let tupled_args = lower_ty(tcx, args[1])
-            .map_err(|err| errors::UnsupportedGenericBound::new(span, err.descr))
-            .emit(sess)?;
-        let output = lower_ty(tcx, *output)
-            .map_err(|err| errors::UnsupportedGenericBound::new(span, err.descr))
-            .emit(sess)?;
-
-        let kind = ClauseKind::FnTrait { bounded_ty, tupled_args, output, kind };
-        predicates.push(Clause::new(kind));
-    }
-    Ok(predicates.into())
+            let projection_ty = AliasTy { args, def_id: proj_ty.def_id };
+            let term = lower_ty(tcx, term)
+                .map_err(|err| errors::UnsupportedGenericBound::new(span, err.descr))
+                .emit(sess)?;
+            ClauseKind::Projection(ProjectionPredicate { projection_ty, term })
+        }
+        _ => {
+            return Err(sess.emit_err(errors::UnsupportedGenericBound::new(
+                span,
+                format!("unsupported clause kind `{kind:?}`"),
+            )));
+        }
+    };
+    Ok(Clause::new(kind))
 }
 
 mod errors {

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -462,6 +462,19 @@ impl AdtDefData {
     }
 }
 
+impl TraitRef {
+    pub fn self_ty(&self) -> &Ty {
+        self.args[0].expect_type()
+    }
+}
+
+impl AliasTy {
+    /// This method work only with associated type projections (i.e., no opaque tpes)
+    pub fn self_ty(&self) -> &Ty {
+        self.args[0].expect_type()
+    }
+}
+
 impl TyKind {
     fn intern(self) -> Ty {
         Ty(Interned::new(TyS { kind: self }))

--- a/flux-middle/src/rustc/ty.rs
+++ b/flux-middle/src/rustc/ty.rs
@@ -10,7 +10,7 @@ use rustc_abi::{FieldIdx, VariantIdx, FIRST_VARIANT};
 use rustc_hir::def_id::DefId;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
-use rustc_middle::ty::{AdtFlags, ClosureKind, ParamConst};
+use rustc_middle::ty::{AdtFlags, ParamConst};
 pub use rustc_middle::{
     mir::Mutability,
     ty::{
@@ -77,8 +77,19 @@ pub struct Clause {
 
 #[derive(PartialEq, Eq, Hash, Debug)]
 pub enum ClauseKind {
-    FnTrait { bounded_ty: Ty, tupled_args: Ty, output: Ty, kind: ClosureKind },
+    Trait(TraitPredicate),
     Projection(ProjectionPredicate),
+}
+
+#[derive(PartialEq, Eq, Hash, Debug)]
+pub struct TraitPredicate {
+    pub trait_ref: TraitRef,
+}
+
+#[derive(PartialEq, Eq, Hash, Debug)]
+pub struct TraitRef {
+    pub def_id: DefId,
+    pub args: GenericArgs,
 }
 
 #[derive(PartialEq, Eq, Hash, Debug)]
@@ -379,8 +390,8 @@ impl ClosureArgs {
         self.split().tupled_upvars_ty.expect_type()
     }
 
-    pub fn upvar_tys(&self) -> impl Iterator<Item = &Ty> {
-        self.tupled_upvars_ty().tuple_fields().iter()
+    pub fn upvar_tys(&self) -> &List<Ty> {
+        self.tupled_upvars_ty().tuple_fields()
     }
 
     pub fn split(&self) -> ClosureArgsParts<GenericArg> {

--- a/flux-refineck/src/checker.rs
+++ b/flux-refineck/src/checker.rs
@@ -583,6 +583,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
                     self.check_oblig_generator_pred(rcx, &obligs.snapshot, gen_pred)?;
                 }
                 rty::ClauseKind::Projection(_) => (),
+                rty::ClauseKind::Trait(_) => (),
             }
         }
         Ok(())

--- a/flux-refineck/src/constraint_gen.rs
+++ b/flux-refineck/src/constraint_gen.rs
@@ -248,7 +248,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
         // as we have to recursively walk over their def_id bodies.
         for pred in &obligs {
             if let rty::ClauseKind::Projection(projection_pred) = pred.kind() {
-                let proj_ty = Ty::projection(projection_pred.alias_ty);
+                let proj_ty = Ty::projection(projection_pred.projection_ty);
                 let impl_elem =
                     rty::projections::normalize(infcx.genv, callsite_def_id, &proj_ty, span)?;
 
@@ -618,7 +618,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 .skip_binder();
             for clause in &bounds {
                 if let rty::ClauseKind::Projection(pred) = clause.kind() {
-                    let ty1 = self.project_bty(ty, pred.alias_ty.def_id);
+                    let ty1 = self.project_bty(ty, pred.projection_ty.def_id);
                     let ty2 = pred.term;
                     self.subtyping(rcx, &ty1, &ty2)?;
                 }

--- a/flux-refineck/src/fold_unfold.rs
+++ b/flux-refineck/src/fold_unfold.rs
@@ -514,6 +514,7 @@ impl PlaceNode {
                         let fields = args
                             .as_closure()
                             .upvar_tys()
+                            .iter()
                             .cloned()
                             .map(PlaceNode::Ty)
                             .collect_vec();


### PR DESCRIPTION
Add `ClauseKind::Trait` to `rty` and carry it during lowering and conv. Also move assembling of `FnTraitPredicate` to refining to simplicity logic of lowering.