### PR TITLE
Allow using monomorphic maps as indices

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1345,6 +1345,8 @@ fn resolve_base_sort(
 fn resolve_sort_ctor(sess: &FluxSession, ident: surface::Ident) -> Result<fhir::SortCtor> {
     if ident.name == SORTS.set {
         Ok(fhir::SortCtor::Set)
+    } else if ident.name == SORTS.map {
+        Ok(fhir::SortCtor::Map)
     } else {
         Err(sess.emit_err(errors::UnresolvedSort::new(ident)))
     }
@@ -1636,10 +1638,16 @@ struct Sorts {
     int: Symbol,
     real: Symbol,
     set: Symbol,
+    map: Symbol,
 }
 
 static SORTS: std::sync::LazyLock<Sorts> = std::sync::LazyLock::new(|| {
-    Sorts { int: Symbol::intern("int"), real: Symbol::intern("real"), set: Symbol::intern("Set") }
+    Sorts {
+        int: Symbol::intern("int"),
+        real: Symbol::intern("real"),
+        set: Symbol::intern("Set"),
+        map: Symbol::intern("Map"),
+    }
 });
 
 mod errors {

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -1160,6 +1160,7 @@ pub fn conv_sort(genv: &GlobalEnv, sort: &fhir::Sort) -> rty::Sort {
 fn conv_sort_ctor(ctor: &fhir::SortCtor) -> rty::SortCtor {
     match ctor {
         fhir::SortCtor::Set => rty::SortCtor::Set,
+        fhir::SortCtor::Map => rty::SortCtor::Map,
         fhir::SortCtor::User { name, arity } => rty::SortCtor::User { name: *name, arity: *arity },
     }
 }

--- a/crates/flux-fixpoint/src/constraint.rs
+++ b/crates/flux-fixpoint/src/constraint.rs
@@ -34,6 +34,7 @@ pub enum Sort {
 #[derive(Clone, Hash)]
 pub enum SortCtor {
     Set,
+    Map,
     // User { name: Symbol, arity: usize },
 }
 
@@ -276,7 +277,7 @@ impl fmt::Display for SortCtor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SortCtor::Set => write!(f, "Set_Set"),
-            // SortCtor::User { name, .. } => write!(f, "{}", name),
+            SortCtor::Map => write!(f, "Map_t"),
         }
     }
 }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -142,6 +142,7 @@ pub struct GeneratorObligPredicate {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum SortCtor {
     Set,
+    Map,
     User { name: Symbol, arity: usize },
 }
 
@@ -1697,6 +1698,7 @@ mod pretty {
             define_scoped!(_cx, f);
             match self {
                 SortCtor::Set => w!("Set"),
+                SortCtor::Map => w!("Map"),
                 SortCtor::User { name, .. } => w!("{}", ^name),
             }
         }

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -520,8 +520,12 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
         // user declared opaque sorts and type variable sorts as integers. Well-formedness should
         // ensure values of these sorts are properly used.
         rty::Sort::App(rty::SortCtor::User { .. }, _) | rty::Sort::Param(_) => fixpoint::Sort::Int,
-        rty::Sort::App(rty::SortCtor::Set, sorts) => {
-            let ctor = fixpoint::SortCtor::Set;
+        rty::Sort::App(ctor, sorts) => {
+            let ctor = match ctor {
+                rty::SortCtor::Set => fixpoint::SortCtor::Set,
+                rty::SortCtor::Map => fixpoint::SortCtor::Map,
+                rty::SortCtor::User { .. } => unreachable!(),
+            };
             let sorts = sorts.iter().map(sort_to_fixpoint).collect_vec();
             fixpoint::Sort::App(ctor, sorts)
         }

--- a/crates/flux-tests/tests/neg/surface/maps00.rs
+++ b/crates/flux-tests/tests/neg/surface/maps00.rs
@@ -1,6 +1,5 @@
-// #![feature(register_tool)]
-// #![register_tool(flux)]
-
+#![feature(register_tool)]
+#![register_tool(flux)]
 #![feature(custom_inner_attributes)]
 #![flux::defs {
     fn map_set(m:Map<int, int>, k: int, v: int) -> Map<int, int> { map_store(m, k, v) }
@@ -10,12 +9,6 @@
 
 #[flux::sig(fn (bool[true]))]
 fn assert(_b: bool) {}
-
-pub fn test() {
-    assert(true);
-    assert(1 == 2);
-    assert(1 + 1 == 2)
-}
 
 /// define a type indexed by a map
 #[flux::opaque]
@@ -39,7 +32,7 @@ impl MyMap {
     #[flux::trusted]
     #[flux::sig(fn(&MyMap[@m], k: i32) -> Option<i32[map_get(m, k)]>)]
     pub fn get(&self, k: i32) -> Option<i32> {
-        *self.inner.get(&k)
+        self.inner.get(&k).copied()
     }
 }
 
@@ -49,6 +42,7 @@ pub fn test() {
     m.set(10, 1);
     m.set(20, 2);
 
+    assert(1 + 1 == 2);
     assert(m.get(10).unwrap() == 1);
     assert(m.get(20).unwrap() == 2);
     assert(m.get(30).unwrap() == 3); //~ ERROR refinement type

--- a/crates/flux-tests/tests/todo/maps00.rs
+++ b/crates/flux-tests/tests/todo/maps00.rs
@@ -1,0 +1,55 @@
+// #![feature(register_tool)]
+// #![register_tool(flux)]
+
+#![feature(custom_inner_attributes)]
+#![flux::defs {
+    fn map_set(m:Map<int, int>, k: int, v: int) -> Map<int, int> { map_store(m, k, v) }
+    fn map_get(m: Map<int,int>, k:int) -> int { map_select(m, k) }
+    fn map_def(v:int) -> Map<int, int> { map_default(v) }
+}]
+
+#[flux::sig(fn (bool[true]))]
+fn assert(_b: bool) {}
+
+pub fn test() {
+    assert(true);
+    assert(1 == 2);
+    assert(1 + 1 == 2)
+}
+
+/// define a type indexed by a map
+#[flux::opaque]
+#[flux::refined_by(map: Map<int, int>)]
+struct MyMap {
+    inner: std::collections::HashMap<i32, i32>,
+}
+
+impl MyMap {
+    #[flux::trusted]
+    pub fn new() -> Self {
+        Self { inner: std::collections::HashMap::new() }
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(self: &strg MyMap[@m], k: i32, v: i32) ensures self: MyMap[map_set(m, k, v)])]
+    pub fn set(&mut self, k: i32, v: i32) {
+        self.inner.insert(k, v);
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(&MyMap[@m], k: i32) -> Option<i32[map_get(m, k)]>)]
+    pub fn get(&self, k: i32) -> Option<i32> {
+        *self.inner.get(&k)
+    }
+}
+
+/// USE the type
+pub fn test() {
+    let mut m = MyMap::new();
+    m.set(10, 1);
+    m.set(20, 2);
+
+    assert(m.get(10).unwrap() == 1);
+    assert(m.get(20).unwrap() == 2);
+    assert(m.get(30).unwrap() == 3); //~ ERROR refinement type
+}


### PR DESCRIPTION
This works now:

```rust
#![flux::defs {
    fn map_set(m:Map<int, int>, k: int, v: int) -> Map<int, int> { map_store(m, k, v) }
    fn map_get(m: Map<int,int>, k:int) -> int { map_select(m, k) }
    fn map_def(v:int) -> Map<int, int> { map_default(v) }
}]

#[flux::sig(fn (bool[true]))]
fn assert(_b: bool) {}

// define a type indexed by a map
#[flux::opaque]
#[flux::refined_by(map: Map<int, int>)]
struct MyMap {
    inner: std::collections::HashMap<i32, i32>,
}

impl MyMap {
    #[flux::trusted]
    pub fn new() -> Self {
        Self { inner: std::collections::HashMap::new() }
    }

    #[flux::trusted]
    #[flux::sig(fn(self: &strg MyMap[@m], k: i32, v: i32) ensures self: MyMap[map_set(m, k, v)])]
    pub fn set(&mut self, k: i32, v: i32) {
        self.inner.insert(k, v);
    }

    #[flux::trusted]
    #[flux::sig(fn(&MyMap[@m], k: i32) -> Option<i32[map_get(m, k)]>)]
    pub fn get(&self, k: i32) -> Option<i32> {
        self.inner.get(&k).copied()
    }
}

// USE the type
pub fn test() {
    let mut m = MyMap::new();
    m.set(10, 1);
    m.set(20, 2);

    assert(1 + 1 == 2);
    assert(m.get(10).unwrap() == 1);
    assert(m.get(20).unwrap() == 2);
    assert(m.get(30).unwrap() == 3); //~ ERROR refinement type
}
```