### PR TITLE
`RMap` with tracked keys

### DIFF
--- a/crates/flux-tests/tests/lib/rmap.rs
+++ b/crates/flux-tests/tests/lib/rmap.rs
@@ -1,4 +1,4 @@
-#![feature(custom_inner_attributes)]
+#![allow(dead_code)]
 #![flux::defs {
     fn map_set(m:Map<int, int>, k: int, v: int) -> Map<int, int> { map_store(m, k, v) }
     fn map_get(m: Map<int,int>, k:int) -> int { map_select(m, k) }

--- a/crates/flux-tests/tests/lib/rmap.rs
+++ b/crates/flux-tests/tests/lib/rmap.rs
@@ -1,0 +1,32 @@
+#![feature(custom_inner_attributes)]
+#![flux::defs {
+    fn map_set(m:Map<int, int>, k: int, v: int) -> Map<int, int> { map_store(m, k, v) }
+    fn map_get(m: Map<int,int>, k:int) -> int { map_select(m, k) }
+    fn map_def(v:int) -> Map<int, int> { map_default(v) }
+}]
+
+/// define a type indexed by a map
+#[flux::opaque]
+#[flux::refined_by(map: Map<int, int>)]
+pub struct RMap {
+    inner: std::collections::HashMap<i32, i32>,
+}
+
+impl RMap {
+    #[flux::trusted]
+    pub fn new() -> Self {
+        Self { inner: std::collections::HashMap::new() }
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(self: &strg RMap[@m], k: i32, v: i32) ensures self: RMap[map_set(m, k, v)])]
+    pub fn set(&mut self, k: i32, v: i32) {
+        self.inner.insert(k, v);
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(&RMap[@m], k: i32) -> Option<i32[map_get(m, k)]>)]
+    pub fn get(&self, k: i32) -> Option<i32> {
+        self.inner.get(&k).copied()
+    }
+}

--- a/crates/flux-tests/tests/lib/rmapk.rs
+++ b/crates/flux-tests/tests/lib/rmapk.rs
@@ -1,0 +1,36 @@
+#![flux::defs {
+    fn map_set(m:Map<int, int>, k: int, v: int) -> Map<int, int> { map_store(m, k, v) }
+    fn map_get(m: Map<int,int>, k:int) -> int { map_select(m, k) }
+    fn map_def(v:int) -> Map<int, int> { map_default(v) }
+    fn set_add(x: int, s: Set<int>) -> Set<int> { set_union(set_singleton(x), s) }
+    fn set_is_empty(s: Set<int>) -> bool { s == set_empty(0) }
+    fn set_emp() -> Set<int> { set_empty(0) }
+}]
+
+/// define a type indexed by a map
+#[flux::opaque]
+#[flux::refined_by(keys: Set<int>, vals: Map<int, int>)]
+pub struct RMap {
+    inner: std::collections::HashMap<i32, i32>,
+}
+
+impl RMap {
+    #[flux::trusted]
+    #[flux::sig(fn() -> RMap[set_empty(0), map_def(0)])]
+    pub fn new() -> Self {
+        Self { inner: std::collections::HashMap::new() }
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(self: &strg RMap[@m], k: i32, v: i32)
+                ensures self: RMap[set_add(k, m.keys), map_set(m.vals, k, v)])]
+    pub fn set(&mut self, k: i32, v: i32) {
+        self.inner.insert(k, v);
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(&RMap[@m], k: i32 where set_mem(k,m.keys)) -> i32[map_get(m.vals, k)])]
+    pub fn get(&self, k: i32) -> Option<i32> {
+        self.inner.get(&k).copied()
+    }
+}

--- a/crates/flux-tests/tests/lib/rmapk.rs
+++ b/crates/flux-tests/tests/lib/rmapk.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 #![flux::defs {
     fn map_set(m:Map<int, int>, k: int, v: int) -> Map<int, int> { map_store(m, k, v) }
     fn map_get(m: Map<int,int>, k:int) -> int { map_select(m, k) }
@@ -29,8 +30,20 @@ impl RMap {
     }
 
     #[flux::trusted]
