### PR TITLE
Use attribute to indicate fake_impl method

### DIFF
--- a/crates/flux-driver/src/collector.rs
+++ b/crates/flux-driver/src/collector.rs
@@ -537,7 +537,6 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
 
     fn fake_method_of(&mut self, items: &[ImplItemRef]) -> Option<LocalDefId> {
         for item in items {
-            // TODO(RJ): ask-nico, why is fake_impl() not visible?
             let attrs = self.tcx.hir().attrs(item.id.hir_id());
             if let Ok(mut attrs) = self.parse_flux_attrs(attrs, DefKind::Impl { of_trait: false }) {
                 if let AssocItemKind::Fn { .. } = item.kind

--- a/crates/flux-tests/tests/neg/surface/extern_spec_impl02_exp.rs
+++ b/crates/flux-tests/tests/neg/surface/extern_spec_impl02_exp.rs
@@ -27,6 +27,7 @@ struct __FluxExternStruct1usize();
 #[flux::extern_spec]
 #[flux::predicate{ f = |x:int| { 10 < x } }]
 impl __FluxExternStruct1usize {
+    #[flux::fake_impl]
     fn __flux_extern_impl_fake_method<FluxFake: MyTrait>(x: usize) {}
 }
 

--- a/lib/flux-attrs/src/extern_spec.rs
+++ b/lib/flux-attrs/src/extern_spec.rs
@@ -140,6 +140,7 @@ impl ToTokens for ExternItemImpl {
                 //     quote!(fn __flux_extern_impl_fake_method() where #self_ty : #trait_, {});
                 let fake_fn =
                     quote!(fn __flux_extern_impl_fake_method<FluxFake : #trait_>(x: #self_ty) {});
+                quote!(#[flux::fake_impl]).to_tokens(tokens);
                 fake_fn.to_tokens(tokens);
             }
         });


### PR DESCRIPTION
fixes the dangling `attributes` issue from #611 