### PR TITLE
Implement *inlined* refined syntax for structs

### DIFF
--- a/crates/flux-driver/src/collector.rs
+++ b/crates/flux-driver/src/collector.rs
@@ -17,7 +17,7 @@ use rustc_hir::{
     EnumDef, ImplItemKind, Item, ItemKind, OwnerId, VariantData,
 };
 use rustc_middle::ty::{ScalarInt, TyCtxt};
-use rustc_span::{Span, Symbol};
+use rustc_span::{Span, Symbol, SyntaxContext};
 
 pub(crate) struct SpecCollector<'tcx, 'a> {
     tcx: TyCtxt<'tcx>,
@@ -490,7 +490,8 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
         parser: impl FnOnce(&mut ParseSess, &TokenStream, Span) -> ParseResult<T>,
         ctor: impl FnOnce(T) -> FluxAttrKind,
     ) -> Result<FluxAttrKind, ErrorGuaranteed> {
-        parser(&mut self.parse_sess, &dargs.tokens, dargs.dspan.entire())
+        let entire = dargs.dspan.entire().with_ctxt(SyntaxContext::root());
+        parser(&mut self.parse_sess, &dargs.tokens, entire)
             .map(ctor)
             .map_err(|err| self.emit_err(errors::SyntaxErr::from(err)))
     }

--- a/lib/flux-attrs/src/ast.rs
+++ b/lib/flux-attrs/src/ast.rs
@@ -1004,9 +1004,8 @@ impl ToTokens for Field {
         let Field { attrs, vis, mutability: _, ident, colon_token, ty } = self;
         #[cfg(flux_sysroot)]
         {
-            let span = colon_token.span();
             let flux_ty = ToTokensFlux(ty);
-            quote_spanned! {span=>
+            quote! {
                 #[flux_tool::field(#flux_ty)]
             }
             .to_tokens(tokens);


### PR DESCRIPTION
Now we can write

```rust
flux_rs::flux! {

struct Range refined by [a: int, b: int]
{
    start: i32[a],
    end: {i32[b] | b >= a},
}

fn test(r: Range[@a, @b]) -> i32{v: v >= 0} {
    r.end - r.start
}

}
```