-    #[flux::sig(fn(&RMap[@m], k: i32 where set_mem(k,m.keys)) -> i32[map_get(m.vals, k)])]
+    #[flux::sig(fn(&RMap[@m], k: i32) -> Option<i32[map_get(m.vals, k)]>)]
     pub fn get(&self, k: i32) -> Option<i32> {
         self.inner.get(&k).copied()
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(&RMap[@m], k: i32) -> i32[map_get(m.vals, k)] requires set_is_in(k, m.keys))]
+    pub fn lookup(&self, k: i32) -> i32 {
+        *self.inner.get(&k).unwrap()
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(&RMap[@m], k: i32) -> bool[set_is_in(k, m.keys)])]
+    pub fn contains(&self, k: i32) -> bool {
+        self.inner.contains_key(&k)
     }
 }

--- a/crates/flux-tests/tests/neg/surface/maps00.rs
+++ b/crates/flux-tests/tests/neg/surface/maps00.rs
@@ -1,44 +1,16 @@
 #![feature(register_tool)]
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
-#![flux::defs {
-    fn map_set(m:Map<int, int>, k: int, v: int) -> Map<int, int> { map_store(m, k, v) }
-    fn map_get(m: Map<int,int>, k:int) -> int { map_select(m, k) }
-    fn map_def(v:int) -> Map<int, int> { map_default(v) }
-}]
+
+#[path = "../../lib/rmap.rs"]
+mod rmap;
+use rmap::RMap;
 
 #[flux::sig(fn (bool[true]))]
 fn assert(_b: bool) {}
 
-/// define a type indexed by a map
-#[flux::opaque]
-#[flux::refined_by(map: Map<int, int>)]
-struct MyMap {
-    inner: std::collections::HashMap<i32, i32>,
-}
-
-impl MyMap {
-    #[flux::trusted]
-    pub fn new() -> Self {
-        Self { inner: std::collections::HashMap::new() }
-    }
-
-    #[flux::trusted]
-    #[flux::sig(fn(self: &strg MyMap[@m], k: i32, v: i32) ensures self: MyMap[map_set(m, k, v)])]
-    pub fn set(&mut self, k: i32, v: i32) {
-        self.inner.insert(k, v);
-    }
-
-    #[flux::trusted]
-    #[flux::sig(fn(&MyMap[@m], k: i32) -> Option<i32[map_get(m, k)]>)]
-    pub fn get(&self, k: i32) -> Option<i32> {
-        self.inner.get(&k).copied()
-    }
-}
-
-/// USE the type
 pub fn test() {
-    let mut m = MyMap::new();
+    let mut m = RMap::new();
     m.set(10, 1);
     m.set(20, 2);
 

--- a/crates/flux-tests/tests/neg/surface/maps01.rs
+++ b/crates/flux-tests/tests/neg/surface/maps01.rs
@@ -1,0 +1,21 @@
+#![feature(register_tool)]
+#![register_tool(flux)]
+#![feature(custom_inner_attributes)]
+
+#[path = "../../lib/rmap.rs"]
+mod rmap;
+use rmap::RMap;
+
+#[flux::sig(fn (bool[true]))]
+fn assert(_b: bool) {}
+
+pub fn test() {
+    let mut m = RMap::new();
+    m.set(10, 1);
+    m.set(20, 2);
+
+    assert(1 + 1 == 2);
+    assert(m.get(10).unwrap() == 1);
+    assert(m.get(20).unwrap() == 2);
+    assert(m.get(30).unwrap() == 3); //~ ERROR refinement type
+}

--- a/crates/flux-tests/tests/neg/surface/maps01.rs
+++ b/crates/flux-tests/tests/neg/surface/maps01.rs
@@ -2,9 +2,9 @@
 #![register_tool(flux)]
 #![feature(custom_inner_attributes)]
 
-#[path = "../../lib/rmap.rs"]
-mod rmap;
-use rmap::RMap;
+#[path = "../../lib/rmapk.rs"]
+mod rmapk;
+use rmapk::RMap;
 
 #[flux::sig(fn (bool[true]))]
 fn assert(_b: bool) {}
@@ -15,7 +15,9 @@ pub fn test() {
     m.set(20, 2);
 
     assert(1 + 1 == 2);
-    assert(m.get(10).unwrap() == 1);
     assert(m.get(20).unwrap() == 2);
-    assert(m.get(30).unwrap() == 3); //~ ERROR refinement type
+    assert(m.lookup(10) == 1);
+    assert(m.lookup(20) == 2);
+    assert(m.contains(10));
+    assert(m.contains(30)); //~ ERROR refinement type
 }


### PR DESCRIPTION
Factor `rmap` out, and add an extra index that tracks the set of defined `keys`.