### PR TITLE
Nested assoc preds in `rty`

### DIFF
--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -662,7 +662,7 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
         env: &mut Env,
         alias_pred: &fhir::AliasPred,
         refine_args: &[fhir::RefineArg],
-    ) -> QueryResult<rty::Pred> {
+    ) -> QueryResult<rty::Expr> {
         let trait_id = alias_pred.trait_id;
         let generic_args = self
             .conv_generic_args(env, trait_id, &alias_pred.generic_args)?
@@ -673,12 +673,12 @@ impl<'a, 'tcx> ConvCtxt<'a, 'tcx> {
             .collect_vec()
             .into();
         let alias_pred = rty::AliasPred { trait_id, name: alias_pred.name, args: generic_args };
-        Ok(rty::Pred::Alias(alias_pred, refine_args))
+        Ok(rty::Expr::alias_pred(alias_pred, refine_args))
     }
 
-    fn conv_pred(&self, env: &mut Env, pred: &fhir::Pred) -> QueryResult<rty::Pred> {
+    fn conv_pred(&self, env: &mut Env, pred: &fhir::Pred) -> QueryResult<rty::Expr> {
         let pred = match &pred.kind {
-            fhir::PredKind::Expr(expr) => rty::Pred::Expr(self.conv_expr(env, expr)),
+            fhir::PredKind::Expr(expr) => self.conv_expr(env, expr),
             fhir::PredKind::Alias(alias_pred, refine_args) => {
                 self.conv_alias_pred(env, alias_pred, refine_args)?
             }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -809,8 +809,6 @@ pub enum FuncKind {
     Uif,
     /// User-defined functions with a body definition
     Def,
-    /// Associated predicate symbol
-    Asp,
 }
 
 #[derive(Debug)]

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -452,7 +452,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
             let sort = bty.sort();
             let mut ty = rty::Ty::indexed(bty.shift_in_escaping(1), rty::Expr::nu());
             if !sort.is_unit() {
-                ty = rty::Ty::constr_expr(rty::Expr::hole(rty::HoleKind::Pred), ty);
+                ty = rty::Ty::constr(rty::Expr::hole(rty::HoleKind::Pred), ty);
             }
             rty::Binder::with_sort(ty, sort)
         })

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -11,7 +11,7 @@ use rustc_span::{BytePos, Span, Symbol, SyntaxContext};
 use rustc_target::abi::FieldIdx;
 use rustc_type_ir::{DebruijnIndex, INNERMOST};
 
-use super::{evars::EVar, BaseTy, Binder, IntTy, Sort, UintTy};
+use super::{evars::EVar, AliasPred, BaseTy, Binder, IntTy, Sort, UintTy};
 use crate::{
     fhir::FuncKind,
     intern::{impl_internable, impl_slice_internable, Interned, List},
@@ -86,6 +86,7 @@ pub enum ExprKind {
     PathProj(Expr, FieldIdx),
     IfThenElse(Expr, Expr, Expr),
     KVar(KVar),
+    AliasPred(AliasPred, List<Expr>),
     /// Lambda abstractions. They are purely syntactic and we don't encode them in the logic. As such,
     /// they have some syntactic restrictions that we must carefully maintain:
     ///
@@ -366,6 +367,10 @@ impl Expr {
 
     pub fn kvar(kvar: KVar) -> Expr {
         ExprKind::KVar(kvar).intern()
+    }
+
+    pub fn alias_pred(alias: AliasPred, args: List<Expr>) -> Expr {
+        ExprKind::AliasPred(alias, args).intern()
     }
 
     pub fn binary_op(
@@ -833,6 +838,9 @@ mod pretty {
                 }
                 ExprKind::KVar(kvar) => {
                     w!("{:?}", kvar)
+                }
+                ExprKind::AliasPred(alias, args) => {
+                    w!("{:?}({:?}", ^alias, join!(", ", args))
                 }
                 ExprKind::Abs(body) => {
                     w!("{:?}", body)

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -78,7 +78,6 @@ pub enum ExprKind {
     Constant(Constant),
     ConstDefId(DefId),
     BinaryOp(BinOp, Expr, Expr),
-    App(Expr, List<Expr>),
     GlobalFunc(Symbol, FuncKind),
     UnaryOp(UnOp, Expr),
     FieldProj(Expr, FieldProj),
@@ -87,25 +86,34 @@ pub enum ExprKind {
     IfThenElse(Expr, Expr, Expr),
     KVar(KVar),
     AliasPred(AliasPred, List<Expr>),
+    /// Function application. The syntax allows arbitrary expressions in function position, but in
+    /// practice we are restricted by what's possible to encode in fixpoint. In a nutshell, we need
+    /// to make sure that expressions that can't be encoded are eliminated before we generate the
+    /// fixpoint constraint. Most notably, lambda abstractions have to be fully applied before
+    /// encoding into fixpoint (except when they appear as an index at the top-level).
+    App(Expr, List<Expr>),
     /// Lambda abstractions. They are purely syntactic and we don't encode them in the logic. As such,
     /// they have some syntactic restrictions that we must carefully maintain:
     ///
     /// 1. They can appear as an index at the top level.
     /// 2. We can only substitute an abstraction for a variable in function position (or as an index).
     ///    More generaly, we need to partially evaluate expressions such that all abstractions in
-    ///    non-index position are eliminated before encoding into fixpoint. Right now, the implementation
-    ///    only evaluates abstractions that are immediately applied to arguments, thus the restriction.
+    ///    non-index position are eliminated before encoding into fixpoint. Right now, the
+    ///    implementation only evaluates abstractions that are immediately applied to arguments,
+    ///    thus the restriction.
     Abs(Binder<Expr>),
     /// A hole is an expression that must be inferred either *semantically* by generating a kvar or
-    /// *syntactically* by generating an evar. Whether a hole can be inferred semantically or syntactically
-    /// depends on the position it appears: only holes appearing in predicate position can be inferred
-    /// with a kvar (provided it satisfy the fixpoint horn constraints) and only holes used as a refinement
-    /// argument or index (a position that fully determines their value) can be inferred with an evar.
+    /// *syntactically* by generating an evar. Whether a hole can be inferred semantically or
+    /// syntactically depends on the position it appears: only holes appearing in predicate position
+    /// can be inferred with a kvar (provided it satisfies the fixpoint horn constraints) and only
+    /// holes used as an index (a position that fully determines their value) can be inferred with
+    /// an evar.
     ///
-    /// Holes are implicitly defined in a scope, i.e., their solution could mention free and bound variables
-    /// in this scope. This must be considered when generating an inference variables for them (either evar or kvar).
-    /// In fact, the main reason we have holes is that we want to decouple the places where we generate them,
-    /// (where we don't want to worry about the scope) and the places where we infer them (where we do need to worry
+    /// Holes are implicitly defined in a scope, i.e., their solution could mention free and bound
+    /// variables in this scope. This must be considered when generating an inference variables for
+    /// them (either evar or kvar). In fact, the main reason we have holes is that we want to
+    /// decouple the places where we generate holes (where we don't want to worry about the scope),
+    /// and the places where we generate inference variable for them (where we do need to worry
     /// about the scope).
     Hole(HoleKind),
 }

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -16,7 +16,7 @@ use super::{
     subst::EVarSubstFolder,
     AliasPred, AliasTy, BaseTy, Binder, BoundVariableKind, Clause, ClauseKind, Constraint, Expr,
     ExprKind, FnOutput, FnSig, FnTraitPredicate, FuncSort, GeneratorObligPredicate, GenericArg,
-    Invariant, KVar, Name, OpaqueArgsMap, Opaqueness, OutlivesPredicate, PolyFuncSort, Pred,
+    Invariant, KVar, Name, OpaqueArgsMap, Opaqueness, OutlivesPredicate, PolyFuncSort,
     ProjectionPredicate, PtrKind, Qualifier, ReLateBound, Region, Sort, TraitPredicate, TraitRef,
     Ty, TyKind,
 };
@@ -83,10 +83,6 @@ pub trait FallibleTypeFolder: Sized {
 
     fn try_fold_expr(&mut self, expr: &Expr) -> Result<Expr, Self::Error> {
         expr.try_super_fold_with(self)
-    }
-
-    fn try_fold_pred(&mut self, pred: &Pred) -> Result<Pred, Self::Error> {
-        pred.try_super_fold_with(self)
     }
 }
 
@@ -319,7 +315,7 @@ pub trait TypeFoldable: TypeVisitable {
                         Ty::exists(ty.fold_with(&mut WithHoles { in_exists: true }))
                     }
                     TyKind::Constr(_, ty) => {
-                        Ty::constr_expr(Expr::hole(HoleKind::Pred), ty.fold_with(self))
+                        Ty::constr(Expr::hole(HoleKind::Pred), ty.fold_with(self))
                     }
                     _ => ty.super_fold_with(self),
                 }
@@ -798,18 +794,6 @@ impl TypeVisitable for AliasPred {
     }
 }
 
-impl TypeVisitable for Pred {
-    fn visit_with<V: TypeVisitor>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy, ()> {
-        match self {
-            Pred::Expr(expr) => expr.visit_with(visitor),
-            Pred::Alias(alias_pred, refine_args) => {
-                alias_pred.visit_with(visitor)?;
-                refine_args.visit_with(visitor)
-            }
-        }
-    }
-}
-
 impl TypeVisitable for Ty {
     fn visit_with<V: TypeVisitor>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy, ()> {
         visitor.visit_ty(self)
@@ -1077,26 +1061,6 @@ impl TypeFoldable for AliasPred {
         let generic_args = self.args.try_fold_with(folder)?;
         let alias_pred = AliasPred { trait_id, name: self.name, args: generic_args };
         Ok(alias_pred)
-    }
-}
-
-impl TypeFoldable for Pred {
-    fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
-        folder.try_fold_pred(self)
-    }
-}
-
-impl TypeSuperFoldable for Pred {
-    fn try_super_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
-        let pred = match self {
-            Pred::Expr(expr) => Pred::Expr(expr.try_fold_with(folder)?),
-            Pred::Alias(alias_pred, refine_args) => {
-                let alias_pred = alias_pred.try_fold_with(folder)?;
-                let refine_args = refine_args.try_fold_with(folder)?;
-                Pred::Alias(alias_pred, refine_args)
-            }
-        };
-        Ok(pred)
     }
 }
 

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -1048,6 +1048,10 @@ impl TypeSuperVisitable for Expr {
                 e2.visit_with(visitor)
             }
             ExprKind::KVar(kvar) => kvar.visit_with(visitor),
+            ExprKind::AliasPred(alias, args) => {
+                alias.visit_with(visitor)?;
+                args.visit_with(visitor)
+            }
             ExprKind::Abs(body) => body.visit_with(visitor),
             ExprKind::Constant(_)
             | ExprKind::Hole(_)
@@ -1135,6 +1139,11 @@ impl TypeSuperFoldable for Expr {
             ExprKind::KVar(kvar) => Expr::kvar(kvar.try_fold_with(folder)?),
             ExprKind::Abs(body) => Expr::abs(body.try_fold_with(folder)?),
             ExprKind::GlobalFunc(func, kind) => Expr::global_func(*func, *kind),
+            ExprKind::AliasPred(alias, args) => {
+                let alias = alias.try_fold_with(folder)?;
+                let args = args.try_fold_with(folder)?;
+                Expr::alias_pred(alias, args)
+            }
         };
         Ok(expr)
     }

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -61,7 +61,7 @@ impl<'a, 'tcx> Refiner<'a, 'tcx> {
             refine: |bty| {
                 let sort = bty.sort();
                 let indexed = rty::Ty::indexed(bty.shift_in_escaping(1), rty::Expr::nu());
-                let constr = rty::Ty::constr_expr(rty::Expr::hole(rty::HoleKind::Pred), indexed);
+                let constr = rty::Ty::constr(rty::Expr::hole(rty::HoleKind::Pred), indexed);
                 rty::Binder::with_sort(constr, sort)
             },
         }

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -10,8 +10,7 @@ use flux_middle::{
         fold::TypeFoldable,
         AliasTy, BaseTy, BinOp, Binder, Constraint, ESpan, EVarGen, EarlyBinder, Expr, ExprKind,
         FnOutput, GeneratorObligPredicate, GenericArg, GenericArgs, GenericParamDefKind, HoleKind,
-        InferMode, Mutability, Path, PolyFnSig, PolyVariant, Pred, PtrKind, Ref, Sort, Ty, TyKind,
-        Var,
+        InferMode, Mutability, Path, PolyFnSig, PolyVariant, PtrKind, Ref, Sort, Ty, TyKind, Var,
     },
     rustc::mir::{BasicBlock, Place},
 };
@@ -110,7 +109,7 @@ impl<'a, 'tcx> ConstrGen<'a, 'tcx> {
     pub(crate) fn check_pred(
         &self,
         rcx: &mut RefineCtxt,
-        pred: impl Into<Pred>,
+        pred: impl Into<Expr>,
         reason: ConstrReason,
     ) {
         rcx.check_pred(pred, Tag::new(reason, self.span));
@@ -492,7 +491,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         Expr::fold_sort(sort, |_| Expr::evar(self.evar_gen.fresh_in_cx(cx)))
     }
 
-    pub(crate) fn check_pred(&self, rcx: &mut RefineCtxt, pred: impl Into<Pred>) {
+    pub(crate) fn check_pred(&self, rcx: &mut RefineCtxt, pred: impl Into<Expr>) {
         rcx.check_pred(pred, self.tag);
     }
 

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -910,8 +910,7 @@ impl<'a, 'tcx> ExprCtxt<'a, 'tcx> {
         match func.kind() {
             rty::ExprKind::Var(var) => self.var_to_fixpoint(var).into(),
             rty::ExprKind::GlobalFunc(_, FuncKind::Thy(sym)) => fixpoint::Var::Itf(*sym),
-            rty::ExprKind::GlobalFunc(sym, FuncKind::Uif)
-            | rty::ExprKind::GlobalFunc(sym, FuncKind::Asp) => {
+            rty::ExprKind::GlobalFunc(sym, FuncKind::Uif) => {
                 let cinfo = self.const_map.get(&Key::Uif(*sym)).unwrap_or_else(|| {
                     span_bug!(
                         self.dbg_span,

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -448,24 +448,11 @@ where
         })
     }
 
-    pub fn pred_to_fixpoint(&mut self, pred: &rty::Pred) -> (Bindings, PredSpans) {
-        match pred {
-            rty::Pred::Expr(expr) => {
-                let mut bindings = vec![];
-                let mut preds = vec![];
-                self.pred_to_fixpoint_internal(expr, &mut bindings, &mut preds);
-                (bindings, preds)
-            }
-            rty::Pred::Alias(alias_pred, args) => {
-                let func = self.register_const_for_alias_pred(alias_pred, args.len());
-                let args = args
-                    .iter()
-                    .map(|expr| self.as_expr_cx().expr_to_fixpoint(expr))
-                    .collect_vec();
-                let pred = fixpoint::Expr::App(func, args);
-                (vec![], vec![(fixpoint::Pred::Expr(pred), None)])
-            }
-        }
+    pub fn pred_to_fixpoint(&mut self, pred: &rty::Expr) -> (Bindings, PredSpans) {
+        let mut bindings = vec![];
+        let mut preds = vec![];
+        self.pred_to_fixpoint_internal(pred, &mut bindings, &mut preds);
+        (bindings, preds)
     }
 
     fn pred_to_fixpoint_internal(

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -12,7 +12,7 @@ use flux_middle::{
         fold::{FallibleTypeFolder, TypeFoldable, TypeFolder, TypeVisitable, TypeVisitor},
         subst::RegionSubst,
         BaseTy, Binder, BoundVariableKind, Expr, ExprKind, GenericArg, HoleKind, Mutability, Path,
-        Pred, PtrKind, Region, Ty, TyKind, INNERMOST,
+        PtrKind, Region, Ty, TyKind, INNERMOST,
     },
     rustc::mir::{BasicBlock, Local, LocalDecls, Place, PlaceElem},
 };
@@ -421,7 +421,7 @@ impl BasicBlockEnvShape {
                 if sorts.is_empty() {
                     Ty::indexed(bty, idx)
                 } else {
-                    let ty = Ty::constr_expr(Expr::hole(HoleKind::Pred), Ty::indexed(bty, idx));
+                    let ty = Ty::constr(Expr::hole(HoleKind::Pred), Ty::indexed(bty, idx));
                     Ty::exists(Binder::with_sorts(ty, sorts))
                 }
             }
@@ -606,7 +606,7 @@ impl TypeFolder for Generalizer {
                 })
                 .fold_with(self)
             }
-            TyKind::Constr(Pred::Expr(pred), ty) => {
+            TyKind::Constr(pred, ty) => {
                 self.preds.push(pred.clone());
                 ty.fold_with(self)
             }


### PR DESCRIPTION
Make assoc pred applications/alias pred part of the syntax of `Expr` in `rty`. Encoding into fixpoint assumes that assoc preds can only be used at the top level in the surface syntax, but the restriction could easily be lifted.