### PR TITLE
Do not generate sorts during gathering

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -841,10 +841,9 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
             Some(param) => {
                 if let Some(sort) = sort {
                     param.sort = sort;
+                } else {
+                    param.sort = fhir::Sort::Error;
                 }
-                // else {
-                //     return Err(self.emit_err(errors::RefinedUnrefinableType::new(ident.span)));
-                // }
                 let kind = fhir::ExprKind::Var(fhir::Ident::new(param.name, ident));
                 let expr = fhir::Expr { kind, span: ident.span, fhir_id: self.next_fhir_id() };
                 Ok(Some(fhir::RefineArg::Expr { expr, is_binder: true }))

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -2,7 +2,7 @@ mod env;
 mod gather;
 use std::iter;
 
-use flux_common::{bug, index::IndexGen, iter::IterExt, span_bug};
+use flux_common::{bug, index::IndexGen, iter::IterExt};
 use flux_errors::FluxSession;
 use flux_middle::{
     fhir::{self, lift::LiftCtxt, ExprKind, FhirId, FluxOwnerId, Res},
@@ -841,9 +841,10 @@ impl<'a, 'tcx> DesugarCtxt<'a, 'tcx> {
             Some(param) => {
                 if let Some(sort) = sort {
                     param.sort = sort;
-                } else {
-                    return Err(self.emit_err(errors::RefinedUnrefinableType::new(ident.span)));
                 }
+                // else {
+                //     return Err(self.emit_err(errors::RefinedUnrefinableType::new(ident.span)));
+                // }
                 let kind = fhir::ExprKind::Var(fhir::Ident::new(param.name, ident));
                 let expr = fhir::Expr { kind, span: ident.span, fhir_id: self.next_fhir_id() };
                 Ok(Some(fhir::RefineArg::Expr { expr, is_binder: true }))
@@ -1323,7 +1324,6 @@ static SORTS: std::sync::LazyLock<Sorts> = std::sync::LazyLock::new(|| {
 
 mod errors {
     use flux_macros::Diagnostic;
-    use flux_middle::fhir;
     use flux_syntax::surface::{self, BindKind, QPathExpr};
     use itertools::Itertools;
     use rustc_span::{symbol::Ident, Span, Symbol};

--- a/crates/flux-desugar/src/desugar/env.rs
+++ b/crates/flux-desugar/src/desugar/env.rs
@@ -1,0 +1,253 @@
+use std::fmt;
+
+use flux_errors::FluxSession;
+use flux_syntax::surface::{Ident, NodeId};
+use rustc_data_structures::fx::{FxIndexMap, IndexEntry};
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_span::ErrorGuaranteed;
+
+use super::errors::DuplicateParam;
+
+type Result<T = ()> = std::result::Result<T, ErrorGuaranteed>;
+
+pub(crate) struct Env<P> {
+    scopes: FxHashMap<ScopeId, Scope<P>>,
+    parent: FxHashMap<ScopeId, ScopeId>,
+    children: FxHashMap<ScopeId, FxHashSet<ScopeId>>,
+    root: ScopeId,
+    curr: ScopeId,
+}
+
+impl<P> Env<P> {
+    pub(crate) fn new(root: ScopeId) -> Self {
+        let mut scopes = FxHashMap::default();
+        scopes.insert(root, Scope { map: Default::default(), id: root });
+        Self { scopes, parent: Default::default(), children: Default::default(), root, curr: root }
+    }
+
+    pub(crate) fn insert(&mut self, sess: &FluxSession, ident: Ident, param: P) -> Result {
+        self.curr().insert(sess, ident, param)
+    }
+
+    pub(crate) fn extend(
+        &mut self,
+        sess: &FluxSession,
+        params: impl IntoIterator<Item = (Ident, P)>,
+    ) -> Result {
+        self.curr().extend(sess, params)
+    }
+
+    pub(crate) fn get(&self, ident: Ident) -> Option<&P> {
+        self.find_map(|scope| scope.map.get(&ident))
+    }
+
+    pub(crate) fn get_with_scope(&self, ident: Ident) -> Option<(ScopeId, &P)> {
+        self.find_map(|scope| scope.map.get(&ident).map(|param| (scope.id, param)))
+    }
+
+    fn find_map<'a, T>(&'a self, mut f: impl FnMut(&'a Scope<P>) -> Option<T>) -> Option<T> {
+        let mut curr = self.curr;
+        loop {
+            let scope = self.scopes.get(&curr).unwrap();
+            if let Some(res) = f(scope) {
+                return Some(res);
+            }
+            if let Some(parent) = self.parent.get(&curr) {
+                curr = *parent;
+            } else {
+                return None;
+            }
+        }
+    }
+
+    pub(crate) fn get_mut(&mut self, ident: Ident) -> Option<&mut P> {
+        let (scope_id, _) = self.get_with_scope(ident)?;
+        self.scopes.get_mut(&scope_id).unwrap().map.get_mut(&ident)
+    }
+
+    pub(crate) fn push(&mut self, id: ScopeId) {
+        let scope = Scope { map: Default::default(), id };
+        self.scopes.insert(id, scope);
+        self.children.entry(self.curr).or_default().insert(id);
+        self.parent.insert(id, self.curr);
+        self.curr = id;
+    }
+
+    /// Remove the current scope and return it.
+    pub(crate) fn pop(&mut self) -> Scope<P> {
+        let children = self.children.remove(&self.curr).unwrap_or_default();
+        if !children.is_empty() {
+            panic!("cannot pop scope with children");
+        }
+        let id = self.curr;
+        let parent = self.parent.remove(&id).unwrap();
+        self.children.entry(parent).or_default().remove(&id);
+        self.curr = parent;
+        self.scopes.remove(&id).unwrap()
+    }
+
+    #[track_caller]
+    pub(crate) fn enter(&mut self, id: ScopeId) {
+        if self.curr != self.parent[&id] {
+            panic!("{id:?} is not a children of the current scope");
+        }
+        self.curr = id;
+    }
+
+    #[track_caller]
+    pub(crate) fn exit(&mut self) {
+        self.curr = self.parent[&self.curr];
+    }
+
+    pub(crate) fn filter_map<T>(self, mut f: impl FnMut(ScopeId, Ident, P) -> Option<T>) -> Env<T> {
+        let scopes = self
+            .scopes
+            .into_iter()
+            .map(|(id, scope)| {
+                let map = scope
+                    .map
+                    .into_iter()
+                    .flat_map(|(ident, param)| Some((ident, f(scope.id, ident, param)?)))
+                    .collect();
+                (id, Scope { map, id: scope.id })
+            })
+            .collect();
+        Env {
+            scopes,
+            parent: self.parent,
+            children: self.children,
+            root: self.root,
+            curr: self.root,
+        }
+    }
+
+    fn curr(&mut self) -> &mut Scope<P> {
+        self.scopes.get_mut(&self.curr).unwrap()
+    }
+
+    pub(crate) fn root(&mut self) -> &mut Scope<P> {
+        self.scopes.get_mut(&self.root).unwrap()
+    }
+
+    pub(crate) fn into_root(mut self) -> Scope<P> {
+        assert!(self.curr == self.root);
+        self.scopes.remove(&self.root).unwrap()
+    }
+}
+
+impl<P: fmt::Debug> Env<P> {
+    fn fmt_rec(
+        &self,
+        scope_id: ScopeId,
+        prefix: &str,
+        is_last: bool,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        let is_root = scope_id == self.root;
+        let scope = self.scopes.get(&scope_id).unwrap();
+        let node_str = if is_root {
+            ""
+        } else if is_last {
+            "└── "
+        } else {
+            "├── "
+        };
+        writeln!(f, "{}{}{:?} {:?}", prefix, node_str, scope_id, scope.map)?;
+
+        let Some(children) = self.children.get(&scope_id) else {
+            return Ok(());
+        };
+
+        let new_prefix = format!(
+            "{}{}",
+            prefix,
+            if is_root {
+                ""
+            } else if is_last {
+                "    "
+            } else {
+                "│   "
+            }
+        );
+
+        for (i, child) in children.iter().enumerate() {
+            let is_last_child = i == children.len() - 1;
+            self.fmt_rec(*child, &new_prefix, is_last_child, f)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Scope<P> {
+    pub(crate) id: ScopeId,
+    map: FxIndexMap<Ident, P>,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub(crate) enum ScopeId {
+    FnInput(NodeId),
+    FnOutput(NodeId),
+    Struct(NodeId),
+    Enum(NodeId),
+    Variant(NodeId),
+    TyAlias(NodeId),
+    Abs(NodeId),
+    Exists(NodeId),
+    FluxItem,
+}
+
+impl<P> Scope<P> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Ident, &P)> {
+        self.map.iter()
+    }
+
+    pub(crate) fn into_iter(self) -> impl Iterator<Item = (Ident, P)> {
+        self.map.into_iter()
+    }
+
+    fn insert(&mut self, sess: &FluxSession, ident: Ident, param: P) -> Result {
+        match self.map.entry(ident) {
+            IndexEntry::Occupied(entry) => {
+                Err(sess.emit_err(DuplicateParam::new(*entry.key(), ident)))
+            }
+            IndexEntry::Vacant(entry) => {
+                entry.insert(param);
+                Ok(())
+            }
+        }
+    }
+
+    fn extend(
+        &mut self,
+        sess: &FluxSession,
+        params: impl IntoIterator<Item = (Ident, P)>,
+    ) -> Result {
+        for (ident, param) in params {
+            self.insert(sess, ident, param)?;
+        }
+        Ok(())
+    }
+}
+
+impl<P: fmt::Debug> fmt::Debug for Env<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_rec(self.root, "", true, f)
+    }
+}
+
+impl fmt::Debug for ScopeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ScopeId::FnInput(node_id) => write!(f, "FnInput({})", node_id.as_usize()),
+            ScopeId::FnOutput(node_id) => write!(f, "FnOutput({})", node_id.as_usize()),
+            ScopeId::Struct(node_id) => write!(f, "Struct({})", node_id.as_usize()),
+            ScopeId::Enum(node_id) => write!(f, "Enum({})", node_id.as_usize()),
+            ScopeId::Variant(node_id) => write!(f, "Variant({})", node_id.as_usize()),
+            ScopeId::TyAlias(node_id) => write!(f, "TyAlias({})", node_id.as_usize()),
+            ScopeId::Abs(node_id) => write!(f, "Abs({})", node_id.as_usize()),
+            ScopeId::Exists(node_id) => write!(f, "Exists({})", node_id.as_usize()),
+            ScopeId::FluxItem => write!(f, "FluxItem"),
+        }
+    }
+}

--- a/crates/flux-desugar/src/desugar/gather.rs
+++ b/crates/flux-desugar/src/desugar/gather.rs
@@ -1,0 +1,304 @@
+//! Gathering is the process of traversing a type to collect parameters.
+//!
+//! A parameter can be declared explicitly with a sort as in `fn<refine n: int>(i32[n])` or implicitly
+//! with the `@` or `#` syntax, e.g., `fn foo(&i32[@n])`.
+use flux_common::{iter::IterExt, span_bug};
+use flux_middle::fhir;
+use flux_syntax::surface;
+use rustc_errors::ErrorGuaranteed;
+use rustc_hir::def::DefKind;
+
+use super::{
+    errors::{IllegalBinder, RefinedUnrefinableType},
+    DesugarCtxt, Env,
+};
+
+type Result<T = ()> = std::result::Result<T, ErrorGuaranteed>;
+
+/// A position within a type to track where binders are allowed.
+#[derive(Clone, Copy)]
+enum TypePos {
+    /// Type in input position allowing `@n` binders
+    Input,
+    /// Type in output position allowing `#n` binders
+    Output,
+    /// Any other position which doesn't allow binders, e.g., inside generic arguments (except for boxes)
+    Other,
+}
+
+impl TypePos {
+    fn is_binder_allowed(self, kind: surface::BindKind) -> bool {
+        match self {
+            TypePos::Input => matches!(kind, surface::BindKind::At),
+            TypePos::Output => matches!(kind, surface::BindKind::Pound),
+            TypePos::Other => false,
+        }
+    }
+}
+
+impl DesugarCtxt<'_, '_> {
+    pub(crate) fn gather_params_variant(
+        &self,
+        variant_def: &surface::VariantDef,
+        env: &mut Env,
+    ) -> Result {
+        for ty in &variant_def.fields {
+            self.gather_params_ty(None, ty, TypePos::Input, env)?;
+        }
+        // Traverse `VariantRet` to find illegal binders and report invalid refinement errors.
+        self.gather_params_variant_ret(&variant_def.ret, env)?;
+
+        // Check params in `VariantRet`
+        variant_def
+            .ret
+            .indices
+            .indices
+            .iter()
+            .try_for_each_exhaust(|idx| {
+                if let surface::RefineArg::Bind(_, kind, span) = idx {
+                    Err(self.emit_err(IllegalBinder::new(*span, *kind)))
+                } else {
+                    Ok(())
+                }
+            })
+    }
+
+    fn gather_params_variant_ret(&self, ret: &surface::VariantRet, env: &mut Env) -> Result {
+        self.gather_params_path(&ret.path, TypePos::Other, env)?;
+        self.gather_params_indices(&ret.indices, TypePos::Other, env)
+    }
+
+    /// Parameters cannot be defined inside predicates but we traverse it to report errors if we
+    /// find them.
+    pub(crate) fn gather_params_predicates(
+        &self,
+        predicates: &[surface::WhereBoundPredicate],
+        env: &mut Env,
+    ) -> Result {
+        for predicate in predicates {
+            self.gather_params_ty(None, &predicate.bounded_ty, TypePos::Other, env)?;
+            for bound in &predicate.bounds {
+                self.gather_params_path(&bound.path, TypePos::Other, env)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn gather_input_params_fn_sig(
+        &self,
+        fn_sig: &surface::FnSig,
+        env: &mut Env,
+    ) -> Result {
+        for param in fn_sig.generics.iter().flat_map(|g| &g.params) {
+            let surface::GenericParamKind::Refine { sort } = &param.kind else { continue };
+            env.insert_explicit(
+                self.genv.sess,
+                param.name,
+                self.sort_resolver.resolve_sort(sort)?,
+            )?;
+        }
+        for arg in &fn_sig.args {
+            self.gather_params_fun_arg(arg, env)?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn gather_output_params_fn_sig(
+        &self,
+        fn_sig: &surface::FnSig,
+        env: &mut Env,
+    ) -> Result {
+        if let surface::FnRetTy::Ty(ty) = &fn_sig.returns {
+            self.gather_params_ty(None, ty, TypePos::Output, env)?;
+        }
+        for cstr in &fn_sig.ensures {
+            if let surface::Constraint::Type(_, ty) = cstr {
+                self.gather_params_ty(None, ty, TypePos::Output, env)?;
+            };
+        }
+        Ok(())
+    }
+
+    fn gather_params_fun_arg(&self, arg: &surface::Arg, env: &mut Env) -> Result {
+        match arg {
+            surface::Arg::Constr(bind, path, _) => {
+                if self.path_is_refinable(path) {
+                    env.insert_implicit(self.genv.sess, *bind)?;
+                } else {
+                    env.insert_unrefined(self.genv.sess, *bind)?;
+                }
+                self.gather_params_path(path, TypePos::Input, env)?;
+            }
+            surface::Arg::StrgRef(loc, ty) => {
+                env.insert_implicit(self.genv.sess, *loc)?;
+                self.gather_params_ty(None, ty, TypePos::Input, env)?;
+            }
+            surface::Arg::Ty(bind, ty) => {
+                self.gather_params_ty(*bind, ty, TypePos::Input, env)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn gather_params_ty(
+        &self,
+        bind: Option<surface::Ident>,
+        ty: &surface::Ty,
+        pos: TypePos,
+        env: &mut Env,
+    ) -> Result {
+        match &ty.kind {
+            surface::TyKind::Indexed { bty, indices } => {
+                if let Some(bind) = bind {
+                    env.insert_unrefined(self.genv.sess, bind)?;
+                }
+                if self.bty_is_refinable(bty) {
+                    self.gather_params_indices(indices, pos, env)?;
+                } else {
+                    Err(self.emit_err(RefinedUnrefinableType::new(ty.span)))?;
+                }
+                self.gather_params_bty(bty, pos, env)
+            }
+            surface::TyKind::Base(bty) => {
+                if let Some(bind) = bind {
+                    if self.bty_is_refinable(bty) {
+                        env.insert_implicit(self.genv.sess, bind)?;
+                    } else {
+                        env.insert_unrefined(self.genv.sess, bind)?;
+                    }
+                }
+                self.gather_params_bty(bty, pos, env)
+            }
+            surface::TyKind::Ref(_, ty) | surface::TyKind::Constr(_, ty) => {
+                if let Some(bind) = bind {
+                    env.insert_unrefined(self.genv.sess, bind)?;
+                }
+                self.gather_params_ty(None, ty, pos, env)
+            }
+            surface::TyKind::Tuple(tys) => {
+                if let Some(bind) = bind {
+                    env.insert_unrefined(self.genv.sess, bind)?;
+                }
+                for ty in tys {
+                    self.gather_params_ty(None, ty, pos, env)?;
+                }
+                Ok(())
+            }
+            surface::TyKind::Array(ty, _) => {
+                if let Some(bind) = bind {
+                    env.insert_unrefined(self.genv.sess, bind)?;
+                }
+                self.gather_params_ty(None, ty, TypePos::Other, env)
+            }
+            surface::TyKind::Exists { bty, .. } => {
+                if let Some(bind) = bind {
+                    env.insert_unrefined(self.genv.sess, bind)?;
+                }
+                self.gather_params_bty(bty, pos, env)
+            }
+            surface::TyKind::GeneralExists { ty, .. } => {
+                if let Some(bind) = bind {
+                    env.insert_unrefined(self.genv.sess, bind)?;
+                }
+                // Declaring parameters with @ inside and existential has weird behavior if names
+                // are being shadowed. Thus, we don't allow it to keep things simple. We could eventually
+                // allow it if we resolve the weird behavior by detecting shadowing.
+                self.gather_params_ty(None, ty, TypePos::Other, env)
+            }
+            surface::TyKind::ImplTrait(_, bounds) => {
+                for bound in bounds {
+                    self.gather_params_path(&bound.path, TypePos::Other, env)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn gather_params_indices(
+        &self,
+        indices: &surface::Indices,
+        pos: TypePos,
+        env: &mut Env,
+    ) -> Result {
+        if let [surface::RefineArg::Bind(ident, kind, span)] = indices.indices[..] {
+            if !pos.is_binder_allowed(kind) {
+                return Err(self.emit_err(IllegalBinder::new(span, kind)));
+            }
+            env.insert_implicit(self.genv.sess, ident)?;
+        } else {
+            for idx in &indices.indices {
+                if let surface::RefineArg::Bind(ident, kind, span) = idx {
+                    if !pos.is_binder_allowed(*kind) {
+                        return Err(self.emit_err(IllegalBinder::new(*span, *kind)));
+                    }
+                    env.insert_implicit(self.genv.sess, *ident)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn gather_params_path(&self, path: &surface::Path, pos: TypePos, env: &mut Env) -> Result {
+        // CODESYNC(type-holes, 3) type holes do not have a corresponding `Res`.
+        if path.is_hole() {
+            return Ok(());
+        }
+
+        // Check refinement args
+        for arg in &path.refine {
+            if let surface::RefineArg::Bind(_, kind, span) = arg {
+                return Err(self.emit_err(IllegalBinder::new(*span, *kind)));
+            }
+        }
+
+        // Check generic args
+        let res = self.resolver_output.path_res_map[&path.node_id];
+        let pos = if self.genv.is_box(res) { pos } else { TypePos::Other };
+        path.generics
+            .iter()
+            .try_for_each_exhaust(|arg| self.gather_params_generic_arg(arg, pos, env))
+    }
+
+    fn gather_params_generic_arg(
+        &self,
+        arg: &surface::GenericArg,
+        pos: TypePos,
+        env: &mut Env,
+    ) -> Result {
+        match arg {
+            surface::GenericArg::Type(ty) => self.gather_params_ty(None, ty, pos, env),
+            surface::GenericArg::Constraint(_, ty) => self.gather_params_ty(None, ty, pos, env),
+        }
+    }
+
+    fn gather_params_bty(&self, bty: &surface::BaseTy, pos: TypePos, env: &mut Env) -> Result {
+        match &bty.kind {
+            surface::BaseTyKind::Path(path) => self.gather_params_path(path, pos, env),
+            surface::BaseTyKind::Slice(ty) => self.gather_params_ty(None, ty, TypePos::Other, env),
+        }
+    }
+
+    fn bty_is_refinable(&self, ty: &surface::BaseTy) -> bool {
+        match &ty.kind {
+            surface::BaseTyKind::Path(path) => self.path_is_refinable(path),
+            surface::BaseTyKind::Slice(_) => true,
+        }
+    }
+
+    fn path_is_refinable(&self, path: &surface::Path) -> bool {
+        let res = self.resolver_output.path_res_map[&path.node_id];
+        match res {
+            fhir::Res::Def(DefKind::TyParam, def_id) => {
+                self.genv.sort_of_generic_param(def_id).is_some()
+            }
+            fhir::Res::Def(DefKind::TyAlias { .. } | DefKind::Enum | DefKind::Struct, _)
+            | fhir::Res::PrimTy(_) => true,
+            fhir::Res::SelfTyAlias { alias_to, .. } => {
+                self.genv.sort_of_self_ty_alias(alias_to).is_some()
+            }
+            fhir::Res::SelfTyParam { .. } => false,
+            fhir::Res::Def(..) => span_bug!(path.span, "unexpected res `{res:?}`"),
+        }
+    }
+}

--- a/crates/flux-desugar/src/desugar/gather.rs
+++ b/crates/flux-desugar/src/desugar/gather.rs
@@ -126,7 +126,7 @@ impl DesugarCtxt<'_, '_> {
                 if self.path_is_refinable(path) {
                     env.insert_implicit(self.genv.sess, *bind)?;
                 } else {
-                    env.insert_unrefined(self.genv.sess, *bind)?;
+                    return Err(self.emit_err(RefinedUnrefinableType::new(path.span)));
                 }
                 self.gather_params_path(path, TypePos::Input, env)?;
             }

--- a/crates/flux-desugar/src/lib.rs
+++ b/crates/flux-desugar/src/lib.rs
@@ -5,7 +5,7 @@
 //! Desugaring requires knowing the sort of each type so we can correctly resolve binders declared with
 //! @ syntax or arg syntax. In particular, to know the sort of a type parameter we need to know its
 //! kind because only type parameters of sort `base` can be refined. The essential function implementing
-//! this logic is [`GlobalEnv::sort_of_res`]. This function requires the generics for the item being
+//! this logic is [`GlobalEnv::sort_of_path`]. This function requires the generics for the item being
 //! desugared to be register in [`fhir::Map`], thus we need to make sure that when desugaring an item,
 //! generics are registered before desugaring the rest of the item.
 

--- a/crates/flux-desugar/src/lib.rs
+++ b/crates/flux-desugar/src/lib.rs
@@ -18,7 +18,7 @@ extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;
 
-use desugar::{DesugarCtxt, Env};
+use desugar::DesugarCtxt;
 use flux_common::dbg;
 use flux_config as config;
 use flux_macros::fluent_messages;
@@ -56,7 +56,7 @@ pub fn desugar_struct_def(
     let predicates = cx.as_lift_cx().lift_predicates()?;
 
     // Desugar of struct_def needs to happen AFTER inserting generics. See #generics-and-desugaring
-    let struct_def = cx.desugar_struct_def(struct_def, &mut Env::new())?;
+    let struct_def = cx.desugar_struct_def(struct_def)?;
     if config::dump_fhir() {
         dbg::dump_item_info(genv.tcx, owner_id, "fhir", &struct_def).unwrap();
     }
@@ -81,7 +81,7 @@ pub fn desugar_enum_def(
     genv.map().insert_generics(def_id, generics);
 
     // Desugar of enum def needs to happen AFTER inserting generics. See crate level comment
-    let enum_def = cx.desugar_enum_def(enum_def, &mut Env::new())?;
+    let enum_def = cx.desugar_enum_def(enum_def)?;
     if config::dump_fhir() {
         dbg::dump_item_info(genv.tcx, owner_id, "fhir", &enum_def).unwrap();
     }
@@ -107,7 +107,7 @@ pub fn desugar_type_alias(
         genv.map().insert_generics(def_id, generics);
 
         // Desugar of type alias needs to happen AFTER desugaring generics. See crate level comment
-        let ty_alias = cx.desugar_type_alias(ty_alias, &mut Env::new())?;
+        let ty_alias = cx.desugar_type_alias(ty_alias)?;
         if config::dump_fhir() {
             dbg::dump_item_info(genv.tcx, owner_id, "fhir", &ty_alias).unwrap();
         }
@@ -147,7 +147,7 @@ pub fn desugar_fn_sig(
         genv.map().insert_generics(def_id, generics);
 
         // Desugar of fn_sig needs to happen AFTER inserting generics. See crate level comment
-        let (generic_preds, fn_sig) = cx.desugar_fn_sig(fn_sig, &mut Env::new())?;
+        let (generic_preds, fn_sig) = cx.desugar_fn_sig(fn_sig)?;
 
         if config::dump_fhir() {
             dbg::dump_item_info(genv.tcx, def_id, "fhir", &fn_sig).unwrap();

--- a/crates/flux-desugar/src/lib.rs
+++ b/crates/flux-desugar/src/lib.rs
@@ -18,7 +18,7 @@ extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;
 
-use desugar::{Binders, DesugarCtxt};
+use desugar::{DesugarCtxt, Env};
 use flux_common::dbg;
 use flux_config as config;
 use flux_macros::fluent_messages;
@@ -56,7 +56,7 @@ pub fn desugar_struct_def(
     let predicates = cx.as_lift_cx().lift_predicates()?;
 
     // Desugar of struct_def needs to happen AFTER inserting generics. See #generics-and-desugaring
-    let struct_def = cx.desugar_struct_def(struct_def, &mut Binders::new())?;
+    let struct_def = cx.desugar_struct_def(struct_def, &mut Env::new())?;
     if config::dump_fhir() {
         dbg::dump_item_info(genv.tcx, owner_id, "fhir", &struct_def).unwrap();
     }
@@ -81,7 +81,7 @@ pub fn desugar_enum_def(
     genv.map().insert_generics(def_id, generics);
 
     // Desugar of enum def needs to happen AFTER inserting generics. See crate level comment
-    let enum_def = cx.desugar_enum_def(enum_def, &mut Binders::new())?;
+    let enum_def = cx.desugar_enum_def(enum_def, &mut Env::new())?;
     if config::dump_fhir() {
         dbg::dump_item_info(genv.tcx, owner_id, "fhir", &enum_def).unwrap();
     }
@@ -107,7 +107,7 @@ pub fn desugar_type_alias(
         genv.map().insert_generics(def_id, generics);
 
         // Desugar of type alias needs to happen AFTER desugaring generics. See crate level comment
-        let ty_alias = cx.desugar_type_alias(ty_alias, &mut Binders::new())?;
+        let ty_alias = cx.desugar_type_alias(ty_alias, &mut Env::new())?;
         if config::dump_fhir() {
             dbg::dump_item_info(genv.tcx, owner_id, "fhir", &ty_alias).unwrap();
         }
@@ -147,7 +147,7 @@ pub fn desugar_fn_sig(
         genv.map().insert_generics(def_id, generics);
 
         // Desugar of fn_sig needs to happen AFTER inserting generics. See crate level comment
-        let (generic_preds, fn_sig) = cx.desugar_fn_sig(fn_sig, &mut Binders::new())?;
+        let (generic_preds, fn_sig) = cx.desugar_fn_sig(fn_sig, &mut Env::new())?;
 
         if config::dump_fhir() {
             dbg::dump_item_info(genv.tcx, def_id, "fhir", &fn_sig).unwrap();

--- a/crates/flux-driver/src/bin/main.rs
+++ b/crates/flux-driver/src/bin/main.rs
@@ -107,7 +107,7 @@ impl FluxMetadata {
             .and_then(|package| package.get("metadata"))
             .and_then(|metadata| metadata.get("flux"))
             .and_then(|flux| flux.get("enabled"))
-            .and_then(|enabled| enabled.as_bool())
+            .and_then(toml::Value::as_bool)
             .unwrap_or(false);
         Some(FluxMetadata { enabled })
     }

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -45,7 +45,7 @@ impl Callbacks for FluxCallbacks {
         queries: &'tcx Queries<'tcx>,
     ) -> Compilation {
         if self.verify {
-            self.verify(compiler, queries)
+            self.verify(compiler, queries);
         }
 
         if self.full_compilation {

--- a/crates/flux-driver/src/collector.rs
+++ b/crates/flux-driver/src/collector.rs
@@ -249,7 +249,14 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
 
         self.specs.structs.insert(
             owner_id,
-            surface::StructDef { generics, refined_by, fields, opaque, invariants },
+            surface::StructDef {
+                generics,
+                refined_by,
+                fields,
+                opaque,
+                invariants,
+                node_id: self.parse_sess.next_node_id(),
+            },
         );
 
         Ok(())
@@ -286,9 +293,15 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
 
         let invariants = attrs.invariants();
 
-        self.specs
-            .enums
-            .insert(owner_id, surface::EnumDef { refined_by, variants, invariants });
+        self.specs.enums.insert(
+            owner_id,
+            surface::EnumDef {
+                refined_by,
+                variants,
+                invariants,
+                node_id: self.parse_sess.next_node_id(),
+            },
+        );
         Ok(())
     }
 

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -1170,8 +1170,10 @@ fn conv_sort(genv: &GlobalEnv, sort: &fhir::Sort) -> rty::Sort {
         fhir::Sort::Param(def_id) => {
             rty::Sort::Param(def_id_to_param_ty(genv.tcx, def_id.expect_local()))
         }
-        fhir::Sort::Wildcard | fhir::Sort::Infer(_) => bug!("unexpected sort `{sort:?}`"),
         fhir::Sort::Var(n) => rty::Sort::Var(rty::SortVar::from(*n)),
+        fhir::Sort::Error | fhir::Sort::Wildcard | fhir::Sort::Infer(_) => {
+            bug!("unexpected sort `{sort:?}`")
+        }
     }
 }
 

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -253,7 +253,7 @@ pub(crate) fn conv_defn(
     rty::Defn { name: defn.name, expr }
 }
 
-pub fn conv_qualifier(
+pub(crate) fn conv_qualifier(
     genv: &GlobalEnv,
     qualifier: &fhir::Qualifier,
     wfckresults: &fhir::WfckResults,
@@ -1144,13 +1144,13 @@ fn conv_sorts<'a>(
         .collect()
 }
 
-pub(crate) fn conv_refine_param(genv: &GlobalEnv, param: &fhir::RefineParam) -> rty::RefineParam {
+fn conv_refine_param(genv: &GlobalEnv, param: &fhir::RefineParam) -> rty::RefineParam {
     let sort = conv_sort(genv, &param.sort);
     let mode = param.infer_mode();
     rty::RefineParam { sort, mode }
 }
 
-pub fn conv_sort(genv: &GlobalEnv, sort: &fhir::Sort) -> rty::Sort {
+fn conv_sort(genv: &GlobalEnv, sort: &fhir::Sort) -> rty::Sort {
     match sort {
         fhir::Sort::Int => rty::Sort::Int,
         fhir::Sort::Real => rty::Sort::Real,

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -337,8 +337,9 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         match &ty.kind {
             fhir::TyKind::BaseTy(bty) => self.check_base_ty(infcx, bty),
             fhir::TyKind::Indexed(bty, idx) => {
-                let expected = self.sort_of_bty(bty);
-                self.check_refine_arg(infcx, idx, &expected)?;
+                if let Some(expected) = self.genv.sort_of_bty(bty) {
+                    self.check_refine_arg(infcx, idx, &expected)?;
+                }
                 self.check_base_ty(infcx, bty)
             }
             fhir::TyKind::Exists(params, ty) => {
@@ -498,7 +499,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         }
         let snapshot = self.xi.snapshot();
 
-        if let fhir::Res::Def(_kind, did) = &path.res /*&& !matches!(_kind, DefKind::TyParam) */ && !path.args.is_empty() {
+        if let fhir::Res::Def(_kind, did) = &path.res && !path.args.is_empty() {
             self.check_generic_args(infcx, *did, &path.args)?;
         }
         let bindings = self.check_type_bindings(infcx, &path.bindings);

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -448,7 +448,7 @@ pub struct RefineParam {
     pub ident: Ident,
     pub sort: Sort,
     /// Whether the parameter was declared implicitly with `@` or `#` syntax
-    pub implicit: bool,
+    pub synthetic: bool,
     pub fhir_id: FhirId,
 }
 
@@ -948,7 +948,7 @@ impl RefineParam {
     }
 
     pub fn infer_mode(&self) -> InferMode {
-        if self.sort.is_pred() && !self.implicit {
+        if self.sort.is_pred() && !self.synthetic {
             InferMode::KVar
         } else {
             InferMode::EVar

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -859,6 +859,14 @@ impl Sort {
         matches!(self, Self::Bool)
     }
 
+    /// Returns `true` if the sort is [`Wildcard`].
+    ///
+    /// [`Wildcard`]: Sort::Wildcard
+    #[must_use]
+    pub fn is_wildcard(&self) -> bool {
+        matches!(self, Self::Wildcard)
+    }
+
     pub fn is_numeric(&self) -> bool {
         matches!(self, Self::Int | Self::Real)
     }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -505,6 +505,7 @@ pub enum Sort {
     Wildcard,
     /// Sort inference variable generated for a [Sort::Wildcard] during sort checking
     Infer(SortVid),
+    Error,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
@@ -895,16 +896,6 @@ impl Sort {
     /// replace all "sort-vars" (indexed 0...n-1) with the corresponding sort in `subst`
     fn subst(&self, subst: &[Sort]) -> Sort {
         match self {
-            Sort::Int
-            | Sort::Bool
-            | Sort::Real
-            | Sort::Loc
-            | Sort::Unit
-            | Sort::BitVec(_)
-            | Sort::Param(_)
-            | Sort::Wildcard
-            | Sort::Record(_, _)
-            | Sort::Infer(_) => self.clone(),
             Sort::Var(i) => subst[*i].clone(),
             Sort::App(c, args) => {
                 let args = args.iter().map(|arg| arg.subst(subst)).collect();
@@ -918,6 +909,17 @@ impl Sort {
                     bug!("unexpected subst in (nested) func-sort")
                 }
             }
+            Sort::Int
+            | Sort::Bool
+            | Sort::Real
+            | Sort::Loc
+            | Sort::Unit
+            | Sort::BitVec(_)
+            | Sort::Param(_)
+            | Sort::Wildcard
+            | Sort::Record(_, _)
+            | Sort::Infer(_)
+            | Sort::Error => self.clone(),
         }
     }
 }
@@ -1702,6 +1704,7 @@ impl fmt::Debug for Sort {
             Sort::Wildcard => write!(f, "_"),
             Sort::Infer(vid) => write!(f, "{vid:?}"),
             Sort::App(ctor, args) => write!(f, "{ctor}<{}>", args.iter().join(", ")),
+            Sort::Error => write!(f, "err"),
         }
     }
 }

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -226,7 +226,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             fhir::Res::Def(DefKind::TyParam, def_id) => self.sort_of_generic_param(def_id),
             fhir::Res::Def(DefKind::AssocTy | DefKind::OpaqueTy, _)
             | fhir::Res::SelfTyParam { .. } => None,
-            fhir::Res::Def(..) => bug!("unexpected res {:?}", path.res),
+            fhir::Res::Def(..) => bug!("unexpected res `{:?}`", path.res),
         }
     }
 
@@ -235,7 +235,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         self.sort_of_self_ty(alias_to, self_ty)
     }
 
-    fn sort_of_generic_param(&self, def_id: DefId) -> Option<fhir::Sort> {
+    pub fn sort_of_generic_param(&self, def_id: DefId) -> Option<fhir::Sort> {
         let param = self.get_generic_param(def_id.expect_local());
         match &param.kind {
             fhir::GenericParamKind::BaseTy | fhir::GenericParamKind::SplTy => {
@@ -273,8 +273,8 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             ty::TyKind::Adt(adt_def, args) => {
                 let mut sort_args = vec![];
                 for arg in *args {
-                    if let Some(ty) = arg.as_type() &&
-                       let Some(sort) = self.sort_of_self_ty(def_id, ty)
+                    if let Some(ty) = arg.as_type()
+                        && let Some(sort) = self.sort_of_self_ty(def_id, ty)
                     {
                         sort_args.push(sort);
                     }

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -327,9 +327,11 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
                     .all(|sort| self.has_equality(sort))
             }
             fhir::Sort::App(ctor, sorts) => self.ctor_has_equality(ctor, sorts),
-            fhir::Sort::Loc | fhir::Sort::Func(_) | fhir::Sort::Wildcard | fhir::Sort::Infer(_) => {
-                false
-            }
+            fhir::Sort::Loc
+            | fhir::Sort::Func(_)
+            | fhir::Sort::Wildcard
+            | fhir::Sort::Infer(_)
+            | fhir::Sort::Error => false,
         }
     }
 

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -202,7 +202,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
     }
 
     pub fn sort_of_path(&self, path: &fhir::Path) -> Option<fhir::Sort> {
-        // CODESYNC(sort-of-path, 2) sorts should be given consistently
+        // CODESYNC(sort-of, 3) sorts should be given consistently
         match path.res {
             fhir::Res::PrimTy(PrimTy::Int(_) | PrimTy::Uint(_)) => Some(fhir::Sort::Int),
             fhir::Res::PrimTy(PrimTy::Bool) => Some(fhir::Sort::Bool),

--- a/crates/flux-middle/src/rustc/mir.rs
+++ b/crates/flux-middle/src/rustc/mir.rs
@@ -67,7 +67,7 @@ pub struct Body<'tcx> {
     ///
     /// Additionally, the [`InferCtxt`] is used during type projection normalization.
     ///
-    /// [region variable ids]: RegionVid
+    /// [region variable ids]: super::ty::RegionVid
     /// [`InferCtxt`]: rustc_infer::infer::InferCtxt
     pub infcx: rustc_infer::infer::InferCtxt<'tcx>,
     /// See [`mk_fake_predecessors`]

--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -57,6 +57,7 @@ pub TyAlias: surface::TyAlias = {
             generics: generics.unwrap_or_default(),
             refined_by,
             ty,
+            node_id: cx.next_node_id(),
             span: cx.map_span(lo, hi)
         }
     }
@@ -172,7 +173,8 @@ pub FnSig: surface::FnSig = {
             ensures,
             requires,
             predicates,
-            span: cx.map_span(lo, hi)
+            span: cx.map_span(lo, hi),
+            node_id: cx.next_node_id(),
         }
     },
 
@@ -195,7 +197,7 @@ pub Variant: surface::VariantDef = {
             Some(fields) => fields,
             None => vec![],
         };
-        surface::VariantDef { fields, ret, span: cx.map_span(lo, hi) }
+        surface::VariantDef { fields, ret, node_id: cx.next_node_id(), span: cx.map_span(lo, hi) }
     }
 }
 
@@ -248,6 +250,7 @@ Arg: surface::Arg = {
 pub Ty: surface::Ty = {
     <lo:@L> <kind:TyKind> <hi:@L> => surface::Ty {
         kind,
+        node_id: cx.next_node_id(),
         span: cx.map_span(lo, hi)
     }
 }
@@ -333,7 +336,7 @@ RefineArg: surface::RefineArg = {
     <lo:@L> "#" <bind:Ident> <hi:@R> => surface::RefineArg::Bind(bind, surface::BindKind::Pound, cx.map_span(lo, hi)),
     <Expr>                           => surface::RefineArg::Expr(<>),
     <lo:@L> "|"<params:RefineParams<"?">> "|" <body:Expr> <hi:@R> => {
-        surface::RefineArg::Abs(params, body, cx.map_span(lo, hi))
+        surface::RefineArg::Abs(params, body, cx.next_node_id(), cx.map_span(lo, hi))
     }
 };
 

--- a/crates/flux-syntax/src/lib.rs
+++ b/crates/flux-syntax/src/lib.rs
@@ -97,7 +97,7 @@ impl ParseSess {
         parse!(self, grammar::ExprParser, tokens, span)
     }
 
-    fn next_node_id(&mut self) -> NodeId {
+    pub fn next_node_id(&mut self) -> NodeId {
         let id = NodeId(self.next_node_id);
         self.next_node_id += 1;
         id

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -14,6 +14,12 @@ use rustc_span::{symbol::kw, Span};
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct NodeId(pub(super) usize);
 
+impl NodeId {
+    pub fn as_usize(&self) -> usize {
+        self.0
+    }
+}
+
 #[derive(Debug)]
 pub struct SortDecl {
     pub name: Ident,
@@ -73,6 +79,7 @@ pub struct TyAlias {
     pub generics: Vec<Ty>,
     pub refined_by: RefinedBy,
     pub ty: Ty,
+    pub node_id: NodeId,
     pub span: Span,
 }
 
@@ -83,6 +90,7 @@ pub struct StructDef {
     pub fields: Vec<Option<Ty>>,
     pub opaque: bool,
     pub invariants: Vec<Expr>,
+    pub node_id: NodeId,
 }
 
 impl StructDef {
@@ -97,6 +105,7 @@ pub struct EnumDef {
     pub refined_by: Option<RefinedBy>,
     pub variants: Vec<Option<VariantDef>>,
     pub invariants: Vec<Expr>,
+    pub node_id: NodeId,
 }
 
 impl EnumDef {
@@ -110,6 +119,7 @@ impl EnumDef {
 pub struct VariantDef {
     pub fields: Vec<Ty>,
     pub ret: VariantRet,
+    pub node_id: NodeId,
     pub span: Span,
 }
 
@@ -183,6 +193,7 @@ pub struct FnSig {
     pub predicates: Vec<WhereBoundPredicate>,
     /// source span
     pub span: Span,
+    pub node_id: NodeId,
 }
 
 #[derive(Debug)]
@@ -233,6 +244,7 @@ pub enum Arg {
 #[derive(Debug)]
 pub struct Ty {
     pub kind: TyKind,
+    pub node_id: NodeId,
     pub span: Span,
 }
 
@@ -309,7 +321,7 @@ pub enum RefineArg {
     /// `@n` or `#n`, the span corresponds to the span of the identifier plus the binder token (`@` or `#`)
     Bind(Ident, BindKind, Span),
     Expr(Expr),
-    Abs(Vec<RefineParam>, Expr, Span),
+    Abs(Vec<RefineParam>, Expr, NodeId, Span),
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/flux-tests/tests/lib/range.rs
+++ b/crates/flux-tests/tests/lib/range.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(lo: int, hi: int)]
 pub struct RngIter {
-    #[flux::field(i32[@lo])]
+    #[flux::field(i32[lo])]
     _lo: i32,
-    #[flux::field(i32[@hi])]
+    #[flux::field(i32[hi])]
     hi: i32,
     #[flux::field(i32{v:lo <= v && v <= hi})]
     cur: i32,
@@ -17,9 +17,9 @@ impl RngIter {
 
 #[flux::refined_by(lo: int, hi: int)]
 pub struct Rng {
-    #[flux::field(i32[@lo])]
+    #[flux::field(i32[lo])]
     lo: i32,
-    #[flux::field({i32[@hi] | lo <= hi})]
+    #[flux::field({i32[hi] | lo <= hi})]
     hi: i32,
 }
 

--- a/crates/flux-tests/tests/neg/abstract_refinements/test01.rs
+++ b/crates/flux-tests/tests/neg/abstract_refinements/test01.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(a: int, b: int, p: (int, int) -> bool)]
 struct Pair {
-    #[flux::field(i32[@a])]
+    #[flux::field(i32[a])]
     fst: i32,
-    #[flux::field({i32[@b] | p(a, b)})]
+    #[flux::field({i32[b] | p(a, b)})]
     snd: i32,
 }
 

--- a/crates/flux-tests/tests/neg/error_messages/desugar/index_errors00.rs
+++ b/crates/flux-tests/tests/neg/error_messages/desugar/index_errors00.rs
@@ -39,8 +39,3 @@ pub struct Chair {
 pub fn mk_chair() -> Chair {
     Chair { x: 0 }
 }
-
-#[flux::sig(fn(x: T) -> i32[x])] //~ ERROR invalid use of refinement parameter
-fn generic<T>(x: T) -> i32 {
-    0
-}

--- a/crates/flux-tests/tests/neg/error_messages/desugar/index_errors00.rs
+++ b/crates/flux-tests/tests/neg/error_messages/desugar/index_errors00.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(x:int, y:int)]
 pub struct Pair {
-    #[flux::field(i32[@x])]
+    #[flux::field(i32[x])]
     pub x: i32,
-    #[flux::field(i32[@y])]
+    #[flux::field(i32[y])]
     pub y: i32,
 }
 

--- a/crates/flux-tests/tests/neg/error_messages/resolver/invalid_type.rs
+++ b/crates/flux-tests/tests/neg/error_messages/resolver/invalid_type.rs
@@ -1,5 +1,5 @@
 #[flux::refined_by(a: int)]
 struct S {
-    #[flux::field(i31[@a])] //~ ERROR cannot resolve
+    #[flux::field(i31[a])] //~ ERROR cannot resolve
     f: i32,
 }

--- a/crates/flux-tests/tests/neg/error_messages/wf/index_errors.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/index_errors.rs
@@ -41,3 +41,9 @@ pub fn use_chair(c: Chair) -> i32 {
 fn ira(f: f32) -> i32 {
     0
 }
+
+// We should improve this error message it currently says expected int but found err
+#[flux::sig(fn(x: T) -> i32[x])] //~ ERROR mismatched sorts
+fn generic<T>(x: T) -> i32 {
+    0
+}

--- a/crates/flux-tests/tests/neg/error_messages/wf/index_errors.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/index_errors.rs
@@ -6,9 +6,9 @@ pub struct Chair {
 
 #[flux::refined_by(x:int, y:int)]
 pub struct Pair {
-    #[flux::field(i32[@x])]
+    #[flux::field(i32[x])]
     pub x: i32,
-    #[flux::field(i32[@y])]
+    #[flux::field(i32[y])]
     pub y: i32,
 }
 

--- a/crates/flux-tests/tests/neg/error_messages/wf/issue-162.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/issue-162.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(a: int, b: int)]
 pub struct S {
-    #[flux::field(i32[@a])]
+    #[flux::field(i32[a])]
     a: i32,
-    #[flux::field(i32[@b])]
+    #[flux::field(i32[b])]
     b: i32,
 }
 

--- a/crates/flux-tests/tests/neg/error_messages/wf/local_qual00.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/local_qual00.rs
@@ -9,9 +9,9 @@ use rvec::RVec;
 
 #[flux::refined_by(x: int, y:int)]
 pub struct Pair {
-    #[flux::field(i32[@x])]
+    #[flux::field(i32[x])]
     pub x: i32,
-    #[flux::field(i32[@y])]
+    #[flux::field(i32[y])]
     pub y: i32,
 }
 

--- a/crates/flux-tests/tests/neg/structs/dep-field-00.rs
+++ b/crates/flux-tests/tests/neg/structs/dep-field-00.rs
@@ -1,6 +1,6 @@
 #[flux::refined_by(a: int)]
 pub struct Range {
-    #[flux::field(i32[@a])]
+    #[flux::field(i32[a])]
     pub x: i32,
     #[flux::field(i32{v : a < v})]
     pub y: i32,

--- a/crates/flux-tests/tests/neg/structs/dot00.rs
+++ b/crates/flux-tests/tests/neg/structs/dot00.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(x: int, y:int)]
 pub struct Pair {
-    #[flux::field(i32[@x])]
+    #[flux::field(i32[x])]
     pub x: i32,
-    #[flux::field(i32[@y])]
+    #[flux::field(i32[y])]
     pub y: i32,
 }
 

--- a/crates/flux-tests/tests/neg/structs/dot01.rs
+++ b/crates/flux-tests/tests/neg/structs/dot01.rs
@@ -5,9 +5,9 @@ use rvec::RVec;
 
 #[flux::refined_by(x: int, y:int)]
 pub struct Pair {
-    #[flux::field(i32[@x])]
+    #[flux::field(i32[x])]
     pub x: i32,
-    #[flux::field(i32[@y])]
+    #[flux::field(i32[y])]
     pub y: i32,
 }
 

--- a/crates/flux-tests/tests/neg/structs/field-00.rs
+++ b/crates/flux-tests/tests/neg/structs/field-00.rs
@@ -4,7 +4,7 @@ use rvec::RVec;
 
 #[flux::refined_by(n: int)]
 pub struct S {
-    #[flux::field(usize[@n])]
+    #[flux::field(usize[n])]
     pub size: usize,
     #[flux::field(RVec<i32>[n])]
     pub payload: RVec<i32>,

--- a/crates/flux-tests/tests/neg/structs/fold-on-drop.rs
+++ b/crates/flux-tests/tests/neg/structs/fold-on-drop.rs
@@ -1,6 +1,6 @@
 #[flux::refined_by(a: int)]
 pub struct S {
-    #[flux::field({i32[@a] | a >= 0})]
+    #[flux::field({i32[a] | a >= 0})]
     f1: i32,
     _f2: Vec<i32>,
 }

--- a/crates/flux-tests/tests/neg/structs/invariant00.rs
+++ b/crates/flux-tests/tests/neg/structs/invariant00.rs
@@ -2,8 +2,8 @@
 #[flux::invariant(a > 0)]
 #[flux::invariant(b > 0)] //~ ERROR invariant
 pub struct S {
-    #[flux::field({i32[@a] | a > 0})]
+    #[flux::field({i32[a] | a > 0})]
     fst: i32,
-    #[flux::field({i32[@b] | a >= b})]
+    #[flux::field({i32[b] | a >= b})]
     snd: i32,
 }

--- a/crates/flux-tests/tests/neg/structs/struct-join.rs
+++ b/crates/flux-tests/tests/neg/structs/struct-join.rs
@@ -1,6 +1,6 @@
 #[flux::refined_by(a: int)]
 pub struct S<T> {
-    #[flux::field({i32[@a] | a >= 0})]
+    #[flux::field({i32[a] | a >= 0})]
     f1: i32,
     f2: T,
 }

--- a/crates/flux-tests/tests/neg/structs/struct01.rs
+++ b/crates/flux-tests/tests/neg/structs/struct01.rs
@@ -5,7 +5,7 @@ use rvec::RVec;
 
 #[flux::refined_by(n: int)]
 pub struct Foo {
-    #[flux::field(RVec<usize>[@n])]
+    #[flux::field(RVec<usize>[n])]
     inner: RVec<usize>,
 }
 

--- a/crates/flux-tests/tests/neg/surface/alias03.rs
+++ b/crates/flux-tests/tests/neg/surface/alias03.rs
@@ -2,7 +2,7 @@
 
 #[flux::refined_by(f: int)]
 pub struct S {
-    #[flux::field(i32[@f])]
+    #[flux::field(i32[f])]
     f: i32,
 }
 

--- a/crates/flux-tests/tests/neg/surface/const02.rs
+++ b/crates/flux-tests/tests/neg/surface/const02.rs
@@ -5,7 +5,7 @@ pub const FORTY_TWO: usize = 21 + 21;
 
 #[flux::refined_by(a:int)]
 pub struct Silly {
-    #[flux::field({usize[@a] | a < FORTY_TWO})]
+    #[flux::field({usize[a] | a < FORTY_TWO})]
     fld: usize,
 }
 

--- a/crates/flux-tests/tests/neg/surface/const03.rs
+++ b/crates/flux-tests/tests/neg/surface/const03.rs
@@ -5,7 +5,7 @@ pub const FORTY_TWO: usize = 21 + 21;
 
 #[flux::refined_by(a:int)]
 pub struct Silly {
-    #[flux::field({usize[@a] | a < FORTY_TWO})]
+    #[flux::field({usize[a] | a < FORTY_TWO})]
     fld: usize,
 }
 

--- a/crates/flux-tests/tests/neg/surface/constr01.rs
+++ b/crates/flux-tests/tests/neg/surface/constr01.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(a: int, b: int)]
 struct Foo {
-    #[flux::field({i32[@a] | 0 <= a})]
+    #[flux::field({i32[a] | 0 <= a})]
     x: i32,
-    #[flux::field({i32[@b] | a <= b})]
+    #[flux::field({i32[b] | a <= b})]
     y: i32,
 }
 

--- a/crates/flux-tests/tests/neg/surface/date.rs
+++ b/crates/flux-tests/tests/neg/surface/date.rs
@@ -13,11 +13,11 @@
 #[allow(dead_code)]
 #[flux::refined_by(d:int, m:int, y:int)]
 pub struct Date {
-    #[flux::field({ usize[@d] | ok_day(d) })]
+    #[flux::field({ usize[d] | ok_day(d) })]
     day: usize,
-    #[flux::field({ usize[@m] | ok_month(d, m)})]
+    #[flux::field({ usize[m] | ok_month(d, m)})]
     month: usize,
-    #[flux::field({ usize[@y] | ok_year(d, m, y)})]
+    #[flux::field({ usize[y] | ok_year(d, m, y)})]
     year: usize,
 }
 

--- a/crates/flux-tests/tests/neg/surface/issue-141.rs
+++ b/crates/flux-tests/tests/neg/surface/issue-141.rs
@@ -5,7 +5,7 @@ use rvec::RVec;
 
 #[flux::refined_by(len: int)]
 pub struct Vecs {
-    #[flux::field(RVec<i32>[@len])]
+    #[flux::field(RVec<i32>[len])]
     pub my: RVec<i32>,
 }
 

--- a/crates/flux-tests/tests/neg/surface/issue-158.rs
+++ b/crates/flux-tests/tests/neg/surface/issue-158.rs
@@ -5,7 +5,7 @@ use rvec::RVec;
 
 #[flux::refined_by(size:int)]
 pub struct Bob {
-    #[flux::field(RVec<i32{v: v > 0}>[@size])]
+    #[flux::field(RVec<i32{v: v > 0}>[size])]
     elems: RVec<i32>,
 }
 

--- a/crates/flux-tests/tests/neg/surface/issue-299.rs
+++ b/crates/flux-tests/tests/neg/surface/issue-299.rs
@@ -3,7 +3,7 @@
 #[flux::refined_by(a: int)]
 struct S1 {
     f1: S2,
-    #[flux::field(i32[@a])]
+    #[flux::field(i32[a])]
     f2: i32,
     #[flux::field(i32{v: v > 0})]
     f3: i32,
@@ -13,9 +13,9 @@ struct S1 {
 struct S2 {
     #[flux::field(i32)]
     pub f1: i32,
-    #[flux::field(i32[@a])]
+    #[flux::field(i32[a])]
     pub f2: i32,
-    #[flux::field({i32[@b] | b > 0})]
+    #[flux::field({i32[b] | b > 0})]
     pub f3: i32,
     #[flux::field(i32{v: v > 0})]
     pub f4: i32,

--- a/crates/flux-tests/tests/neg/surface/local_qual00.rs
+++ b/crates/flux-tests/tests/neg/surface/local_qual00.rs
@@ -9,9 +9,9 @@ use rvec::RVec;
 
 #[flux::refined_by(x: int, y:int)]
 pub struct Pair {
-    #[flux::field(i32[@x])]
+    #[flux::field(i32[x])]
     pub x: i32,
-    #[flux::field(i32[@y])]
+    #[flux::field(i32[y])]
     pub y: i32,
 }
 

--- a/crates/flux-tests/tests/neg/surface/range.rs
+++ b/crates/flux-tests/tests/neg/surface/range.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(lo: int, hi: int)]
 pub struct Rng {
-    #[flux::field(i32[@lo])]
+    #[flux::field(i32[lo])]
     _lo: i32,
-    #[flux::field(i32[@hi])]
+    #[flux::field(i32[hi])]
     hi: i32,
     #[flux::field(i32{v:lo <= v && v <= hi})]
     cur: i32,

--- a/crates/flux-tests/tests/neg/surface/rmat.rs
+++ b/crates/flux-tests/tests/neg/surface/rmat.rs
@@ -5,9 +5,9 @@ use rvec::RVec;
 
 #[flux::refined_by(rows: int, cols: int)]
 pub struct RMat {
-    #[flux::field(usize[@cols])]
+    #[flux::field(usize[cols])]
     cols: usize,
-    #[flux::field(RVec<RVec<f32>[cols]>[@rows])]
+    #[flux::field(RVec<RVec<f32>[cols]>[rows])]
     inner: RVec<RVec<f32>>,
 }
 

--- a/crates/flux-tests/tests/neg/surface/too_many_linked_lists.rs
+++ b/crates/flux-tests/tests/neg/surface/too_many_linked_lists.rs
@@ -3,7 +3,7 @@
 
 #[flux::refined_by(len: int)]
 pub struct List<T> {
-    #[flux::field(Link<T>[@len])]
+    #[flux::field(Link<T>[len])]
     head: Link<T>,
 }
 
@@ -18,7 +18,7 @@ enum Link<T> {
 #[flux::refined_by(len: int)]
 struct Node<T> {
     elem: T,
-    #[flux::field(Link<T>[@len])]
+    #[flux::field(Link<T>[len])]
     next: Link<T>,
 }
 

--- a/crates/flux-tests/tests/pos/abstract_refinements/test01.rs
+++ b/crates/flux-tests/tests/pos/abstract_refinements/test01.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(a: int, b: int, p: (int, int) -> bool)]
 struct Pair {
-    #[flux::field(i32[@a])]
+    #[flux::field(i32[a])]
     fst: i32,
-    #[flux::field({i32[@b] | p(a, b)})]
+    #[flux::field({i32[b] | p(a, b)})]
     snd: i32,
 }
 

--- a/crates/flux-tests/tests/pos/enums/invariant02.rs
+++ b/crates/flux-tests/tests/pos/enums/invariant02.rs
@@ -8,7 +8,7 @@
 #[flux::refined_by(n: int)]
 #[flux::invariant(gtzero(n))]
 struct S {
-    #[flux::field({i32[@n] | gtzero(n)})]
+    #[flux::field({i32[n] | gtzero(n)})]
     x: i32,
 }
 

--- a/crates/flux-tests/tests/pos/structs/dep-field-00.rs
+++ b/crates/flux-tests/tests/pos/structs/dep-field-00.rs
@@ -1,6 +1,6 @@
 #[flux::refined_by(a: int)]
 pub struct Range {
-    #[flux::field(i32[@a])]
+    #[flux::field(i32[a])]
     pub x: i32,
     #[flux::field(i32{v : a < v})]
     pub y: i32,

--- a/crates/flux-tests/tests/pos/structs/dot00.rs
+++ b/crates/flux-tests/tests/pos/structs/dot00.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(x: int, y:int)]
 pub struct Pair {
-    #[flux::field(i32[@x])]
+    #[flux::field(i32[x])]
     pub x: i32,
-    #[flux::field(i32[@y])]
+    #[flux::field(i32[y])]
     pub y: i32,
 }
 

--- a/crates/flux-tests/tests/pos/structs/dot01.rs
+++ b/crates/flux-tests/tests/pos/structs/dot01.rs
@@ -8,9 +8,9 @@ use rvec::RVec;
 
 #[flux::refined_by(x: int, y:int)]
 pub struct Pair {
-    #[flux::field(i32[@x])]
+    #[flux::field(i32[x])]
     pub x: i32,
-    #[flux::field(i32[@y])]
+    #[flux::field(i32[y])]
     pub y: i32,
 }
 

--- a/crates/flux-tests/tests/pos/structs/dot02.rs
+++ b/crates/flux-tests/tests/pos/structs/dot02.rs
@@ -9,9 +9,9 @@ use rvec::RVec;
 
 #[flux::refined_by(x: int, y:int)]
 pub struct Pair {
-    #[flux::field(i32[@x])]
+    #[flux::field(i32[x])]
     pub x: i32,
-    #[flux::field(i32[@y])]
+    #[flux::field(i32[y])]
     pub y: i32,
 }
 

--- a/crates/flux-tests/tests/pos/structs/fold-on-drop.rs
+++ b/crates/flux-tests/tests/pos/structs/fold-on-drop.rs
@@ -1,6 +1,6 @@
 #[flux::refined_by(a: int)]
 pub struct S {
-    #[flux::field({i32[@a] | a >= 0})]
+    #[flux::field({i32[a] | a >= 0})]
     f1: i32,
     _f2: Vec<i32>,
 }

--- a/crates/flux-tests/tests/pos/structs/invariant00.rs
+++ b/crates/flux-tests/tests/pos/structs/invariant00.rs
@@ -2,8 +2,8 @@
 #[flux::invariant(a > 0)]
 #[flux::invariant(b > 0)]
 pub struct S {
-    #[flux::field({i32[@a] | a > 0})]
+    #[flux::field({i32[a] | a > 0})]
     fst: i32,
-    #[flux::field({i32[@b] | b >= a})]
+    #[flux::field({i32[b] | b >= a})]
     snd: i32,
 }

--- a/crates/flux-tests/tests/pos/structs/issue-158.rs
+++ b/crates/flux-tests/tests/pos/structs/issue-158.rs
@@ -5,7 +5,7 @@ use rvec::RVec;
 
 #[flux::refined_by(size:int)]
 pub struct Bob {
-    #[flux::field(RVec<i32{v: v >= 0}>[@size])]
+    #[flux::field(RVec<i32{v: v >= 0}>[size])]
     elems: RVec<i32>,
 }
 

--- a/crates/flux-tests/tests/pos/structs/struct-join.rs
+++ b/crates/flux-tests/tests/pos/structs/struct-join.rs
@@ -1,6 +1,6 @@
 #[flux::refined_by(a: int)]
 pub struct S<T> {
-    #[flux::field({i32[@a] | a >= 0})]
+    #[flux::field({i32[a] | a >= 0})]
     f1: i32,
     f2: T,
 }

--- a/crates/flux-tests/tests/pos/structs/struct01.rs
+++ b/crates/flux-tests/tests/pos/structs/struct01.rs
@@ -5,7 +5,7 @@ use rvec::RVec;
 
 #[flux::refined_by(n: int)]
 pub struct Foo {
-    #[flux::field(RVec<usize>[@n])]
+    #[flux::field(RVec<usize>[n])]
     pub inner: RVec<usize>,
 }
 

--- a/crates/flux-tests/tests/pos/surface/alias03.rs
+++ b/crates/flux-tests/tests/pos/surface/alias03.rs
@@ -2,7 +2,7 @@
 
 #[flux::refined_by(f: int)]
 pub struct S {
-    #[flux::field(i32[@f])]
+    #[flux::field(i32[f])]
     f: i32,
 }
 

--- a/crates/flux-tests/tests/pos/surface/const02.rs
+++ b/crates/flux-tests/tests/pos/surface/const02.rs
@@ -5,7 +5,7 @@ pub const FORTY_TWO: usize = 21 + 21;
 
 #[flux::refined_by(a:int)]
 pub struct Silly {
-    #[flux::field({usize[@a] | a < FORTY_TWO})]
+    #[flux::field({usize[a] | a < FORTY_TWO})]
     fld: usize,
 }
 

--- a/crates/flux-tests/tests/pos/surface/constr01.rs
+++ b/crates/flux-tests/tests/pos/surface/constr01.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(a: int, b: int)]
 struct Foo {
-    #[flux::field({i32[@a] | 0 <= a})]
+    #[flux::field({i32[a] | 0 <= a})]
     x: i32,
-    #[flux::field({i32[@b] | a < b})]
+    #[flux::field({i32[b] | a < b})]
     y: i32,
 }
 

--- a/crates/flux-tests/tests/pos/surface/date.rs
+++ b/crates/flux-tests/tests/pos/surface/date.rs
@@ -13,11 +13,11 @@
 #[allow(dead_code)]
 #[flux::refined_by(d:int, m:int, y:int)]
 pub struct Date {
-    #[flux::field({ usize[@d] | ok_day(d) })]
+    #[flux::field({ usize[d] | ok_day(d) })]
     day: usize,
-    #[flux::field({ usize[@m] | ok_month(d, m)})]
+    #[flux::field({ usize[m] | ok_month(d, m)})]
     month: usize,
-    #[flux::field({ usize[@y] | ok_year(d, m, y)})]
+    #[flux::field({ usize[y] | ok_year(d, m, y)})]
     year: usize,
 }
 

--- a/crates/flux-tests/tests/pos/surface/issue-141.rs
+++ b/crates/flux-tests/tests/pos/surface/issue-141.rs
@@ -5,7 +5,7 @@ use rvec::RVec;
 
 #[flux::refined_by(len: int)]
 pub struct Vecs {
-    #[flux::field(RVec<i32>[@len])]
+    #[flux::field(RVec<i32>[len])]
     pub my: RVec<i32>,
 }
 

--- a/crates/flux-tests/tests/pos/surface/issue-299.rs
+++ b/crates/flux-tests/tests/pos/surface/issue-299.rs
@@ -3,7 +3,7 @@
 #[flux::refined_by(a: int)]
 struct S1 {
     f1: S2,
-    #[flux::field(i32[@a])]
+    #[flux::field(i32[a])]
     f2: i32,
     #[flux::field(i32{v: v > 0})]
     f3: i32,
@@ -13,9 +13,9 @@ struct S1 {
 struct S2 {
     #[flux::field(i32)]
     pub f1: i32,
-    #[flux::field(i32[@a])]
+    #[flux::field(i32[a])]
     pub f2: i32,
-    #[flux::field({i32[@b] | b > 0})]
+    #[flux::field({i32[b] | b > 0})]
     pub f3: i32,
     #[flux::field(i32{v: v > 0})]
     pub f4: i32,

--- a/crates/flux-tests/tests/pos/surface/issue-334.rs
+++ b/crates/flux-tests/tests/pos/surface/issue-334.rs
@@ -1,6 +1,6 @@
 #[flux::refined_by(n: int)]
 struct S {
-    #[flux::field(i32[@n])]
+    #[flux::field(i32[n])]
     x: i32,
 }
 

--- a/crates/flux-tests/tests/pos/surface/local_qual00.rs
+++ b/crates/flux-tests/tests/pos/surface/local_qual00.rs
@@ -9,9 +9,9 @@ use rvec::RVec;
 
 #[flux::refined_by(x: int, y:int)]
 pub struct Pair {
-    #[flux::field(i32[@x])]
+    #[flux::field(i32[x])]
     pub x: i32,
-    #[flux::field(i32[@y])]
+    #[flux::field(i32[y])]
     pub y: i32,
 }
 

--- a/crates/flux-tests/tests/pos/surface/nested_binders_kvar.rs
+++ b/crates/flux-tests/tests/pos/surface/nested_binders_kvar.rs
@@ -1,7 +1,7 @@
 #[flux::refined_by(n: int)]
 struct S<T> {
     f: T,
-    #[flux::field(i32[@n])]
+    #[flux::field(i32[n])]
     _n: i32,
 }
 

--- a/crates/flux-tests/tests/pos/surface/range.rs
+++ b/crates/flux-tests/tests/pos/surface/range.rs
@@ -1,8 +1,8 @@
 #[flux::refined_by(lo: int, hi: int)]
 pub struct Rng {
-    #[flux::field(i32[@lo])]
+    #[flux::field(i32[lo])]
     _lo: i32,
-    #[flux::field(i32[@hi])]
+    #[flux::field(i32[hi])]
     hi: i32,
     #[flux::field(i32{v:lo <= v && v <= hi})]
     cur: i32,

--- a/crates/flux-tests/tests/pos/surface/rmat.rs
+++ b/crates/flux-tests/tests/pos/surface/rmat.rs
@@ -5,9 +5,9 @@ use rvec::RVec;
 
 #[flux::refined_by(rows: int, cols: int)]
 pub struct RMat {
-    #[flux::field(usize[@cols])]
+    #[flux::field(usize[cols])]
     cols: usize,
-    #[flux::field(RVec<RVec<f32>[cols]>[@rows])]
+    #[flux::field(RVec<RVec<f32>[cols]>[rows])]
     inner: RVec<RVec<f32>>,
 }
 

--- a/crates/flux-tests/tests/pos/surface/self_ty_alias00.rs
+++ b/crates/flux-tests/tests/pos/surface/self_ty_alias00.rs
@@ -1,6 +1,6 @@
 #[flux::refined_by(n: int)]
 struct S<T> {
-    #[flux::field(i32[@n])]
+    #[flux::field(i32[n])]
     f1: i32,
     f2: T,
 }

--- a/crates/flux-tests/tests/pos/surface/too_many_linked_lists.rs
+++ b/crates/flux-tests/tests/pos/surface/too_many_linked_lists.rs
@@ -4,7 +4,7 @@
 #[flux::refined_by(len: int)]
 #[flux::invariant(len >= 0)]
 pub struct List<T> {
-    #[flux::field(Link<T>[@len])]
+    #[flux::field(Link<T>[len])]
     head: Link<T>,
 }
 
@@ -21,7 +21,7 @@ enum Link<T> {
 #[flux::invariant(len >= 0)]
 struct Node<T> {
     elem: T,
-    #[flux::field(Link<T>[@len])]
+    #[flux::field(Link<T>[len])]
     next: Link<T>,
 }
 

--- a/crates/flux-tests/tests/todo/alias03.rs
+++ b/crates/flux-tests/tests/todo/alias03.rs
@@ -1,6 +1,6 @@
 #[flux::refined_by(f: int)]
 pub struct S {
-    #[flux::field(i32[@f])]
+    #[flux::field(i32[f])]
     f: i32,
 }
 

--- a/crates/flux-tests/tests/todo/too_many_linked_lists.rs
+++ b/crates/flux-tests/tests/todo/too_many_linked_lists.rs
@@ -3,7 +3,7 @@
 
 #[flux::refined_by(len: int)]
 pub struct List<T> {
-    #[flux::field(Link<T>[@len])]
+    #[flux::field(Link<T>[len])]
     head: Link<T>,
 }
 
@@ -18,7 +18,7 @@ enum Link<T> {
 #[flux::refined_by(len: int)]
 struct Node<T> {
     elem: T,
-    #[flux::field(Link<T>[@len])]
+    #[flux::field(Link<T>[len])]
     next: Link<T>,
 }
 


### PR DESCRIPTION
Do not generate sorts during gathering but delay it until desugaring when we already have an `fhir::BaseTy`. This way we can avoid duplicating `sort_of_path` in the surface.