### PR TITLE
Do not infer sorts during desugaring

### DIFF
--- a/crates/flux-common/src/dbg.rs
+++ b/crates/flux-common/src/dbg.rs
@@ -24,7 +24,7 @@ pub fn dump_item_info<T: fmt::Debug>(
     tcx: TyCtxt,
     def_id: impl Into<DefId>,
     ext: impl AsRef<str>,
-    val: &T,
+    val: T,
 ) -> io::Result<()> {
     let mut writer = writer_for_item(tcx, def_id.into(), ext)?;
     write!(writer, "{val:#?}")

--- a/crates/flux-desugar/locales/en-US.ftl
+++ b/crates/flux-desugar/locales/en-US.ftl
@@ -37,21 +37,6 @@ desugar_sort_arity_mismatch =
         *[other] 1 or {$expected} arguments
     }, found {$found}
 
-desugar_refine_arg_count_mismatch =
-    this type takes {$expected ->
-        [0] 0 refinement arguments
-        [one] 1 refinement argument
-        *[other] 1 or {$expected} refinement arguments
-    } but {$found ->
-        [one] {$found} was found
-        *[other] {$found} were found
-    }
-    .label = expected {$expected ->
-        [0] 0 refinement arguments
-        [one] {$expected} argument
-        *[other] 1 or {$expected} arguments
-    }, found {$found}
-
 desugar_invalid_unrefined_param =
     invalid use of refinement parameter
     .label = parameter `{$var}` refers to a type with no indices
@@ -63,9 +48,6 @@ desugar_illegal_binder =
 desugar_invalid_numeric_suffix =
     invalid suffix `{$suffix}` for number literal
     .label = the suffix must be one of the numeric sorts `int` or `real`
