### PR TITLE
Use record types in rty

### DIFF
--- a/crates/flux-common/src/dbg.rs
+++ b/crates/flux-common/src/dbg.rs
@@ -117,3 +117,11 @@ fn dump_base_name(tcx: TyCtxt, def_id: DefId, ext: impl AsRef<str>) -> String {
     let item_name = tcx.def_path(def_id).to_filename_friendly_no_crate();
     format!("{crate_name}.{item_name}.{}", ext.as_ref())
 }
+
+#[macro_export]
+macro_rules! _debug_assert_eq3 {
+    ($e1:expr, $e2:expr, $e3:expr) => {{
+        debug_assert!($e1 == $e2 && $e2 == $e3, "{:?} != {:?} != {:?}", $e1, $e2, $e3);
+    }};
+}
+pub use crate::_debug_assert_eq3 as debug_assert_eq3;

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -404,6 +404,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
             params: env.into_root().into_params(self),
             kind,
             invariants,
+            extern_id: struct_def.extern_id,
         })
     }
 

--- a/crates/flux-driver/src/collector.rs
+++ b/crates/flux-driver/src/collector.rs
@@ -237,16 +237,17 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
 
         let invariants = attrs.invariants();
 
-        if attrs.extern_spec() {
+        let extern_id = if attrs.extern_spec() {
             // extern_spec dummy structs are always opaque because they contain
             // one field: the external struct they are meant to represent.
             opaque = true;
-            let extern_def_id =
+            let extern_id =
                 self.extract_extern_def_id_from_extern_spec_struct(owner_id.def_id, data)?;
-            self.specs
-                .extern_specs
-                .insert(extern_def_id, owner_id.def_id);
-        }
+            self.specs.extern_specs.insert(extern_id, owner_id.def_id);
+            Some(extern_id)
+        } else {
+            None
+        };
 
         self.specs.structs.insert(
             owner_id,
@@ -257,6 +258,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
                 opaque,
                 invariants,
                 node_id: self.parse_sess.next_node_id(),
+                extern_id,
             },
         );
 
@@ -312,12 +314,10 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
         let invariants = attrs.invariants();
 
         let extern_id = if attrs.extern_spec() {
-            let extern_def_id =
+            let extern_id =
                 self.extract_extern_def_id_from_extern_spec_enum(owner_id.def_id, enum_def)?;
-            self.specs
-                .extern_specs
-                .insert(extern_def_id, owner_id.def_id);
-            Some(extern_def_id)
+            self.specs.extern_specs.insert(extern_id, owner_id.def_id);
+            Some(extern_id)
         } else {
             None
         };

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -1014,7 +1014,9 @@ impl ConvCtxt<'_, '_> {
                         let sorts = conv_sorts(self.genv, sorts);
                         rty::Expr::record(*def_id, List::from_vec(sorts), List::singleton(expr))
                     }
-                    fhir::Coercion::Project => rty::Expr::tuple_proj(expr, 0, span),
+                    fhir::Coercion::Project(def_id) => {
+                        rty::Expr::field_proj(expr, *def_id, 0, span)
+                    }
                 };
             }
         }
@@ -1155,7 +1157,7 @@ impl LookupResult<'_> {
             let i = genv
                 .field_index(def_id, fld.name)
                 .unwrap_or_else(|| span_bug!(fld.span, "field `{fld:?}` not found in {def_id:?}"));
-            rty::Expr::tuple_proj(self.to_expr(), i as u32, None)
+            rty::Expr::field_proj(self.to_expr(), def_id, i as u32, None)
         } else {
             span_bug!(fld.span, "expected record sort")
         }

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -698,6 +698,9 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
         if sort.is_unit() {
             let idx = rty::Expr::unit();
             self.conv_indexed_type(env, bty, idx)
+        } else if let Some(def_id) = sort.is_unit_adt() {
+            let idx = rty::Expr::unit_record(def_id);
+            self.conv_indexed_type(env, bty, idx)
         } else {
             env.push_layer(Layer::empty());
             let idx = rty::Expr::nu();

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -1000,12 +1000,10 @@ impl ConvCtxt<'_, '_> {
     }
 
     fn conv_invariant(&self, env: &Env, invariant: &fhir::Expr) -> rty::Invariant {
-        rty::Invariant {
-            pred: rty::Binder::new(
-                self.conv_expr(env, invariant),
-                env.top_layer().to_bound_vars(self.genv),
-            ),
-        }
+        rty::Invariant::new(rty::Binder::new(
+            self.conv_expr(env, invariant),
+            env.top_layer().to_bound_vars(self.genv),
+        ))
     }
 
     fn add_coercions(&self, mut expr: rty::Expr, fhir_id: FhirId) -> rty::Expr {

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -85,13 +85,17 @@ enum LookupResultKind<'a> {
 }
 
 pub(crate) fn conv_adt_sort_def(genv: &GlobalEnv, refined_by: &fhir::RefinedBy) -> rty::AdtSortDef {
-    let sorts = conv_sorts(genv, &refined_by.sorts);
+    let sorts = conv_sorts(genv, refined_by.index_sorts_raw());
     let params = refined_by
         .sort_params
         .iter()
         .map(|def_id| def_id_to_param_index(genv.tcx, def_id.expect_local()))
         .collect();
-    rty::AdtSortDef::new(refined_by.def_id, params, List::from_vec(sorts))
+    let def_id = genv
+        .map()
+        .extern_id_of(genv.tcx, refined_by.def_id)
+        .unwrap_or(refined_by.def_id.to_def_id());
+    rty::AdtSortDef::new(def_id, params, List::from_vec(sorts))
 }
 
 pub(crate) fn expand_type_alias(

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -222,7 +222,11 @@ pub(crate) fn adt_def_for_struct(
     struct_def: &fhir::StructDef,
 ) -> rty::AdtDef {
     let def_id = struct_def.owner_id.def_id;
-    let adt_def = lowering::lower_adt_def(&genv.tcx.adt_def(struct_def.owner_id));
+    let adt_def = if let Some(extern_id) = struct_def.extern_id {
+        lowering::lower_adt_def(&genv.tcx.adt_def(extern_id))
+    } else {
+        lowering::lower_adt_def(&genv.tcx.adt_def(struct_def.owner_id))
+    };
     rty::AdtDef::new(adt_def, genv.adt_sort_def_of(def_id), invariants, struct_def.is_opaque())
 }
 

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -196,14 +196,11 @@ fn conv_generic_param_kind(kind: &fhir::GenericParamKind) -> rty::GenericParamDe
     }
 }
 
