### PR TITLE
Make GenericsSubstFolder configurable

### DIFF
--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -22,7 +22,7 @@ use rustc_hir::{def::DefKind, def_id::DefId, OwnerId};
 use rustc_span::{Span, Symbol};
 
 use self::sortck::InferCtxt;
-use crate::conv::{self, ConvCtxt};
+use crate::conv;
 
 struct Wf<'a, 'tcx> {
     genv: &'a GlobalEnv<'a, 'tcx>,
@@ -637,15 +637,9 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         args: &[fhir::RefineArg],
         span: Span,
     ) -> Result<(), ErrorGuaranteed> {
-        let conv = ConvCtxt::new(self.genv, &infcx.wfckresults);
-        let mut env = conv::Env::new(self.genv, &[], &infcx.wfckresults);
-        let generic_args = conv
-            .conv_generic_args(&mut env, alias_pred.trait_id, &alias_pred.generic_args)
-            .emit(self.genv.sess)?;
-
         if let Some(inputs) = self
             .genv
-            .sort_of_alias_pred(alias_pred, &generic_args)
+            .sort_of_alias_pred(alias_pred)
             .emit(self.genv.sess)?
         {
             if args.len() != inputs.len() {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -591,7 +591,6 @@ pub struct AliasPred {
     pub trait_id: DefId,
     pub name: Symbol,
     pub generic_args: Vec<GenericArg>,
-    // pub refine_args: Vec<RefineArg>,
 }
 
 #[derive(Clone)]

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1082,13 +1082,17 @@ impl Binder<Ty> {
 
 impl<T: TypeFoldable> EarlyBinder<T> {
     pub fn instantiate(self, args: &[GenericArg], refine_args: &[Expr]) -> T {
-        self.0
-            .fold_with(&mut subst::GenericsSubstFolder::new(Some(args), refine_args))
+        self.0.fold_with(&mut subst::GenericsSubstFolder::new(
+            subst::GenericArgsDelegate(args),
+            refine_args,
+        ))
     }
 
     pub fn instantiate_identity(self, refine_args: &[Expr]) -> T {
-        self.0
-            .fold_with(&mut subst::GenericsSubstFolder::new(None, refine_args))
+        self.0.fold_with(&mut subst::GenericsSubstFolder::new(
+            subst::IdentitySubstDelegate,
+            refine_args,
+        ))
     }
 }
 


### PR DESCRIPTION
Spawn out of [this discussion](https://github.com/flux-rs/flux/pull/599#discussion_r1453770766).

This makes the substitution of generic parameters configurable. This is similar to the original implementation with a different substitution for sorts but I believe this is more honest about explaining the underlying issue.