-
-desugar_refined_unrefinable_type =
-    type cannot be refined
 
 # Resolve errors
 

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -468,7 +468,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
         let generic_preds = if let Some(predicates) = &fn_sig.predicates {
             self.desugar_predicates(predicates, &mut env)?
         } else {
-            self.as_lift_cx().lift_predicates()?
+            self.as_lift_cx().lift_generic_predicates()?
         };
 
         if let Some(e) = &fn_sig.requires {

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -202,14 +202,8 @@ fn self_res(genv: &GlobalEnv, owner: OwnerId) -> SelfRes {
     let def_id = owner.def_id;
     if let Some(alias_to) = genv.tcx.opt_parent(def_id.to_def_id()) {
         match genv.tcx.def_kind(alias_to) {
-            DefKind::Trait => SelfRes::Param(alias_to),
-            DefKind::Impl { .. } => {
-                if let Some(sort) = genv.sort_of_self_ty_alias(alias_to) {
-                    SelfRes::Alias(sort)
-                } else {
-                    SelfRes::None
-                }
-            }
+            DefKind::Trait => SelfRes::Param { trait_id: alias_to },
+            DefKind::Impl { .. } => SelfRes::Alias { alias_to },
             _ => SelfRes::None,
         }
     } else {

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -755,7 +755,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
                     .map(|(arg, sort)| self.desugar_refine_arg(arg, Some(sort), env))
                     .try_collect_exhaust()?;
                 Ok(fhir::RefineArg {
-                    kind: fhir::RefineArgKind::Record(def_id, sort_args, flds),
+                    kind: fhir::RefineArgKind::Record(flds),
                     fhir_id: self.next_fhir_id(),
                     span: idxs.span,
                 })

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -648,7 +648,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
 
                 let idx = fhir::RefineArg {
                     kind: fhir::RefineArgKind::Expr(fhir::Expr {
-                        kind: fhir::ExprKind::Var(params[0].ident, false),
+                        kind: fhir::ExprKind::Var(params[0].ident, None),
                         span: ex_bind.span,
                         fhir_id: self.next_fhir_id(),
                     }),
@@ -777,13 +777,16 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
     fn bind_into_refine_arg(
         &self,
         ident: surface::Ident,
-        env: &mut Env,
+        env: &Env,
     ) -> Result<Option<fhir::RefineArg>> {
-        match env.get_mut(ident) {
+        match env.get(ident) {
             Some(param) => {
                 Ok(Some(fhir::RefineArg {
                     kind: fhir::RefineArgKind::Expr(fhir::Expr {
-                        kind: fhir::ExprKind::Var(fhir::Ident::new(param.name, ident), true),
+                        kind: fhir::ExprKind::Var(
+                            fhir::Ident::new(param.name, ident),
+                            Some(param.kind),
+                        ),
                         span: ident.span,
                         fhir_id: self.next_fhir_id(),
                     }),
@@ -967,7 +970,7 @@ impl Scope<Param> {
             let ident = fhir::Ident::new(param.name, *ident);
             refine_args.push(fhir::RefineArg {
                 kind: fhir::RefineArgKind::Expr(fhir::Expr {
-                    kind: ExprKind::Var(ident, false),
+                    kind: ExprKind::Var(ident, None),
                     span,
                     fhir_id: cx.next_fhir_id(),
                 }),
@@ -997,7 +1000,7 @@ trait DesugarCtxt<'a, 'tcx: 'a> {
         let kind = match &expr.kind {
             surface::ExprKind::QPath(qpath) => {
                 match self.resolve_qpath(env, qpath)? {
-                    QPathRes::Param(ident) => fhir::ExprKind::Var(ident, false),
+                    QPathRes::Param(ident) => fhir::ExprKind::Var(ident, None),
                     QPathRes::Const(const_info) => {
                         fhir::ExprKind::Const(const_info.def_id, qpath.span)
                     }

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -648,7 +648,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
 
                 let idx = fhir::RefineArg {
                     kind: fhir::RefineArgKind::Expr(fhir::Expr {
-                        kind: fhir::ExprKind::Var(params[0].ident),
+                        kind: fhir::ExprKind::Var(params[0].ident, false),
                         span: ex_bind.span,
                         fhir_id: self.next_fhir_id(),
                     }),
@@ -783,7 +783,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
             Some(param) => {
                 Ok(Some(fhir::RefineArg {
                     kind: fhir::RefineArgKind::Expr(fhir::Expr {
-                        kind: fhir::ExprKind::Var(fhir::Ident::new(param.name, ident)),
+                        kind: fhir::ExprKind::Var(fhir::Ident::new(param.name, ident), true),
                         span: ident.span,
                         fhir_id: self.next_fhir_id(),
                     }),
@@ -965,10 +965,9 @@ impl Scope<Param> {
         let mut refine_args = vec![];
         for (ident, param) in self.iter() {
             let ident = fhir::Ident::new(param.name, *ident);
-            let kind = ExprKind::Var(ident);
             refine_args.push(fhir::RefineArg {
                 kind: fhir::RefineArgKind::Expr(fhir::Expr {
-                    kind,
+                    kind: ExprKind::Var(ident, false),
                     span,
                     fhir_id: cx.next_fhir_id(),
                 }),
@@ -998,7 +997,7 @@ trait DesugarCtxt<'a, 'tcx: 'a> {
         let kind = match &expr.kind {
             surface::ExprKind::QPath(qpath) => {
                 match self.resolve_qpath(env, qpath)? {
-                    QPathRes::Param(ident) => fhir::ExprKind::Var(ident),
+                    QPathRes::Param(ident) => fhir::ExprKind::Var(ident, false),
                     QPathRes::Const(const_info) => {
                         fhir::ExprKind::Const(const_info.def_id, qpath.span)
                     }

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -481,6 +481,18 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
         }
     }
 
+    pub(crate) fn desugar_generics_for_adt(
+        &mut self,
+        generics: Option<&surface::Generics>,
+    ) -> Result<fhir::Generics> {
+        Ok(if let Some(generics) = generics {
+            self.desugar_generics(generics)?
+        } else {
+            self.as_lift_cx().lift_generics()?
+        }
+        .with_refined_by(self.genv.map().refined_by(self.owner.def_id)))
+    }
+
     pub(crate) fn desugar_type_alias(
         &mut self,
         ty_alias: &surface::TyAlias,

--- a/crates/flux-desugar/src/desugar/env.rs
+++ b/crates/flux-desugar/src/desugar/env.rs
@@ -69,11 +69,6 @@ impl<P> Env<P> {
         }
     }
 
-    pub(crate) fn get_mut(&mut self, ident: Ident) -> Option<&mut P> {
-        let (scope_id, _) = self.get_with_scope(ident)?;
-        self.scopes.get_mut(&scope_id).unwrap().map.get_mut(&ident)
-    }
-
     pub(crate) fn scope(&mut self, id: ScopeId) -> &mut Scope<P> {
         self.scopes.get_mut(&id).unwrap()
     }

--- a/crates/flux-desugar/src/errors.rs
+++ b/crates/flux-desugar/src/errors.rs
@@ -1,5 +1,5 @@
 use flux_macros::Diagnostic;
-use flux_syntax::surface::{self, BindKind, QPathExpr};
+use flux_syntax::surface::{BindKind, QPathExpr};
 use itertools::Itertools;
 use rustc_span::{symbol::Ident, Span, Symbol};
 
@@ -96,22 +96,6 @@ impl SortArityMismatch {
 }
 
 #[derive(Diagnostic)]
-#[diag(desugar_refine_arg_count_mismatch, code = "FLUX")]
-pub(super) struct RefineArgCountMismatch {
-    #[primary_span]
-    #[label]
-    span: Span,
-    expected: usize,
-    found: usize,
-}
-
-impl RefineArgCountMismatch {
-    pub(super) fn new(idxs: &surface::Indices, expected: usize) -> Self {
-        Self { span: idxs.span, expected, found: idxs.indices.len() }
-    }
-}
-
-#[derive(Diagnostic)]
 #[diag(desugar_invalid_unrefined_param, code = "FLUX")]
 pub(super) struct InvalidUnrefinedParam {
     #[primary_span]
@@ -138,19 +122,6 @@ pub(super) struct InvalidNumericSuffix {
 impl InvalidNumericSuffix {
     pub(super) fn new(span: Span, suffix: Symbol) -> Self {
         Self { span, suffix }
-    }
-}
-
-#[derive(Diagnostic)]
-#[diag(desugar_refined_unrefinable_type, code = "FLUX")]
-pub(super) struct RefinedUnrefinableType {
-    #[primary_span]
-    span: Span,
-}
-
-impl RefinedUnrefinableType {
-    pub(super) fn new(span: Span) -> Self {
-        Self { span }
     }
 }
 

--- a/crates/flux-desugar/src/lib.rs
+++ b/crates/flux-desugar/src/lib.rs
@@ -42,13 +42,7 @@ pub fn desugar_struct_def(
 
     let mut cx = RustItemCtxt::new(genv, owner_id, resolver_output, None);
 
-    let generics = if let Some(generics) = &struct_def.generics {
-        cx.desugar_generics(generics)?
-    } else {
-        cx.as_lift_cx().lift_generics()?
-    }
-    .with_refined_by(genv.map().refined_by(def_id));
-
+    let generics = cx.desugar_generics_for_adt(struct_def.generics.as_ref())?;
     let predicates = cx.as_lift_cx().lift_generic_predicates()?;
 
     let struct_def = cx.desugar_struct_def(struct_def)?;
@@ -74,12 +68,7 @@ pub fn desugar_enum_def(
 
     let mut cx = RustItemCtxt::new(genv, owner_id, resolver_output, None);
 
-    let generics = if let Some(generics) = &enum_def.generics {
-        cx.desugar_generics(generics)?
-    } else {
-        cx.as_lift_cx().lift_generics()?
-    }
-    .with_refined_by(genv.map().refined_by(def_id));
+    let generics = cx.desugar_generics_for_adt(enum_def.generics.as_ref())?;
     let predicates = cx.as_lift_cx().lift_generic_predicates()?;
 
     let enum_def = cx.desugar_enum_def(enum_def)?;

--- a/crates/flux-desugar/src/lib.rs
+++ b/crates/flux-desugar/src/lib.rs
@@ -1,13 +1,4 @@
 //! Desugaring from types in [`flux_syntax::surface`] to types in [`flux_middle::fhir`]
-//!
-//! # Generics and Desugaring
-//!
-//! Desugaring requires knowing the sort of each type so we can correctly resolve binders declared with
-//! @ syntax or arg syntax. In particular, to know the sort of a type parameter we need to know its
-//! kind because only type parameters of sort `base` can be refined. The essential function implementing
-//! this logic is [`GlobalEnv::sort_of_path`]. This function requires the generics for the item being
-//! desugared to be register in [`fhir::Map`], thus we need to make sure that when desugaring an item,
-//! generics are registered before desugaring the rest of the item.
 
 #![feature(rustc_private, min_specialization, box_patterns, lazy_cell, let_chains)]
 
@@ -51,15 +42,24 @@ pub fn desugar_struct_def(
 
     let mut cx = RustItemCtxt::new(genv, owner_id, resolver_output, None);
 
+    let generics = if let Some(generics) = &struct_def.generics {
+        cx.desugar_generics(generics)?
+    } else {
+        cx.as_lift_cx().lift_generics()?
+    }
+    .with_refined_by(genv.map().refined_by(def_id));
+
     let predicates = cx.as_lift_cx().lift_predicates()?;
 
-    // Desugar of struct_def needs to happen AFTER inserting generics. See #generics-and-desugaring
     let struct_def = cx.desugar_struct_def(struct_def)?;
     if config::dump_fhir() {
         dbg::dump_item_info(genv.tcx, owner_id, "fhir", &struct_def).unwrap();
     }
-    genv.map_mut().insert_generic_predicates(def_id, predicates);
-    genv.map_mut().insert_struct(def_id, struct_def);
+
+    let map = genv.map_mut();
+    map.insert_generics(def_id, generics);
+    map.insert_generic_predicates(def_id, predicates);
+    map.insert_struct(def_id, struct_def);
 
     Ok(())
 }
@@ -74,15 +74,23 @@ pub fn desugar_enum_def(
 
     let mut cx = RustItemCtxt::new(genv, owner_id, resolver_output, None);
 
+    let generics = if let Some(generics) = &enum_def.generics {
+        cx.desugar_generics(generics)?
+    } else {
+        cx.as_lift_cx().lift_generics()?
+    }
+    .with_refined_by(genv.map().refined_by(def_id));
     let predicates = cx.as_lift_cx().lift_predicates()?;
 
-    // Desugar of enum_def needs to happen AFTER inserting generics. See #generics-and-desugaring
     let enum_def = cx.desugar_enum_def(enum_def)?;
     if config::dump_fhir() {
         dbg::dump_item_info(genv.tcx, owner_id, "fhir", &enum_def).unwrap();
     }
-    genv.map_mut().insert_generic_predicates(def_id, predicates);
-    genv.map_mut().insert_enum(def_id, enum_def);
+
+    let map = genv.map_mut();
+    map.insert_generics(def_id, generics);
+    map.insert_generic_predicates(def_id, predicates);
+    map.insert_enum(def_id, enum_def);
 
     Ok(())
 }
@@ -98,26 +106,30 @@ pub fn desugar_type_alias(
     if let Some(ty_alias) = ty_alias {
         let mut cx = RustItemCtxt::new(genv, owner_id, resolver_output, None);
 
-        // Desugar and insert generics
         let (generics, predicates) = cx.as_lift_cx().lift_generics_with_predicates()?;
-        genv.map().insert_generics(def_id, generics);
 
-        // Desugar of type alias needs to happen AFTER desugaring generics. See crate level comment
         let ty_alias = cx.desugar_type_alias(ty_alias)?;
+
         if config::dump_fhir() {
             dbg::dump_item_info(genv.tcx, owner_id, "fhir", &ty_alias).unwrap();
         }
-        genv.map_mut().insert_generic_predicates(def_id, predicates);
-        genv.map_mut().insert_type_alias(def_id, ty_alias);
+
+        let map = genv.map_mut();
+        map.insert_generics(def_id, generics);
+        map.insert_generic_predicates(def_id, predicates);
+        map.insert_type_alias(def_id, ty_alias);
     } else {
         let (generics, predicates, ty_alias) =
             lift::lift_type_alias(genv.tcx, genv.sess, owner_id)?;
+
         if config::dump_fhir() {
             dbg::dump_item_info(genv.tcx, owner_id, "fhir", &ty_alias).unwrap();
         }
-        genv.map().insert_generics(def_id, generics);
-        genv.map_mut().insert_generic_predicates(def_id, predicates);
-        genv.map_mut().insert_type_alias(def_id, ty_alias);
+
+        let map = genv.map_mut();
+        map.insert_generics(def_id, generics);
+        map.insert_generic_predicates(def_id, predicates);
+        map.insert_type_alias(def_id, ty_alias);
     }
 
     Ok(())
@@ -134,35 +146,34 @@ pub fn desugar_fn_sig(
         let mut opaque_tys = Default::default();
         let mut cx = RustItemCtxt::new(genv, owner_id, resolver_output, Some(&mut opaque_tys));
 
-        // Desugar and insert generics
         let generics = if let Some(generics) = &fn_sig.generics {
             cx.desugar_generics(generics)?
         } else {
             cx.as_lift_cx().lift_generics()?
         };
-        genv.map().insert_generics(def_id, generics);
 
-        // Desugar of fn_sig needs to happen AFTER inserting generics. See crate level comment
         let (generic_preds, fn_sig) = cx.desugar_fn_sig(fn_sig)?;
 
         if config::dump_fhir() {
             dbg::dump_item_info(genv.tcx, def_id, "fhir", &fn_sig).unwrap();
         }
 
-        genv.map_mut()
-            .insert_generic_predicates(def_id, generic_preds);
-        genv.map_mut().insert_fn_sig(def_id, fn_sig);
-        genv.map_mut().insert_opaque_tys(opaque_tys);
+        let map = genv.map_mut();
+        map.insert_generics(def_id, generics);
+        map.insert_generic_predicates(def_id, generic_preds);
+        map.insert_fn_sig(def_id, fn_sig);
+        map.insert_opaque_tys(opaque_tys);
     } else {
         let (generics, fn_info) = lift::lift_fn(genv.tcx, genv.sess, owner_id)?;
         if config::dump_fhir() {
             dbg::dump_item_info(genv.tcx, def_id, "fhir", &fn_info.fn_sig).unwrap();
         }
-        genv.map().insert_generics(def_id, generics);
-        genv.map_mut()
-            .insert_generic_predicates(def_id, fn_info.predicates);
-        genv.map_mut().insert_fn_sig(def_id, fn_info.fn_sig);
-        genv.map_mut().insert_opaque_tys(fn_info.opaque_tys);
+
+        let map = genv.map_mut();
+        map.insert_generics(def_id, generics);
+        map.insert_generic_predicates(def_id, fn_info.predicates);
+        map.insert_fn_sig(def_id, fn_info.fn_sig);
+        map.insert_opaque_tys(fn_info.opaque_tys);
     }
     Ok(())
 }
@@ -200,8 +211,11 @@ pub fn desugar_generics_and_predicates(
         lifted_generics
     };
     let def_id = owner_id.def_id;
-    genv.map().insert_generics(def_id, generics);
-    genv.map_mut().insert_generic_predicates(def_id, predicates);
+
+    let map = genv.map_mut();
+    map.insert_generics(def_id, generics);
+    map.insert_generic_predicates(def_id, predicates);
+
     Ok(())
 }
 

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -93,8 +93,8 @@ fn check_crate(tcx: TyCtxt, sess: &FluxSession) -> Result<(), ErrorGuaranteed> {
 
         flux_fhir_analysis::provide(genv.providers());
 
+        stage1_desugar(&mut genv, &specs)?;
         let resolver_output = resolve_crate(tcx, sess, &specs)?;
-        stage1_desugar(&mut genv, &specs, &resolver_output)?;
         stage2_desugar(&mut genv, &mut specs, &resolver_output)?;
 
         flux_fhir_analysis::check_crate_wf(&genv)?;
@@ -123,11 +123,7 @@ fn check_crate(tcx: TyCtxt, sess: &FluxSession) -> Result<(), ErrorGuaranteed> {
     })
 }
 
-fn stage1_desugar(
-    genv: &mut GlobalEnv,
-    specs: &Specs,
-    resolver_output: &ResolverOutput,
-) -> Result<(), ErrorGuaranteed> {
+fn stage1_desugar(genv: &mut GlobalEnv, specs: &Specs) -> Result<(), ErrorGuaranteed> {
     let mut err: Option<ErrorGuaranteed> = None;
     let tcx = genv.tcx;
     let sess = genv.sess;
@@ -175,14 +171,14 @@ fn stage1_desugar(
             } else {
                 lift::lift_refined_by(tcx, owner_id)
             };
-            let generics = desugar::desugar_generics_for_adt(
-                genv,
-                owner_id,
-                resolver_output,
-                specs.generics_of_adt(owner_id),
-            )?
-            .with_refined_by(&refined_by);
-            genv.map_mut().insert_generics(owner_id.def_id, generics);
+            // let generics = desugar::desugar_generics_for_adt(
+            //     genv,
+            //     owner_id,
+            //     resolver_output,
+            //     specs.generics_of_adt(owner_id),
+            // )?
+            // .with_refined_by(&refined_by);
+            // genv.map_mut().insert_generics(owner_id.def_id, generics);
             genv.map_mut()
                 .insert_refined_by(owner_id.def_id, refined_by);
             Ok(())

--- a/crates/flux-driver/src/collector.rs
+++ b/crates/flux-driver/src/collector.rs
@@ -614,16 +614,6 @@ impl Specs {
             .map(|(owner_id, alias)| (*owner_id, alias.as_ref().map(|alias| &alias.refined_by)));
         itertools::chain!(structs, enums, aliases)
     }
-
-    pub fn generics_of_adt(&self, owner_id: OwnerId) -> Option<&surface::Generics> {
-        if let Some(struct_def) = self.structs.get(&owner_id) {
-            return struct_def.generics.as_ref();
-        }
-        if let Some(enum_def) = self.enums.get(&owner_id) {
-            return enum_def.generics.as_ref();
-        }
-        None
-    }
 }
 
 #[derive(Debug)]

--- a/crates/flux-driver/src/collector.rs
+++ b/crates/flux-driver/src/collector.rs
@@ -292,6 +292,9 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
     ) -> Result<(), ErrorGuaranteed> {
         let mut attrs = self.parse_flux_attrs(attrs)?;
         self.report_dups(&attrs)?;
+
+        let generics = attrs.generics();
+
         let refined_by = attrs.refined_by();
 
         let enum_variants = if attrs.extern_spec() {
@@ -321,6 +324,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
         self.specs.enums.insert(
             owner_id,
             surface::EnumDef {
+                generics,
                 refined_by,
                 variants,
                 invariants,
@@ -609,6 +613,16 @@ impl Specs {
             .iter()
             .map(|(owner_id, alias)| (*owner_id, alias.as_ref().map(|alias| &alias.refined_by)));
         itertools::chain!(structs, enums, aliases)
+    }
+
+    pub fn generics_of_adt(&self, owner_id: OwnerId) -> Option<&surface::Generics> {
+        if let Some(struct_def) = self.structs.get(&owner_id) {
+            return struct_def.generics.as_ref();
+        }
+        if let Some(enum_def) = self.enums.get(&owner_id) {
+            return enum_def.generics.as_ref();
+        }
+        None
     }
 }
 

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -97,6 +97,10 @@ fhir_analysis_cannot_infer_sort =
     .label = cannot infer sort
     .note = sort must be known at this point
 
+
+fhir_analysis_refined_unrefinable_type =
+    type cannot be refined
+
 # Annot check
 
 fhir_analysis_invalid_refinement =

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -955,7 +955,7 @@ impl ConvCtxt<'_, '_> {
         let espan = Some(ESpan::new(expr.span));
         let expr = match &expr.kind {
             fhir::ExprKind::Const(did, _) => rty::Expr::const_def_id(*did, espan),
-            fhir::ExprKind::Var(var) => env.lookup(*var).to_expr(),
+            fhir::ExprKind::Var(var, _) => env.lookup(*var).to_expr(),
             fhir::ExprKind::Literal(lit) => rty::Expr::constant_at(conv_lit(*lit), espan),
             fhir::ExprKind::BinaryOp(op, box [e1, e2]) => {
                 rty::Expr::binary_op(*op, self.conv_expr(env, e1), self.conv_expr(env, e2), espan)

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -1207,7 +1207,10 @@ fn conv_sort(genv: &GlobalEnv, sort: &fhir::Sort) -> rty::Sort {
         fhir::Sort::Param(def_id) => {
             rty::Sort::Param(def_id_to_param_ty(genv.tcx, def_id.expect_local()))
         }
-        fhir::Sort::SelfParam(_def_id) => rty::Sort::Param(self_param_ty()),
+        fhir::Sort::SelfParam { trait_id: _def_id } => rty::Sort::Param(self_param_ty()),
+        fhir::Sort::SelfAlias { alias_to } => {
+            conv_sort(genv, &genv.sort_of_self_ty_alias(*alias_to).unwrap())
+        }
         fhir::Sort::Var(n) => rty::Sort::Var(rty::SortVar::from(*n)),
         fhir::Sort::Error | fhir::Sort::Wildcard | fhir::Sort::Infer(_) => {
             bug!("unexpected sort `{sort:?}`")

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -751,7 +751,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
                 let body = rty::Binder::new(pred, vars);
                 self.add_coercions(rty::Expr::abs(body), arg.fhir_id)
             }
-            fhir::RefineArgKind::Record(_, _, flds) => {
+            fhir::RefineArgKind::Record(flds) => {
                 let exprs: List<_> = flds
                     .iter()
                     .map(|arg| self.conv_refine_arg(env, arg))

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -118,15 +118,16 @@ pub(crate) fn conv_generic_predicates(
 
 pub(crate) fn conv_opaque_ty(
     genv: &GlobalEnv,
-    def_id: DefId,
+    def_id: LocalDefId,
     opaque_ty: &fhir::OpaqueTy,
     wfckresults: &fhir::WfckResults,
 ) -> QueryResult<List<rty::Clause>> {
     let cx = ConvCtxt::new(genv, wfckresults);
-    let parent = genv.tcx.parent(def_id).expect_local();
+    let parent = genv.tcx.local_parent(def_id);
     let refparams = genv.map().get_refine_params(genv.tcx, parent);
+    let parent_wfckresults = genv.check_wf(parent)?;
 
-    let env = &mut Env::new(refparams.unwrap_or(&[]), Some(wfckresults));
+    let env = &mut Env::new(refparams.unwrap_or(&[]), Some(&parent_wfckresults));
 
     let args = rty::GenericArgs::identity_for_item(genv, def_id)?;
     let self_ty = rty::Ty::opaque(def_id, args, env.to_early_bound_vars());

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -1181,7 +1181,7 @@ fn resolve_param_sort<'a>(
         wfckresults
             .node_sorts()
             .get(param.fhir_id)
-            .unwrap_or_else(|| bug!("{param:?}"))
+            .unwrap_or_else(|| bug!("unresolved sort for param: `{param:?}`"))
     } else {
         &param.sort
     }

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -1189,7 +1189,10 @@ fn resolve_param_sort<'a>(
     if fhir::Sort::Wildcard == param.sort
         && let Some(wfckresults) = wfckresults
     {
-        wfckresults.node_sorts().get(param.fhir_id).unwrap()
+        wfckresults
+            .node_sorts()
+            .get(param.fhir_id)
+            .unwrap_or_else(|| bug!("{param:?}"))
     } else {
         &param.sort
     }

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -185,7 +185,7 @@ fn refinement_generics_of(
         DefKind::Fn | DefKind::AssocFn => {
             let fn_sig = genv.map().get_fn_sig(local_id);
             let wfckresults = genv.check_wf(local_id)?;
-            let params = conv::conv_refinement_generics(genv, &fn_sig.params, Some(&wfckresults));
+            let params = conv::conv_refinement_generics(genv, &fn_sig.params, &wfckresults);
             Ok(rty::RefinementGenerics { parent, parent_count, params })
         }
         _ => Ok(rty::RefinementGenerics { parent, parent_count, params: List::empty() }),

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -138,7 +138,7 @@ fn item_bounds(
 ) -> QueryResult<rty::EarlyBinder<List<rty::Clause>>> {
     let wfckresults = genv.check_wf(local_id)?;
     let opaque_ty = genv.map().get_opaque_ty(local_id).unwrap();
-    Ok(rty::EarlyBinder(conv::conv_opaque_ty(genv, local_id.to_def_id(), opaque_ty, &wfckresults)?))
+    Ok(rty::EarlyBinder(conv::conv_opaque_ty(genv, local_id, opaque_ty, &wfckresults)?))
 }
 
 fn generics_of(genv: &GlobalEnv, local_id: LocalDefId) -> QueryResult<rty::Generics> {

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -141,6 +141,11 @@ fn item_bounds(
 }
 
 fn generics_of(genv: &GlobalEnv, local_id: LocalDefId) -> QueryResult<rty::Generics> {
+    static A: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+    println!("{local_id:?}");
+    if A.fetch_add(1, std::sync::atomic::Ordering::Relaxed) >= 2 {
+        panic!();
+    }
     let def_id = local_id.to_def_id();
     let rustc_generics = genv.lower_generics_of(local_id)?;
 
@@ -252,7 +257,8 @@ fn fn_sig(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<
         .map(|fn_sig| fn_sig.normalize(defns));
 
     if config::dump_rty() {
-        dbg::dump_item_info(genv.tcx, def_id, "rty", &fn_sig).unwrap();
+        let generics = genv.generics_of(def_id)?;
+        dbg::dump_item_info(genv.tcx, def_id, "rty", (generics, &fn_sig)).unwrap();
     }
     Ok(fn_sig)
 }

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -142,11 +142,6 @@ fn item_bounds(
 }
 
 fn generics_of(genv: &GlobalEnv, local_id: LocalDefId) -> QueryResult<rty::Generics> {
-    static A: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-    println!("{local_id:?}");
-    if A.fetch_add(1, std::sync::atomic::Ordering::Relaxed) >= 2 {
-        panic!();
-    }
     let def_id = local_id.to_def_id();
     let rustc_generics = genv.lower_generics_of(local_id)?;
 

--- a/crates/flux-fhir-analysis/src/wf/errors.rs
+++ b/crates/flux-fhir-analysis/src/wf/errors.rs
@@ -268,3 +268,16 @@ impl CannotInferSort {
         Self { span: ident.span() }
     }
 }
+
+#[derive(Diagnostic)]
+#[diag(fhir_analysis_refined_unrefinable_type, code = "FLUX")]
+pub(super) struct RefinedUnrefinableType {
+    #[primary_span]
+    span: Span,
+}
+
+impl RefinedUnrefinableType {
+    pub(super) fn new(span: Span) -> Self {
+        Self { span }
+    }
+}

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -536,7 +536,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                 Ok(())
             }
             fhir::RefineArgKind::Abs(_, body) => self.check_param_uses_expr(infcx, body, true),
-            fhir::RefineArgKind::Record(_, _, flds) => {
+            fhir::RefineArgKind::Record(flds) => {
                 flds.iter()
                     .try_for_each_exhaust(|arg| self.check_param_uses_refine_arg(infcx, arg))
             }

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -181,6 +181,7 @@ pub(crate) fn check_fn_sig(
     requires?;
     constrs?;
 
+    infcx.resolve_params_sorts(&fn_sig.params)?;
     wf.check_params_are_determined(&infcx, &fn_sig.params)?;
 
     Ok(infcx.into_results())

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -256,8 +256,13 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
             .try_for_each_exhaust(|field| self.check_type(infcx, &field.ty));
         let expected = self.sort_of_bty(&variant.ret.bty);
         let indices = self.check_refine_arg(infcx, &variant.ret.idx, &expected);
+
         fields?;
         indices?;
+
+        infcx.resolve_params_sorts(&variant.params)?;
+        self.check_params_are_determined(infcx, &variant.params)?;
+
         Ok(())
     }
 

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -503,7 +503,9 @@ impl<'a> InferCtxt<'a, '_> {
     }
 
     fn is_numeric(&mut self, sort: &fhir::Sort) -> bool {
-        self.resolve_sort(sort).map_or(false, |s| s.is_numeric())
+        let b = self.resolve_sort(sort).map_or(false, |s| s.is_numeric());
+        println!("{sort:?} {b:?}");
+        b
     }
 
     fn is_bool(&mut self, sort: &fhir::Sort) -> bool {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -406,6 +406,18 @@ pub struct RefineArg {
     pub span: Span,
 }
 
+impl RefineArg {
+    pub fn is_colon_param(&self) -> Option<Ident> {
+        if let RefineArgKind::Expr(expr) = &self.kind
+            && let ExprKind::Var(var, Some(ParamKind::Colon)) = &expr.kind
+        {
+            Some(*var)
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Clone)]
 pub enum RefineArgKind {
     Expr(Expr),

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -609,7 +609,7 @@ pub struct Expr {
 #[derive(Clone)]
 pub enum ExprKind {
     Const(DefId, Span),
-    Var(Ident, /* is_binder */ bool),
+    Var(Ident, Option<ParamKind>),
     Dot(Ident, SurfaceIdent),
     Literal(Lit),
     BinaryOp(BinOp, Box<[Expr; 2]>),

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -609,7 +609,7 @@ pub struct Expr {
 #[derive(Clone)]
 pub enum ExprKind {
     Const(DefId, Span),
-    Var(Ident),
+    Var(Ident, /* is_binder */ bool),
     Dot(Ident, SurfaceIdent),
     Literal(Lit),
     BinaryOp(BinOp, Box<[Expr; 2]>),

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -970,9 +970,9 @@ impl Sort {
     fn subst(&self, subst: &[Sort]) -> Sort {
         match self {
             Sort::Var(i) => subst[*i].clone(),
-            Sort::App(c, args) => {
+            Sort::App(ctor, args) => {
                 let args = args.iter().map(|arg| arg.subst(subst)).collect();
-                Sort::App(c.clone(), args)
+                Sort::App(*ctor, args)
             }
             Sort::Func(fsort) => {
                 if fsort.params == 0 {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -138,14 +138,12 @@ pub struct OpaqueTy {
     pub bounds: GenericBounds,
 }
 
-type Cache<K, V> = elsa::FrozenMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
-
 /// A map between rust definitions and flux annotations in their desugared `fhir` form.
 ///
 /// note: `Map` is a very generic name, so we typically use the type qualified as `fhir::Map`.
 #[derive(Default)]
 pub struct Map {
-    generics: Cache<LocalDefId, Box<Generics>>,
+    generics: UnordMap<LocalDefId, Generics>,
     predicates: ItemPredicates,
     opaque_tys: UnordMap<LocalDefId, OpaqueTy>,
     func_decls: FxHashMap<Symbol, FuncDecl>,
@@ -1064,8 +1062,8 @@ impl Map {
         me
     }
 
-    pub fn insert_generics(&self, def_id: LocalDefId, generics: Generics) {
-        self.generics.insert(def_id, Box::new(generics));
+    pub fn insert_generics(&mut self, def_id: LocalDefId, generics: Generics) {
+        self.generics.insert(def_id, generics);
     }
 
     pub fn insert_generic_predicates(&mut self, def_id: LocalDefId, predicates: GenericPredicates) {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -842,9 +842,9 @@ impl Generics {
         self.params.iter().find(|p| p.def_id == def_id).unwrap()
     }
 
-    pub fn with_refined_by(self, refined_by: &RefinedBy) -> Self {
+    pub fn with_refined_by(&self, refined_by: &RefinedBy) -> Self {
         let mut params = vec![];
-        for param in self.params {
+        for param in &self.params {
             let kind = if refined_by.is_base_generic(param.def_id.to_def_id()) {
                 GenericParamKind::SplTy
             } else {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -410,7 +410,7 @@ pub struct RefineArg {
 pub enum RefineArgKind {
     Expr(Expr),
     Abs(Vec<RefineParam>, Expr),
-    Record(DefId, List<Sort>, Vec<RefineArg>),
+    Record(Vec<RefineArg>),
 }
 
 /// These are types of things that may be refined with indices or existentials
@@ -1612,13 +1612,8 @@ impl fmt::Debug for RefineArg {
                     })
                 )
             }
-            RefineArgKind::Record(def_id, _, flds) => {
-                write!(
-                    f,
-                    "{} {{ {:?} }}",
-                    pretty::def_id_to_string(*def_id),
-                    flds.iter().format(", ")
-                )
+            RefineArgKind::Record(flds) => {
+                write!(f, "{{ {:?} }}", flds.iter().format(", "))
             }
         }
     }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -1573,7 +1573,7 @@ impl fmt::Debug for Path {
             .chain(self.bindings.iter().map(|b| b as &dyn std::fmt::Debug))
             .collect();
         if !args.is_empty() {
-            write!(f, "{:?}", args)?;
+            write!(f, "<{:?}>", args.iter().format(", "))?;
         }
         if !self.refine.is_empty() {
             write!(f, "({:?})", self.refine.iter().format(", "))?;

--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -12,7 +12,7 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_middle::{middle::resolve_bound_vars::ResolvedArg, ty::TyCtxt};
 
 use super::{FhirId, FluxOwnerId};
-use crate::{fhir, intern::List};
+use crate::fhir;
 
 pub struct LiftCtxt<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
@@ -416,11 +416,7 @@ impl<'a, 'tcx> LiftCtxt<'a, 'tcx> {
             span,
         };
         let bty = fhir::BaseTy::from(fhir::QPath::Resolved(None, path));
-        let kind = fhir::RefineArgKind::Record(
-            self.owner.to_def_id(),
-            List::empty(), // TODO:RJ: or should we use the generics and just make it T1,...Tn?
-            vec![],
-        );
+        let kind = fhir::RefineArgKind::Record(vec![]);
         fhir::VariantRet {
             bty,
             idx: fhir::RefineArg {

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -276,9 +276,8 @@ pub fn walk_refine_arg<V: Visitor>(vis: &mut V, arg: &RefineArg) {
             walk_list!(vis, visit_refine_param, params);
             vis.visit_expr(body);
         }
-        RefineArgKind::Record(_def_id, vars, args) => {
-            walk_list!(vis, visit_sort, vars);
-            walk_list!(vis, visit_refine_arg, args);
+        RefineArgKind::Record(flds) => {
+            walk_list!(vis, visit_refine_arg, flds);
         }
     }
 }

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -248,7 +248,8 @@ pub fn walk_sort<V: Visitor>(vis: &mut V, sort: &Sort) {
         Sort::BitVec(_)
         | Sort::Int
         | Sort::Param(_)
-        | Sort::SelfParam(_)
+        | Sort::SelfParam { .. }
+        | Sort::SelfAlias { .. }
         | Sort::Var(_)
         | Sort::Bool
         | Sort::Real

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -285,7 +285,7 @@ pub fn walk_refine_arg<V: Visitor>(vis: &mut V, arg: &RefineArg) {
 pub fn walk_expr<V: Visitor>(vis: &mut V, expr: &Expr) {
     match &expr.kind {
         ExprKind::Const(_def_id, _span) => {}
-        ExprKind::Var(var) => vis.visit_ident(*var),
+        ExprKind::Var(var, _) => vis.visit_ident(*var),
         ExprKind::Dot(base, _fld) => {
             vis.visit_ident(*base);
         }

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -268,7 +268,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         let kind = generics.self_kind.as_ref()?;
         match kind {
             fhir::GenericParamKind::BaseTy | fhir::GenericParamKind::SplTy => {
-                Some(fhir::Sort::SelfParam(owner))
+                Some(fhir::Sort::SelfParam { trait_id: owner })
             }
             fhir::GenericParamKind::Type { .. } | fhir::GenericParamKind::Lifetime => None,
         }
@@ -349,8 +349,12 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             | fhir::Sort::Unit
             | fhir::Sort::BitVec(_)
             | fhir::Sort::Param(_)
-            | fhir::Sort::SelfParam(_)
+            | fhir::Sort::SelfParam { trait_id: _ }
             | fhir::Sort::Var(_) => true,
+            fhir::Sort::SelfAlias { alias_to } => {
+                self.sort_of_self_ty_alias(*alias_to)
+                    .map_or(false, |sort| self.has_equality(&sort))
+            }
             fhir::Sort::Record(def_id, sort_args) => {
                 self.index_sorts_of(*def_id, sort_args)
                     .iter()

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -12,7 +12,6 @@
 
 //! This crate contains common type definitions that are used by other crates.
 
-extern crate elsa;
 extern crate rustc_ast;
 extern crate rustc_borrowck;
 extern crate rustc_data_structures;

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -422,7 +422,7 @@ impl Expr {
     /// An expression is an *atom* if it is "self-delimiting", i.e., it has a clear boundary
     /// when printed. This is used to avoid unnecesary parenthesis when pretty printing.
     pub fn is_atom(&self) -> bool {
-        !self.is_binary_op()
+        !matches!(self.kind, ExprKind::Abs(..) | ExprKind::BinaryOp(..))
     }
 
     /// Simple syntactic check to see if the expression is a trivially true predicate. This is used
@@ -751,17 +751,17 @@ mod pretty {
                     Ok(())
                 }
                 ExprKind::UnaryOp(op, e) => {
-                    if e.is_binary_op() {
-                        w!("{:?}({:?})", op, e)
-                    } else {
+                    if e.is_atom() {
                         w!("{:?}{:?}", op, e)
+                    } else {
+                        w!("{:?}({:?})", op, e)
                     }
                 }
                 ExprKind::TupleProj(e, field) => {
-                    if e.is_binary_op() {
-                        w!("({:?}).{:?}", e, ^field)
-                    } else {
+                    if e.is_atom() {
                         w!("{:?}.{:?}", e, ^field)
+                    } else {
+                        w!("({:?}).{:?}", e, ^field)
                     }
                 }
                 ExprKind::Tuple(exprs) => {
@@ -772,10 +772,10 @@ mod pretty {
                     }
                 }
                 ExprKind::PathProj(e, field) => {
-                    if e.is_binary_op() {
-                        w!("({:?}).{:?}", e, field)
-                    } else {
+                    if e.is_atom() {
                         w!("{:?}.{:?}", e, field)
+                    } else {
+                        w!("({:?}).{:?}", e, field)
                     }
                 }
                 ExprKind::App(func, args) => {

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -104,6 +104,7 @@ impl StructDef {
 
 #[derive(Debug)]
 pub struct EnumDef {
+    pub generics: Option<Generics>,
     pub refined_by: Option<RefinedBy>,
     pub variants: Vec<Option<VariantDef>>,
     pub invariants: Vec<Expr>,

--- a/crates/flux-tests/tests/neg/error_messages/desugar/index_errors00.rs
+++ b/crates/flux-tests/tests/neg/error_messages/desugar/index_errors00.rs
@@ -6,11 +6,6 @@ pub struct Pair {
     pub y: i32,
 }
 
-#[flux::sig(fn(Pair[@p,@q,@r]) -> i32[p])] //~ ERROR this type takes 1 or 2 refinement arguments but 3 were found
-pub fn mytuple1(p: Pair) -> i32 {
-    p.x
-}
-
 #[flux::sig(fn(Pair[@p1]) -> i32[p.x])] //~ ERROR cannot find value
 pub fn mytuple3(p: Pair) -> i32 {
     p.x
@@ -33,9 +28,4 @@ fn stout(x: i32, y: i32) {}
 pub struct Chair {
     #[flux::field(i32{v: 0 < v})]
     pub x: i32,
-}
-
-#[flux::sig(fn () -> Chair[0])] //~ ERROR this type takes 0 refinement arguments but 1 was found
-pub fn mk_chair() -> Chair {
-    Chair { x: 0 }
 }

--- a/crates/flux-tests/tests/neg/error_messages/wf/index_errors.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/index_errors.rs
@@ -12,7 +12,7 @@ pub struct Pair {
     pub y: i32,
 }
 
-#[flux::sig(fn(Pair[@p,@q,@r]) -> i32[p])] //~ ERROR this type takes 1 or 2 refinement arguments but 3 were found
+#[flux::sig(fn(Pair[@p,@q,@r]) -> i32[p])] //~ ERROR this type takes 2 refinement arguments but 3 were found
 pub fn mytuple1(p: Pair) -> i32 {
     p.x
 }
@@ -37,7 +37,8 @@ fn ipa(f: f32) -> i32 {
     0
 }
 
-#[flux::sig(fn () -> Chair[0])] //~ ERROR this type takes 0 refinement arguments but 1 was found
+// We should improve this error message. Mismatched sorts is a bit confusing here
+#[flux::sig(fn () -> Chair[0])] //~ ERROR mismatched sorts
 pub fn mk_chair() -> Chair {
     Chair { x: 0 }
 }

--- a/crates/flux-tests/tests/neg/error_messages/wf/index_errors.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/index_errors.rs
@@ -12,6 +12,11 @@ pub struct Pair {
     pub y: i32,
 }
 
+#[flux::sig(fn(Pair[@p,@q,@r]) -> i32[p])] //~ ERROR this type takes 1 or 2 refinement arguments but 3 were found
+pub fn mytuple1(p: Pair) -> i32 {
+    p.x
+}
+
 #[flux::sig(fn(Pair[@p]) -> i32[p])] //~ ERROR mismatched sorts
 pub fn mytuple2(p: Pair) -> i32 {
     p.x
@@ -30,6 +35,11 @@ fn ris(f: f32) -> i32 {
 #[flux::sig(fn(f: f32) -> i32[f])] //~ ERROR mismatched sorts
 fn ipa(f: f32) -> i32 {
     0
+}
+
+#[flux::sig(fn () -> Chair[0])] //~ ERROR this type takes 0 refinement arguments but 1 was found
+pub fn mk_chair() -> Chair {
+    Chair { x: 0 }
 }
 
 #[flux::sig(fn(c: Chair) -> i32[c.a])] //~ ERROR no field `a` on sort `Chair`

--- a/crates/flux-tests/tests/neg/error_messages/wf/kinds01.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/kinds01.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 
 use rset::RSet;
 
-#[flux::sig(fn(soup:RSet<Tinker>))] //~ values of this type cannot be used as base sorted instances
+#[flux::sig(fn(soup:RSet<Tinker>))] //~ ERROR values of this type cannot be used as base sorted instances
 pub fn test04<Tinker: Eq + Hash>(_s: RSet<Tinker>) {}
 
 #[flux::sig(fn(RSet<T>[@salt]))] //~ ERROR type cannot be refined

--- a/crates/flux-tests/tests/neg/error_messages/wf/kinds01.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/kinds01.rs
@@ -5,8 +5,7 @@ use std::hash::Hash;
 
 use rset::RSet;
 
-// this is OK because we just dont generate an index for `soup`
-#[flux::sig(fn(soup:RSet<Tinker>))]
+#[flux::sig(fn(soup:RSet<Tinker>))] //~ values of this type cannot be used as base sorted instances
 pub fn test04<Tinker: Eq + Hash>(_s: RSet<Tinker>) {}
 
 #[flux::sig(fn(RSet<T>[@salt]))] //~ ERROR type cannot be refined

--- a/lib/flux-attrs/src/extern_spec.rs
+++ b/lib/flux-attrs/src/extern_spec.rs
@@ -61,6 +61,16 @@ impl ExternItemImpl {
         Ok(())
     }
 
+    fn find_generics_attr(&self) -> Option<&Attribute> {
+        self.attrs.iter().find(|attr| {
+            let segments = &attr.path().segments;
+            if segments.len() != 2 {
+                return false;
+            }
+            segments[0].ident == "flux" && segments[1].ident == "generics"
+        })
+    }
+
     fn dummy_struct(&self) -> syn::ItemStruct {
         let self_ty = &self.self_ty;
         let struct_field: syn::FieldsUnnamed = if let Some(mod_path) = &self.mod_path {
@@ -70,7 +80,7 @@ impl ExternItemImpl {
         };
 
         syn::ItemStruct {
-            attrs: vec![],
+            attrs: self.find_generics_attr().into_iter().cloned().collect(),
             vis: syn::Visibility::Inherited,
             struct_token: syn::token::Struct { span: self.impl_token.span },
             ident: self.dummy_ident.as_ref().unwrap().clone(),


### PR DESCRIPTION
Avoid inferring sorts during desugaring. Instead, defer all inference to well-formedness checking. This breaks the dependency on having all generics desugared before items can be desugared. 

This change makes desugaring purely "syntactic". All "semantic" analysis is performed in `fhir`.