### PR TITLE
Convert `TraitRef` to `PolyTraitRef`

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -263,8 +263,11 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
         &mut self,
         trait_ref: &surface::TraitRef<Res>,
         binders: &mut Binders,
-    ) -> Result<fhir::TraitRef, ErrorGuaranteed> {
-        Ok(fhir::TraitRef { path: self.desugar_path(&trait_ref.path, binders)? })
+    ) -> Result<fhir::PolyTraitRef, ErrorGuaranteed> {
+        Ok(fhir::PolyTraitRef {
+            bound_generic_params: vec![],
+            trait_ref: self.desugar_path(&trait_ref.path, binders)?,
+        })
     }
 
     pub(crate) fn desugar_struct_def(

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -327,7 +327,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                 if let Some(closure_kind) = self.genv.tcx.fn_trait_kind_from_def_id(trait_id) {
                     self.conv_fn_bound(env, bounded_ty, trait_ref, closure_kind, clauses)
                 } else {
-                    let path = &trait_ref.path;
+                    let path = &trait_ref.trait_ref;
                     self.conv_trait_bound(env, bounded_ty, trait_id, &path.args, clauses)?;
                     self.conv_type_bindings(env, bounded_ty, trait_id, &path.bindings, clauses)
                 }
@@ -364,11 +364,11 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
         &self,
         env: &mut Env,
         self_ty: &rty::Ty,
-        trait_ref: &fhir::TraitRef,
+        trait_ref: &fhir::PolyTraitRef,
         kind: rty::ClosureKind,
         clauses: &mut Vec<rty::Clause>,
     ) -> QueryResult<()> {
-        let path = &trait_ref.path;
+        let path = &trait_ref.trait_ref;
         let pred = rty::FnTraitPredicate {
             self_ty: self_ty.clone(),
             tupled_args: self.conv_ty(env, path.args[0].expect_type())?,

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -9,7 +9,7 @@
 //! 3. Refinements are well-sorted.
 use std::borrow::Borrow;
 
-use flux_common::{bug, span_bug};
+use flux_common::{bug, iter::IterExt, span_bug};
 use flux_middle::{
     fhir::{self, FhirId, SurfaceIdent},
     global_env::GlobalEnv,
@@ -328,7 +328,8 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                     self.conv_fn_bound(env, bounded_ty, trait_ref, closure_kind, clauses)
                 } else {
                     let path = &trait_ref.trait_ref;
-                    self.conv_trait_bound(env, bounded_ty, trait_id, &path.args, clauses)?;
+                    let params = &trait_ref.bound_generic_params;
+                    self.conv_trait_bound(env, bounded_ty, trait_id, &path.args, params, clauses)?;
                     self.conv_type_bindings(env, bounded_ty, trait_id, &path.bindings, clauses)
                 }
             }
@@ -349,6 +350,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
         bounded_ty: &rty::Ty,
         trait_id: DefId,
         args: &[fhir::GenericArg],
+        params: &[fhir::GenericParam],
         clauses: &mut Vec<rty::Clause>,
     ) -> QueryResult<()> {
         let mut into = vec![rty::GenericArg::Ty(bounded_ty.clone())];
@@ -356,8 +358,32 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
         self.fill_generic_args_defaults(trait_id, &mut into)?;
         let trait_ref = rty::TraitRef { def_id: trait_id, args: into.into() };
         let pred = rty::TraitPredicate { trait_ref };
-        clauses.push(rty::Clause::new(rty::ClauseKind::Trait(pred)));
+        let vars = params
+            .iter()
+            .map(|param| self.conv_trait_bound_generic_param(param))
+            .try_collect_vec()?;
+        clauses.push(rty::Clause::new(List::from_vec(vars), rty::ClauseKind::Trait(pred)));
         Ok(())
+    }
+
+    fn conv_trait_bound_generic_param(
+        &self,
+        param: &fhir::GenericParam,
+    ) -> QueryResult<rty::BoundVariableKind> {
+        match &param.kind {
+            fhir::GenericParamKind::Lifetime => {
+                let def_id = param.def_id;
+                let name = self
+                    .genv
+                    .tcx
+                    .hir()
+                    .name(self.genv.tcx.hir().local_def_id_to_hir_id(def_id));
+                let kind = rty::BoundRegionKind::BrNamed(def_id.to_def_id(), name);
+                Ok(rty::BoundVariableKind::Region(kind))
+            }
+            fhir::GenericParamKind::Type { default: _ } => bug!("unexpected!"),
+            fhir::GenericParamKind::BaseTy => bug!("unexpected!"),
+        }
     }
 
     fn conv_fn_bound(
@@ -369,13 +395,21 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
         clauses: &mut Vec<rty::Clause>,
     ) -> QueryResult<()> {
         let path = &trait_ref.trait_ref;
+        let layer = Layer::list(self, trait_ref.bound_generic_params.len() as u32, &[], true);
+        env.push_layer(layer);
+
         let pred = rty::FnTraitPredicate {
             self_ty: self_ty.clone(),
             tupled_args: self.conv_ty(env, path.args[0].expect_type())?,
             output: self.conv_ty(env, &path.bindings[0].term)?,
             kind,
         };
-        clauses.push(rty::Clause::new(rty::ClauseKind::FnTrait(pred)));
+        let vars = trait_ref
+            .bound_generic_params
+            .iter()
+            .map(|param| self.conv_trait_bound_generic_param(param))
+            .try_collect_vec()?;
+        clauses.push(rty::Clause::new(vars, rty::ClauseKind::FnTrait(pred)));
         Ok(())
     }
 