-fn sort_args_for_adt(genv: &GlobalEnv, def_id: impl Into<DefId>) -> List<fhir::Sort> {
-    let mut sort_args = vec![];
-    for param in &genv.tcx.generics_of(def_id.into()).params {
-        if let rustc_middle::ty::GenericParamDefKind::Type { .. } = param.kind {
-            sort_args.push(fhir::Sort::Param(param.def_id));
-        }
-    }
-    List::from_vec(sort_args)
+fn identity_sort_args_for_adt(genv: &GlobalEnv, def_id: LocalDefId) -> List<rty::Sort> {
+    let refined_by = genv.map().refined_by(def_id);
+    (0..refined_by.param_count())
+        .map(|i| rty::Sort::Var(rty::SortVar::from(i)))
+        .collect()
 }
 
 pub(crate) fn adt_def_for_struct(
@@ -211,9 +208,9 @@ pub(crate) fn adt_def_for_struct(
     invariants: Vec<rty::Invariant>,
     struct_def: &fhir::StructDef,
 ) -> rty::AdtDef {
-    let def_id = struct_def.owner_id;
-    let sort_args = sort_args_for_adt(genv, def_id);
-    let sort = rty::Sort::tuple(conv_sorts(genv, &genv.index_sorts_of(def_id, &sort_args)));
+    let def_id = struct_def.owner_id.to_def_id();
+    let sort_args = identity_sort_args_for_adt(genv, struct_def.owner_id.def_id);
+    let sort = rty::Sort::Record(def_id, sort_args);
     let adt_def = lowering::lower_adt_def(&genv.tcx.adt_def(struct_def.owner_id));
     rty::AdtDef::new(adt_def, sort, invariants, struct_def.is_opaque())
 }
@@ -223,9 +220,9 @@ pub(crate) fn adt_def_for_enum(
     invariants: Vec<rty::Invariant>,
     enum_def: &fhir::EnumDef,
 ) -> rty::AdtDef {
-    let def_id = enum_def.owner_id;
-    let sort_args = sort_args_for_adt(genv, def_id);
-    let sort = rty::Sort::tuple(conv_sorts(genv, &genv.index_sorts_of(def_id, &sort_args)));
+    let def_id = enum_def.owner_id.to_def_id();
+    let sort_args = identity_sort_args_for_adt(genv, enum_def.owner_id.def_id);
+    let sort = rty::Sort::Record(def_id, sort_args);
     let adt_def = if let Some(extern_id) = enum_def.extern_id {
         lowering::lower_adt_def(&genv.tcx.adt_def(extern_id))
     } else {
@@ -1195,7 +1192,7 @@ fn conv_sort(genv: &GlobalEnv, sort: &fhir::Sort) -> rty::Sort {
         fhir::Sort::Unit => rty::Sort::unit(),
         fhir::Sort::Func(fsort) => rty::Sort::Func(conv_func_sort(genv, fsort)),
         fhir::Sort::Record(def_id, sort_args) => {
-            rty::Sort::tuple(conv_sorts(genv, &genv.index_sorts_of(*def_id, sort_args)))
+            rty::Sort::Record(*def_id, List::from_vec(conv_sorts(genv, sort_args)))
         }
         fhir::Sort::App(ctor, args) => {
             let ctor = conv_sort_ctor(ctor);

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -703,7 +703,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
             let idx = rty::Expr::unit();
             self.conv_indexed_type(env, bty, idx)
         } else if let Some(def_id) = sort.is_unit_adt() {
-            let idx = rty::Expr::unit_record(def_id);
+            let idx = rty::Expr::unit_adt(def_id);
             self.conv_indexed_type(env, bty, idx)
         } else {
             env.push_layer(Layer::empty());

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -104,7 +104,7 @@ fn invariants_of(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<Vec<rty::I
         kind => bug!("expected struct or enum found `{kind:?}`"),
     };
     let wfckresults = genv.check_wf(def_id)?;
-    conv::conv_invariants(genv, params, invariants, &wfckresults)
+    conv::conv_invariants(genv, def_id, params, invariants, &wfckresults)
         .into_iter()
         .map(|invariant| normalize(genv, invariant))
         .collect()

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -260,7 +260,9 @@ fn fn_sig(genv: &GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<
 
     if config::dump_rty() {
         let generics = genv.generics_of(def_id)?;
-        dbg::dump_item_info(genv.tcx, def_id, "rty", (generics, &fn_sig)).unwrap();
+        let refinement_generics = genv.refinement_generics_of(def_id)?;
+        dbg::dump_item_info(genv.tcx, def_id, "rty", (generics, refinement_generics, &fn_sig))
+            .unwrap();
     }
     Ok(fn_sig)
 }

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -38,6 +38,7 @@ pub fn provide(providers: &mut Providers) {
         defns,
         qualifiers,
         func_decls,
+        adt_sort_def_of,
         check_wf,
         adt_def,
         type_of,
@@ -48,6 +49,10 @@ pub fn provide(providers: &mut Providers) {
         predicates_of,
         item_bounds,
     };
+}
+
+fn adt_sort_def_of(genv: &GlobalEnv, def_id: LocalDefId) -> rty::AdtSortDef {
+    conv::conv_adt_sort_def(genv, genv.map().refined_by(def_id))
 }
 
 fn func_decls(genv: &GlobalEnv) -> FxHashMap<Symbol, rty::FuncDecl> {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -6,11 +6,12 @@ use flux_errors::ErrorGuaranteed;
 use flux_middle::{
     fhir::{self, FhirId, FluxOwnerId, WfckResults},
     global_env::GlobalEnv,
+    intern::List,
 };
 use itertools::izip;
 use rustc_data_structures::unord::UnordMap;
 use rustc_errors::IntoDiagnostic;
-use rustc_span::Span;
+use rustc_span::{def_id::DefId, Span};
 
 use super::errors;
 
@@ -41,28 +42,25 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     ) -> Result<(), ErrorGuaranteed> {
         match &arg.kind {
             fhir::RefineArgKind::Expr(expr) => self.check_expr(expr, expected),
-            fhir::RefineArgKind::Abs(params, body) => {
-                self.check_abs(params, body, arg.span, arg.fhir_id, expected)
-            }
-            fhir::RefineArgKind::Record(flds) => self.check_record(flds, arg.span, expected),
+            fhir::RefineArgKind::Abs(params, body) => self.check_abs(arg, params, body, expected),
+            fhir::RefineArgKind::Record(flds) => self.check_record(arg, flds, expected),
         }
     }
 
     fn check_abs(
         &mut self,
+        arg: &fhir::RefineArg,
         params: &Vec<fhir::RefineParam>,
         body: &fhir::Expr,
-        span: Span,
-        fhir_id: FhirId,
         expected: &fhir::Sort,
     ) -> Result<(), ErrorGuaranteed> {
-        if let Some(fsort) = self.is_coercible_to_func(expected, fhir_id, fhir::Coercion::Inject) {
+        if let Some(fsort) = self.is_coercible_from_func(expected, arg.fhir_id) {
             let fsort = fsort.skip_binders();
             self.push_layer(params);
 
             if params.len() != fsort.inputs().len() {
                 return Err(self.emit_err(errors::ParamCountMismatch::new(
-                    span,
+                    arg.span,
                     fsort.inputs().len(),
                     params.len(),
                 )));
@@ -77,35 +75,39 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             self.check_expr(body, fsort.output())?;
             self.resolve_params_sorts(params)
         } else {
-            Err(self.emit_err(errors::UnexpectedFun::new(span, expected)))
+            Err(self.emit_err(errors::UnexpectedFun::new(arg.span, expected)))
         }
     }
 
     fn check_record(
         &mut self,
-        args: &[fhir::RefineArg],
-        span: Span,
+        arg: &fhir::RefineArg,
+        flds: &[fhir::RefineArg],
         expected: &fhir::Sort,
     ) -> Result<(), ErrorGuaranteed> {
         if let fhir::Sort::Record(def_id, sort_args) = expected {
             let sorts = self.genv.index_sorts_of(*def_id, sort_args);
-            if args.len() != sorts.len() {
+            if flds.len() != sorts.len() {
                 return Err(self.emit_err(errors::ArgCountMismatch::new(
-                    Some(span),
+                    Some(arg.span),
                     String::from("type"),
                     sorts.len(),
-                    args.len(),
+                    flds.len(),
                 )));
             }
-            izip!(args, sorts)
+            self.wfckresults
+                .record_ctors_mut()
+                .insert(arg.fhir_id, (*def_id, sort_args.clone()));
+
+            izip!(flds, sorts)
                 .map(|(arg, expected)| self.check_refine_arg(arg, &expected))
                 .try_collect_exhaust()
         } else {
             Err(self.emit_err(errors::ArgCountMismatch::new(
-                Some(span),
+                Some(arg.span),
                 String::from("type"),
                 1,
-                args.len(),
+                flds.len(),
             )))
         }
     }
@@ -163,9 +165,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 }
             }
             fhir::BinOp::Add | fhir::BinOp::Sub | fhir::BinOp::Mul | fhir::BinOp::Div => {
-                if let Some(expected) =
-                    self.is_coercible_to_numeric(expected, expr.fhir_id, fhir::Coercion::Inject)
-                {
+                if let Some(expected) = self.is_coercible_from_numeric(expected, expr.fhir_id) {
                     self.check_expr(e1, &expected)?;
                     self.check_expr(e2, &expected)?;
                     return Ok(());
@@ -253,9 +253,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             fhir::BinOp::Lt | fhir::BinOp::Le | fhir::BinOp::Gt | fhir::BinOp::Ge => {
                 let found = self.synth_expr(e1)?;
-                if let Some(found) =
-                    self.is_coercible_to_numeric(&found, e1.fhir_id, fhir::Coercion::Project)
-                {
+                if let Some(found) = self.is_coercible_to_numeric(&found, e1.fhir_id) {
                     self.check_expr(e2, &found)?;
                     Ok(fhir::Sort::Bool)
                 } else {
@@ -264,9 +262,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             fhir::BinOp::Add | fhir::BinOp::Sub | fhir::BinOp::Mul | fhir::BinOp::Div => {
                 let found = self.synth_expr(e1)?;
-                if let Some(found) =
-                    self.is_coercible_to_numeric(&found, e1.fhir_id, fhir::Coercion::Project)
-                {
+                if let Some(found) = self.is_coercible_to_numeric(&found, e1.fhir_id) {
                     self.check_expr(e2, &found)?;
                     Ok(found)
                 } else {
@@ -319,9 +315,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         let func_sort = match func {
             fhir::Func::Var(var, fhir_id) => {
                 let sort = self.lookup_var(*var);
-                if let Some(fsort) =
-                    self.is_coercible_to_func(&sort, *fhir_id, fhir::Coercion::Project)
-                {
+                if let Some(fsort) = self.is_coercible_to_func(&sort, *fhir_id) {
                     Ok(fsort)
                 } else {
                     Err(self.emit_err(errors::ExpectedFun::new(var.span(), &sort)))
@@ -381,33 +375,70 @@ impl<'a> InferCtxt<'a, '_> {
         let mut sort2 = sort2.clone();
 
         let mut coercions = vec![];
-        if let Some(sort) = self.is_single_field_record(&sort1) {
+        if let Some((_def_id, _sort_args, sort)) = self.is_single_field_record(&sort1) {
             coercions.push(fhir::Coercion::Project);
             sort1 = sort.clone();
         }
-        if let Some(sort) = self.is_single_field_record(&sort2) {
-            coercions.push(fhir::Coercion::Inject);
+        if let Some((def_id, sort_args, sort)) = self.is_single_field_record(&sort2) {
+            coercions.push(fhir::Coercion::Inject(def_id, sort_args));
             sort2 = sort.clone();
         }
         self.wfckresults.coercions_mut().insert(fhir_id, coercions);
         self.try_equate(&sort1, &sort2).is_some()
     }
 
-    fn is_coercible_to_numeric(
+    fn is_coercible_from_numeric(
         &mut self,
         sort: &fhir::Sort,
         fhir_id: FhirId,
-        coercion: fhir::Coercion,
     ) -> Option<fhir::Sort> {
         if self.is_numeric(sort) {
             Some(sort.clone())
-        } else if let Some(sort) = self.is_single_field_record(sort)
+        } else if let Some((def_id, sort_args, sort)) = self.is_single_field_record(sort)
             && sort.is_numeric()
         {
             self.wfckresults
                 .coercions_mut()
-                .insert(fhir_id, vec![coercion]);
+                .insert(fhir_id, vec![fhir::Coercion::Inject(def_id, sort_args)]);
             Some(sort.clone())
+        } else {
+            None
+        }
+    }
+
+    fn is_coercible_to_numeric(
+        &mut self,
+        sort: &fhir::Sort,
+        fhir_id: FhirId,
+    ) -> Option<fhir::Sort> {
+        if self.is_numeric(sort) {
+            Some(sort.clone())
+        } else if let Some((_def_id, _sort_args, sort)) = self.is_single_field_record(sort)
+            && sort.is_numeric()
+        {
+            self.wfckresults
+                .coercions_mut()
+                .insert(fhir_id, vec![fhir::Coercion::Project]);
+            Some(sort.clone())
+        } else {
+            None
+        }
+    }
+
+    fn is_coercible_from_func(
+        &mut self,
+        sort: &fhir::Sort,
+        fhir_id: FhirId,
+    ) -> Option<fhir::PolyFuncSort> {
+        if let Some(fsort) = self.is_func(sort) {
+            Some(fsort)
+        } else if let Some((def_id, sort_args, fhir::Sort::Func(fsort))) =
+            self.is_single_field_record(sort)
+        {
+            self.wfckresults
+                .coercions_mut()
+                .insert(fhir_id, vec![fhir::Coercion::Inject(def_id, sort_args)]);
+            Some(fsort.clone())
         } else {
             None
         }
@@ -417,14 +448,15 @@ impl<'a> InferCtxt<'a, '_> {
         &mut self,
         sort: &fhir::Sort,
         fhir_id: FhirId,
-        coercion: fhir::Coercion,
     ) -> Option<fhir::PolyFuncSort> {
         if let Some(fsort) = self.is_func(sort) {
             Some(fsort)
-        } else if let Some(fhir::Sort::Func(fsort)) = self.is_single_field_record(sort) {
+        } else if let Some((_def_id, _sort_args, fhir::Sort::Func(fsort))) =
+            self.is_single_field_record(sort)
+        {
             self.wfckresults
                 .coercions_mut()
-                .insert(fhir_id, vec![coercion]);
+                .insert(fhir_id, vec![fhir::Coercion::Project]);
             Some(fsort.clone())
         } else {
             None
@@ -550,12 +582,15 @@ impl<'a> InferCtxt<'a, '_> {
         })
     }
 
-    fn is_single_field_record(&mut self, sort: &fhir::Sort) -> Option<fhir::Sort> {
+    fn is_single_field_record(
+        &mut self,
+        sort: &fhir::Sort,
+    ) -> Option<(DefId, List<fhir::Sort>, fhir::Sort)> {
         self.resolve_sort(sort).and_then(|s| {
             if let fhir::Sort::Record(def_id, sort_args) = s
                 && let [sort] = &self.genv.index_sorts_of(def_id, &sort_args)[..]
             {
-                Some(sort.clone())
+                Some((def_id, sort_args.clone(), sort.clone()))
             } else {
                 None
             }

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -375,8 +375,8 @@ impl<'a> InferCtxt<'a, '_> {
         let mut sort2 = sort2.clone();
 
         let mut coercions = vec![];
-        if let Some((_def_id, _sort_args, sort)) = self.is_single_field_record(&sort1) {
-            coercions.push(fhir::Coercion::Project);
+        if let Some((def_id, _sort_args, sort)) = self.is_single_field_record(&sort1) {
+            coercions.push(fhir::Coercion::Project(def_id));
             sort1 = sort.clone();
         }
         if let Some((def_id, sort_args, sort)) = self.is_single_field_record(&sort2) {
@@ -413,12 +413,12 @@ impl<'a> InferCtxt<'a, '_> {
     ) -> Option<fhir::Sort> {
         if self.is_numeric(sort) {
             Some(sort.clone())
-        } else if let Some((_def_id, _sort_args, sort)) = self.is_single_field_record(sort)
+        } else if let Some((def_id, _sort_args, sort)) = self.is_single_field_record(sort)
             && sort.is_numeric()
         {
             self.wfckresults
                 .coercions_mut()
-                .insert(fhir_id, vec![fhir::Coercion::Project]);
+                .insert(fhir_id, vec![fhir::Coercion::Project(def_id)]);
             Some(sort.clone())
         } else {
             None
@@ -451,12 +451,12 @@ impl<'a> InferCtxt<'a, '_> {
     ) -> Option<fhir::PolyFuncSort> {
         if let Some(fsort) = self.is_func(sort) {
             Some(fsort)
-        } else if let Some((_def_id, _sort_args, fhir::Sort::Func(fsort))) =
+        } else if let Some((def_id, _sort_args, fhir::Sort::Func(fsort))) =
             self.is_single_field_record(sort)
         {
             self.wfckresults
                 .coercions_mut()
-                .insert(fhir_id, vec![fhir::Coercion::Project]);
+                .insert(fhir_id, vec![fhir::Coercion::Project(def_id)]);
             Some(fsort.clone())
         } else {
             None

--- a/crates/flux-fixpoint/src/constraint.rs
+++ b/crates/flux-fixpoint/src/constraint.rs
@@ -80,17 +80,10 @@ pub enum Expr<T: Types> {
     Var(T::Var),
     Constant(Constant),
     BinaryOp(BinOp, Box<[Self; 2]>),
-    App(Func<T>, Vec<Self>),
+    App(T::Var, Vec<Self>),
     UnaryOp(UnOp, Box<Self>),
     Proj(Box<Self>, Proj),
     IfThenElse(Box<[Self; 3]>),
-}
-
-#[derive_where(Hash)]
-pub enum Func<T: Types> {
-    Var(T::Var),
-    /// interpreted (theory) function
-    Itf(String),
 }
 
 #[derive(Clone, Copy, Hash)]
@@ -381,15 +374,6 @@ impl<T: Types> fmt::Display for Expr<T> {
                 write!(f, "if {p} then {e1} else {e2}")
             }
             Expr::Unit => write!(f, "unit"),
-        }
-    }
-}
-
-impl<T: Types> fmt::Display for Func<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Func::Var(name) => write!(f, "{name}"),
-            Func::Itf(itf) => write!(f, "{itf}"),
         }
     }
 }

--- a/crates/flux-fixpoint/src/lib.rs
+++ b/crates/flux-fixpoint/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 pub use constraint::{
-    BinOp, Const, Constant, Constraint, DataCtor, DataDecl, DataField, Expr, Func, FuncSort,
+    BinOp, Const, Constant, Constraint, DataCtor, DataDecl, DataField, Expr, FuncSort,
     PolyFuncSort, Pred, Proj, Qualifier, Sort, SortCtor, UnOp,
 };
 use derive_where::derive_where;
@@ -45,7 +45,6 @@ macro_rules! declare_types {
             pub struct FixpointTypes;
             pub type Expr = $crate::Expr<FixpointTypes>;
             pub type Pred = $crate::Pred<FixpointTypes>;
-            pub type Func = $crate::Func<FixpointTypes>;
             pub type Constraint = $crate::Constraint<FixpointTypes>;
             pub type KVar = $crate::KVar<FixpointTypes>;
             pub type ConstInfo = $crate::ConstInfo<FixpointTypes>;

--- a/crates/flux-fixpoint/src/lib.rs
+++ b/crates/flux-fixpoint/src/lib.rs
@@ -16,8 +16,8 @@ use std::{
 };
 
 pub use constraint::{
-    BinOp, Const, Constant, Constraint, Expr, Func, FuncSort, PolyFuncSort, Pred, Proj, Qualifier,
-    Sort, SortCtor, UnOp,
+    BinOp, Const, Constant, Constraint, DataCtor, DataDecl, DataField, Expr, Func, FuncSort,
+    PolyFuncSort, Pred, Proj, Qualifier, Sort, SortCtor, UnOp,
 };
 use derive_where::derive_where;
 use flux_common::{cache::QueryCache, format::PadAdapter};
@@ -54,6 +54,9 @@ macro_rules! declare_types {
             pub type Sort = $crate::Sort<FixpointTypes>;
             pub type SortCtor = $crate::SortCtor<FixpointTypes>;
             pub type PolyFuncSort = $crate::PolyFuncSort<FixpointTypes>;
+            pub type DataDecl = $crate::DataDecl<FixpointTypes>;
+            pub type DataCtor = $crate::DataCtor<FixpointTypes>;
+            pub type DataField = $crate::DataField<FixpointTypes>;
             pub use $crate::Proj;
         }
 
@@ -87,6 +90,7 @@ pub struct Task<T: Types> {
     #[derive_where(skip)]
     pub comments: Vec<String>,
     pub constants: Vec<ConstInfo<T>>,
+    pub data_decls: Vec<DataDecl<T>>,
     pub kvars: Vec<KVar<T>>,
     pub constraint: Constraint<T>,
     pub qualifiers: Vec<Qualifier<T>>,
@@ -194,6 +198,12 @@ impl<T: Types> fmt::Display for Task<T> {
         }
         writeln!(f)?;
 
+        writeln!(f, "(data Unit 0 = [| unit {{ }}])")?;
+
+        for data_decl in &self.data_decls {
+            writeln!(f, "{data_decl}")?;
+        }
+
         for qualif in DEFAULT_QUALIFIERS.iter() {
             writeln!(f, "{qualif}")?;
         }
@@ -201,8 +211,6 @@ impl<T: Types> fmt::Display for Task<T> {
         for qualif in &self.qualifiers {
             writeln!(f, "{qualif}")?;
         }
-
-        writeln!(f, "(data Unit 0 = [| unit {{ }}])")?;
 
         for cinfo in &self.constants {
             writeln!(f, "{cinfo}")?;

--- a/crates/flux-fixpoint/src/lib.rs
+++ b/crates/flux-fixpoint/src/lib.rs
@@ -84,7 +84,6 @@ pub struct Task<T: Types> {
     pub kvars: Vec<KVar<T>>,
     pub constraint: Constraint<T>,
     pub qualifiers: Vec<Qualifier<T>>,
-    pub sorts: Vec<String>,
     pub scrape_quals: bool,
 }
 
@@ -122,18 +121,6 @@ pub struct KVar<T: Types> {
 }
 
 impl<T: Types> Task<T> {
-    pub fn new(
-        comments: Vec<String>,
-        constants: Vec<ConstInfo<T>>,
-        kvars: Vec<KVar<T>>,
-        constraint: Constraint<T>,
-        qualifiers: Vec<Qualifier<T>>,
-        sorts: Vec<String>,
-        scrape_quals: bool,
-    ) -> Self {
-        Task { comments, constants, kvars, constraint, qualifiers, sorts, scrape_quals }
-    }
-
     pub fn hash_with_default(&self) -> u64 {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);

--- a/crates/flux-fixpoint/src/lib.rs
+++ b/crates/flux-fixpoint/src/lib.rs
@@ -27,11 +27,12 @@ use serde::{de, Deserialize};
 
 use crate::constraint::DEFAULT_QUALIFIERS;
 
-pub trait Symbol: fmt::Display + Hash {}
+pub trait Symbol: fmt::Display + Hash + Clone {}
 
-impl<T: fmt::Display + Hash> Symbol for T {}
+impl<T: fmt::Display + Hash + Clone> Symbol for T {}
 
 pub trait Types {
+    type Sort: Symbol;
     type KVar: Symbol;
     type Var: Symbol;
     type Tag: fmt::Display + Hash + FromStr;
@@ -39,7 +40,7 @@ pub trait Types {
 
 #[macro_export]
 macro_rules! declare_types {
-    (type KVar = $kvar:ty; type Var = $var:ty; type Tag = $tag:ty;) => {
+    (type Sort = $sort:ty; type KVar = $kvar:ty; type Var = $var:ty; type Tag = $tag:ty;) => {
         pub mod fixpoint_generated {
             pub struct FixpointTypes;
             pub type Expr = $crate::Expr<FixpointTypes>;
@@ -50,10 +51,14 @@ macro_rules! declare_types {
             pub type ConstInfo = $crate::ConstInfo<FixpointTypes>;
             pub type Task = $crate::Task<FixpointTypes>;
             pub type Qualifier = $crate::Qualifier<FixpointTypes>;
-            pub use $crate::{PolyFuncSort, Proj, Sort, SortCtor};
+            pub type Sort = $crate::Sort<FixpointTypes>;
+            pub type SortCtor = $crate::SortCtor<FixpointTypes>;
+            pub type PolyFuncSort = $crate::PolyFuncSort<FixpointTypes>;
+            pub use $crate::Proj;
         }
 
         impl $crate::Types for fixpoint_generated::FixpointTypes {
+            type Sort = $sort;
             type KVar = $kvar;
             type Var = $var;
             type Tag = $tag;
@@ -64,6 +69,7 @@ macro_rules! declare_types {
 struct StringTypes;
 
 impl Types for StringTypes {
+    type Sort = &'static str;
     type KVar = &'static str;
     type Var = &'static str;
     type Tag = String;
@@ -73,7 +79,7 @@ impl Types for StringTypes {
 pub struct ConstInfo<T: Types> {
     pub name: T::Var,
     pub orig: String,
-    pub sort: Sort,
+    pub sort: Sort<T>,
 }
 
 #[derive_where(Hash)]
@@ -116,7 +122,7 @@ pub struct CrashInfo(Vec<serde_json::Value>);
 #[derive_where(Hash)]
 pub struct KVar<T: Types> {
     kvid: T::KVar,
-    sorts: Vec<Sort>,
+    sorts: Vec<Sort<T>>,
     comment: String,
 }
 
@@ -173,7 +179,7 @@ impl<T: Types> Task<T> {
 }
 
 impl<T: Types> KVar<T> {
-    pub fn new(kvid: T::KVar, sorts: Vec<Sort>, comment: String) -> Self {
+    pub fn new(kvid: T::KVar, sorts: Vec<Sort<T>>, comment: String) -> Self {
         Self { kvid, sorts, comment }
     }
 }
@@ -196,8 +202,7 @@ impl<T: Types> fmt::Display for Task<T> {
             writeln!(f, "{qualif}")?;
         }
 
-        writeln!(f, "(data Pair 2 = [| Pair {{ fst: @(0), snd: @(1) }} ])")?;
-        writeln!(f, "(data Unit 0 = [| Unit {{ }}])")?;
+        writeln!(f, "(data Unit 0 = [| unit {{ }}])")?;
 
         for cinfo in &self.constants {
             writeln!(f, "{cinfo}")?;

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -341,7 +341,7 @@ pub struct WfckResults {
 #[derive(Debug)]
 pub enum Coercion {
     Inject(DefId, List<Sort>),
-    Project,
+    Project(DefId),
 }
 
 pub type ItemLocalMap<T> = FxHashMap<ItemLocalId, T>;

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -830,7 +830,7 @@ pub struct RefinedBy {
     /// The number of early bound parameters
     early_bound: usize,
     /// Sorts of both early bound and index parameters. Early bound parameter appear first.
-    sorts: Vec<Sort>,
+    pub sorts: Vec<Sort>,
 }
 
 #[derive(Debug)]

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -340,7 +340,7 @@ pub struct WfckResults {
 
 #[derive(Debug)]
 pub enum Coercion {
-    Inject(DefId, List<Sort>),
+    Inject(DefId),
     Project(DefId),
 }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -927,6 +927,10 @@ impl RefinedBy {
             .collect()
     }
 
+    pub fn param_count(&self) -> usize {
+        self.sort_params.len()
+    }
+
     fn is_base_generic(&self, def_id: DefId) -> bool {
         self.sort_params.contains(&def_id)
     }

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -101,13 +101,13 @@ pub trait Visitor: Sized {
 }
 
 pub fn walk_struct_def<V: Visitor>(vis: &mut V, struct_def: &StructDef) {
-    let StructDef { owner_id: _, params, kind: _, invariants } = struct_def;
+    let StructDef { owner_id: _, params, kind: _, invariants, extern_id: _ } = struct_def;
     walk_list!(vis, visit_refine_param, params);
     walk_list!(vis, visit_expr, invariants);
 }
 
 pub fn walk_enum_def<V: Visitor>(vis: &mut V, enum_def: &EnumDef) {
-    let EnumDef { owner_id: _, params, variants, invariants, .. } = enum_def;
+    let EnumDef { owner_id: _, params, variants, invariants, extern_id: _ } = enum_def;
     walk_list!(vis, visit_refine_param, params);
     walk_list!(vis, visit_variant, variants);
     walk_list!(vis, visit_expr, invariants);

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -76,7 +76,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         let args = vec![rty::GenericArg::Ty(ty), rty::GenericArg::Ty(alloc)];
 
         let bty = rty::BaseTy::adt(adt_def, args);
-        rty::Ty::indexed(bty, rty::Expr::unit_record(def_id))
+        rty::Ty::indexed(bty, rty::Expr::unit_adt(def_id))
     }
 
     pub fn mir(&self, def_id: LocalDefId) -> QueryResult<Rc<rustc::mir::Body<'tcx>>> {

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -75,14 +75,8 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
 
         let args = vec![rty::GenericArg::Ty(ty), rty::GenericArg::Ty(alloc)];
 
-        // this is harcoding that `Box` has two type parameters and
-        // it is indexed by unit. We leave this as a reminder in case
-        // that ever changes.
-        debug_assert_eq!(self.generics_of(def_id).unwrap().params.len(), 2);
-        debug_assert!(adt_def.sort(&args).is_unit());
-
         let bty = rty::BaseTy::adt(adt_def, args);
-        rty::Ty::indexed(bty, rty::Expr::unit())
+        rty::Ty::indexed(bty, rty::Expr::unit_record(def_id))
     }
 
     pub fn mir(&self, def_id: LocalDefId) -> QueryResult<Rc<rustc::mir::Body<'tcx>>> {

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -73,14 +73,15 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         let def_id = self.tcx.require_lang_item(LangItem::OwnedBox, None);
         let adt_def = self.adt_def(def_id).unwrap();
 
+        let args = vec![rty::GenericArg::Ty(ty), rty::GenericArg::Ty(alloc)];
+
         // this is harcoding that `Box` has two type parameters and
         // it is indexed by unit. We leave this as a reminder in case
         // that ever changes.
         debug_assert_eq!(self.generics_of(def_id).unwrap().params.len(), 2);
-        debug_assert!(adt_def.sort().is_unit());
+        debug_assert!(adt_def.sort(&args).is_unit());
 
-        let bty =
-            rty::BaseTy::adt(adt_def, vec![rty::GenericArg::Ty(ty), rty::GenericArg::Ty(alloc)]);
+        let bty = rty::BaseTy::adt(adt_def, args);
         rty::Ty::indexed(bty, rty::Expr::unit())
     }
 

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -111,6 +111,10 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         self.queries.adt_def(self, def_id.into())
     }
 
+    pub fn adt_sort_def_of(&self, def_id: impl Into<DefId>) -> rty::AdtSortDef {
+        self.queries.adt_sort_def_of(self, def_id.into())
+    }
+
     pub fn check_wf(
         &self,
         flux_id: impl Into<FluxLocalDefId>,

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -465,7 +465,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         self.tcx.hir()
     }
 
-    pub(crate) fn lookup_extern(&self, def_id: DefId) -> Option<DefId> {
+    pub fn lookup_extern(&self, def_id: DefId) -> Option<DefId> {
         self.map().get_extern(def_id).map(LocalDefId::to_def_id)
     }
 

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -214,7 +214,7 @@ impl<'tcx> Queries<'tcx> {
             if let Some(local_id) = def_id.as_local() {
                 (self.providers.adt_sort_def_of)(genv, local_id)
             } else {
-                todo!()
+                rty::AdtSortDef::new(def_id, vec![], List::empty())
             }
         })
     }
@@ -241,7 +241,7 @@ impl<'tcx> Queries<'tcx> {
                 } else {
                     lowering::lower_adt_def(&genv.tcx.adt_def(def_id))
                 };
-                Ok(rty::AdtDef::new(adt_def, rty::Sort::unit(), vec![], false))
+                Ok(rty::AdtDef::new(adt_def, genv.adt_sort_def_of(def_id), vec![], false))
             }
         })
     }

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -255,17 +255,17 @@ impl Expr {
         Expr::late_bvar(INNERMOST, 0)
     }
 
-    pub fn expect_tuple(&self) -> &[Expr] {
-        if let ExprKind::Tuple(tup) = self.kind() {
-            tup
+    #[track_caller]
+    pub fn expect_record(&self) -> (DefId, List<Sort>, List<Expr>) {
+        if let ExprKind::Record(def_id, sorts, flds) = self.kind() {
+            (*def_id, sorts.clone(), flds.clone())
         } else {
             bug!("expected tuple")
         }
     }
 
     pub fn unit() -> Expr {
-        todo!()
-        // Expr::tuple(vec![])
+        Expr::tuple(vec![])
     }
 
     pub fn var(var: Var, espan: Option<ESpan>) -> Expr {

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -260,7 +260,7 @@ impl Expr {
         if let ExprKind::Record(def_id, sorts, flds) = self.kind() {
             (*def_id, sorts.clone(), flds.clone())
         } else {
-            bug!("expected tuple")
+            bug!("expected record, found {self:?}")
         }
     }
 

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -110,7 +110,7 @@ pub enum ExprKind {
     Hole(HoleKind),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable, Debug)]
 pub enum FieldProj {
     Tuple { arity: usize, field: u32 },
     Adt { def_id: DefId, field: u32 },
@@ -366,6 +366,10 @@ impl Expr {
 
     pub fn record(def_id: DefId, flds: List<Expr>) -> Expr {
         ExprKind::Record(def_id, flds).intern()
+    }
+
+    pub fn unit_record(def_id: DefId) -> Expr {
+        ExprKind::Record(def_id, List::empty()).intern()
     }
 
     pub fn app(func: impl Into<Expr>, args: impl Into<List<Expr>>, espan: Option<ESpan>) -> Expr {
@@ -783,11 +787,12 @@ mod pretty {
                     }
                 }
                 ExprKind::FieldProj(e, proj) => {
-                    if e.is_atom() {
-                        w!("{:?}.{:?}", e, ^proj.field())
-                    } else {
-                        w!("({:?}).{:?}", e, ^proj.field())
-                    }
+                    w!("({:?}.{:?})", e, ^proj)
+                    // if e.is_atom() {
+                    //     w!("{:?}.{:?}", e, ^proj.field())
+                    // } else {
+                    //     w!("({:?}).{:?}", e, ^proj.field())
+                    // }
                 }
                 ExprKind::Tuple(exprs) => {
                     if let [e] = &exprs[..] {

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -263,7 +263,8 @@ impl Expr {
     }
 
     pub fn unit() -> Expr {
-        Expr::tuple(vec![])
+        todo!()
+        // Expr::tuple(vec![])
     }
 
     pub fn var(var: Var, espan: Option<ESpan>) -> Expr {

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -82,6 +82,7 @@ pub enum ExprKind {
     GlobalFunc(Symbol, FuncKind),
     UnaryOp(UnOp, Expr),
     TupleProj(Expr, u32),
+    FieldProj(Expr, DefId, u32),
     Tuple(List<Expr>),
     Record(DefId, List<Sort>, List<Expr>),
     PathProj(Expr, FieldIdx),
@@ -407,6 +408,10 @@ impl Expr {
             .iter()
             .copied()
             .fold(e.into(), |e, p| Expr::tuple_proj(e, p, None))
+    }
+
+    pub fn field_proj(e: impl Into<Expr>, def_id: DefId, proj: u32, espan: Option<ESpan>) -> Expr {
+        ExprKind::FieldProj(e.into(), def_id, proj).intern_at(espan)
     }
 
     pub fn path_proj(base: Expr, field: FieldIdx) -> Expr {
@@ -764,6 +769,13 @@ mod pretty {
                     }
                 }
                 ExprKind::TupleProj(e, field) => {
+                    if e.is_atom() {
+                        w!("{:?}.{:?}", e, ^field)
+                    } else {
+                        w!("({:?}).{:?}", e, ^field)
+                    }
+                }
+                ExprKind::FieldProj(e, _, field) => {
                     if e.is_atom() {
                         w!("{:?}.{:?}", e, ^field)
                     } else {

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -83,6 +83,7 @@ pub enum ExprKind {
     UnaryOp(UnOp, Expr),
     TupleProj(Expr, u32),
     Tuple(List<Expr>),
+    Record(DefId, List<Sort>, List<Expr>),
     PathProj(Expr, FieldIdx),
     IfThenElse(Expr, Expr, Expr),
     KVar(KVar),
@@ -346,6 +347,10 @@ impl Expr {
         espan: Option<ESpan>,
     ) -> Expr {
         ExprKind::BinaryOp(op, e1.into(), e2.into()).intern_at(espan)
+    }
+
+    pub fn record(def_id: DefId, sorts: List<Sort>, flds: List<Expr>) -> Expr {
+        ExprKind::Record(def_id, sorts, flds).intern()
     }
 
     pub fn app(func: impl Into<Expr>, args: impl Into<List<Expr>>, espan: Option<ESpan>) -> Expr {
@@ -799,6 +804,9 @@ mod pretty {
                     w!("{:?}", body)
                 }
                 ExprKind::GlobalFunc(func, _) => w!("{}", ^func),
+                ExprKind::Record(def_id, sorts, flds) => {
+                    w!("{:?}<{:?}>{{ {:?} }}", def_id, join!(", ", sorts), join!(", ", flds))
+                }
             }
         }
     }

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -1039,7 +1039,9 @@ impl TypeSuperFoldable for Expr {
             }
             ExprKind::UnaryOp(op, e) => Expr::unary_op(*op, e.try_fold_with(folder)?, span),
             ExprKind::TupleProj(e, proj) => Expr::tuple_proj(e.try_fold_with(folder)?, *proj, span),
-            ExprKind::FieldProj(e, def_id, fld) => Expr::field_proj(e, *def_id, *fld, span),
+            ExprKind::FieldProj(e, def_id, fld) => {
+                Expr::field_proj(e.try_fold_with(folder)?, *def_id, *fld, span)
+            }
             ExprKind::Tuple(exprs) => {
                 let exprs = exprs
                     .iter()

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -984,9 +984,11 @@ impl TypeSuperVisitable for Expr {
                 flds.visit_with(visitor)
             }
             ExprKind::Tuple(exprs) => exprs.iter().try_for_each(|e| e.visit_with(visitor)),
-            ExprKind::PathProj(e, _) | ExprKind::UnaryOp(_, e) | ExprKind::TupleProj(e, _) => {
-                e.visit_with(visitor)
-            }
+
+            ExprKind::FieldProj(e, _, _)
+            | ExprKind::PathProj(e, _)
+            | ExprKind::UnaryOp(_, e)
+            | ExprKind::TupleProj(e, _) => e.visit_with(visitor),
             ExprKind::App(func, arg) => {
                 func.visit_with(visitor)?;
                 arg.visit_with(visitor)
@@ -1035,6 +1037,7 @@ impl TypeSuperFoldable for Expr {
             }
             ExprKind::UnaryOp(op, e) => Expr::unary_op(*op, e.try_fold_with(folder)?, span),
             ExprKind::TupleProj(e, proj) => Expr::tuple_proj(e.try_fold_with(folder)?, *proj, span),
+            ExprKind::FieldProj(e, def_id, fld) => Expr::field_proj(e, *def_id, *fld, span),
             ExprKind::Tuple(exprs) => {
                 let exprs = exprs
                     .iter()

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -981,12 +981,8 @@ impl TypeSuperVisitable for Expr {
                 e1.visit_with(visitor)?;
                 e2.visit_with(visitor)
             }
-            ExprKind::Record(_, sorts, flds) => {
-                sorts.visit_with(visitor)?;
-                flds.visit_with(visitor)
-            }
+            ExprKind::Record(_, flds) => flds.visit_with(visitor),
             ExprKind::Tuple(exprs) => exprs.iter().try_for_each(|e| e.visit_with(visitor)),
-
             ExprKind::FieldProj(e, _, _)
             | ExprKind::PathProj(e, _)
             | ExprKind::UnaryOp(_, e)
@@ -1049,9 +1045,7 @@ impl TypeSuperFoldable for Expr {
                     .try_collect_vec()?;
                 Expr::tuple(exprs)
             }
-            ExprKind::Record(def_id, sorts, flds) => {
-                Expr::record(*def_id, sorts.try_fold_with(folder)?, flds.try_fold_with(folder)?)
-            }
+            ExprKind::Record(def_id, flds) => Expr::record(*def_id, flds.try_fold_with(folder)?),
             ExprKind::PathProj(e, field) => Expr::path_proj(e.try_fold_with(folder)?, *field),
             ExprKind::App(func, arg) => {
                 Expr::app(func.try_fold_with(folder)?, arg.try_fold_with(folder)?, span)

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -995,10 +995,9 @@ impl TypeSuperVisitable for Expr {
             }
             ExprKind::Record(_, flds) => flds.visit_with(visitor),
             ExprKind::Tuple(exprs) => exprs.iter().try_for_each(|e| e.visit_with(visitor)),
-            ExprKind::FieldProj(e, _, _)
-            | ExprKind::PathProj(e, _)
-            | ExprKind::UnaryOp(_, e)
-            | ExprKind::TupleProj(e, _) => e.visit_with(visitor),
+            ExprKind::FieldProj(e, _) | ExprKind::PathProj(e, _) | ExprKind::UnaryOp(_, e) => {
+                e.visit_with(visitor)
+            }
             ExprKind::App(func, arg) => {
                 func.visit_with(visitor)?;
                 arg.visit_with(visitor)
@@ -1046,10 +1045,7 @@ impl TypeSuperFoldable for Expr {
                 Expr::binary_op(*op, e1.try_fold_with(folder)?, e2.try_fold_with(folder)?, span)
             }
             ExprKind::UnaryOp(op, e) => Expr::unary_op(*op, e.try_fold_with(folder)?, span),
-            ExprKind::TupleProj(e, proj) => Expr::tuple_proj(e.try_fold_with(folder)?, *proj, span),
-            ExprKind::FieldProj(e, def_id, fld) => {
-                Expr::field_proj(e.try_fold_with(folder)?, *def_id, *fld, span)
-            }
+            ExprKind::FieldProj(e, proj) => Expr::field_proj(e.try_fold_with(folder)?, *proj, span),
             ExprKind::Tuple(exprs) => {
                 let exprs = exprs
                     .iter()

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -549,7 +549,7 @@ impl TypeVisitable for Sort {
             | Sort::BitVec(_)
             | Sort::Loc
             | Sort::Param(_)
-            | Sort::Record(..)
+            | Sort::Adt(..)
             | Sort::Var(_) => ControlFlow::Continue(()),
         }
     }
@@ -577,7 +577,9 @@ impl TypeSuperFoldable for Sort {
                 };
                 Sort::Func(PolyFuncSort { params, fsort })
             }
-            Sort::Record(def_id, sorts) => Sort::Record(*def_id, sorts.try_fold_with(folder)?),
+            Sort::Adt(adt_sort_def, sorts) => {
+                Sort::Adt(adt_sort_def.clone(), sorts.try_fold_with(folder)?)
+            }
             Sort::Int
             | Sort::Bool
             | Sort::Real

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -730,6 +730,16 @@ impl Sort {
         matches!(self, Sort::Tuple(sorts) if sorts.is_empty())
     }
 
+    pub fn is_unit_adt(&self) -> Option<DefId> {
+        if let Sort::Adt(sort_def, _) = self
+            && sort_def.fields() == 0
+        {
+            Some(sort_def.did())
+        } else {
+            None
+        }
+    }
+
     /// Whether the sort is a function with return sort bool
     fn is_pred(&self) -> bool {
         matches!(self, Sort::Func(fsort) if fsort.skip_binders().output().is_bool())

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -77,6 +77,10 @@ impl AdtSortDef {
         self.0.def_id
     }
 
+    pub fn fields(&self) -> usize {
+        self.0.fields.len()
+    }
+
     pub fn instantiate(&self, args: &[Sort]) -> List<Sort> {
         struct Subst<'a> {
             args: &'a [Sort],

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -180,6 +180,7 @@ pub enum Sort {
     Tuple(List<Sort>),
     Func(PolyFuncSort),
     App(SortCtor, List<Sort>),
+    Record(DefId, List<Sort>),
     Var(SortVar),
 }
 
@@ -1689,6 +1690,13 @@ mod pretty {
                 Sort::Loc => w!("loc"),
                 Sort::Var(n) => w!("@{}", ^n.index),
                 Sort::Func(sort) => w!("{:?}", sort),
+                Sort::Record(def_id, sorts) => {
+                    if sorts.is_empty() {
+                        w!("{:?}", *def_id)
+                    } else {
+                        w!("{:?}<{:?}>", *def_id, join!(", ", sorts))
+                    }
+                }
                 Sort::Tuple(sorts) => {
                     if let [sort] = &sorts[..] {
                         w!("({:?},)", sort)
@@ -1697,8 +1705,8 @@ mod pretty {
                     }
                 }
                 Sort::App(ctor, sorts) => {
-                    if let [sort] = &sorts[..] {
-                        w!("{:?}<{:?}>", ctor, sort)
+                    if sorts.is_empty() {
+                        w!("{:?}", ctor)
                     } else {
                         w!("{:?}<{:?}>", ctor, join!(", ", sorts))
                     }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -92,6 +92,12 @@ impl AdtSortDef {
         }
         self.0.fields.fold_with(&mut Subst { args })
     }
+
+    pub fn identity_args(&self) -> List<Sort> {
+        (0..self.0.params.len())
+            .map(|i| Sort::Var(SortVar::from(i)))
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -15,7 +15,9 @@ pub mod subst;
 use std::{fmt, hash::Hash, iter, slice, sync::LazyLock};
 
 pub use evars::{EVar, EVarGen};
-pub use expr::{ESpan, Expr, ExprKind, FieldProj, HoleKind, KVar, KVid, Loc, Name, Path, Var};
+pub use expr::{
+    AggregateKind, ESpan, Expr, ExprKind, FieldProj, HoleKind, KVar, KVid, Loc, Name, Path, Var,
+};
 use flux_common::bug;
 pub use flux_fixpoint::{BinOp, Constant, UnOp};
 use itertools::Itertools;

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -284,7 +284,24 @@ pub static UINT_TYS: [UintTy; 6] =
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub struct Invariant {
-    pub pred: Binder<Expr>,
+    // This predicate may have sort variables, but we don't explicitly mark it like in `PolyFuncSort`.
+    // See comment on `apply` for details.
+    pred: Binder<Expr>,
+}
+
+impl Invariant {
+    pub fn new(pred: Binder<Expr>) -> Self {
+        Self { pred }
+    }
+
+    pub fn apply(&self, idx: &Expr) -> Expr {
+        // The predicate may have sort variables but we don't explicitly instantiate them. This
+        // works because sort variables can only appear in sorts and not in expressions. Since
+        // we are removing the binder (which contains the sorts) we can avoid the explicit instantiation.
+        // Ultimately, this works because the expression we generate in fixpoint/z3 doesn't need
+        // sort annotations (sorts are re-inferred).
+        self.pred.replace_bound_expr(idx)
+    }
 }
 
 pub type PolyVariants = List<Binder<VariantSig>>;

--- a/crates/flux-middle/src/rty/normalize.rs
+++ b/crates/flux-middle/src/rty/normalize.rs
@@ -139,7 +139,7 @@ impl<'a> Normalizer<'a> {
     fn field_proj(&self, e: &Expr, proj: FieldProj) -> Expr {
         match e.kind() {
             ExprKind::Record(def_id2, flds) => {
-                let FieldProj::Adt { def_id, field } = proj else { bug!("expected at proj") };
+                let FieldProj::Adt { def_id, field } = proj else { bug!("expected adt proj") };
                 debug_assert_eq!(def_id, *def_id2);
                 flds[field as usize].clone()
             }

--- a/crates/flux-middle/src/rty/normalize.rs
+++ b/crates/flux-middle/src/rty/normalize.rs
@@ -144,7 +144,7 @@ impl<'a> Normalizer<'a> {
     }
 
     fn field_proj(&self, e: &Expr, def_id: DefId, fld: u32) -> Expr {
-        if let ExprKind::Record(def_id2, _, flds) = e.kind() {
+        if let ExprKind::Record(def_id2, flds) = e.kind() {
             debug_assert_eq!(def_id, *def_id2);
             flds[fld as usize].clone()
         } else {

--- a/crates/flux-middle/src/rty/normalize.rs
+++ b/crates/flux-middle/src/rty/normalize.rs
@@ -1,6 +1,5 @@
 use std::ops::ControlFlow;
 
-use flux_common::bug;
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_span::Symbol;
@@ -138,16 +137,7 @@ impl<'a> Normalizer<'a> {
 
     fn field_proj(&self, e: &Expr, proj: FieldProj) -> Expr {
         match e.kind() {
-            ExprKind::Record(def_id2, flds) => {
-                let FieldProj::Adt { def_id, field } = proj else { bug!("expected adt proj") };
-                debug_assert_eq!(def_id, *def_id2);
-                flds[field as usize].clone()
-            }
-            ExprKind::Tuple(flds) => {
-                let FieldProj::Tuple { arity, field } = proj else { bug!("expected tuple proj") };
-                debug_assert_eq!(arity, flds.len());
-                flds[field as usize].clone()
-            }
+            ExprKind::Aggregate(_, flds) => flds[proj.field() as usize].clone(),
             _ => Expr::field_proj(e, proj, None),
         }
     }

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -176,7 +176,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
             adt_def,
             rty::GenericArgs::identity_for_item(self.genv, adt_def_id)?,
             fields,
-            rty::Expr::unit(),
+            rty::Expr::record(adt_def_id, List::empty(), List::empty()),
         );
         Ok(rty::Binder::new(value, List::empty()))
     }

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -176,7 +176,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
             adt_def,
             rty::GenericArgs::identity_for_item(self.genv, adt_def_id)?,
             fields,
-            rty::Expr::unit_record(adt_def_id),
+            rty::Expr::unit_adt(adt_def_id),
         );
         Ok(rty::Binder::new(value, List::empty()))
     }
@@ -271,7 +271,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
                 if s.is_unit() {
                     poly_ty.replace_bound_expr(&rty::Expr::unit())
                 } else if let Some(def_id) = s.is_unit_adt() {
-                    poly_ty.replace_bound_expr(&rty::Expr::unit_record(def_id))
+                    poly_ty.replace_bound_expr(&rty::Expr::unit_adt(def_id))
                 } else {
                     rty::Ty::exists(poly_ty)
                 }

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -176,7 +176,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
             adt_def,
             rty::GenericArgs::identity_for_item(self.genv, adt_def_id)?,
             fields,
-            rty::Expr::record(adt_def_id, List::empty(), List::empty()),
+            rty::Expr::record(adt_def_id, List::empty()),
         );
         Ok(rty::Binder::new(value, List::empty()))
     }

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -176,7 +176,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
             adt_def,
             rty::GenericArgs::identity_for_item(self.genv, adt_def_id)?,
             fields,
-            rty::Expr::record(adt_def_id, List::empty()),
+            rty::Expr::unit_record(adt_def_id),
         );
         Ok(rty::Binder::new(value, List::empty()))
     }
@@ -264,14 +264,21 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
     }
 
     pub(crate) fn refine_ty(&self, ty: &rustc::ty::Ty) -> QueryResult<rty::Ty> {
-        let ty = self.refine_poly_ty(ty)?;
-        match &ty.vars()[..] {
-            [] => Ok(ty.skip_binder().shift_out_escaping(1)),
-            [rty::BoundVariableKind::Refine(s, _)] if s.is_unit() => {
-                Ok(ty.replace_bound_exprs(&[rty::Expr::unit()]))
+        let poly_ty = self.refine_poly_ty(ty)?;
+        let ty = match &poly_ty.vars()[..] {
+            [] => poly_ty.skip_binder().shift_out_escaping(1),
+            [rty::BoundVariableKind::Refine(s, _)] => {
+                if s.is_unit() {
+                    poly_ty.replace_bound_expr(&rty::Expr::unit())
+                } else if let Some(def_id) = s.is_unit_adt() {
+                    poly_ty.replace_bound_expr(&rty::Expr::unit_record(def_id))
+                } else {
+                    rty::Ty::exists(poly_ty)
+                }
             }
-            _ => Ok(rty::Ty::exists(ty)),
-        }
+            _ => rty::Ty::exists(poly_ty),
+        };
+        Ok(ty)
     }
 
     fn refine_alias_kind(kind: &rustc::ty::AliasKind) -> rty::AliasKind {

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -386,7 +386,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
             }
             StatementKind::PlaceMention(_) => {
                 // Place mentions are a no-op used to detect uses of unsafe that would
-                // otherwise optimized away.
+                // otherwise be optimized away.
             }
             StatementKind::Nop => {}
         }

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -741,9 +741,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     self.idx_subtyping(rcx, e1, e2);
                 }
             }
-            (ExprKind::Record(def_id1, args1, flds1), ExprKind::Record(def_id2, args2, flds2)) => {
+            (ExprKind::Record(def_id1, flds1), ExprKind::Record(def_id2, flds2)) => {
                 debug_assert_eq!(def_id1, def_id2);
-                debug_assert_eq!(args1, args2);
                 debug_assert_eq!(flds1.len(), flds2.len());
 
                 for (e1, e2) in iter::zip(flds1, flds2) {

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -734,15 +734,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         }
 
         match (e1.kind(), e2.kind()) {
-            (ExprKind::Tuple(flds1), ExprKind::Tuple(flds2)) => {
-                debug_assert_eq!(flds1.len(), flds2.len());
-
-                for (e1, e2) in iter::zip(flds1, flds2) {
-                    self.idx_subtyping(rcx, e1, e2);
-                }
-            }
-            (ExprKind::Record(def_id1, flds1), ExprKind::Record(def_id2, flds2)) => {
-                debug_assert_eq!(def_id1, def_id2);
+            (ExprKind::Aggregate(kind1, flds1), ExprKind::Aggregate(kind2, flds2)) => {
+                debug_assert_eq!(kind1, kind2);
                 debug_assert_eq!(flds1.len(), flds2.len());
 
                 for (e1, e2) in iter::zip(flds1, flds2) {

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -734,10 +734,19 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         }
 
         match (e1.kind(), e2.kind()) {
-            (ExprKind::Tuple(tup1), ExprKind::Tuple(tup2)) => {
-                debug_assert_eq!(tup1.len(), tup2.len());
+            (ExprKind::Tuple(flds1), ExprKind::Tuple(flds2)) => {
+                debug_assert_eq!(flds1.len(), flds2.len());
 
-                for (e1, e2) in iter::zip(tup1, tup2) {
+                for (e1, e2) in iter::zip(flds1, flds2) {
+                    self.idx_subtyping(rcx, e1, e2);
+                }
+            }
+            (ExprKind::Record(def_id1, args1, flds1), ExprKind::Record(def_id2, args2, flds2)) => {
+                debug_assert_eq!(def_id1, def_id2);
+                debug_assert_eq!(args1, args2);
+                debug_assert_eq!(flds1.len(), flds2.len());
+
+                for (e1, e2) in iter::zip(flds1, flds2) {
                     self.idx_subtyping(rcx, e1, e2);
                 }
             }

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -63,8 +63,11 @@ pub enum KVarEncoding {
     Conj,
 }
 
+/// Keep track of all the sorts we need to define in the fixpoint constraint. Currently, we encode
+/// every aggregate sort as a tuple in fixpoint.
 #[derive(Default)]
 struct SortStore {
+    /// Set of all the arities
     tuples: UnordSet<usize>,
 }
 
@@ -304,6 +307,7 @@ where
         }
     }
 
+    /// Collect all the sorts that need to be defined in fixpoint to encode `t`
     pub(crate) fn collect_sorts<T: TypeVisitable>(&mut self, t: &T) {
         struct Visitor<'a> {
             sorts: &'a mut SortStore,

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -695,7 +695,7 @@ impl<'a> ExprCtxt<'a> {
                     })
             }
             rty::ExprKind::FieldProj(_, _, _) => todo!(),
-            rty::ExprKind::Record(_, _, _) => todo!(),
+            rty::ExprKind::Record(_, _) => todo!(),
             rty::ExprKind::Tuple(exprs) => self.tuple_to_fixpoint(exprs),
             rty::ExprKind::ConstDefId(did) => {
                 let const_info = self.const_map.get(&Key::Const(*did)).unwrap_or_else(|| {

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -300,7 +300,7 @@ where
         }
         impl TypeVisitor for Visitor<'_> {
             fn visit_expr(&mut self, expr: &rty::Expr) -> ControlFlow<!> {
-                if let rty::ExprKind::Record(_, flds) | rty::ExprKind::Tuple(flds) = expr.kind() {
+                if let rty::ExprKind::Aggregate(_, flds) = expr.kind() {
                     self.sorts.declare_tuple(flds.len());
                 }
                 expr.super_visit_with(self)
@@ -761,7 +761,7 @@ impl<'a, 'tcx> ExprCtxt<'a, 'tcx> {
                 let proj = fixpoint::Var::TupleProj { arity, field };
                 fixpoint::Expr::App(fixpoint::Func::Var(proj), vec![self.expr_to_fixpoint(e)])
             }
-            rty::ExprKind::Record(_, flds) | rty::ExprKind::Tuple(flds) => {
+            rty::ExprKind::Aggregate(_, flds) => {
                 let ctor = fixpoint::Func::Var(fixpoint::Var::TupleCtor { arity: flds.len() });
                 let args = flds.iter().map(|e| self.expr_to_fixpoint(e)).collect();
                 fixpoint::Expr::App(ctor, args)

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -636,6 +636,7 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
             let sorts = sorts.iter().map(sort_to_fixpoint).collect_vec();
             fixpoint::Sort::App(ctor, sorts)
         }
+        rty::Sort::Record(_, _) => todo!(),
         rty::Sort::Tuple(sorts) => {
             match &sorts[..] {
                 [] => fixpoint::Sort::Unit,
@@ -693,6 +694,7 @@ impl<'a> ExprCtxt<'a> {
                         fixpoint::Expr::Proj(Box::new(e), proj)
                     })
             }
+            rty::ExprKind::Record(_, _, _) => todo!(),
             rty::ExprKind::Tuple(exprs) => self.tuple_to_fixpoint(exprs),
             rty::ExprKind::ConstDefId(did) => {
                 let const_info = self.const_map.get(&Key::Const(*did)).unwrap_or_else(|| {

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -694,6 +694,7 @@ impl<'a> ExprCtxt<'a> {
                         fixpoint::Expr::Proj(Box::new(e), proj)
                     })
             }
+            rty::ExprKind::FieldProj(_, _, _) => todo!(),
             rty::ExprKind::Record(_, _, _) => todo!(),
             rty::ExprKind::Tuple(exprs) => self.tuple_to_fixpoint(exprs),
             rty::ExprKind::ConstDefId(did) => {

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -636,7 +636,7 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
             let sorts = sorts.iter().map(sort_to_fixpoint).collect_vec();
             fixpoint::Sort::App(ctor, sorts)
         }
-        rty::Sort::Record(_, _) => todo!(),
+        rty::Sort::Adt(_, _) => todo!(),
         rty::Sort::Tuple(sorts) => {
             match &sorts[..] {
                 [] => fixpoint::Sort::Unit,

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -8,7 +8,7 @@ use rustc_span::{Span, DUMMY_SP};
 use crate::{
     constraint_gen::{ConstrReason, Tag},
     fixpoint_encoding::{FixpointCtxt, KVarStore},
-    refine_tree::RefineTree,
+    refine_tree::{AssumeInvariants, RefineTree},
     CheckerConfig,
 };
 
@@ -52,8 +52,7 @@ fn check_invariant(
             .replace_bound_exprs_with(|sort, _| rcx.define_vars(sort));
 
         for ty in variant.fields() {
-            let ty = rcx.unpack(ty, crate::refine_tree::AssumeInvariants::No);
-            rcx.assume_invariants(&ty, checker_config.check_overflow);
+            rcx.unpack(ty, AssumeInvariants::Yes { check_overflow: checker_config.check_overflow });
         }
         let pred = invariant.pred.replace_bound_expr(&variant.idx);
         rcx.check_pred(pred, Tag::new(ConstrReason::Other, DUMMY_SP));

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -52,7 +52,8 @@ fn check_invariant(
             .replace_bound_exprs_with(|sort, _| rcx.define_vars(sort));
 
         for ty in variant.fields() {
-            rcx.unpack(ty, AssumeInvariants::Yes { check_overflow: checker_config.check_overflow });
+            let ty = rcx.unpack(ty, AssumeInvariants::No);
+            rcx.assume_invariants(&ty, checker_config.check_overflow);
         }
         let pred = invariant.pred.replace_bound_expr(&variant.idx);
         rcx.check_pred(pred, Tag::new(ConstrReason::Other, DUMMY_SP));

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -55,7 +55,7 @@ fn check_invariant(
             let ty = rcx.unpack(ty, AssumeInvariants::No);
             rcx.assume_invariants(&ty, checker_config.check_overflow);
         }
-        let pred = invariant.pred.replace_bound_expr(&variant.idx);
+        let pred = invariant.apply(&variant.idx);
         rcx.check_pred(pred, Tag::new(ConstrReason::Other, DUMMY_SP));
     }
     let mut fcx = FixpointCtxt::new(genv, def_id, KVarStore::default());

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -94,6 +94,7 @@ pub fn check_fn(
             dbg::dump_item_info(genv.tcx, def_id, "fluxc", &refine_tree).unwrap();
         }
         let mut fcx = fixpoint_encoding::FixpointCtxt::new(genv, def_id, kvars);
+        fcx.collect_sorts(&refine_tree);
         let constraint = refine_tree.into_fixpoint(&mut fcx);
         let errors = fcx.check(cache, constraint, &config).emit(genv.sess)?;
 

--- a/crates/flux-refineck/src/refine_tree.rs
+++ b/crates/flux-refineck/src/refine_tree.rs
@@ -252,7 +252,7 @@ impl<'rcx> RefineCtxt<'rcx> {
                     && !idx.has_escaping_bvars()
                 {
                     for invariant in bty.invariants(self.overflow_checking) {
-                        let invariant = invariant.pred.replace_bound_expr(idx);
+                        let invariant = invariant.apply(idx);
                         self.rcx.assume_pred(invariant);
                     }
                 }

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -468,19 +468,17 @@ impl BasicBlockEnvShape {
                 )
             }
             (
-                ExprKind::Record(def_id1, args1, flds1),
-                ExprKind::Record(def_id2, args2, flds2),
-                Sort::Adt(sort_def, args3),
+                ExprKind::Record(def_id1, flds1),
+                ExprKind::Record(def_id2, flds2),
+                Sort::Adt(sort_def, args),
             ) => {
                 debug_assert_eq3!(*def_id1, *def_id2, sort_def.did());
-                debug_assert_eq3!(args1, args2, args3);
 
-                let sorts = sort_def.instantiate(args3);
+                let sorts = sort_def.instantiate(args);
                 debug_assert_eq3!(flds1.len(), flds2.len(), sorts.len());
 
                 Expr::record(
                     *def_id1,
-                    args3.clone(),
                     izip!(flds1, flds2, &sorts)
                         .map(|(f1, f2, sort)| self.join_idx(f1, f2, sort, bound_sorts))
                         .collect(),

--- a/crates/flux-refineck/src/type_env/projection.rs
+++ b/crates/flux-refineck/src/type_env/projection.rs
@@ -747,7 +747,7 @@ fn downcast_struct(
     args: &[GenericArg],
     idx: &Expr,
 ) -> CheckerResult<Vec<Ty>> {
-    let (.., flds) = idx.expect_record();
+    let (.., flds) = idx.expect_adt();
     Ok(struct_variant(genv, adt.did())?
         .instantiate(args, &[])
         .replace_bound_exprs(&flds)
@@ -787,8 +787,8 @@ fn downcast_enum(
         .replace_bound_exprs_with(|sort, _| rcx.define_vars(sort));
 
     // FIXME(nilehmann) flatten indices
-    let (.., exprs1) = idx1.expect_record();
-    let (.., exprs2) = variant_def.idx.expect_record();
+    let (.., exprs1) = idx1.expect_adt();
+    let (.., exprs2) = variant_def.idx.expect_adt();
     debug_assert_eq!(exprs1.len(), exprs2.len());
     let constr = Expr::and(iter::zip(&exprs1, &exprs2).filter_map(|(e1, e2)| {
         if !e1.is_abs() && !e2.is_abs() {

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -93,6 +93,8 @@ pub struct StructDef {
     pub opaque: bool,
     pub invariants: Vec<Expr>,
     pub node_id: NodeId,
+    /// Whether the struct is an extern spec for some [DefId]
+    pub extern_id: Option<DefId>,
 }
 
 impl StructDef {
@@ -109,7 +111,7 @@ pub struct EnumDef {
     pub variants: Vec<Option<VariantDef>>,
     pub invariants: Vec<Expr>,
     pub node_id: NodeId,
-    /// whether the enum is an extern spec for some [DefId]
+    /// Whether the enum is an extern spec for some [DefId]
     pub extern_id: Option<DefId>,
 }
 


### PR DESCRIPTION
Carry on record sorts from fhir in rty instead of encoding them as tuples. Records are still encoded as tuples in the fixpoint constraint.