### PR TITLE
Put GenericPredicates inside Generics

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -151,10 +151,10 @@ pub(crate) struct RustItemCtxt<'a, 'tcx> {
     sort_resolver: SortResolver<'a>,
 }
 
-pub(crate) type Env = env::Env<Param>;
+type Env = env::Env<Param>;
 
 #[derive(Debug, Clone)]
-pub(crate) struct Param {
+struct Param {
     name: fhir::Name,
     sort: fhir::Sort,
     kind: fhir::ParamKind,
@@ -218,7 +218,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
         RustItemCtxt::new(self.genv, owner, self.resolver_output, self.opaque_tys.as_deref_mut())
     }
 
-    pub(crate) fn as_lift_cx<'b>(&'b mut self) -> LiftCtxt<'b, 'tcx> {
+    fn as_lift_cx<'b>(&'b mut self) -> LiftCtxt<'b, 'tcx> {
         LiftCtxt::new(
             self.genv.tcx,
             self.genv.sess,
@@ -247,7 +247,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
     }
 
     /// [desugar_generics] starts with the `lifted_generics` and "updates" it with the surface `generics`
-    pub(crate) fn desugar_generics(
+    fn desugar_generics(
         &mut self,
         generics: &surface::Generics,
         env: &mut Env,
@@ -520,7 +520,7 @@ impl<'a, 'tcx> RustItemCtxt<'a, 'tcx> {
         }
     }
 
-    pub(crate) fn desugar_generics_for_adt(
+    fn desugar_generics_for_adt(
         &mut self,
         generics: Option<&surface::Generics>,
         env: &mut Env,

--- a/crates/flux-desugar/src/desugar/env.rs
+++ b/crates/flux-desugar/src/desugar/env.rs
@@ -221,10 +221,10 @@ pub(crate) struct Scope<P> {
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub(crate) enum ScopeId {
     /// The scope introduced by a function's input parameters. It contains explicit parameters plus
-    /// synthetic parameters declared with `@x` or `x: T`.
+    /// implicitly scoped parameters declared with `@x` or `x: T`.
     FnInput(NodeId),
-    /// The scope introduced by a function's output parameters. It contains synthetic parameters
-    /// declared with `#n` syntax.
+    /// The scope introduced by a function's output parameters. It contains implicitly scoped
+    /// parameters declared with `#n` syntax.
     FnOutput(NodeId),
     /// The scope introduced by the `refined_by` annotation in a struct.
     Struct(NodeId),
@@ -242,6 +242,8 @@ pub(crate) enum ScopeId {
     /// The scope introduced by a flux item like a func definition or a qualifier. It includes
     /// parameters of the item
     FluxItem,
+    /// Other scope we don't care to clasify
+    Misc,
 }
 
 impl<P> Scope<P> {
@@ -304,6 +306,7 @@ impl fmt::Debug for ScopeId {
             ScopeId::Abs(node_id) => write!(f, "Abs({})", node_id.as_usize()),
             ScopeId::Exists(node_id) => write!(f, "Exists({})", node_id.as_usize()),
             ScopeId::FluxItem => write!(f, "FluxItem"),
+            ScopeId::Misc => write!(f, "Misc"),
         }
     }
 }

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -89,13 +89,11 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             .iter()
             .try_for_each_exhaust(|cstr| item_resolver.resolve_constraint(cstr));
 
-        let predicates = if let Some(predicates) = &fn_sig.predicates {
-            predicates
-                .iter()
-                .try_for_each_exhaust(|pred| item_resolver.resolve_where_bound_predicate(pred))
-        } else {
-            Ok(())
-        };
+        let predicates = fn_sig
+            .generics
+            .predicates
+            .iter()
+            .try_for_each_exhaust(|pred| item_resolver.resolve_where_bound_predicate(pred));
 
         let returns = item_resolver.resolve_fn_ret_ty(&fn_sig.returns);
 

--- a/crates/flux-fhir-analysis/src/annot_check.rs
+++ b/crates/flux-fhir-analysis/src/annot_check.rs
@@ -32,7 +32,7 @@ pub fn check_fn_sig(
         return Ok(());
     }
     let self_ty = lift::lift_self_ty(genv.tcx, genv.sess, owner_id)?;
-    let expected_fn_sig = &lift::lift_fn(genv.tcx, genv.sess, owner_id)?.1.fn_sig;
+    let expected_fn_sig = &lift::lift_fn(genv.tcx, genv.sess, owner_id)?.0;
     Zipper::new(genv, wfckresults, self_ty.as_ref()).zip_fn_sig(fn_sig, expected_fn_sig)
 }
 
@@ -44,7 +44,7 @@ pub fn check_alias(
     if ty_alias.lifted {
         return Ok(());
     }
-    let (.., expected_ty_alias) = lift::lift_type_alias(genv.tcx, genv.sess, ty_alias.owner_id)?;
+    let expected_ty_alias = lift::lift_type_alias(genv.tcx, genv.sess, ty_alias.owner_id)?;
     Zipper::new(genv, wfckresults, None).zip_ty(&ty_alias.ty, &expected_ty_alias.ty)
 }
 

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -119,7 +119,7 @@ pub(crate) fn expand_type_alias(
 pub(crate) fn conv_generic_predicates(
     genv: &GlobalEnv,
     def_id: LocalDefId,
-    predicates: &fhir::GenericPredicates,
+    predicates: &[fhir::WhereBoundPredicate],
     wfckresults: &WfckResults,
 ) -> QueryResult<rty::EarlyBinder<rty::GenericPredicates>> {
     let cx = ConvCtxt::new(genv, wfckresults);
@@ -129,7 +129,7 @@ pub(crate) fn conv_generic_predicates(
     let env = &mut Env::new(genv, refparams.unwrap_or(&[]), wfckresults);
 
     let mut clauses = vec![];
-    for pred in &predicates.predicates {
+    for pred in predicates {
         let bounded_ty = cx.conv_ty(env, &pred.bounded_ty)?;
         for clause in cx.conv_generic_bounds(env, bounded_ty, &pred.bounds)? {
             clauses.push(clause);
@@ -287,11 +287,10 @@ fn conv_assoc_predicate(
 
 pub(crate) fn conv_assoc_predicates(
     genv: &GlobalEnv,
-    assoc_predicates: &fhir::AssocPredicates,
+    assoc_predicates: &[fhir::AssocPredicate],
     wfckresults: &WfckResults,
 ) -> rty::AssocPredicates {
     let predicates = assoc_predicates
-        .predicates
         .iter()
         .map(|assoc_pred| conv_assoc_predicate(genv, assoc_pred, wfckresults))
         .collect_vec()

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -110,16 +110,14 @@ pub trait Visitor: Sized {
 }
 
 pub fn walk_struct_def<V: Visitor>(vis: &mut V, struct_def: &StructDef) {
-    let StructDef { owner_id: _, params, kind: _, invariants, extern_id: _ } = struct_def;
-    walk_list!(vis, visit_refine_param, params);
-    walk_list!(vis, visit_expr, invariants);
+    walk_list!(vis, visit_refine_param, &struct_def.params);
+    walk_list!(vis, visit_expr, &struct_def.invariants);
 }
 
 pub fn walk_enum_def<V: Visitor>(vis: &mut V, enum_def: &EnumDef) {
-    let EnumDef { owner_id: _, params, variants, invariants, extern_id: _ } = enum_def;
-    walk_list!(vis, visit_refine_param, params);
-    walk_list!(vis, visit_variant, variants);
-    walk_list!(vis, visit_expr, invariants);
+    walk_list!(vis, visit_refine_param, &enum_def.params);
+    walk_list!(vis, visit_variant, &enum_def.variants);
+    walk_list!(vis, visit_expr, &enum_def.invariants);
 }
 
 pub fn walk_variant<V: Visitor>(vis: &mut V, variant: &VariantDef) {
@@ -141,11 +139,10 @@ pub fn walk_variant_ret<V: Visitor>(vis: &mut V, ret: &VariantRet) {
 }
 
 pub fn walk_fn_sig<V: Visitor>(vis: &mut V, sig: &FnSig) {
-    let FnSig { params, requires, args, output, lifted: _, span: _ } = sig;
-    walk_list!(vis, visit_refine_param, params);
-    walk_list!(vis, visit_constraint, requires);
-    walk_list!(vis, visit_ty, args);
-    vis.visit_fn_output(output);
+    walk_list!(vis, visit_refine_param, &sig.params);
+    walk_list!(vis, visit_constraint, &sig.requires);
+    walk_list!(vis, visit_ty, &sig.args);
+    vis.visit_fn_output(&sig.output);
 }
 
 pub fn walk_refine_param<V: Visitor>(vis: &mut V, param: &RefineParam) {

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -208,7 +208,10 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
 
     pub fn get_generic_param(&self, def_id: LocalDefId) -> &fhir::GenericParam {
         let owner = self.hir().ty_param_owner(def_id);
-        self.map().get_generics(owner).unwrap().get_param(def_id)
+        self.map()
+            .get_generics(self.tcx, owner)
+            .unwrap()
+            .get_param(def_id)
     }
 
     pub fn is_box(&self, res: fhir::Res) -> bool {
@@ -323,7 +326,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
     }
 
     fn sort_of_self_param(&self, owner: DefId) -> Option<rty::Sort> {
-        let generics = self.map().get_generics(owner.expect_local())?;
+        let generics = self.map().get_generics(self.tcx, owner.expect_local())?;
         let kind = generics.self_kind.as_ref()?;
         match kind {
             fhir::GenericParamKind::BaseTy | fhir::GenericParamKind::SplTy => {

--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -14,6 +14,18 @@ pub Generics: surface::Generics = {
     <lo:@L> <params:Comma<GenericParam>> <hi:@R> => {
         surface::Generics {
             params,
+            predicates: vec![],
+            span: cx.map_span(lo, hi),
+        }
+    }
+}
+
+GenericsWithAngleBrackets: surface::Generics = {
+    "<" <Generics> ">" => <>,
+    <lo:@L> <hi:@R> => {
+        surface::Generics {
+            params: vec![],
+            predicates: vec![],
             span: cx.map_span(lo, hi),
         }
     }
@@ -39,22 +51,15 @@ pub TyAlias: surface::TyAlias = {
     <lo:@L>
     "type"
     <ident:Ident>
-    <generics_lo:@L>
-    <generics: ("<" <Generics> ">")?>
+    <mut generics:GenericsWithAngleBrackets>
     <early_bound_params:("(" <RefineParams<"!">> ")")?>
-    <generics_hi:@R>
     <refined_by_lo:@L>
     <index_params:("[" <RefineParams<"!">> "]")?>
     <refined_by_hi:@R>
     "="
     <ty:Ty>
     <hi:@R> => {
-        let mut params = if let Some(generics) = generics {
-            generics.params
-        } else {
-            vec![]
-        };
-        params.extend(
+        generics.params.extend(
             early_bound_params
                 .unwrap_or_default()
                 .into_iter()
@@ -64,10 +69,6 @@ pub TyAlias: surface::TyAlias = {
                 }
             )
         );
-        let generics = surface::Generics {
-            params,
-            span: cx.map_span(generics_lo, generics_hi),
-        };
         let refined_by = surface::RefinedBy {
             index_params: index_params.unwrap_or_default(),
             span: cx.map_span(refined_by_lo, refined_by_hi),
@@ -178,7 +179,7 @@ pub FnSig: surface::FnSig = {
     <lo:@L>
     <asyncness:Async>
     "fn"
-    <generics:("<" Generics ">")?>
+    <mut generics:GenericsWithAngleBrackets>
     "(" <args:Args> ")"
     <ret_lo:@L> <ret_hi:@R>
     <returns:("->" <Ty>)?>
@@ -193,7 +194,7 @@ pub FnSig: surface::FnSig = {
         } else {
             surface::FnRetTy::Default(cx.map_span(ret_lo, ret_hi))
         };
-        let generics = generics.map(|z| z.1);
+        generics.predicates = predicates.unwrap_or_default();
         surface::FnSig {
             asyncness,
             generics,
@@ -201,7 +202,6 @@ pub FnSig: surface::FnSig = {
             returns,
             ensures,
             requires,
-            predicates,
             span: cx.map_span(lo, hi),
             node_id: cx.next_node_id(),
         }

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -58,6 +58,7 @@ pub struct FuncDef {
 #[derive(Debug)]
 pub struct Generics {
     pub params: Vec<GenericParam>,
+    pub predicates: Vec<WhereBoundPredicate>,
     pub span: Span,
 }
 
@@ -184,10 +185,16 @@ pub struct ConstSig {
     pub span: Span,
 }
 
+// FIXME(nilehmann) We should have separate definitions for trait and impls
+pub struct TraitOrImpl {
+    pub generics: Option<Generics>,
+    pub assoc_predicates: Option<AssocPredicate>,
+}
+
 #[derive(Debug)]
 pub struct FnSig {
     pub asyncness: Async,
-    pub generics: Option<Generics>,
+    pub generics: Generics,
     /// example: `requires n > 0`
     pub requires: Option<Expr>,
     /// example: `i32<@n>`
@@ -196,8 +203,6 @@ pub struct FnSig {
     pub returns: FnRetTy,
     /// example: `*x: i32{v. v = n+1}` or just `x > 10`
     pub ensures: Vec<Constraint>,
-    /// example: `where I: Iterator<Item = i32{v:0<=v}>`
-    pub predicates: Option<Vec<WhereBoundPredicate>>,
     /// source span
     pub span: Span,
     pub node_id: NodeId,

--- a/crates/flux-syntax/src/surface/visit.rs
+++ b/crates/flux-syntax/src/surface/visit.rs
@@ -221,18 +221,12 @@ pub fn walk_fn_sig<V: Visitor>(vis: &mut V, fn_sig: &FnSig) {
         args,
         returns,
         ensures,
-        predicates,
         span: _span,
         node_id: _node_id,
     } = fn_sig;
 
     vis.visit_async(asyncness);
-    if let Some(generics) = generics {
-        vis.visit_generics(generics);
-    }
-    if let Some(predicates) = predicates {
-        walk_list!(vis, visit_where_predicate, predicates);
-    }
+    vis.visit_generics(generics);
     if let Some(requires) = requires {
         vis.visit_expr(requires);
     }
@@ -243,6 +237,7 @@ pub fn walk_fn_sig<V: Visitor>(vis: &mut V, fn_sig: &FnSig) {
 
 pub fn walk_generics<V: Visitor>(vis: &mut V, generics: &Generics) {
     walk_list!(vis, visit_generic_param, &generics.params);
+    walk_list!(vis, visit_where_predicate, &generics.predicates);
 }
 
 pub fn walk_fun_arg<V: Visitor>(vis: &mut V, arg: &Arg) {


### PR DESCRIPTION
Put generic predicates inside `Generics` and keep them inside the item instead of a different map