### PR TITLE
Allow single condition in `ensures` clause

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -490,31 +490,6 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
                 Ok(vec![fhir::Constraint::Pred(pred)])
             }
         }
-        // CUT let ensures = fn_sig
-        // CUT    .ensures
-        //     .iter()
-        //     .map(|(bind, ty)| {
-        //         let loc = self.as_expr_ctxt().resolve_loc(binders, *bind);
-        //         let ty = self.desugar_ty(None, ty, binders);
-        //         Ok(fhir::Constraint::Type(loc?, ty?))
-        //     })
-        //     .try_collect_exhaust();
-
-        // if let Some(ensures) = fn_sig.ensures {
-        //     match ensures {
-        //         surface::Ensures::Binds(cstrs) => {
-        //             let cstrs = cstrs.iter().map(|(bind, ty)| {
-        //                 let loc = self.as_expr_ctxt().resolve_loc(binders, *bind)?;
-        //                 let ty = self.desugar_ty(None, ty, binders)?;
-        //                 fhir::Constraint::Type(loc, ty)
-        //             }).try_collect_exhaust()?;
-        //             // Ok(cstrs)
-        //         }
-        //         surface::Ensures::Cond(_) => todo!(),
-        //     }
-        // } else {
-        //     vec![]
-        // };
     }
 
     fn desugar_fun_arg(

--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -131,11 +131,6 @@ Sort: surface::Sort = {
     <input:BaseSort> "->" <output:BaseSort>                 => surface::Sort::Func { inputs: vec![input], output }
 }
 
-Ensures: surface::Ensures = {
-   <binds:EnsuresBinds> => surface::Ensures::Binds(binds),
-   <pred:Expr> => surface::Ensures::Cond(pred),
-}
-
 pub FnSig: surface::FnSig = {
     <lo:@L>
     <asyncness:Async>
@@ -207,10 +202,13 @@ Fields: Vec<surface::Ty> = {
 }
 
 Args    = <Comma<Arg>>;
-EnsuresBinds = <Comma<(<Ident> ":" <Ty>)>>;
+Ensures    = <Comma<Constraint>>;
 Predicates = <Comma<WhereBoundPredicate>>;
 
-
+Constraint: surface::Constraint = {
+    <ident:Ident> ":" <ty:Ty> => surface::Constraint::Type(ident, ty),
+    <expr:Expr> => surface::Constraint::Pred(expr),
+}
 
 
 WhereBoundPredicate: surface::WhereBoundPredicate = {

--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -131,6 +131,11 @@ Sort: surface::Sort = {
     <input:BaseSort> "->" <output:BaseSort>                 => surface::Sort::Func { inputs: vec![input], output }
 }
 
+Ensures: surface::Ensures = {
+   <binds:EnsuresBinds> => surface::Ensures::Binds(binds),
+   <pred:Expr> => surface::Ensures::Cond(pred),
+}
+
 pub FnSig: surface::FnSig = {
     <lo:@L>
     <asyncness:Async>
@@ -144,7 +149,6 @@ pub FnSig: surface::FnSig = {
     <predicates:("where" <Predicates>)?>
     <hi:@R>
     => {
-        let ensures = ensures.unwrap_or_default();
         let predicates = predicates.unwrap_or_default();
         let returns = if let Some(ty) = returns {
             surface::FnRetTy::Ty(ty)
@@ -202,8 +206,11 @@ Fields: Vec<surface::Ty> = {
 }
 
 Args    = <Comma<Arg>>;
-Ensures = <Comma<(<Ident> ":" <Ty>)>>;
+EnsuresBinds = <Comma<(<Ident> ":" <Ty>)>>;
 Predicates = <Comma<WhereBoundPredicate>>;
+
+
+
 
 WhereBoundPredicate: surface::WhereBoundPredicate = {
     <lo:@L> <bounded_ty:Ty> ":" <bounds:GenericBounds>  <hi:@R> => {

--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -149,6 +149,7 @@ pub FnSig: surface::FnSig = {
     <predicates:("where" <Predicates>)?>
     <hi:@R>
     => {
+        let ensures = ensures.unwrap_or_default();
         let predicates = predicates.unwrap_or_default();
         let returns = if let Some(ty) = returns {
             surface::FnRetTy::Ty(ty)

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -169,14 +169,6 @@ pub enum Constraint<R = ()> {
     Pred(Expr),
 }
 
-// CUT #[derive(Debug, Default)]
-// CUT pub enum Ensures<R = ()> {
-// CUT     Binds(Vec<(Ident, Ty<R>)>),
-// CUT     Cond(Expr),
-// CUT     #[default]
-// CUT     None,
-// CUT }
-
 #[derive(Debug)]
 pub enum FnRetTy<R = ()> {
     Default(Span),

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -155,17 +155,19 @@ pub struct FnSig<R = ()> {
     pub returns: FnRetTy<R>,
     /// example: `*x: i32{v. v = n+1}`
     // pub ensures: Vec<(Ident, Ty<R>)>,
-    pub ensures: Option<Ensures<R>>,
+    pub ensures: Ensures<R>,
     /// example: `where I: Iterator<Item = i32{v:0<=v}>`
     pub predicates: Vec<WhereBoundPredicate<R>>,
     /// source span
     pub span: Span,
 }
 
-#[derive(Debug)]
-pub enum Ensures<R=()> {
+#[derive(Debug, Default)]
+pub enum Ensures<R = ()> {
     Binds(Vec<(Ident, Ty<R>)>),
     Cond(Expr),
+    #[default]
+    None,
 }
 
 #[derive(Debug)]

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -154,11 +154,18 @@ pub struct FnSig<R = ()> {
     /// example `i32{v:v >= 0}`
     pub returns: FnRetTy<R>,
     /// example: `*x: i32{v. v = n+1}`
-    pub ensures: Vec<(Ident, Ty<R>)>,
+    // pub ensures: Vec<(Ident, Ty<R>)>,
+    pub ensures: Option<Ensures<R>>,
     /// example: `where I: Iterator<Item = i32{v:0<=v}>`
     pub predicates: Vec<WhereBoundPredicate<R>>,
     /// source span
     pub span: Span,
+}
+
+#[derive(Debug)]
+pub enum Ensures<R=()> {
+    Binds(Vec<(Ident, Ty<R>)>),
+    Cond(Expr),
 }
 
 #[derive(Debug)]

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -154,20 +154,28 @@ pub struct FnSig<R = ()> {
     /// example `i32{v:v >= 0}`
     pub returns: FnRetTy<R>,
     /// example: `*x: i32{v. v = n+1}` or just `x > 10`
-    pub ensures: Ensures<R>,
+    pub ensures: Vec<Constraint<R>>,
     /// example: `where I: Iterator<Item = i32{v:0<=v}>`
     pub predicates: Vec<WhereBoundPredicate<R>>,
     /// source span
     pub span: Span,
 }
 
-#[derive(Debug, Default)]
-pub enum Ensures<R = ()> {
-    Binds(Vec<(Ident, Ty<R>)>),
-    Cond(Expr),
-    #[default]
-    None,
+#[derive(Debug)]
+pub enum Constraint<R = ()> {
+    /// A type constraint on a location
+    Type(Ident, Ty<R>),
+    /// A predicate that needs to hold
+    Pred(Expr),
 }
+
+// CUT #[derive(Debug, Default)]
+// CUT pub enum Ensures<R = ()> {
+// CUT     Binds(Vec<(Ident, Ty<R>)>),
+// CUT     Cond(Expr),
+// CUT     #[default]
+// CUT     None,
+// CUT }
 
 #[derive(Debug)]
 pub enum FnRetTy<R = ()> {

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -153,8 +153,7 @@ pub struct FnSig<R = ()> {
     pub args: Vec<Arg<R>>,
     /// example `i32{v:v >= 0}`
     pub returns: FnRetTy<R>,
-    /// example: `*x: i32{v. v = n+1}`
-    // pub ensures: Vec<(Ident, Ty<R>)>,
+    /// example: `*x: i32{v. v = n+1}` or just `x > 10`
     pub ensures: Ensures<R>,
     /// example: `where I: Iterator<Item = i32{v:0<=v}>`
     pub predicates: Vec<WhereBoundPredicate<R>>,

--- a/crates/flux-tests/tests/neg/surface/assume00.rs
+++ b/crates/flux-tests/tests/neg/surface/assume00.rs
@@ -1,0 +1,20 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[flux::sig(fn(b:bool[true]))]
+pub fn assert(_b: bool) {}
+
+#[flux::sig(fn(b:bool) ensures b)]
+pub fn assume(b: bool) {
+    if !b {
+        panic!("assume fails")
+    }
+}
+
+#[flux::sig(fn(x:i32))]
+pub fn dec(x: i32) {
+    assume(x > 10);
+    assert(x > 0);
+    assert(x > 20); //~ ERROR refinement type
+
+}

--- a/crates/flux-tests/tests/neg/surface/assume00.rs
+++ b/crates/flux-tests/tests/neg/surface/assume00.rs
@@ -1,8 +1,8 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 
-#[flux::sig(fn(b:bool[true]))]
-pub fn assert(_b: bool) {}
+#[flux::sig(fn(bool[true]))]
+pub fn assert(_: bool) {}
 
 #[flux::sig(fn(b:bool) ensures b)]
 pub fn assume(b: bool) {
@@ -16,5 +16,11 @@ pub fn dec(x: i32) {
     assume(x > 10);
     assert(x > 0);
     assert(x > 20); //~ ERROR refinement type
+}
 
+#[flux::sig(fn(b: bool) ensures b)]
+pub fn bad_assume(b: bool) {
+    if b {
+        panic!("assume fails");
+    } //~ ERROR refinement type
 }


### PR DESCRIPTION
e.g. to write 

```rust
#[flux::sig(fn(b:bool) ensures b)]
pub fn assume(b: bool) {
    if !b {
        panic!("assume fails")
    }
}
```