### PR TITLE
Setup cargo xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
           cargo build
       - name: Run tests
         run: |
-          which fixpoint && cargo test -p flux-tests
+          which fixpoint && cargo xtask test
 
   check-fmt:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ checksum = "d78ea013094e5ea606b1c05fe35f1dd7ea1eb1ea259908d040b25bd5ec677ee5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "ascii-canvas"
@@ -1908,6 +1908,45 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "xflags"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4554b580522d0ca238369c16b8f6ce34524d61dafe7244993754bbd05f2c2ea"
+dependencies = [
+ "xflags-macros",
+]
+
+[[package]]
+name = "xflags-macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58e7b3ca8977093aae6b87b6a7730216fc4c53a6530bab5c43a783cd810c1a8"
+
+[[package]]
+name = "xshell"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2107fe03e558353b4c71ad7626d58ed82efaf56c54134228608893c77023ad"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2c411759b501fb9501aac2b1b2d287a6e93e5bdcf13c25306b23e1b716dd0e"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "xflags",
+ "xshell",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 resolver = "2"
 
-
 members = [
     "flux",
     "flux-attrs",
@@ -21,4 +20,5 @@ members = [
     "flux-refineck",
     "flux-syntax",
     "flux-tests",
+    "xtask",
 ]

--- a/flux-docs/src/dev/develop.md
+++ b/flux-docs/src/dev/develop.md
@@ -5,7 +5,13 @@
 You can run the various regression tests in the `tests/pos` and `tests/neg` directory using
 
 ```console
-$ cargo test -p flux-tests
+$ cargo xtask test
+```
+
+This will build the flux binary and then run it against the entire test suite. You can optionally pass a _filter_ to run tests containing some substring. For example:
+
+```console
+$ cargo xtask test impl_trait
 ```
 
 ## Profiling Flux

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+edition = "2021"
+name = "xtask"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.75"
+xflags = "0.3.1"
+xshell = "0.2.5"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,44 @@
+use xshell::{cmd, Shell};
+
+xflags::xflags! {
+    cmd xtask {
+        /// Run regression tests
+        cmd test {
+            /// Only run tests containing `filter` as substring
+            optional filter: String
+         }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let cmd = match Xtask::from_env() {
+        Ok(cmd) => cmd,
+        Err(err) => {
+            if err.is_help() {
+                println!("{err}");
+                std::process::exit(0);
+            } else {
+                eprintln!("error: {err}\n");
+                println!("{}", Xtask::HELP_);
+                std::process::exit(2);
+            }
+        }
+    };
+
+    let sh = Shell::new()?;
+    match cmd.subcommand {
+        XtaskCmd::Test(args) => test(sh, args),
+    }
+}
+
+fn test(sh: Shell, args: Test) -> anyhow::Result<()> {
+    let Test { filter } = args;
+    cmd!(sh, "cargo build").run()?;
+
+    if let Some(filter) = filter {
+        cmd!(sh, "cargo test -p flux-tests -- --test-args {filter}").run()?;
+    } else {
+        cmd!(sh, "cargo test -p flux-tests").run()?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
Setup [cargo xtask](https://github.com/matklad/cargo-xtask) with a command to conveniently run regression tests passing a filter.

```bash
cargo xtask test [filter]
```