@@ -402,7 +436,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                 projection_ty: alias_ty,
                 term: self.conv_ty(env, &binding.term)?,
             });
-            clauses.push(rty::Clause::new(kind));
+            clauses.push(rty::Clause::new(List::empty(), kind));
         }
         Ok(())
     }

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -232,7 +232,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         bound: &fhir::GenericBound,
     ) -> Result<(), ErrorGuaranteed> {
         match bound {
-            fhir::GenericBound::Trait(trait_ref, _) => self.check_path(infcx, &trait_ref.path),
+            fhir::GenericBound::Trait(trait_ref, _) => self.check_path(infcx, &trait_ref.trait_ref),
             fhir::GenericBound::LangItemTrait(_, args, bindings) => {
                 self.check_generic_args(infcx, args)?;
                 self.check_type_bindings(infcx, bindings)?;

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -115,13 +115,14 @@ pub type GenericBounds = Vec<GenericBound>;
 
 #[derive(Debug)]
 pub enum GenericBound {
-    Trait(TraitRef, TraitBoundModifier),
+    Trait(PolyTraitRef, TraitBoundModifier),
     LangItemTrait(LangItem, Vec<GenericArg>, Vec<TypeBinding>),
 }
 
 #[derive(Debug)]
-pub struct TraitRef {
-    pub path: Path,
+pub struct PolyTraitRef {
+    pub bound_generic_params: Vec<GenericParam>,
+    pub trait_ref: Path,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -555,9 +556,9 @@ newtype_index! {
     pub struct Name {}
 }
 
-impl TraitRef {
+impl PolyTraitRef {
     pub fn trait_def_id(&self) -> DefId {
-        let path = &self.path;
+        let path = &self.trait_ref;
         if let Res::Def(DefKind::Trait, did) = path.res {
             did
         } else {

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -96,7 +96,7 @@ pub struct GenericPredicates {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Clause {
-    kind: ClauseKind,
+    kind: Binder<ClauseKind>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -426,12 +426,12 @@ impl GenericArg {
 }
 
 impl Clause {
-    pub fn new(kind: ClauseKind) -> Self {
-        Clause { kind }
+    pub fn new(vars: impl Into<List<BoundVariableKind>>, kind: ClauseKind) -> Self {
+        Clause { kind: Binder::new(kind, vars.into()) }
     }
 
     pub fn kind(&self) -> ClauseKind {
-        self.kind.clone()
+        self.kind.clone().skip_binder()
     }
 }
 

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -131,6 +131,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
                 rty::ClauseKind::Projection(pred)
             }
         };
+        let kind = rty::Binder::new(kind, List::empty());
         Ok(Some(rty::Clause { kind }))
     }
 

--- a/crates/flux-middle/src/rustc/lowering.rs
+++ b/crates/flux-middle/src/rustc/lowering.rs
@@ -841,7 +841,7 @@ fn lower_clause<'tcx>(
     let Some(kind) = clause.kind().no_bound_vars() else {
         return Err(sess.emit_err(errors::UnsupportedGenericBound::new(
             span,
-            "higher-rank trait bounds are not supported",
+            "higher-rank trait bounds are not supported 1",
         )));
     };
     let kind = match kind {

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -766,7 +766,7 @@ fn mk_generator_obligations(
     } else {
         panic!("mk_generator_obligations: unexpected bounds")
     };
-    let clause = rty::Clause::new(rty::ClauseKind::GeneratorOblig(pred));
+    let clause = rty::Clause::new(vec![], rty::ClauseKind::GeneratorOblig(pred));
     Ok(vec![clause])
 }
 

--- a/crates/flux-tests/tests/lib/rvec.rs
+++ b/crates/flux-tests/tests/lib/rvec.rs
@@ -94,14 +94,13 @@ impl<T> RVec<T> {
         vec
     }
 
+    #[flux::trusted]
     #[flux::sig(fn(&RVec<T>[@n]) -> RVec<T>[n])]
     pub fn clone(&self) -> Self
     where
         T: Clone,
     {
-        Self {
-            inner: self.inner.clone(),
-        }
+        Self { inner: self.inner.clone() }
     }
 
     #[flux::trusted]
@@ -126,25 +125,22 @@ impl<T> RVec<T> {
         res
     } */
 
+    #[flux::trusted]
     #[flux::sig(fn (&RVec<T>[@n], F) -> RVec<U>[n])]
     pub fn map<U, F>(&self, f: F) -> RVec<U>
     where
         F: Fn(&T) -> U,
     {
-        RVec {
-            inner: self.inner.iter().map(f).collect(),
-        }
+        RVec { inner: self.inner.iter().map(f).collect() }
     }
 
+    #[flux::trusted]
     pub fn fold<B, F>(&self, init: B, f: F) -> B
     where
         F: FnMut(B, &T) -> B,
     {
         self.inner.iter().fold(init, f)
     }
-
-
-
 }
 
 #[flux::opaque]

--- a/crates/flux-tests/tests/lib/rvec.rs
+++ b/crates/flux-tests/tests/lib/rvec.rs
@@ -112,19 +112,6 @@ impl<T> RVec<T> {
         self.inner.extend_from_slice(other)
     }
 
-    /*
-    #[flux::trusted]
-    pub fn map<U, F>(self, f: F) -> RVec<U>
-    where
-        F: Fn(T) -> U,
-    {
-        let mut res = RVec::new();
-        for x in self.into_iter() {
-            res.push(f(x));
-        }
-        res
-    } */
-
     #[flux::trusted]
     #[flux::sig(fn (&RVec<T>[@n], F) -> RVec<U>[n])]
     pub fn map<U, F>(&self, f: F) -> RVec<U>

--- a/crates/flux-tests/tests/pos/surface/fold00.rs
+++ b/crates/flux-tests/tests/pos/surface/fold00.rs
@@ -1,0 +1,23 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+
+#[path = "../../lib/rvec.rs"]
+mod rvec;
+use rvec::RVec;
+
+#[flux::trusted]
+#[flux::sig(fn(lo: usize, hi:usize{lo < hi}) -> RVec<usize{v:lo<=v && v<hi}>[hi-lo])]
+pub fn range(lo: usize, hi: usize) -> RVec<usize> {
+    let mut i = lo;
+    let mut res = RVec::new();
+    while i < hi {
+        res.push(i);
+        i += 1;
+    }
+    res
+}
+
+#[flux::sig(fn(a: { &RVec<f32>[@k] | 0 < k}) -> usize{v: v < k})]
+pub fn min_index_fold(a: &RVec<f32>) -> usize {
+    range(0, a.len()).fold(0, |min, i| if a[*i] < a[min] { *i } else { min })
+}


### PR DESCRIPTION
To support using (lifting) signatures like

```rust
    pub fn fold<B, F>(&self, init: B, f: F) -> B
    where
        F: FnMut(B, &T) -> B,
    {
        self.inner.iter().fold(init, f)
    }
```