### PR TITLE
Improve pprint

### DIFF
--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -84,9 +84,9 @@ fhir_analysis_invalid_base_instance =
     values of this type cannot be used as base sorted instances
 
 fhir_analysis_param_not_determined =
-    parameter `{$sym}` cannot be determined
+    parameter `{$name}` cannot be determined
     .label = undetermined parameter
-    .help = try indexing a type with `{$sym}` in a position that fully determines its value
+    .help = try indexing a type with `{$name}` in a position that fully determines its value
 
 fhir_analysis_sort_annotation_needed =
     sort annotation needed

--- a/crates/flux-fhir-analysis/src/wf/errors.rs
+++ b/crates/flux-fhir-analysis/src/wf/errors.rs
@@ -59,12 +59,12 @@ impl EarlyBoundArgCountMismatch {
 pub(super) struct DuplicatedEnsures {
     #[primary_span]
     span: Span,
-    loc: Symbol,
+    loc: String,
 }
 
 impl DuplicatedEnsures {
-    pub(super) fn new(loc: &fhir::Ident) -> DuplicatedEnsures {
-        Self { span: loc.span(), loc: loc.sym() }
+    pub(super) fn new(loc: &fhir::PathExpr) -> DuplicatedEnsures {
+        Self { span: loc.span, loc: format!("{loc:?}") }
     }
 }
 
@@ -89,8 +89,8 @@ pub(super) struct MissingEnsures {
 }
 
 impl MissingEnsures {
-    pub(super) fn new(loc: &fhir::Ident) -> MissingEnsures {
-        Self { span: loc.span() }
+    pub(super) fn new(loc: &fhir::PathExpr) -> MissingEnsures {
+        Self { span: loc.span }
     }
 }
 
@@ -205,12 +205,12 @@ pub(super) struct ParamNotDetermined {
     #[primary_span]
     #[label]
     span: Span,
-    sym: Symbol,
+    name: Symbol,
 }
 
 impl ParamNotDetermined {
-    pub(super) fn new(ident: fhir::Ident) -> Self {
-        Self { span: ident.span(), sym: ident.sym() }
+    pub(super) fn new(span: Span, name: Symbol) -> Self {
+        Self { span, name }
     }
 }
 
@@ -224,7 +224,7 @@ pub(super) struct SortAnnotationNeeded {
 
 impl SortAnnotationNeeded {
     pub(super) fn new(param: &fhir::RefineParam) -> Self {
-        Self { span: param.ident.span() }
+        Self { span: param.span }
     }
 }
 

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -231,27 +231,14 @@ pub type ScopeId = NodeId;
 pub struct ResolverOutput {
     pub path_res_map: UnordMap<NodeId, fhir::Res>,
     pub impl_trait_res_map: UnordMap<NodeId, hir::ItemId>,
-    /// Resolution of parameters both explicit and implicit. The [`fhir::Name`] is unique per item.
+    /// Resolution of parameters both explicit and implicit. The [`fhir::ParamId`] is unique per item.
     /// The [`NodeId`] correspond to the node introducing the parameter. When explicit, this is the
     /// id of the [`surface::GenericArg`] or [`surface::RefineParam`], when implicit, this is the id
     /// of the [`surface::RefineArg::Bind`] or [`surface::Arg`].
-    pub param_res_map: UnordMap<NodeId, (fhir::Name, fhir::ParamKind)>,
+    pub param_res_map: UnordMap<NodeId, (fhir::ParamId, fhir::ParamKind)>,
     /// List of implicit params defined in a scope. The [`NodeId`] is the id of the node introducing
     /// the scope, i.e., [`surface::FnSig`], [`surface::FnOutput`], or [`surface::VariantDef`].
     pub implicit_params: UnordMap<NodeId, Vec<(Ident, NodeId)>>,
     pub sort_path_res_map: UnordMap<NodeId, fhir::SortRes>,
-    pub path_expr_res_map: UnordMap<NodeId, PathRes>,
-}
-
-pub struct ResolvedParam {
-    pub ident: fhir::Ident,
-    pub kind: fhir::ParamKind,
-}
-
-#[derive(Clone, Copy)]
-pub enum PathRes<Id = fhir::Name> {
-    Param(fhir::ParamKind, Id),
-    Const(DefId),
-    NumConst(i128),
-    GlobalFunc(fhir::SpecFuncKind, Symbol),
+    pub path_expr_res_map: UnordMap<NodeId, fhir::ExprRes>,
 }

--- a/crates/flux-middle/src/rty/evars.rs
+++ b/crates/flux-middle/src/rty/evars.rs
@@ -147,7 +147,7 @@ mod pretty {
     use crate::pretty::*;
 
     impl Pretty for EVar {
-        fn fmt(&self, _cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, _cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             w!("?e{}#{}", ^self.id.as_u32(), ^self.cx.0)
         }

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -232,10 +232,16 @@ pub struct KVar {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
+pub struct EarlyParamVar {
+    pub index: u32,
+    pub name: Symbol,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
 pub enum Var {
     Free(Name),
     LateBound(DebruijnIndex, u32),
-    EarlyBound(u32),
+    EarlyParam(EarlyParamVar),
     EVar(EVar),
 }
 
@@ -374,8 +380,8 @@ impl Expr {
         Var::LateBound(bvar, idx).to_expr()
     }
 
-    pub fn early_bvar(idx: u32) -> Expr {
-        Var::EarlyBound(idx).to_expr()
+    pub fn early_param(index: u32, name: Symbol) -> Expr {
+        Var::EarlyParam(EarlyParamVar { index, name }).to_expr()
     }
 
     pub fn local(local: Local, espan: Option<ESpan>) -> Expr {
@@ -964,7 +970,7 @@ mod pretty {
             define_scoped!(cx, f);
             match self {
                 Var::LateBound(bvar, idx) => w!("({:?}.{})", bvar, ^idx),
-                Var::EarlyBound(idx) => w!("#{}", ^idx),
+                Var::EarlyParam(var) => w!("{}", ^var.name),
                 Var::Free(name) => w!("{:?}", ^name),
                 Var::EVar(evar) => w!("{:?}", evar),
             }

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -644,6 +644,11 @@ impl Expr {
         matches!(self.kind(), ExprKind::Abs(..))
     }
 
+    /// Wether this is an aggregate expression with no fields.
+    pub fn is_unit(&self) -> bool {
+        matches!(self.kind(), ExprKind::Aggregate(_, flds) if flds.is_empty())
+    }
+
     pub fn eta_expand_abs(&self, inputs: &[Sort], output: Sort) -> Lambda {
         let args = (0..inputs.len())
             .map(|idx| Expr::late_bvar(INNERMOST, idx as u32))

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -1068,7 +1068,7 @@ impl TypeVisitable for Var {
     fn visit_with<V: TypeVisitor>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy, ()> {
         match self {
             Var::Free(name) => visitor.visit_fvar(*name),
-            Var::LateBound(_, _) | Var::EarlyBound(_) | Var::EVar(_) => ControlFlow::Continue(()),
+            Var::LateBound(_, _) | Var::EarlyParam(_) | Var::EVar(_) => ControlFlow::Continue(()),
         }
     }
 }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -557,7 +557,6 @@ pub struct AliasReft {
     pub trait_id: DefId,
     pub name: Symbol,
     pub args: GenericArgs,
-    // pub refine_args: RefineArgs,
 }
 
 impl AliasReft {
@@ -2099,7 +2098,12 @@ mod pretty {
             match self.kind() {
                 TyKind::Indexed(bty, idx) => {
                     w!("{:?}", bty)?;
-                    if !cx.hide_refinements && !bty.sort().is_unit() {
+                    if cx.hide_refinements {
+                        return Ok(());
+                    }
+                    if idx.is_unit() {
+                        w!("[]")?;
+                    } else {
                         w!("[{:?}]", idx)?;
                     }
                     Ok(())

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -259,7 +259,7 @@ impl From<usize> for ParamSort {
 
 newtype_index! {
     /// A *sort* *v*variable *id*
-    #[debug_format = "s#{}"]
+    #[debug_format = "?{}s"]
     pub struct SortVid {}
 }
 
@@ -285,7 +285,7 @@ impl ena::unify::EqUnifyValue for Sort {}
 
 newtype_index! {
     /// A *num*eric *v*variable *id*
-    #[debug_format = "n#{}"]
+    #[debug_format = "?{}n"]
     pub struct NumVid {}
 }
 

--- a/crates/flux-middle/src/rty/normalize.rs
+++ b/crates/flux-middle/src/rty/normalize.rs
@@ -124,7 +124,7 @@ impl<'a> Normalizer<'a> {
             ExprKind::GlobalFunc(sym, SpecFuncKind::Def)
                 if let Some(defn) = self.defs.func_defn(sym) =>
             {
-                let res = defn.expr.replace_bound_exprs(args);
+                let res = defn.expr.replace_bound_refts(args);
                 Self::at_base(res, espan)
             }
             ExprKind::Abs(lam) => {

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -267,11 +267,11 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
         let poly_ty = self.refine_poly_ty(ty)?;
         let ty = match &poly_ty.vars()[..] {
             [] => poly_ty.skip_binder().shift_out_escaping(1),
-            [rty::BoundVariableKind::Refine(s, _)] => {
+            [rty::BoundVariableKind::Refine(s, ..)] => {
                 if s.is_unit() {
-                    poly_ty.replace_bound_expr(&rty::Expr::unit())
+                    poly_ty.replace_bound_reft(&rty::Expr::unit())
                 } else if let Some(def_id) = s.is_unit_adt() {
-                    poly_ty.replace_bound_expr(&rty::Expr::unit_adt(def_id))
+                    poly_ty.replace_bound_reft(&rty::Expr::unit_adt(def_id))
                 } else {
                     rty::Ty::exists(poly_ty)
                 }

--- a/crates/flux-middle/src/rty/subst.rs
+++ b/crates/flux-middle/src/rty/subst.rs
@@ -390,8 +390,8 @@ impl<D: GenericsSubstDelegate> TypeFolder for GenericsSubstFolder<'_, D> {
     }
 
     fn fold_expr(&mut self, expr: &Expr) -> Expr {
-        if let ExprKind::Var(Var::EarlyBound(idx)) = expr.kind() {
-            self.expr_for_param(*idx)
+        if let ExprKind::Var(Var::EarlyParam(var)) = expr.kind() {
+            self.expr_for_param(var.index)
         } else {
             expr.super_fold_with(self)
         }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -513,7 +513,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             .check_fn_call(rcx, env, did, fn_sig, generic_args, &actuals)
             .with_span(terminator_span)?;
 
-        let output = output.replace_bound_exprs_with(|sort, _| rcx.define_vars(sort));
+        let output = output.replace_bound_refts_with(|sort, _, _| rcx.define_vars(sort));
 
         for constr in &output.ensures {
             match constr {

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -826,7 +826,7 @@ mod pretty {
     use super::*;
 
     impl Pretty for Tag {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             w!("{:?} at {:?}", ^self.reason, self.src_span)
         }

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -284,7 +284,7 @@ impl<'a, 'genv, 'tcx> ConstrGen<'a, 'genv, 'tcx> {
         let mut infcx = self.infcx(rcx, ConstrReason::Ret);
 
         let output =
-            output.replace_bound_exprs_with(|sort, mode| infcx.fresh_infer_var(sort, mode));
+            output.replace_bound_refts_with(|sort, mode, _| infcx.fresh_infer_var(sort, mode));
 
         infcx.subtyping(rcx, &ret_place_ty, &output.ret)?;
         for constraint in &output.ensures {
@@ -314,7 +314,7 @@ impl<'a, 'genv, 'tcx> ConstrGen<'a, 'genv, 'tcx> {
 
         let variant = variant
             .instantiate(&generic_args, &[])
-            .replace_bound_exprs_with(|sort, mode| infcx.fresh_infer_var(sort, mode));
+            .replace_bound_refts_with(|sort, mode, _| infcx.fresh_infer_var(sort, mode));
 
         // Check arguments
         for (actual, formal) in iter::zip(fields, variant.fields()) {
@@ -517,7 +517,7 @@ impl<'a, 'genv, 'tcx> InferCtxt<'a, 'genv, 'tcx> {
             (_, TyKind::Exists(ty2)) => {
                 self.push_scope(rcx);
                 let ty2 =
-                    ty2.replace_bound_exprs_with(|sort, mode| self.fresh_infer_var(sort, mode));
+                    ty2.replace_bound_refts_with(|sort, mode, _| self.fresh_infer_var(sort, mode));
                 self.subtyping(rcx, &ty1, &ty2)?;
                 self.pop_scope();
                 Ok(())

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -306,7 +306,7 @@ impl Env {
                     span_bug!(dbg_span, "no entry found for late bound var: `{var:?}`")
                 })
             }
-            rty::Var::EarlyBound(_) | rty::Var::EVar(_) => {
+            rty::Var::EarlyParam(_) | rty::Var::EVar(_) => {
                 span_bug!(dbg_span, "unexpected var: `{var:?}`")
             }
         }

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -301,8 +301,8 @@ impl Env {
                 self.get_fvar(*name)
                     .unwrap_or_else(|| span_bug!(dbg_span, "no entry found for name: `{name:?}`"))
             }
-            rty::Var::LateBound(debruijn, idx) => {
-                self.get_late_bvar(*debruijn, *idx).unwrap_or_else(|| {
+            rty::Var::LateBound(debruijn, var) => {
+                self.get_late_bvar(*debruijn, var.index).unwrap_or_else(|| {
                     span_bug!(dbg_span, "no entry found for late bound var: `{var:?}`")
                 })
             }
@@ -676,11 +676,11 @@ impl KVarStore {
         let args = itertools::chain(
             binders.iter().rev().enumerate().flat_map(|(level, sorts)| {
                 let debruijn = DebruijnIndex::from_usize(level);
-                sorts
-                    .iter()
-                    .cloned()
-                    .enumerate()
-                    .map(move |(idx, sort)| (rty::Var::LateBound(debruijn, idx as u32), sort))
+                sorts.iter().cloned().enumerate().map(move |(index, sort)| {
+                    let var =
+                        rty::BoundReft { index: index as u32, kind: rty::BoundReftKind::Annon };
+                    (rty::Var::LateBound(debruijn, var), sort)
+                })
             }),
             scope
                 .iter()

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -49,7 +49,7 @@ fn check_invariant(
             .emit(genv.sess())?
             .expect("cannot check opaque structs")
             .instantiate_identity(&[])
-            .replace_bound_exprs_with(|sort, _| rcx.define_vars(sort));
+            .replace_bound_refts_with(|sort, _, _| rcx.define_vars(sort));
 
         for ty in variant.fields() {
             let ty = rcx.unpack(ty);

--- a/crates/flux-refineck/src/refine_tree.rs
+++ b/crates/flux-refineck/src/refine_tree.rs
@@ -713,21 +713,21 @@ mod pretty {
     }
 
     impl Pretty for RefineTree {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             w!("{:?}", &self.root)
         }
     }
 
     impl Pretty for RefineSubtree<'_> {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             w!("{:?}", &self.root)
         }
     }
 
     impl Pretty for NodePtr {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             let node = self.borrow();
             match &node.kind {
@@ -783,7 +783,7 @@ mod pretty {
 
     fn fmt_children(
         children: &[NodePtr],
-        cx: &PPrintCx,
+        cx: &PrettyCx,
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
         let mut f = PadAdapter::wrap_fmt(f, 2);
@@ -804,7 +804,7 @@ mod pretty {
     }
 
     impl Pretty for RefineCtxt<'_> {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             let parents = ParentsIter::new(NodePtr::clone(&self.ptr)).collect_vec();
             write!(
@@ -836,7 +836,7 @@ mod pretty {
     }
 
     impl Pretty for Scope {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             write!(
                 f,

--- a/crates/flux-refineck/src/refine_tree.rs
+++ b/crates/flux-refineck/src/refine_tree.rs
@@ -329,7 +329,7 @@ impl TypeFolder for Unpacker<'_, '_> {
                 // opening of mutable references. See also `ConstrGen::check_fn_call`.
                 if !self.in_mut_ref || self.unpack_inside_mut_ref {
                     let bound_ty = bound_ty
-                        .replace_bound_exprs_with(|sort, _| self.rcx.define_vars(sort))
+                        .replace_bound_refts_with(|sort, _, _| self.rcx.define_vars(sort))
                         .fold_with(self);
                     if let AssumeInvariants::Yes { check_overflow } = self.assume_invariants {
                         self.rcx.assume_invariants(&bound_ty, check_overflow);

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -886,7 +886,7 @@ mod pretty {
     use super::*;
 
     impl Pretty for PlacesTree {
-        fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             w!(
                 "{{{}}}",
@@ -900,15 +900,15 @@ mod pretty {
             )
         }
 
-        fn default_cx(tcx: TyCtxt) -> PPrintCx {
-            PPrintCx::default(tcx)
+        fn default_cx(tcx: TyCtxt) -> PrettyCx {
+            PrettyCx::default(tcx)
                 .kvar_args(KVarArgs::Hide)
                 .hide_binder(true)
         }
     }
 
     impl Pretty for LocKind {
-        fn fmt(&self, _cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, _cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             match self {
                 LocKind::Local | LocKind::Universal => Ok(()),

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -762,7 +762,7 @@ fn downcast_struct(
     let (.., flds) = idx.expect_adt();
     Ok(struct_variant(genv, adt.did())?
         .instantiate(args, &[])
-        .replace_bound_exprs(&flds)
+        .replace_bound_refts(&flds)
         .fields
         .to_vec())
 }
@@ -796,7 +796,7 @@ fn downcast_enum(
         .variant_sig(adt.did(), variant_idx)?
         .expect("enums cannot be opaque")
         .instantiate(args, &[])
-        .replace_bound_exprs_with(|sort, _| rcx.define_vars(sort));
+        .replace_bound_refts_with(|sort, _, _| rcx.define_vars(sort));
 
     // FIXME(nilehmann) flatten indices
     let (.., exprs1) = idx1.expect_adt();


### PR DESCRIPTION
* Represent vars in fhir as paths
* Carry parameter names down to rty
* Generate fresh names for anonymous bound variables instead of printing de Bruijn indices.