### PR TITLE
Eq sort

### DIFF
--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -426,7 +426,7 @@ impl<'a> InferCtxt<'a, '_> {
                 Some(fhir::Sort::Infer(*vid1))
             }
             (fhir::Sort::Infer(vid), sort) | (sort, fhir::Sort::Infer(vid))
-                if !self.is_eq_sort_vid(*vid) || !matches!(sort, fhir::Sort::Func(_)) =>
+                if !self.is_eq_sort_vid(*vid) || self.has_equality(sort) =>
             {
                 self.unification_table
                     .unify_var_value(*vid, Some(sort.clone()))

--- a/crates/flux-tests/tests/neg/error_messages/wf/eqsort.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/eqsort.rs
@@ -1,0 +1,16 @@
+// #![feature(register_tool)]
+// #![register_tool(flux)]
+
+#[flux::opaque]
+#[flux::refined_by(p: int -> bool)]
+struct S;
+
+#[flux::sig(fn(x: S) -> bool[set_is_in(x.p, set_singleton(x.p))])] //~ ERROR mismatched sorts
+fn foo(x: S) -> bool {
+    true
+}
+
+#[flux::sig(fn(S[|x| x > 0]) -> bool[true])]
+fn baz(x: S) -> bool {
+    foo(x)
+}

--- a/crates/flux-tests/tests/neg/error_messages/wf/eqsort.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/eqsort.rs
@@ -1,16 +1,17 @@
-// #![feature(register_tool)]
-// #![register_tool(flux)]
+#![feature(register_tool)]
+#![register_tool(flux)]
 
 #[flux::opaque]
 #[flux::refined_by(p: int -> bool)]
-struct S;
+pub struct S;
 
 #[flux::sig(fn(x: S) -> bool[set_is_in(x.p, set_singleton(x.p))])] //~ ERROR mismatched sorts
-fn foo(x: S) -> bool {
+                                                                   //~^ ERROR mismatched sorts
+pub fn foo(_x: S) -> bool {
     true
 }
 
 #[flux::sig(fn(S[|x| x > 0]) -> bool[true])]
-fn baz(x: S) -> bool {
+pub fn baz(x: S) -> bool {
     foo(x)
 }


### PR DESCRIPTION
Restrict sort-instantiation to equality-supporting sorts (i.e. not `FuncSort`) to avoid unpleasant downstream crashes in Fixpoint