### PR TITLE
Do not strong update lifetime when blocking path

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -541,7 +541,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
             surface::Constraint::Type(bind, ty) => {
                 let (idx, loc) = self.resolve_loc(env, *bind)?;
                 let ty = self.desugar_ty(None, ty, env)?;
-                Ok(fhir::Constraint::Type(loc, idx, ty))
+                Ok(fhir::Constraint::Type(loc, ty, idx))
             }
             surface::Constraint::Pred(e) => {
                 let pred = self.desugar_expr(env, e)?;
@@ -577,7 +577,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
                 let span = loc.span;
                 let (idx, loc) = self.resolve_loc(env, *loc)?;
                 let ty = self.desugar_ty(None, ty, env)?;
-                requires.push(fhir::Constraint::Type(loc, idx, ty));
+                requires.push(fhir::Constraint::Type(loc, ty, idx));
                 let kind = fhir::TyKind::Ptr(self.mk_lft_hole(), loc);
                 Ok(fhir::Ty { kind, span })
             }

--- a/crates/flux-fhir-analysis/src/annot_check.rs
+++ b/crates/flux-fhir-analysis/src/annot_check.rs
@@ -138,7 +138,7 @@ impl<'zip> Zipper<'zip> {
 
     fn zip_constraints(&mut self, constrs: &[fhir::Constraint]) -> Result<(), ErrorGuaranteed> {
         constrs.iter().try_for_each_exhaust(|constr| {
-            if let fhir::Constraint::Type(loc, ty) = constr {
+            if let fhir::Constraint::Type(loc, _, ty) = constr {
                 self.zip_ty(ty, self.locs[&loc.name])
             } else {
                 Ok(())

--- a/crates/flux-fhir-analysis/src/annot_check.rs
+++ b/crates/flux-fhir-analysis/src/annot_check.rs
@@ -138,7 +138,7 @@ impl<'zip> Zipper<'zip> {
 
     fn zip_constraints(&mut self, constrs: &[fhir::Constraint]) -> Result<(), ErrorGuaranteed> {
         constrs.iter().try_for_each_exhaust(|constr| {
-            if let fhir::Constraint::Type(loc, _, ty) = constr {
+            if let fhir::Constraint::Type(loc, ty, _) = constr {
                 self.zip_ty(ty, self.locs[&loc.name])
             } else {
                 Ok(())

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -580,11 +580,11 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
         constr: &fhir::Constraint,
     ) -> QueryResult<rty::Constraint> {
         match constr {
-            fhir::Constraint::Type(loc, idx, ty) => {
+            fhir::Constraint::Type(loc, ty, idx) => {
                 Ok(rty::Constraint::Type(
                     env.lookup(*loc).to_path(),
-                    Local::from_usize(*idx),
                     self.conv_ty(env, ty)?,
+                    Local::from_usize(*idx),
                 ))
             }
             fhir::Constraint::Pred(pred) => Ok(rty::Constraint::Pred(self.conv_expr(env, pred))),

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -27,6 +27,7 @@ use rustc_hir::{
 };
 use rustc_middle::{
     middle::resolve_bound_vars::ResolvedArg,
+    mir::Local,
     ty::{AssocItem, AssocKind, BoundVar, TyCtxt},
 };
 use rustc_span::symbol::kw;
@@ -579,8 +580,12 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
         constr: &fhir::Constraint,
     ) -> QueryResult<rty::Constraint> {
         match constr {
-            fhir::Constraint::Type(loc, ty) => {
-                Ok(rty::Constraint::Type(env.lookup(*loc).to_path(), self.conv_ty(env, ty)?))
+            fhir::Constraint::Type(loc, idx, ty) => {
+                Ok(rty::Constraint::Type(
+                    env.lookup(*loc).to_path(),
+                    Local::from_usize(*idx),
+                    self.conv_ty(env, ty)?,
+                ))
             }
             fhir::Constraint::Pred(pred) => Ok(rty::Constraint::Pred(self.conv_expr(env, pred))),
         }

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -287,7 +287,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
             .ensures
             .iter()
             .try_for_each_exhaust(|constr| {
-                if let fhir::Constraint::Type(loc, _) = constr
+                if let fhir::Constraint::Type(loc, ..) = constr
                     && !output_locs.insert(loc.name)
                 {
                     self.emit_err(errors::DuplicatedEnsures::new(loc))
@@ -297,7 +297,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
             })?;
 
         fn_sig.requires.iter().try_for_each_exhaust(|constr| {
-            if let fhir::Constraint::Type(loc, _) = constr
+            if let fhir::Constraint::Type(loc, ..) = constr
                 && !output_locs.contains(&loc.name)
             {
                 self.emit_err(errors::MissingEnsures::new(loc))
@@ -313,7 +313,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         constr: &fhir::Constraint,
     ) -> Result<(), ErrorGuaranteed> {
         match constr {
-            fhir::Constraint::Type(loc, ty) => {
+            fhir::Constraint::Type(loc, _, ty) => {
                 [infcx.check_loc(*loc), self.check_type(infcx, ty)]
                     .into_iter()
                     .try_collect_exhaust()

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -313,7 +313,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         constr: &fhir::Constraint,
     ) -> Result<(), ErrorGuaranteed> {
         match constr {
-            fhir::Constraint::Type(loc, _, ty) => {
+            fhir::Constraint::Type(loc, ty, _) => {
                 [infcx.check_loc(*loc), self.check_type(infcx, ty)]
                     .into_iter()
                     .try_collect_exhaust()

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -483,6 +483,8 @@ pub enum ParamKind {
     Pound,
     /// An implicitly scoped parameter declared with `x: T` syntax
     Colon,
+    /// A location declared with `x: &strg T` syntax
+    Loc(usize),
 }
 
 impl ParamKind {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -256,7 +256,7 @@ pub struct FnOutput {
 
 pub enum Constraint {
     /// A type constraint on a location
-    Type(Ident, Ty),
+    Type(Ident, usize, Ty),
     /// A predicate that needs to hold
     Pred(Expr),
 }
@@ -1482,7 +1482,7 @@ impl fmt::Debug for FnOutput {
 impl fmt::Debug for Constraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Constraint::Type(loc, ty) => write!(f, "{loc:?}: {ty:?}"),
+            Constraint::Type(loc, _, ty) => write!(f, "{loc:?}: {ty:?}"),
             Constraint::Pred(e) => write!(f, "{e:?}"),
         }
     }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -256,7 +256,12 @@ pub struct FnOutput {
 
 pub enum Constraint {
     /// A type constraint on a location
-    Type(Ident, usize, Ty),
+    Type(
+        Ident,
+        Ty,
+        /// The index of the argument corresponding to the constraint.
+        usize,
+    ),
     /// A predicate that needs to hold
     Pred(Expr),
 }

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -147,7 +147,7 @@ pub fn walk_refine_param<V: Visitor>(vis: &mut V, param: &RefineParam) {
 
 pub fn walk_constraint<V: Visitor>(vis: &mut V, constraint: &Constraint) {
     match constraint {
-        Constraint::Type(loc, ty) => {
+        Constraint::Type(loc, _, ty) => {
             vis.visit_ident(*loc);
             vis.visit_ty(ty);
         }

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -147,7 +147,7 @@ pub fn walk_refine_param<V: Visitor>(vis: &mut V, param: &RefineParam) {
 
 pub fn walk_constraint<V: Visitor>(vis: &mut V, constraint: &Constraint) {
     match constraint {
-        Constraint::Type(loc, _, ty) => {
+        Constraint::Type(loc, ty, _) => {
             vis.visit_ident(*loc);
             vis.visit_ty(ty);
         }

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -154,7 +154,7 @@ pub struct Path {
     projection: List<FieldIdx>,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
 pub enum Loc {
     Local(Local),
     Var(Var),
@@ -660,7 +660,7 @@ impl Path {
 
     pub fn to_loc(&self) -> Option<Loc> {
         if self.projection.is_empty() {
-            Some(self.loc.clone())
+            Some(self.loc)
         } else {
             None
         }

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -723,7 +723,7 @@ impl TypeFoldable for FnOutput {
 impl TypeVisitable for Constraint {
     fn visit_with<V: TypeVisitor>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy, ()> {
         match self {
-            Constraint::Type(path, ty) => {
+            Constraint::Type(path, _, ty) => {
                 path.to_expr().visit_with(visitor)?;
                 ty.visit_with(visitor)
             }
@@ -735,7 +735,7 @@ impl TypeVisitable for Constraint {
 impl TypeFoldable for Constraint {
     fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
         let c = match self {
-            Constraint::Type(path, ty) => {
+            Constraint::Type(path, local, ty) => {
                 let path_expr = path
                     .to_expr()
                     .try_fold_with(folder)?
@@ -744,6 +744,7 @@ impl TypeFoldable for Constraint {
                     path_expr.to_path().unwrap_or_else(|| {
                         bug!("invalid path `{path_expr:?}` produced when folding `{self:?}`",)
                     }),
+                    *local,
                     ty.try_fold_with(folder)?,
                 )
             }

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -723,7 +723,7 @@ impl TypeFoldable for FnOutput {
 impl TypeVisitable for Constraint {
     fn visit_with<V: TypeVisitor>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy, ()> {
         match self {
-            Constraint::Type(path, _, ty) => {
+            Constraint::Type(path, ty, _) => {
                 path.to_expr().visit_with(visitor)?;
                 ty.visit_with(visitor)
             }
@@ -735,7 +735,7 @@ impl TypeVisitable for Constraint {
 impl TypeFoldable for Constraint {
     fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
         let c = match self {
-            Constraint::Type(path, local, ty) => {
+            Constraint::Type(path, ty, local) => {
                 let path_expr = path
                     .to_expr()
                     .try_fold_with(folder)?
@@ -744,8 +744,8 @@ impl TypeFoldable for Constraint {
                     path_expr.to_path().unwrap_or_else(|| {
                         bug!("invalid path `{path_expr:?}` produced when folding `{self:?}`",)
                     }),
-                    *local,
                     ty.try_fold_with(folder)?,
+                    *local,
                 )
             }
             Constraint::Pred(e) => Constraint::Pred(e.try_fold_with(folder)?),

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     queries::QueryResult,
     rustc::{
         self,
-        mir::Place,
+        mir::{Local, Place},
         ty::{GeneratorArgsParts, ValueConst, VariantDef},
     },
 };
@@ -286,7 +286,7 @@ pub type Constraints = List<Constraint>;
 
 #[derive(Clone, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub enum Constraint {
-    Type(Path, Ty),
+    Type(Path, Local, Ty),
     Pred(Expr),
 }
 
@@ -1852,7 +1852,7 @@ mod pretty {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             match self {
-                Constraint::Type(loc, ty) => w!("{:?}: {:?}", ^loc, ty),
+                Constraint::Type(loc, _, ty) => w!("{:?}: {:?}", ^loc, ty),
                 Constraint::Pred(e) => w!("{:?}", e),
             }
         }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -286,7 +286,12 @@ pub type Constraints = List<Constraint>;
 
 #[derive(Clone, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub enum Constraint {
-    Type(Path, Local, Ty),
+    Type(
+        Path,
+        Ty,
+        /// The local of the argument corresponding to the constraint.
+        Local,
+    ),
     Pred(Expr),
 }
 
@@ -1852,7 +1857,7 @@ mod pretty {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             match self {
-                Constraint::Type(loc, _, ty) => w!("{:?}: {:?}", ^loc, ty),
+                Constraint::Type(loc, ty, _) => w!("{:?}: {:?}", ^loc, ty),
                 Constraint::Pred(e) => w!("{:?}", e),
             }
         }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -274,7 +274,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
 
         for constr in fn_sig.requires() {
             match constr {
-                rty::Constraint::Type(path, local, ty) => {
+                rty::Constraint::Type(path, ty, local) => {
                     let loc = path.to_loc().unwrap();
                     let ty = rcx.unpack(ty, AssumeInvariants::No);
                     rcx.assume_invariants(&ty, config.check_overflow);
@@ -535,7 +535,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
 
         for constr in &output.ensures {
             match constr {
-                Constraint::Type(path, _, updated_ty) => {
+                Constraint::Type(path, updated_ty, _) => {
                     let updated_ty = rcx.unpack(updated_ty, AssumeInvariants::No);
                     rcx.assume_invariants(&updated_ty, self.config.check_overflow);
                     env.update_path(path, updated_ty);

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -274,11 +274,11 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
 
         for constr in fn_sig.requires() {
             match constr {
-                rty::Constraint::Type(path, ty) => {
+                rty::Constraint::Type(path, local, ty) => {
                     let loc = path.to_loc().unwrap();
                     let ty = rcx.unpack(ty, AssumeInvariants::No);
                     rcx.assume_invariants(&ty, config.check_overflow);
-                    env.alloc_universal_loc(loc, ty);
+                    env.alloc_universal_loc(loc, Place::new(*local, vec![]), ty);
                 }
                 rty::Constraint::Pred(e) => {
                     rcx.assume_pred(e.clone());
@@ -535,7 +535,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
 
         for constr in &output.ensures {
             match constr {
-                Constraint::Type(path, updated_ty) => {
+                Constraint::Type(path, _, updated_ty) => {
                     let updated_ty = rcx.unpack(updated_ty, AssumeInvariants::No);
                     rcx.assume_invariants(&updated_ty, self.config.check_overflow);
                     env.update_path(path, updated_ty);

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -239,7 +239,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
         let mut requires = FxHashMap::default();
         for constr in inst_fn_sig.requires() {
             match constr {
-                Constraint::Type(path, _, ty) => {
+                Constraint::Type(path, ty, _) => {
                     requires.insert(path.clone(), ty);
                 }
                 Constraint::Pred(pred) => {
@@ -524,7 +524,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     ) -> Result<(), CheckerErrKind> {
         let rcx = &mut rcx.branch();
         match constraint {
-            Constraint::Type(path, _, ty) => self.check_type_constr(rcx, env, path, ty),
+            Constraint::Type(path, ty, _) => self.check_type_constr(rcx, env, path, ty),
             Constraint::Pred(e) => {
                 rcx.check_pred(e, self.tag);
                 Ok(())

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -262,7 +262,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
                     infcx.check_type_constr(rcx, env, path1, bound)?;
                 }
                 (TyKind::Ptr(PtrKind::Mut(_), path), Ref!(_, bound, Mutability::Mut)) => {
-                    let ty = env.block_with(path, bound.clone());
+                    let ty = env.block_with(genv, path, bound.clone())?;
                     infcx.subtyping(rcx, &ty, bound)?;
                 }
                 _ => infcx.subtyping(rcx, actual, &formal)?,
@@ -382,7 +382,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
             // TODO(nilehmann) We should share this logic with `check_fn_call`
             match (ty.kind(), arr_ty.kind()) {
                 (TyKind::Ptr(PtrKind::Mut(_), path), Ref!(_, bound, Mutability::Mut)) => {
-                    let ty = env.block_with(path, bound.clone());
+                    let ty = env.block_with(infcx.genv, path, bound.clone())?;
                     infcx.subtyping(rcx, &ty, bound)?;
                 }
                 _ => infcx.subtyping(rcx, ty, &arr_ty)?,

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -239,7 +239,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
         let mut requires = FxHashMap::default();
         for constr in inst_fn_sig.requires() {
             match constr {
-                Constraint::Type(path, ty) => {
+                Constraint::Type(path, _, ty) => {
                     requires.insert(path.clone(), ty);
                 }
                 Constraint::Pred(pred) => {
@@ -524,7 +524,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     ) -> Result<(), CheckerErrKind> {
         let rcx = &mut rcx.branch();
         match constraint {
-            Constraint::Type(path, ty) => self.check_type_constr(rcx, env, path, ty),
+            Constraint::Type(path, _, ty) => self.check_type_constr(rcx, env, path, ty),
             Constraint::Pred(e) => {
                 rcx.check_pred(e, self.tag);
                 Ok(())

--- a/crates/flux-refineck/src/ghost_statements/points_to.rs
+++ b/crates/flux-refineck/src/ghost_statements/points_to.rs
@@ -744,7 +744,7 @@ impl State {
 
     fn flood_with(&mut self, place: mir::PlaceRef<'_>, map: &Map, value: FlatSet<Loc>) {
         map.for_each_aliasing_place(place, &mut |vi| {
-            self.values[vi] = value.clone();
+            self.values[vi] = value;
         });
     }
 
@@ -780,7 +780,7 @@ impl State {
         // already been performed.
         if let Some(target_value) = map.places[target].value_index {
             if let Some(source_value) = map.places[source].value_index {
-                self.values[target_value] = self.values[source_value].clone();
+                self.values[target_value] = self.values[source_value];
             }
         }
         for target_child in map.children(target) {
@@ -815,9 +815,7 @@ impl State {
 
     /// Retrieve the value stored for a place index if tracked
     fn get_tracked_idx(&self, place: PlaceIndex, map: &Map) -> Option<FlatSet<Loc>> {
-        map.places[place]
-            .value_index
-            .map(|v| self.values[v].clone())
+        map.places[place].value_index.map(|v| self.values[v])
     }
 }
 

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -56,18 +56,19 @@ impl TypeEnv<'_> {
         TypeEnv { bindings: PlacesTree::default(), local_decls }
     }
 
-    pub fn alloc_universal_loc(&mut self, loc: Loc, ty: Ty) {
-        self.bindings.insert(loc, LocKind::Universal, ty);
+    pub fn alloc_universal_loc(&mut self, loc: Loc, place: Place, ty: Ty) {
+        self.bindings.insert(loc, place, LocKind::Universal, ty);
     }
 
     pub fn alloc_with_ty(&mut self, local: Local, ty: Ty) {
         let ty = RegionSubst::new(&ty, &self.local_decls[local].ty).apply(&ty);
-        self.bindings.insert(local.into(), LocKind::Local, ty);
+        self.bindings
+            .insert(local.into(), Place::new(local, vec![]), LocKind::Local, ty);
     }
 
     pub fn alloc(&mut self, local: Local) {
         self.bindings
-            .insert(local.into(), LocKind::Local, Ty::uninit());
+            .insert(local.into(), Place::new(local, vec![]), LocKind::Local, Ty::uninit());
     }
 
     pub(crate) fn into_infer(self, scope: Scope) -> Result<BasicBlockEnvShape, CheckerErrKind> {

--- a/crates/flux-refineck/src/type_env/projection.rs
+++ b/crates/flux-refineck/src/type_env/projection.rs
@@ -140,7 +140,7 @@ impl PlacesTree {
         key: &impl LookupKey,
         checker_conf: CheckerConfig,
     ) -> CheckerResult {
-        let cursor = self.cursor(key);
+        let cursor = self.cursor_for(key);
         Unfolder::new(genv, rcx, cursor, checker_conf).run(self)
     }
 
@@ -149,7 +149,7 @@ impl PlacesTree {
         key: &impl LookupKey,
         mut mode: M,
     ) -> Result<LookupResult, M::Error> {
-        let mut cursor = self.cursor(key);
+        let mut cursor = self.cursor_for(key);
         let mut ty = self.get_loc(&cursor.loc).ty.clone();
         let mut is_strg = true;
         while let Some(elem) = cursor.next() {
@@ -316,9 +316,15 @@ impl PlacesTree {
             .unwrap_or_else(|| tracked_span_bug!("loc not found {loc:?}"))
     }
 
-    fn cursor(&self, key: &impl LookupKey) -> Cursor {
+    fn cursor_for(&self, key: &impl LookupKey) -> Cursor {
         let place = self.loc_to_place[&key.loc()].clone();
         Cursor::new(key, place)
+    }
+
+    pub(crate) fn path_to_place(&self, path: &Path) -> Place {
+        let mut place = self.loc_to_place[&path.loc].clone();
+        place.projection.extend(path.proj());
+        place
     }
 }
 

--- a/crates/flux-refineck/src/type_env/projection.rs
+++ b/crates/flux-refineck/src/type_env/projection.rs
@@ -70,7 +70,7 @@ impl LookupKey for Path {
     type Iter<'a> = impl DoubleEndedIterator<Item = PlaceElem> + 'a;
 
     fn loc(&self) -> Loc {
-        self.loc.clone()
+        self.loc
     }
 
     fn proj(&self) -> Self::Iter<'_> {
@@ -296,7 +296,7 @@ impl PlacesTree {
                         proj.pop();
                     }
                 }
-                _ => f(Path::new(loc.clone(), proj.as_slice()), kind, ty),
+                _ => f(Path::new(*loc, proj.as_slice()), kind, ty),
             }
         }
         for (loc, binding) in &self.map {
@@ -317,7 +317,7 @@ impl PlacesTree {
     }
 
     fn cursor(&self, key: &impl LookupKey) -> Cursor {
-        let place = self.loc_to_place[&key.loc()];
+        let place = self.loc_to_place[&key.loc()].clone();
         Cursor::new(key, place)
     }
 }
@@ -471,7 +471,7 @@ impl<'a, 'rcx, 'tcx> Unfolder<'a, 'rcx, 'tcx> {
         let mut place = self.cursor.to_place();
         place.projection.push(PlaceElem::Deref);
         self.insertions.push((
-            loc.clone(),
+            loc,
             place,
             Binding { kind: LocKind::Box(alloc.clone()), ty: deref_ty.clone() },
         ));
@@ -671,7 +671,7 @@ impl Cursor {
                 .copied()
                 .map(PlaceElem::Field),
         );
-        self.loc = path.loc.clone();
+        self.loc = path.loc;
         self.pos = self.proj.len();
     }
 
@@ -692,7 +692,7 @@ impl Cursor {
                 }
             }
         }
-        Path::new(self.loc.clone(), List::from_vec(proj))
+        Path::new(self.loc, List::from_vec(proj))
     }
 
     fn next(&mut self) -> Option<PlaceElem> {

--- a/crates/flux-tests/tests/neg/enums/issue-578.rs
+++ b/crates/flux-tests/tests/neg/enums/issue-578.rs
@@ -1,0 +1,11 @@
+#[flux::sig(fn(bool[true]))]
+fn assert(_: bool) {}
+
+pub fn test() {
+    let mut s: Vec<i32> = vec![];
+    s.push(0);
+    s.push(1);
+    for v in &s {
+        assert(*v > 0); //~ ERROR refinement type error
+    }
+}

--- a/crates/flux-tests/tests/pos/structs/issue-578.rs
+++ b/crates/flux-tests/tests/pos/structs/issue-578.rs
@@ -1,0 +1,11 @@
+#[flux::sig(fn(bool[true]))]
+fn assert(_: bool) {}
+
+pub fn test() {
+    let mut s: Vec<i32> = vec![];
+    s.push(0);
+    s.push(1);
+    for v in &s {
+        assert(*v >= 0);
+    }
+}

--- a/lib/flux-attrs/src/extern_spec.rs
+++ b/lib/flux-attrs/src/extern_spec.rs
@@ -256,7 +256,7 @@ fn create_dummy_ident_from_path(dummy_prefix: &str, path: &syn::Path) -> syn::Re
 /// struct __FluxExternStructHashSet<T, S = RandomState>(HashSet<T, S>);
 /// ```
 fn strip_generics_eq_default(generics: &mut Generics) {
-    for param in generics.params.iter_mut() {
+    for param in &mut generics.params {
         match param {
             GenericParam::Type(type_param) => {
                 type_param.bounds = Punctuated::new();


### PR DESCRIPTION
* Track a map between locs and places
* Rewrite lifetimes before blocking path

fixes https://github.com/flux-rs/flux/issues/578