### PR TITLE
Support polymorphic theory functions (set_cup, map_store) etc.

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -71,7 +71,7 @@ pub fn func_def_to_func_decl(
         .map(|arg| resolve_sort(sess, sort_decls, &arg.sort))
         .try_collect_exhaust()?;
     inputs_and_output.push(resolve_sort(sess, sort_decls, &defn.output)?);
-    let sort = fhir::FuncSort { inputs_and_output: List::from(inputs_and_output) };
+    let sort = fhir::FuncSort { params: 0, inputs_and_output: List::from(inputs_and_output) };
     let kind = if defn.body.is_some() { fhir::FuncKind::Def } else { fhir::FuncKind::Uif };
     Ok(fhir::FuncDecl { name: defn.name.name, sort, kind })
 }
@@ -1327,7 +1327,7 @@ fn resolve_func_sort(
         .map(|sort| resolve_base_sort(sess, sort_decls, sort))
         .try_collect_exhaust()?;
     inputs_and_output.push(resolve_base_sort(sess, sort_decls, output)?);
-    Ok(fhir::FuncSort { inputs_and_output: List::from_vec(inputs_and_output) })
+    Ok(fhir::FuncSort { params: 0, inputs_and_output: List::from_vec(inputs_and_output) })
 }
 
 fn resolve_base_sort(

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -1154,6 +1154,7 @@ pub fn conv_sort(genv: &GlobalEnv, sort: &fhir::Sort) -> rty::Sort {
             rty::Sort::Param(def_id_to_param_ty(genv.tcx, def_id.expect_local()))
         }
         fhir::Sort::Wildcard | fhir::Sort::Infer(_) => bug!("unexpected sort `{sort:?}`"),
+        fhir::Sort::Var(n) => rty::Sort::Var(*n),
     }
 }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -493,6 +493,8 @@ pub enum Sort {
     /// Sort constructor application (e.g. `Set<int>` or `Map<int, int>`)
     App(SortCtor, List<Sort>),
     Func(FuncSort),
+    /// sort variable
+    Var(usize),
     /// A record sort corresponds to the sort associated with a type alias or an adt (struct/enum).
     /// Values of a record sort can be projected using dot notation to extract their fields.
     Record(DefId),
@@ -506,6 +508,9 @@ pub enum Sort {
 
 #[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub struct FuncSort {
+    /// number of sort parameters
+    pub params: usize,
+    /// inputs and output in order
     pub inputs_and_output: List<Sort>,
 }
 
@@ -849,7 +854,7 @@ impl From<FuncSort> for Sort {
 impl FuncSort {
     pub fn new(mut inputs: Vec<Sort>, output: Sort) -> Self {
         inputs.push(output);
-        FuncSort { inputs_and_output: List::from_vec(inputs) }
+        FuncSort { params: 0, inputs_and_output: List::from_vec(inputs) }
     }
 
     pub fn inputs(&self) -> &[Sort] {
@@ -1553,6 +1558,7 @@ impl fmt::Debug for Sort {
             Sort::Bool => write!(f, "bool"),
             Sort::Int => write!(f, "int"),
             Sort::Real => write!(f, "real"),
+            Sort::Var(n) => write!(f, "@{}", n),
             Sort::BitVec(w) => write!(f, "bitvec({w})"),
             Sort::Loc => write!(f, "loc"),
             Sort::Func(sort) => write!(f, "{sort}"),

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -1179,7 +1179,7 @@ impl Map {
         self.insert_theory_func(
             Symbol::intern("map_store"),
             Symbol::intern("Map_store"),
-            0,
+            2,
             vec![Sort::map(Sort::Var(0), Sort::Var(1)), Sort::Var(0), Sort::Var(1)],
             Sort::map(Sort::Var(0), Sort::Var(1)),
         );

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -809,6 +809,28 @@ impl Sort {
     pub fn map(k: Sort, v: Sort) -> Self {
         Self::App(SortCtor::Map, List::from_vec(vec![k, v]))
     }
+
+    /// replace all "sort-parameters" (indexed 0...n-1) with the corresponding sort in `subst`
+    pub fn subst(&self, subst: &[Sort]) -> Sort {
+        match self {
+            Sort::Int
+            | Sort::Bool
+            | Sort::Real
+            | Sort::Loc
+            | Sort::Unit
+            | Sort::BitVec(_)
+            | Sort::Param(_)
+            | Sort::Wildcard
+            | Sort::Record(_)
+            | Sort::Infer(_) => self.clone(),
+            Sort::Var(i) => subst[*i].clone(),
+            Sort::App(c, args) => {
+                let args = args.iter().map(|arg| arg.subst(subst)).collect();
+                Sort::App(c.clone(), args)
+            }
+            Sort::Func(_) => bug!("unexpected subst in (nested) func-sort"),
+        }
+    }
 }
 
 impl ena::unify::UnifyKey for SortVid {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -852,9 +852,9 @@ impl From<FuncSort> for Sort {
 }
 
 impl FuncSort {
-    pub fn new(mut inputs: Vec<Sort>, output: Sort) -> Self {
+    pub fn new(params: usize, mut inputs: Vec<Sort>, output: Sort) -> Self {
         inputs.push(output);
-        FuncSort { params: 0, inputs_and_output: List::from_vec(inputs) }
+        FuncSort { params, inputs_and_output: List::from_vec(inputs) }
     }
 
     pub fn inputs(&self) -> &[Sort] {
@@ -1069,10 +1069,11 @@ impl Map {
         &mut self,
         name: Symbol,
         fixpoint_name: Symbol,
+        params: usize,
         inputs: Vec<Sort>,
         output: Sort,
     ) {
-        let sort = FuncSort::new(inputs, output);
+        let sort = FuncSort::new(params, inputs, output);
         self.func_decls
             .insert(name, FuncDecl { name, sort, kind: FuncKind::Thy(fixpoint_name) });
     }
@@ -1082,24 +1083,28 @@ impl Map {
         self.insert_theory_func(
             Symbol::intern("bv_int_to_bv32"),
             Symbol::intern("int_to_bv32"),
+            0,
             vec![Sort::Int],
             Sort::BitVec(32),
         );
         self.insert_theory_func(
             Symbol::intern("bv_bv32_to_int"),
             Symbol::intern("bv32_to_int"),
+            0,
             vec![Sort::BitVec(32)],
             Sort::Int,
         );
         self.insert_theory_func(
             Symbol::intern("bv_sub"),
             Symbol::intern("bvsub"),
+            0,
             vec![Sort::BitVec(32), Sort::BitVec(32)],
             Sort::BitVec(32),
         );
         self.insert_theory_func(
             Symbol::intern("bv_and"),
             Symbol::intern("bvand"),
+            0,
             vec![Sort::BitVec(32), Sort::BitVec(32)],
             Sort::BitVec(32),
         );
@@ -1108,25 +1113,29 @@ impl Map {
         self.insert_theory_func(
             Symbol::intern("set_empty"),
             Symbol::intern("Set_empty"),
+            1,
             vec![Sort::Int],
-            Sort::set(Sort::Int),
+            Sort::set(Sort::Var(0)),
         );
         self.insert_theory_func(
             Symbol::intern("set_singleton"),
             Symbol::intern("Set_sng"),
-            vec![Sort::Int],
-            Sort::set(Sort::Int),
+            1,
+            vec![Sort::Var(0)],
+            Sort::set(Sort::Var(0)),
         );
         self.insert_theory_func(
             Symbol::intern("set_union"),
             Symbol::intern("Set_cup"),
-            vec![Sort::set(Sort::Int), Sort::set(Sort::Int)],
-            Sort::set(Sort::Int),
+            1,
+            vec![Sort::set(Sort::Var(0)), Sort::set(Sort::Var(0))],
+            Sort::set(Sort::Var(0)),
         );
         self.insert_theory_func(
             Symbol::intern("set_is_in"),
             Symbol::intern("Set_mem"),
-            vec![Sort::Int, Sort::set(Sort::Int)],
+            1,
+            vec![Sort::Var(0), Sort::set(Sort::Var(0))],
             Sort::Bool,
         );
 
@@ -1134,20 +1143,23 @@ impl Map {
         self.insert_theory_func(
             Symbol::intern("map_default"),
             Symbol::intern("Map_default"),
-            vec![Sort::Int],
-            Sort::map(Sort::Int, Sort::Int),
+            2,
+            vec![Sort::Var(1)],
+            Sort::map(Sort::Var(0), Sort::Var(1)),
         );
         self.insert_theory_func(
             Symbol::intern("map_select"),
             Symbol::intern("Map_select"),
-            vec![Sort::map(Sort::Int, Sort::Int), Sort::Int],
-            Sort::Int,
+            2,
+            vec![Sort::map(Sort::Var(0), Sort::Var(1)), Sort::Var(0)],
+            Sort::Var(1),
         );
         self.insert_theory_func(
             Symbol::intern("map_store"),
             Symbol::intern("Map_store"),
-            vec![Sort::map(Sort::Int, Sort::Int), Sort::Int, Sort::Int],
-            Sort::map(Sort::Int, Sort::Int),
+            0,
+            vec![Sort::map(Sort::Var(0), Sort::Var(1)), Sort::Var(0), Sort::Var(1)],
+            Sort::map(Sort::Var(0), Sort::Var(1)),
         );
     }
 

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -249,7 +249,8 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             | fhir::Sort::Bool
             | fhir::Sort::Real
             | fhir::Sort::Unit
-            | fhir::Sort::BitVec(_) => true,
+            | fhir::Sort::BitVec(_)
+            | fhir::Sort::Var(_) => true,
             fhir::Sort::Record(def_id) => {
                 self.index_sorts_of(*def_id)
                     .iter()

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -524,9 +524,13 @@ impl TypeVisitable for Sort {
         match self {
             Sort::Tuple(sorts) | Sort::App(_, sorts) => sorts.visit_with(visitor),
             Sort::Func(fsort) => fsort.inputs_and_output.visit_with(visitor),
-            Sort::Int | Sort::Bool | Sort::Real | Sort::BitVec(_) | Sort::Loc | Sort::Param(_) => {
-                ControlFlow::Continue(())
-            }
+            Sort::Int
+            | Sort::Bool
+            | Sort::Real
+            | Sort::BitVec(_)
+            | Sort::Loc
+            | Sort::Param(_)
+            | Sort::Var(_) => ControlFlow::Continue(()),
         }
     }
 }
@@ -544,12 +548,17 @@ impl TypeSuperFoldable for Sort {
             Sort::App(ctor, sorts) => Sort::app(*ctor, sorts.try_fold_with(folder)?),
             Sort::Func(fsort) => {
                 Sort::Func(FuncSort {
+                    params: fsort.params,
                     inputs_and_output: fsort.inputs_and_output.try_fold_with(folder)?,
                 })
             }
-            Sort::Int | Sort::Bool | Sort::Real | Sort::Loc | Sort::BitVec(_) | Sort::Param(_) => {
-                self.clone()
-            }
+            Sort::Int
+            | Sort::Bool
+            | Sort::Real
+            | Sort::Loc
+            | Sort::BitVec(_)
+            | Sort::Param(_)
+            | Sort::Var(_) => self.clone(),
         };
         Ok(sort)
     }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -157,10 +157,12 @@ pub enum Sort {
     Tuple(List<Sort>),
     Func(FuncSort),
     App(SortCtor, List<Sort>),
+    Var(usize),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub struct FuncSort {
+    params: usize,
     inputs_and_output: List<Sort>,
 }
 
@@ -667,7 +669,7 @@ impl Sort {
 impl FuncSort {
     pub fn new(mut inputs: Vec<Sort>, output: Sort) -> Self {
         inputs.push(output);
-        FuncSort { inputs_and_output: List::from_vec(inputs) }
+        FuncSort { params: 0, inputs_and_output: List::from_vec(inputs) }
     }
 
     pub fn inputs(&self) -> &[Sort] {
@@ -1713,6 +1715,7 @@ mod pretty {
                 Sort::Real => w!("real"),
                 Sort::BitVec(w) => w!("bitvec({})", ^w),
                 Sort::Loc => w!("loc"),
+                Sort::Var(n) => w!("@{}", ^n),
                 Sort::Func(sort) => w!("{:?}", sort),
                 Sort::Tuple(sorts) => {
                     if let [sort] = &sorts[..] {

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -547,7 +547,7 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
             }
         }
         rty::Sort::Func(sort) => fixpoint::Sort::Func(func_sort_to_fixpoint(sort)),
-        rty::Sort::Loc => bug!("unexpected sort {sort:?}"),
+        rty::Sort::Loc | rty::Sort::Var(_) => bug!("unexpected sort {sort:?}"),
     }
 }
 

--- a/crates/flux-tests/tests/lib/rset.rs
+++ b/crates/flux-tests/tests/lib/rset.rs
@@ -1,0 +1,43 @@
+#![allow(dead_code)]
+#![flux::defs {
+    fn set_add(x: int, s: Set<int>) -> Set<int> { set_union(set_singleton(x), s) }
+    fn set_is_empty(s: Set<int>) -> bool { s == set_empty(0) }
+    fn set_emp() -> Set<int> { set_empty(0) }
+}]
+
+#[flux::opaque]
+#[flux::refined_by(elems: Set<T>)]
+pub struct RSet<T> {
+    inner: std::collections::HashSet<T>,
+}
+
+impl RSet<T> {
+    #[flux::trusted]
+    #[flux::sig(fn() -> RSet[set_empty(0)])]
+    pub fn new() -> Self {
+        Self { inner: std::collections::HashSet::new() }
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(self: &strg RSet[@s], elem: T)
+                ensures self: RSet[set_add(k, s.elems)])]
+    pub fn insert(&mut self, elem: T) {
+        self.inner.insert(elem);
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(&Set[@s], &T[@elem]) -> bool[set_is_in(elem, s.elems)])]
+    pub fn contains(&self, elem: &T) -> bool {
+        self.inner.contains(elem)
+    }
+}
+
+#[flux::sig(fn (bool[true]))]
+fn assert(_b: bool) {}
+
+fn test() {
+    let mut s = RSet::new();
+    s.insert(1);
+    assert(s.contains(1));
+    assert(!s.contains(2));
+}

--- a/crates/flux-tests/tests/lib/rset.rs
+++ b/crates/flux-tests/tests/lib/rset.rs
@@ -1,8 +1,6 @@
 #![allow(dead_code)]
 #![flux::defs {
-    fn set_add(x: int, s: Set<int>) -> Set<int> { set_union(set_singleton(x), s) }
-    fn set_is_empty(s: Set<int>) -> bool { s == set_empty(0) }
-    fn set_emp() -> Set<int> { set_empty(0) }
+    fn set_add<T>(x: int, s: Set<T>) -> Set<T> { set_union(set_singleton(x), s) }
 }]
 
 #[flux::opaque]

--- a/crates/flux-tests/tests/pos/enums/list01.rs
+++ b/crates/flux-tests/tests/pos/enums/list01.rs
@@ -1,6 +1,6 @@
-#![feature(register_tool)]
-#![register_tool(flux)]
-#![feature(custom_inner_attributes)]
+// #![feature(register_tool)]
+// #![register_tool(flux)]
+// #![feature(custom_inner_attributes)]
 #![flux::defs {
     fn set_add(x: int, s: Set<int>) -> Set<int> { set_union(set_singleton(x), s) }
     fn set_is_empty(s: Set<int>) -> bool { s == set_empty(0) }

--- a/crates/flux-tests/tests/pos/enums/list01.rs
+++ b/crates/flux-tests/tests/pos/enums/list01.rs
@@ -51,7 +51,7 @@ pub fn tail(l: &List) -> &List {
     }
 }
 
-#[flux::sig(fn(List[@xs1], List[@xs2]) -> List[set_union(xs1, xs2)])]
+#[flux::sig(fn(List[@xs1], List[@xs2]) -> List[set_union(xs1.elems, xs2.elems)])]
 pub fn append(l1: List, l2: List) -> List {
     match l1 {
         List::Nil => l2,
@@ -62,7 +62,7 @@ pub fn append(l1: List, l2: List) -> List {
 // Silly function, but to get it working with &List we need to memoize the
 // unfolding, as other we get three unfoldings with different names which is
 // ok for int but not for Set.
-#[flux::sig(fn(k:i32, List[@xs]) -> bool[set_is_in(k, xs)])]
+#[flux::sig(fn(k:i32, List[@xs]) -> bool[set_is_in(k, xs.elems)])]
 pub fn mem(k: i32, l: List) -> bool {
     match l {
         List::Cons(h, tl) => {

--- a/crates/flux-tests/tests/pos/enums/list01.rs
+++ b/crates/flux-tests/tests/pos/enums/list01.rs
@@ -1,6 +1,6 @@
-// #![feature(register_tool)]
-// #![register_tool(flux)]
-// #![feature(custom_inner_attributes)]
+#![feature(register_tool)]
+#![register_tool(flux)]
+#![feature(custom_inner_attributes)]
 #![flux::defs {
     fn set_add(x: int, s: Set<int>) -> Set<int> { set_union(set_singleton(x), s) }
     fn set_is_empty(s: Set<int>) -> bool { s == set_empty(0) }


### PR DESCRIPTION
just sets up the infrastructure internally, does not expose polymorphic function sorts to user code yet.

Also doesn't work with implicit coercions e.g. treating a `List` index as `Set<int>` by using the `.elems` selector, 
mostly because (a) I haven't figured out that code yet, and (b) not clear if we should add much/any complexity to 
support that use case...

@nilehmann - should we use some `Binder` like method instead of the `params: usize` business for `FuncSort`?

