### PR TITLE
Refactor treatment of generic args of kind base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           enable-stack: true
           stack-version: "latest"
-      
+
       - name: Install Z3
         uses: cda-tum/setup-z3@v1.0.9
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,10 +3,8 @@ name: gh-pages
 on:
   push:
     branches: [main]
-    paths: book/**
   pull_request:
     branches: [main]
-    paths: book/**
 
 jobs:
   build:

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -212,8 +212,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
                     surface::GenericParamKind::Type => {
                         fhir::GenericParamKind::Type { default: None }
                     }
-                    surface::GenericParamKind::Spl => fhir::GenericParamKind::SplTy,
-                    surface::GenericParamKind::Base => fhir::GenericParamKind::BaseTy,
+                    surface::GenericParamKind::Base => fhir::GenericParamKind::Base,
                     surface::GenericParamKind::Refine { .. } => unreachable!(),
                 };
                 self_kind = Some(kind);
@@ -230,8 +229,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
                                 .transpose()?,
                         }
                     }
-                    surface::GenericParamKind::Base => fhir::GenericParamKind::BaseTy,
-                    surface::GenericParamKind::Spl => fhir::GenericParamKind::SplTy,
+                    surface::GenericParamKind::Base => fhir::GenericParamKind::Base,
                     surface::GenericParamKind::Refine { .. } => unreachable!(),
                 };
                 surface_params.insert(def_id, fhir::GenericParam { def_id, kind });

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -80,9 +80,6 @@ fhir_analysis_expected_numeric =
 fhir_analysis_no_equality =
     values of sort `{$sort}` cannot be compared for equality
 
-fhir_analysis_invalid_base_instance =
-    values of this type cannot be used as base sorted instances
-
 fhir_analysis_param_not_determined =
     parameter `{$name}` cannot be determined
     .label = undetermined parameter
@@ -165,6 +162,9 @@ fhir_analysis_assoc_type_not_found =
     associated type not found
     .label = cannot resolve this associated type
     .note = Flux cannot resolved associated types if they are defined in a super trait
+
+fhir_analysis_invalid_base_instance =
+    values of this type cannot be used as base sorted instances
 
 # Check impl against trait errors
 

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -956,12 +956,12 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                     into.push(rty::GenericArg::Ty(self.conv_ty(env, ty)?));
                 }
                 (fhir::GenericArg::Type(ty), rty::GenericParamDefKind::BaseTy) => {
-                    let arg = self
+                    let sty = self
                         .conv_ty(env, ty)?
                         .shallow_canonicalize()
-                        .to_bty_arg()
+                        .to_simple_ty()
                         .unwrap();
-                    into.push(arg);
+                    into.push(rty::GenericArg::Base(sty));
                 }
                 _ => {
                     bug!("unexpected param `{:?}` for arg `{arg:?}`", param.kind);

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -938,7 +938,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                     let ctor = self
                         .conv_ty(env, ty)?
                         .shallow_canonicalize()
-                        .to_simple_ty_ctor()
+                        .to_subset_ty_ctor()
                         .ok_or_else(|| {
                             self.genv
                                 .sess()

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -959,7 +959,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                     let sty = self
                         .conv_ty(env, ty)?
                         .shallow_canonicalize()
-                        .to_simple_ty()
+                        .to_simple_ty_ctor()
                         .unwrap();
                     into.push(rty::GenericArg::Base(sty));
                 }

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -291,7 +291,7 @@ fn refinement_generics_of(
     }
 }
 
-fn type_of(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<rty::PolyTy>> {
+fn type_of(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<rty::TyCtor>> {
     let ty = match genv.def_kind(def_id) {
         DefKind::TyAlias { .. } => {
             let alias = genv.map().expect_item(def_id).expect_type_alias();
@@ -310,7 +310,7 @@ fn type_of(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<
         DefKind::Impl { .. } | DefKind::Struct | DefKind::Enum | DefKind::AssocTy => {
             let generics = genv.generics_of(def_id)?;
             let ty = genv.lower_type_of(def_id)?.skip_binder();
-            Refiner::default(genv, &generics).refine_poly_ty(&ty)?
+            Refiner::default(genv, &generics).refine_ty_ctor(&ty)?
         }
         kind => {
             bug!("`{:?}` not supported", kind.descr(def_id.to_def_id()))

--- a/crates/flux-fhir-analysis/src/wf/errors.rs
+++ b/crates/flux-fhir-analysis/src/wf/errors.rs
@@ -185,20 +185,6 @@ impl<'a> InvalidPrimitiveDotAccess<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(fhir_analysis_invalid_base_instance, code = "FLUX")]
-pub(super) struct InvalidBaseInstance<'fhir> {
-    #[primary_span]
-    span: Span,
-    ty: fhir::Ty<'fhir>,
-}
-
-impl<'fhir> InvalidBaseInstance<'fhir> {
-    pub(super) fn new(ty: fhir::Ty<'fhir>) -> Self {
-        Self { ty, span: ty.span }
-    }
-}
-
-#[derive(Diagnostic)]
 #[diag(fhir_analysis_param_not_determined, code = "FLUX")]
 #[help]
 pub(super) struct ParamNotDetermined {

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -37,7 +37,7 @@ struct Wf<'genv, 'tcx> {
 /// determined. The context is called Xi because in the paper [Focusing on Liquid Refinement Typing],
 /// the well-formedness judgment uses an uppercase Xi (Ξ) for a context that is similar in purpose.
 ///
-/// This is basically a set of [`fhir::Name`] implemented with a snapshot map such that elements
+/// This is basically a set of [`fhir::ParamId`] implemented with a snapshot map such that elements
 /// can be removed in batch when there's a change in polarity.
 ///
 /// [Focusing on Liquid Refinement Typing]: https://arxiv.org/pdf/2209.13000.pdf

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -12,7 +12,7 @@ use flux_errors::{FluxSession, ResultExt};
 use flux_middle::{
     fhir::{self, ExprRes, FluxOwnerId, SurfaceIdent},
     global_env::GlobalEnv,
-    rty::{self, GenericParamDefKind, WfckResults},
+    rty::{self, WfckResults},
 };
 use rustc_data_structures::{
     snapshot_map::{self, SnapshotMap},
@@ -20,7 +20,7 @@ use rustc_data_structures::{
 };
 use rustc_errors::{ErrorGuaranteed, IntoDiagnostic};
 use rustc_hash::FxHashSet;
-use rustc_hir::{def::DefKind, def_id::DefId, OwnerId};
+use rustc_hir::{def::DefKind, OwnerId};
 use rustc_span::Symbol;
 
 use self::sortck::InferCtxt;
@@ -255,9 +255,8 @@ impl<'genv, 'tcx> Wf<'genv, 'tcx> {
     fn check_generic_bound(&mut self, infcx: &mut InferCtxt, bound: &fhir::GenericBound) -> Result {
         match bound {
             fhir::GenericBound::Trait(trait_ref, _) => self.check_path(infcx, &trait_ref.trait_ref),
-            fhir::GenericBound::LangItemTrait(lang_item, args, bindings) => {
-                let def_id = self.genv.tcx().require_lang_item(*lang_item, None);
-                self.check_generic_args(infcx, def_id, args)?;
+            fhir::GenericBound::LangItemTrait(_, args, bindings) => {
+                self.check_generic_args(infcx, args)?;
                 self.check_type_bindings(infcx, bindings)?;
                 Ok(())
             }
@@ -385,10 +384,9 @@ impl<'genv, 'tcx> Wf<'genv, 'tcx> {
                 self.check_type(infcx, ty)?;
                 self.check_expr_as_pred(infcx, pred)
             }
-            fhir::TyKind::OpaqueDef(item_id, args, _refine_args, _) => {
+            fhir::TyKind::OpaqueDef(_item_id, args, _refine_args, _) => {
                 // TODO sanity check the _refine_args (though they should never fail!) but we'd need their expected sorts
-                let def_id = item_id.owner_id.to_def_id();
-                self.check_generic_args(infcx, def_id, args)
+                self.check_generic_args(infcx, args)
             }
             fhir::TyKind::RawPtr(ty, _) => self.check_type(infcx, ty),
             fhir::TyKind::Hole(_) | fhir::TyKind::Never => Ok(()),
@@ -408,26 +406,7 @@ impl<'genv, 'tcx> Wf<'genv, 'tcx> {
             .try_collect_exhaust()
     }
 
-    fn check_generic_args_kinds(&self, def_id: DefId, args: &[fhir::GenericArg]) -> Result {
-        let generics = self.genv.generics_of(def_id).emit(self.genv.sess())?;
-        for (arg, param) in iter::zip(args, &generics.params) {
-            if param.kind == GenericParamDefKind::SplTy {
-                let ty = arg.expect_type();
-                if self.genv.sort_of_ty(ty).is_none() {
-                    return self.emit_err(errors::InvalidBaseInstance::new(*ty));
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn check_generic_args(
-        &mut self,
-        infcx: &mut InferCtxt,
-        def_id: DefId,
-        args: &[fhir::GenericArg],
-    ) -> Result {
-        self.check_generic_args_kinds(def_id, args)?;
+    fn check_generic_args(&mut self, infcx: &mut InferCtxt, args: &[fhir::GenericArg]) -> Result {
         args.iter()
             .try_for_each_exhaust(|arg| self.check_generic_arg(infcx, arg))
     }
@@ -490,10 +469,8 @@ impl<'genv, 'tcx> Wf<'genv, 'tcx> {
 
         // TODO(nilehmann) we should check all segments
         let last_segment = path.last_segment();
-        if let fhir::Res::Def(_kind, did) = &path.res
-            && !last_segment.args.is_empty()
-        {
-            self.check_generic_args(infcx, *did, last_segment.args)?;
+        if !last_segment.args.is_empty() {
+            self.check_generic_args(infcx, last_segment.args)?;
         }
         let bindings = self.check_type_bindings(infcx, last_segment.bindings);
         if !self.genv.is_box(path.res) {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -352,9 +352,9 @@ impl<'genv> InferCtxt<'genv, '_> {
     }
 
     /// Whether a value of `sort1` can be automatically coerced to a value of `sort2`. A value of an
-    /// [`rty::Sort::Adt`] sort with a single field of sort `s` can be coerced to a value of sort `s`
-    /// and vice versa, i.e., we can automatically project the field out of the record or inject a
-    /// value into a record.
+    /// [`rty::SortCtor::Adt`] sort with a single field of sort `s` can be coerced to a value of sort
+    /// `s` and vice versa, i.e., we can automatically project the field out of the record or inject
+    /// a value into a record.
     fn is_coercible(&mut self, sort1: &rty::Sort, sort2: &rty::Sort, fhir_id: FhirId) -> bool {
         if self.try_equate(sort1, sort2).is_some() {
             return true;

--- a/crates/flux-metadata/src/lib.rs
+++ b/crates/flux-metadata/src/lib.rs
@@ -49,7 +49,7 @@ pub struct CrateMetadata {
     fn_sigs: FxHashMap<DefIndex, rty::EarlyBinder<rty::PolyFnSig>>,
     adts: FxHashMap<DefIndex, AdtMetadata>,
     /// For now it only store type of aliases
-    type_of: FxHashMap<DefIndex, rty::EarlyBinder<rty::PolyTy>>,
+    type_of: FxHashMap<DefIndex, rty::EarlyBinder<rty::TyCtor>>,
 }
 
 #[derive(TyEncodable, TyDecodable)]
@@ -98,7 +98,7 @@ impl CrateStore for CStore {
             .map(|adt| adt.variants.as_ref().map(rty::EarlyBinder::as_deref))
     }
 
-    fn type_of(&self, def_id: DefId) -> Option<&rty::EarlyBinder<rty::PolyTy>> {
+    fn type_of(&self, def_id: DefId) -> Option<&rty::EarlyBinder<rty::TyCtor>> {
         self.meta.get(&def_id.krate)?.type_of.get(&def_id.index)
     }
 }

--- a/crates/flux-middle/locales/en-US.ftl
+++ b/crates/flux-middle/locales/en-US.ftl
@@ -24,3 +24,6 @@ middle_unsupported_generic_bound =
 middle_query_unsupported =
     unsupported signature
     .note = {$reason}
+
+middle_query_invalid_generic_arg =
+    cannot instantiate base generic with opaque type or a type parameter of kind type

--- a/crates/flux-middle/src/cstore.rs
+++ b/crates/flux-middle/src/cstore.rs
@@ -9,7 +9,7 @@ pub trait CrateStore {
         &self,
         def_id: DefId,
     ) -> Option<rty::Opaqueness<rty::EarlyBinder<&[rty::PolyVariant]>>>;
-    fn type_of(&self, def_id: DefId) -> Option<&rty::EarlyBinder<rty::PolyTy>>;
+    fn type_of(&self, def_id: DefId) -> Option<&rty::EarlyBinder<rty::TyCtor>>;
 }
 
 pub type CrateStoreDyn = dyn CrateStore;

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -62,8 +62,7 @@ pub struct GenericParam<'fhir> {
 #[derive(Debug, Clone, Copy)]
 pub enum GenericParamKind<'fhir> {
     Type { default: Option<Ty<'fhir>> },
-    SplTy,
-    BaseTy,
+    Base,
     Lifetime,
 }
 
@@ -1004,7 +1003,7 @@ impl<'fhir> Generics<'fhir> {
     pub fn with_refined_by(self, genv: GlobalEnv<'fhir, '_>, refined_by: &RefinedBy) -> Self {
         let params = genv.alloc_slice_fill_iter(self.params.iter().map(|param| {
             let kind = if refined_by.is_base_generic(param.def_id.to_def_id()) {
-                GenericParamKind::SplTy
+                GenericParamKind::Base
             } else {
                 param.kind
             };

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -474,12 +474,11 @@ pub enum TyKind<'fhir> {
     /// A type that parses as a [`BaseTy`] but was written without refinements. Most types in
     /// this category are base types and will be converted into an [existential], e.g., `i32` is
     /// converted into `∃v:int. i32[v]`. However, this category also contains generic variables
-    /// of kind [type] or [*special*]. We cannot distinguish these syntactially so we resolve them
-    /// later in the analysis.
+    /// of kind [type]. We cannot distinguish these syntactially so we resolve them later in the
+    /// analysis.
     ///
     /// [existential]: crate::rty::TyKind::Exists
     /// [type]: GenericParamKind::Type
-    /// [*special*]: GenericParamKind::SplTy
     BaseTy(BaseTy<'fhir>),
     Indexed(BaseTy<'fhir>, RefineArg<'fhir>),
     Exists(&'fhir [RefineParam<'fhir>], &'fhir Ty<'fhir>),

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -215,8 +215,8 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
 
         let trait_ref = lowering::lower_trait_ref(self.tcx(), poly_trait_ref.skip_binder())
             .map_err(|err| QueryErr::unsupported(self.tcx(), impl_id, err.into_err()))?;
-        let trait_generics = self.generics_of(trait_ref.def_id)?;
-        let trait_ref = Refiner::default(self, &trait_generics).refine_trait_ref(&trait_ref)?;
+        let impl_generics = self.generics_of(impl_id)?;
+        let trait_ref = Refiner::default(self, &impl_generics).refine_trait_ref(&trait_ref)?;
         Ok(Some(rty::EarlyBinder(trait_ref)))
     }
 

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -213,12 +213,10 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
 
         let Some(poly_trait_ref) = self.tcx().impl_trait_ref(impl_id) else { return Ok(None) };
 
-        let impl_generics = self.generics_of(impl_id)?;
-        let trait_ref = poly_trait_ref.skip_binder();
-        let args = lowering::lower_generic_args(self.tcx(), trait_ref.args)
+        let trait_ref = lowering::lower_trait_ref(self.tcx(), poly_trait_ref.skip_binder())
             .map_err(|err| QueryErr::unsupported(self.tcx(), impl_id, err.into_err()))?;
-        let args = self.refine_default_generic_args(&impl_generics, &args)?;
-        let trait_ref = rty::TraitRef { def_id: trait_ref.def_id, args };
+        let trait_generics = self.generics_of(trait_ref.def_id)?;
+        let trait_ref = Refiner::default(self, &trait_generics).refine_trait_ref(&trait_ref)?;
         Ok(Some(rty::EarlyBinder(trait_ref)))
     }
 
@@ -320,19 +318,6 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         let item_def_id = self.hir().ty_param_owner(def_id);
         let generics = self.tcx().generics_of(item_def_id);
         generics.param_def_id_to_index[&def_id.to_def_id()]
-    }
-
-    pub fn refine_default_generic_args(
-        self,
-        generics: &rty::Generics,
-        args: &ty::GenericArgs,
-    ) -> QueryResult<rty::GenericArgs> {
-        let refiner = Refiner::default(self, generics);
-        let mut res = vec![];
-        for arg in args {
-            res.push(refiner.refine_generic_arg_raw(arg)?);
-        }
-        Ok(res.into())
     }
 
     pub fn refine_default(

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -268,7 +268,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         self.inner.queries.item_bounds(self, def_id)
     }
 
-    pub fn type_of(self, def_id: DefId) -> QueryResult<rty::EarlyBinder<rty::PolyTy>> {
+    pub fn type_of(self, def_id: DefId) -> QueryResult<rty::EarlyBinder<rty::TyCtor>> {
         self.inner.queries.type_of(self, def_id)
     }
 

--- a/crates/flux-middle/src/pretty.rs
+++ b/crates/flux-middle/src/pretty.rs
@@ -175,7 +175,7 @@ struct Env {
 impl Env {
     fn lookup(&self, debruijn: DebruijnIndex, index: u32) -> Option<BoundVarName> {
         self.layers
-            .get(self.layers.len() - debruijn.as_usize() - 1)?
+            .get(self.layers.len().checked_sub(debruijn.as_usize() + 1)?)?
             .get(&index)
             .copied()
     }
@@ -328,7 +328,7 @@ impl PrettyCx<'_> {
                 if let Some(name) = self.env.borrow().lookup(debruijn, var.index) {
                     w!("{name:?}")
                 } else {
-                    w!("(⭡{debruijn:?}.{})", ^var.index)
+                    w!("⭡{}/#{}", ^debruijn.as_usize(), ^var.index)
                 }
             }
             BoundReftKind::Named(name) => w!("{name}"),

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -40,6 +40,7 @@ pub type QueryResult<T = ()> = Result<T, QueryErr>;
 #[derive(Debug, Clone)]
 pub enum QueryErr {
     Unsupported { def_id: DefId, def_span: Span, err: UnsupportedErr },
+    InvalidGenericArg { def_id: DefId, def_span: Span },
     Emitted(ErrorGuaranteed),
 }
 
@@ -574,6 +575,14 @@ impl<'a> IntoDiagnostic<'a> for QueryErr {
             QueryErr::Emitted(_) => {
                 let mut builder = handler.struct_err("QueryErr::Emitted should be emitted");
                 builder.downgrade_to_delayed_bug();
+                builder
+            }
+            QueryErr::InvalidGenericArg { def_span, .. } => {
+                let builder = handler.struct_span_err_with_code(
+                    def_span,
+                    fluent::middle_query_invalid_generic_arg,
+                    flux_errors::diagnostic_id(),
+                );
                 builder
             }
         }

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -56,7 +56,7 @@ pub struct Providers {
         FluxLocalDefId,
     ) -> QueryResult<Rc<rty::WfckResults<'genv>>>,
     pub adt_def: fn(GlobalEnv, LocalDefId) -> QueryResult<rty::AdtDef>,
-    pub type_of: fn(GlobalEnv, LocalDefId) -> QueryResult<rty::EarlyBinder<rty::PolyTy>>,
+    pub type_of: fn(GlobalEnv, LocalDefId) -> QueryResult<rty::EarlyBinder<rty::TyCtor>>,
     pub variants_of: fn(
         GlobalEnv,
         LocalDefId,
@@ -129,7 +129,7 @@ pub struct Queries<'genv, 'tcx> {
     assoc_refinement_def: Cache<(DefId, Symbol), QueryResult<rty::EarlyBinder<rty::Lambda>>>,
     sort_of_assoc_reft: Cache<(DefId, Symbol), Option<rty::EarlyBinder<rty::FuncSort>>>,
     item_bounds: Cache<DefId, QueryResult<rty::EarlyBinder<List<rty::Clause>>>>,
-    type_of: Cache<DefId, QueryResult<rty::EarlyBinder<rty::PolyTy>>>,
+    type_of: Cache<DefId, QueryResult<rty::EarlyBinder<rty::TyCtor>>>,
     variants_of: Cache<DefId, QueryResult<rty::Opaqueness<rty::EarlyBinder<rty::PolyVariants>>>>,
     fn_sig: Cache<DefId, QueryResult<rty::EarlyBinder<rty::PolyFnSig>>>,
     lower_late_bound_vars: Cache<LocalDefId, QueryResult<List<rustc::ty::BoundVariableKind>>>,
@@ -443,7 +443,7 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
         &self,
         genv: GlobalEnv,
         def_id: DefId,
-    ) -> QueryResult<rty::EarlyBinder<rty::PolyTy>> {
+    ) -> QueryResult<rty::EarlyBinder<rty::TyCtor>> {
         run_with_cache(&self.type_of, def_id, || {
             if let Some(local_id) = def_id.as_local() {
                 (self.providers.type_of)(genv, local_id)

--- a/crates/flux-middle/src/rty/canonicalize.rs
+++ b/crates/flux-middle/src/rty/canonicalize.rs
@@ -3,7 +3,7 @@ use rustc_type_ir::{Mutability, INNERMOST};
 use super::{
     box_args,
     fold::{TypeFoldable, TypeFolder},
-    BaseTy, Binder, BoundReftKind, BoundVariableKind, Expr, GenericArg, Ty, TyKind,
+    BaseTy, Binder, BoundVariableKind, Expr, GenericArg, Ty, TyKind,
 };
 use crate::intern::List;
 
@@ -84,35 +84,36 @@ pub enum CanonicalTy {
 
 impl CanonicalTy {
     pub fn to_bty_arg(&self) -> Option<GenericArg> {
-        match self {
-            CanonicalTy::Exists(poly_constr_ty) => {
-                let vars = poly_constr_ty.vars();
-                let constr_ty = poly_constr_ty.as_ref().skip_binder();
-                if let TyKind::Indexed(_, idx) = constr_ty.ty.kind()
-                    && idx.is_nu()
-                {
-                    let ty = constr_ty.to_ty();
-                    Some(GenericArg::BaseTy(Binder::new(ty, vars.clone())))
-                } else {
-                    None
-                }
-            }
-            CanonicalTy::Constr(constr_ty) => {
-                if let TyKind::Indexed(bty, idx) = constr_ty.ty.kind() {
-                    let sort = bty.sort();
-                    let infer_mode = sort.default_infer_mode();
-                    let ty = Ty::constr(Expr::eq(Expr::nu(), idx), Ty::indexed(bty.clone(), idx));
-                    let vars = List::singleton(BoundVariableKind::Refine(
-                        sort,
-                        infer_mode,
-                        BoundReftKind::Annon,
-                    ));
-                    Some(GenericArg::BaseTy(Binder::new(ty, vars)))
-                } else {
-                    None
-                }
-            }
-        }
+        todo!()
+        // match self {
+        //     CanonicalTy::Exists(poly_constr_ty) => {
+        //         let vars = poly_constr_ty.vars();
+        //         let constr_ty = poly_constr_ty.as_ref().skip_binder();
+        //         if let TyKind::Indexed(_, idx) = constr_ty.ty.kind()
+        //             && idx.is_nu()
+        //         {
+        //             let ty = constr_ty.to_ty();
+        //             Some(GenericArg::Base(Binder::new(ty, vars.clone())))
+        //         } else {
+        //             None
+        //         }
+        //     }
+        //     CanonicalTy::Constr(constr_ty) => {
+        //         if let TyKind::Indexed(bty, idx) = constr_ty.ty.kind() {
+        //             let sort = bty.sort();
+        //             let infer_mode = sort.default_infer_mode();
+        //             let ty = Ty::constr(Expr::eq(Expr::nu(), idx), Ty::indexed(bty.clone(), idx));
+        //             let vars = List::singleton(BoundVariableKind::Refine(
+        //                 sort,
+        //                 infer_mode,
+        //                 BoundReftKind::Annon,
+        //             ));
+        //             Some(GenericArg::Base(Binder::new(ty, vars)))
+        //         } else {
+        //             None
+        //         }
+        //     }
+        // }
     }
 }
 

--- a/crates/flux-middle/src/rty/canonicalize.rs
+++ b/crates/flux-middle/src/rty/canonicalize.rs
@@ -1,0 +1,88 @@
+use rustc_type_ir::{Mutability, INNERMOST};
+
+use super::{
+    box_args,
+    fold::{TypeFoldable, TypeFolder},
+    BaseTy, Binder, BoundVariableKind, Expr, GenericArg, Ty, TyKind,
+};
+use crate::intern::List;
+
+#[derive(Default)]
+pub struct Hoister {
+    vars: Vec<BoundVariableKind>,
+    preds: Vec<Expr>,
+}
+
+impl Hoister {
+    pub fn into_parts(self) -> (List<BoundVariableKind>, Vec<Expr>) {
+        (List::from_vec(self.vars), self.preds)
+    }
+
+    pub fn hoist(&mut self, ty: &Ty) -> Ty {
+        ty.fold_with(self)
+    }
+}
+
+impl TypeFolder for Hoister {
+    fn fold_ty(&mut self, ty: &Ty) -> Ty {
+        match ty.kind() {
+            TyKind::Exists(ty) => {
+                ty.replace_bound_exprs_with(|sort, mode| {
+                    let idx = self.vars.len();
+                    self.vars
+                        .push(BoundVariableKind::Refine(sort.clone(), mode));
+                    Expr::late_bvar(INNERMOST, idx as u32)
+                })
+                .fold_with(self)
+            }
+            TyKind::Constr(pred, ty) => {
+                self.preds.push(pred.clone());
+                ty.fold_with(self)
+            }
+            _ => ty.clone(),
+        }
+    }
+
+    fn fold_bty(&mut self, bty: &BaseTy) -> BaseTy {
+        match bty {
+            BaseTy::Adt(adt_def, args) if adt_def.is_box() => {
+                let (boxed, alloc) = box_args(args);
+                let args = List::from_arr([
+                    GenericArg::Ty(boxed.fold_with(self)),
+                    GenericArg::Ty(alloc.clone()),
+                ]);
+                BaseTy::Adt(adt_def.clone(), args)
+            }
+            BaseTy::Ref(re, ty, Mutability::Not) => {
+                BaseTy::Ref(*re, ty.fold_with(self), Mutability::Not)
+            }
+            BaseTy::Tuple(tys) => BaseTy::Tuple(tys.fold_with(self)),
+            _ => bty.clone(),
+        }
+    }
+}
+
+impl Ty {
+    pub fn shallow_canonicalize(&self) -> CanonicalTy {
+        let mut hoister = Hoister::default();
+        let ty = hoister.hoist(self);
+        let (vars, preds) = hoister.into_parts();
+        let pred = Expr::and(preds);
+        let constr_ty = ConstrTy { ty, pred };
+        if vars.is_empty() {
+            CanonicalTy::Constr(constr_ty)
+        } else {
+            CanonicalTy::Exists(Binder::new(constr_ty, vars))
+        }
+    }
+}
+
+pub enum CanonicalTy {
+    Exists(Binder<ConstrTy>),
+    Constr(ConstrTy),
+}
+
+pub struct ConstrTy {
+    ty: Ty,
+    pred: Expr,
+}

--- a/crates/flux-middle/src/rty/canonicalize.rs
+++ b/crates/flux-middle/src/rty/canonicalize.rs
@@ -88,10 +88,10 @@ impl CanonicalTy {
             CanonicalTy::Exists(poly_constr_ty) => {
                 let vars = poly_constr_ty.vars();
                 let constr_ty = poly_constr_ty.as_ref().skip_binder();
-                if let TyKind::Indexed(bty, idx) = constr_ty.ty.kind()
+                if let TyKind::Indexed(_, idx) = constr_ty.ty.kind()
                     && idx.is_nu()
                 {
-                    let ty = Ty::constr(constr_ty.pred.clone(), Ty::indexed(bty.clone(), idx));
+                    let ty = constr_ty.to_ty();
                     Some(GenericArg::BaseTy(Binder::new(ty, vars.clone())))
                 } else {
                     None
@@ -119,4 +119,14 @@ impl CanonicalTy {
 pub struct ConstrTy {
     ty: Ty,
     pred: Expr,
+}
+
+impl ConstrTy {
+    pub fn to_ty(&self) -> Ty {
+        if self.pred.is_trivially_true() {
+            self.ty.clone()
+        } else {
+            Ty::constr(self.pred.clone(), self.ty.clone())
+        }
+    }
 }

--- a/crates/flux-middle/src/rty/evars.rs
+++ b/crates/flux-middle/src/rty/evars.rs
@@ -149,7 +149,7 @@ mod pretty {
     impl Pretty for EVar {
         fn fmt(&self, _cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
-            w!("?e{}#{}", ^self.id.as_u32(), ^self.cx.0)
+            w!("?{}e#{}", ^self.id.as_u32(), ^self.cx.0)
         }
     }
 

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -576,7 +576,7 @@ impl Expr {
     }
 
     /// Simple syntactic check to see if the expression is a trivially true predicate. This is used
-    /// mostly for filtering predicates when pretty printing but also to simplify the types.
+    /// mostly for filtering predicates when pretty printing but also to simplify types in general.
     pub fn is_trivially_true(&self) -> bool {
         self.is_true()
             || matches!(self.kind(), ExprKind::BinaryOp(BinOp::Eq | BinOp::Iff | BinOp::Imp, e1, e2) if e1 == e2)

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -938,7 +938,7 @@ mod pretty {
     impl Pretty for AliasReft {
         fn fmt(&self, cx: &PPrintCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
-            w!("<{:?} as {:?}", self.self_ty(), self.trait_id)?;
+            w!("<{:?} as {:?}", &self.args[0], self.trait_id)?;
             let args = &self.args[1..];
             if !args.is_empty() {
                 w!("<{:?}>", join!(", ", args))?;

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -824,6 +824,12 @@ impl From<Name> for Expr {
     }
 }
 
+impl From<Var> for Expr {
+    fn from(var: Var) -> Self {
+        Expr::var(var, None)
+    }
+}
+
 impl From<Loc> for Path {
     fn from(loc: Loc) -> Self {
         Path::new(loc, vec![])

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -77,6 +77,13 @@ pub trait FallibleTypeFolder: Sized {
         bty.try_super_fold_with(self)
     }
 
+    fn try_fold_simple_constr_ty(
+        &mut self,
+        constr: &SimpleConstrTy,
+    ) -> Result<SimpleConstrTy, Self::Error> {
+        constr.try_super_fold_with(self)
+    }
+
     fn try_fold_region(&mut self, re: &Region) -> Result<Region, Self::Error> {
         Ok(*re)
     }
@@ -101,6 +108,10 @@ pub trait TypeFolder: FallibleTypeFolder<Error = !> {
 
     fn fold_bty(&mut self, bty: &BaseTy) -> BaseTy {
         bty.super_fold_with(self)
+    }
+
+    fn fold_simple_constr_ty(&mut self, constr: &SimpleConstrTy) -> SimpleConstrTy {
+        constr.super_fold_with(self)
     }
 
     fn fold_region(&mut self, re: &Region) -> Region {
@@ -135,6 +146,13 @@ where
 
     fn try_fold_bty(&mut self, bty: &BaseTy) -> Result<BaseTy, Self::Error> {
         Ok(self.fold_bty(bty))
+    }
+
+    fn try_fold_simple_constr_ty(
+        &mut self,
+        constr: &SimpleConstrTy,
+    ) -> Result<SimpleConstrTy, Self::Error> {
+        Ok(self.fold_simple_constr_ty(constr))
     }
 
     fn try_fold_region(&mut self, re: &Region) -> Result<Region, Self::Error> {
@@ -977,6 +995,12 @@ impl TypeVisitable for SimpleConstrTy {
 
 impl TypeFoldable for SimpleConstrTy {
     fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
+        folder.try_fold_simple_constr_ty(self)
+    }
+}
+
+impl TypeSuperFoldable for SimpleConstrTy {
+    fn try_super_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
         Ok(SimpleConstrTy {
             bty: self.bty.try_fold_with(folder)?,
             idx: self.idx.try_fold_with(folder)?,

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -1010,7 +1010,7 @@ impl TypeFoldable for GenericArg {
     fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
         let arg = match self {
             GenericArg::Ty(ty) => GenericArg::Ty(ty.try_fold_with(folder)?),
-            GenericArg::Base(ty) => GenericArg::Base(ty.try_fold_with(folder)?),
+            GenericArg::Base(sty) => GenericArg::Base(sty.try_fold_with(folder)?),
             GenericArg::Lifetime(re) => GenericArg::Lifetime(re.try_fold_with(folder)?),
             GenericArg::Const(c) => GenericArg::Const(c.clone()),
         };
@@ -1104,9 +1104,8 @@ impl TypeVisitable for Var {
 impl TypeFoldable for AliasReft {
     fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
         let trait_id = self.trait_id;
-        let generic_args = self.args.try_fold_with(folder)?;
-        let alias_pred = AliasReft { trait_id, name: self.name, args: generic_args };
-        Ok(alias_pred)
+        let args = self.args.try_fold_with(folder)?;
+        Ok(AliasReft { trait_id, name: self.name, args })
     }
 }
 

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1719,6 +1719,10 @@ impl BaseTy {
         matches!(self, BaseTy::Slice(..))
     }
 
+    fn is_adt(&self) -> bool {
+        matches!(self, BaseTy::Adt(..))
+    }
+
     pub fn is_box(&self) -> bool {
         matches!(self, BaseTy::Adt(adt_def, _) if adt_def.is_box())
     }
@@ -2216,7 +2220,9 @@ mod pretty {
             define_scoped!(cx, f);
             let vars = &self.vars;
             cx.with_bound_vars(vars, || {
-                cx.fmt_bound_vars("exists<", vars, ">", f)?;
+                if !vars.is_empty() {
+                    cx.fmt_bound_vars("exists<", vars, "> ", f)?;
+                }
                 w!("{:?}", &self.value.ret)?;
                 if !self.value.ensures.is_empty() {
                     w!("; [{:?}]", join!(", ", &self.value.ensures))?;
@@ -2253,7 +2259,9 @@ mod pretty {
                         return Ok(());
                     }
                     if idx.is_unit() {
-                        w!("[]")?;
+                        if bty.is_adt() {
+                            w!("[]")?;
+                        }
                     } else {
                         w!("[{:?}]", idx)?;
                     }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -862,6 +862,8 @@ pub type RefineArgs = List<Expr>;
 
 pub type OpaqueArgsMap = FxHashMap<DefId, (GenericArgs, RefineArgs)>;
 
+/// A type constructor meant to be used as generic arguments of type base. This is just an
+/// alias to [`Binder<SubsetTy>`]
 pub type SubsetTyCtor = Binder<SubsetTy>;
 
 impl SubsetTyCtor {
@@ -881,9 +883,47 @@ impl SubsetTyCtor {
     }
 }
 
+/// A subset type is a simplified version of a type that has the form `{b[e] | p}` where `b` is a
+/// [`BaseTy`], `e` a refinement index and `p` a predicate. These are mainly found under a [`Binder`]
+/// with a single variable of the base type's sort. This can be interpreted as a type constructor or
+/// an existial type. For example, under a binder with a variable `v` of sort `int`, we can interpret
+/// `{i32[v] | v > 0}` as a lambda `λv:int. {i32[v] | v > 0}` that "constructs" types when applied to
+/// ints or as an existential type `∃v:int. {i32[v] | v > 0}`. This second interpretation is the
+/// reason we call this a subset type, i.e., the type `∃v. {b[v] | p}` corresponds to the subset of
+/// values of (base) type `b` whose index satisfies `p`. In other words, these are the types supported
+/// by liquid haskell, with the difference that we are explicit about separating refinements from
+/// program values via an index.
+///
+/// The main purpose for a [`SubsetTy`] is to be used as generic arguments of [kind base] when
+/// interpreted as a type contructor. The key property of a [`SubsetTy`] is that it can be eagerly
+///
+/// canonicalized via [*strengthening*] during substitution. For example, suppose we have a function
+/// ```text
+/// fn foo<T>(x: T[@a], y: { T[@b] | b == a }) { }
+/// ```
+/// If we instantiate `T` with `λv. { i32[v] | v > 0}`, after substituting an applying the lambda we
+/// get:
+/// ```text
+/// fn foo(x: {i32[@a] | a > 0}, y: { { i32[@b] | b > 0 } | b == a }) { }
+/// ```
+/// By the strengthening rule we can canonicalize this to
+/// ```text
+/// fn foo(x: {i32[@a] | a > 0}, y: { i32[@b] | b == a && b > 0 }) { }
+/// ```
+/// As a result, we can guarantee a simple canonical form that makes it easier to manipulate types
+/// syntactically.
+///
+/// [kind base]: GenericParamDefKind::Base
+/// [*strengthening*]: https://arxiv.org/pdf/2010.07763.pdf
 #[derive(PartialEq, Clone, Eq, Hash, TyEncodable, TyDecodable)]
 pub struct SubsetTy {
+    /// *NOTE*: This [`BaseTy`] is mainly going to be under a [`Binder`]. It is not yet clear whether
+    /// this [`BaseTy`] should be able to mention variables in the binder. In general, in a type
+    /// `∃v. {b[e] | p}` is fine to mention `v` inside `b`, but since [`SubsetTy`] is meant to
+    /// facilitate syntatic manipulation we may restrict this.
     pub bty: BaseTy,
+    /// This can be an arbitrary expression which makes the syntatic manipulation easier, but since
+    /// this is mostly going to be under a binder we expect it to be [`Expr::nu()`].
     pub idx: Expr,
     pub pred: Expr,
 }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! * Types in this module use debruijn indices to represent local binders.
 //! * Data structures are interned so they can be cheaply cloned.
+pub mod canonicalize;
 pub mod evars;
 mod expr;
 pub mod fold;

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -2223,12 +2223,19 @@ mod pretty {
                 if !vars.is_empty() {
                     cx.fmt_bound_vars("exists<", vars, "> ", f)?;
                 }
-                w!("{:?}", &self.value.ret)?;
-                if !self.value.ensures.is_empty() {
-                    w!("; [{:?}]", join!(", ", &self.value.ensures))?;
-                }
-                Ok(())
+                w!("{:?}", &self.value)
             })
+        }
+    }
+
+    impl Pretty for FnOutput {
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            define_scoped!(cx, f);
+            w!("{:?}", &self.ret)?;
+            if !self.ensures.is_empty() {
+                w!("; [{:?}]", join!(", ", &self.ensures))?;
+            }
+            Ok(())
         }
     }
 

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -862,9 +862,9 @@ pub type RefineArgs = List<Expr>;
 
 pub type OpaqueArgsMap = FxHashMap<DefId, (GenericArgs, RefineArgs)>;
 
-/// A type constructor meant to be used as generic arguments of [kind base]. This is just an alias to
-/// [`Binder<SubsetTy>`], but we expect the binder to only have a single bound variable of the sort
-/// of the underlying [`BaseTy`].
+/// A type constructor meant to be used as generic a argument of [kind base]. This is just an alias
+/// to [`Binder<SubsetTy>`], but we expect the binder to have a single bound variable of the sort of
+/// the underlying [`BaseTy`].
 ///
 /// [kind base]: GenericParamDefKind::Base
 pub type SubsetTyCtor = Binder<SubsetTy>;
@@ -887,15 +887,15 @@ impl SubsetTyCtor {
 }
 
 /// A subset type is a simplified version of a type that has the form `{b[e] | p}` where `b` is a
-/// [`BaseTy`], `e` a refinement index and `p` a predicate. These are mainly found under a [`Binder`]
+/// [`BaseTy`], `e` a refinement index, and `p` a predicate. These are mainly found under a [`Binder`]
 /// with a single variable of the base type's sort. This can be interpreted as a type constructor or
 /// an existial type. For example, under a binder with a variable `v` of sort `int`, we can interpret
 /// `{i32[v] | v > 0}` as a lambda `λv:int. {i32[v] | v > 0}` that "constructs" types when applied to
-/// ints or as an existential type `∃v:int. {i32[v] | v > 0}`. This second interpretation is the
+/// ints, or as an existential type `∃v:int. {i32[v] | v > 0}`. This second interpretation is the
 /// reason we call this a subset type, i.e., the type `∃v. {b[v] | p}` corresponds to the subset of
 /// values of (base) type `b` whose index satisfies `p`. In other words, these are the types supported
-/// by liquid haskell, with the difference that we are explicit about separating refinements from
-/// program values via an index.
+/// by liquid haskell (with the difference that we are explicit about separating refinements from
+/// program values via an index).
 ///
 /// The main purpose for a [`SubsetTy`] is to be used as generic arguments of [kind base] when
 /// interpreted as a type contructor. The key property of a [`SubsetTy`] is that it can be eagerly
@@ -919,9 +919,9 @@ impl SubsetTyCtor {
 /// [*strengthening*]: https://arxiv.org/pdf/2010.07763.pdf
 #[derive(PartialEq, Clone, Eq, Hash, TyEncodable, TyDecodable)]
 pub struct SubsetTy {
-    /// *NOTE*: This [`BaseTy`] is mainly going to be under a [`Binder`]. It is not yet clear whether
+    /// **NOTE:** This [`BaseTy`] is mainly going to be under a [`Binder`]. It is not yet clear whether
     /// this [`BaseTy`] should be able to mention variables in the binder. In general, in a type
-    /// `∃v. {b[e] | p}` is fine to mention `v` inside `b`, but since [`SubsetTy`] is meant to
+    /// `∃v. {b[e] | p}`, it's fine to mention `v` inside `b`, but since [`SubsetTy`] is meant to
     /// facilitate syntatic manipulation we may restrict this.
     pub bty: BaseTy,
     /// This can be an arbitrary expression which makes the syntatic manipulation easier, but since

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -862,8 +862,11 @@ pub type RefineArgs = List<Expr>;
 
 pub type OpaqueArgsMap = FxHashMap<DefId, (GenericArgs, RefineArgs)>;
 
-/// A type constructor meant to be used as generic arguments of type base. This is just an
-/// alias to [`Binder<SubsetTy>`]
+/// A type constructor meant to be used as generic arguments of [kind base]. This is just an alias to
+/// [`Binder<SubsetTy>`], but we expect the binder to only have a single bound variable of the sort
+/// of the underlying [`BaseTy`].
+///
+/// [kind base]: GenericParamDefKind::Base
 pub type SubsetTyCtor = Binder<SubsetTy>;
 
 impl SubsetTyCtor {
@@ -896,13 +899,12 @@ impl SubsetTyCtor {
 ///
 /// The main purpose for a [`SubsetTy`] is to be used as generic arguments of [kind base] when
 /// interpreted as a type contructor. The key property of a [`SubsetTy`] is that it can be eagerly
-///
-/// canonicalized via [*strengthening*] during substitution. For example, suppose we have a function
+/// canonicalized via [*strengthening*] during substitution. For example, suppose we have a function:
 /// ```text
 /// fn foo<T>(x: T[@a], y: { T[@b] | b == a }) { }
 /// ```
-/// If we instantiate `T` with `λv. { i32[v] | v > 0}`, after substituting an applying the lambda we
-/// get:
+/// If we instantiate `T` with `λv. { i32[v] | v > 0}`, after substitution and applying the lambda,
+/// we get:
 /// ```text
 /// fn foo(x: {i32[@a] | a > 0}, y: { { i32[@b] | b > 0 } | b == a }) { }
 /// ```

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -893,7 +893,7 @@ impl SubsetTy {
         Self { bty, idx: idx.into(), pred: pred.into() }
     }
 
-    pub fn indexed(bty: BaseTy, idx: impl Into<Expr>) -> Self {
+    pub fn trivial(bty: BaseTy, idx: impl Into<Expr>) -> Self {
         Self::new(bty, idx, Expr::tt())
     }
 
@@ -2086,7 +2086,7 @@ mod pretty {
         default fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
             cx.with_bound_vars(&self.vars, || {
-                cx.fmt_bound_vars("for<", &self.vars, ">", f)?;
+                cx.fmt_bound_vars("for<", &self.vars, "> ", f)?;
                 w!("{:?}", &self.value)
             })
         }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -2245,7 +2245,11 @@ mod pretty {
     impl Pretty for SimpleTy {
         fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             define_scoped!(cx, f);
-            w!("{{ {:?}[{:?}] | {:?} }}", &self.bty, &self.idx, &self.pred)
+            if self.pred.is_trivially_true() {
+                w!("{:?}[{:?}]", &self.bty, &self.idx)
+            } else {
+                w!("{{ {:?}[{:?}] | {:?} }}", &self.bty, &self.idx, &self.pred)
+            }
         }
     }
 

--- a/crates/flux-middle/src/rty/projections.rs
+++ b/crates/flux-middle/src/rty/projections.rs
@@ -11,9 +11,10 @@ use rustc_middle::{
 use rustc_trait_selection::traits::SelectionContext;
 
 use super::{
+    canonicalize::{CanonicalConstrTy, CanonicalTy},
     fold::{FallibleTypeFolder, TypeSuperFoldable},
     AliasKind, AliasReft, AliasTy, BaseTy, Clause, ClauseKind, Expr, ExprKind, GenericArg,
-    GenericArgs, ProjectionPredicate, RefineArgs, Region, Ty, TyKind,
+    GenericArgs, ProjectionPredicate, RefineArgs, Region, SubsetTy, Ty, TyKind,
 };
 use crate::{
     global_env::GlobalEnv,
@@ -49,14 +50,16 @@ impl<'genv, 'tcx, 'cx> Normalizer<'genv, 'tcx, 'cx> {
     ) -> QueryResult<Expr> {
         if let Some(impl_def_id) = self.impl_id_of_alias_reft(obligation)? {
             let impl_trait_ref = self
-                .tcx()
-                .impl_trait_ref(impl_def_id)
+                .genv
+                .impl_trait_ref(impl_def_id)?
                 .unwrap()
                 .skip_binder();
             let generics = self.tcx().generics_of(impl_def_id);
 
-            let mut subst = TVarSubst::new(generics);
-            subst.infer_from_args(impl_trait_ref.args, &obligation.args);
+            let mut subst = Equate::new(generics);
+            for (a, b) in iter::zip(&impl_trait_ref.args, &obligation.args) {
+                subst.generic_args(a, b);
+            }
             let args = subst.finish(self.tcx(), generics);
 
             let pred = self
@@ -100,15 +103,17 @@ impl<'genv, 'tcx, 'cx> Normalizer<'genv, 'tcx, 'cx> {
                 //            => {T -> {v. i32[v] | v > 0}, A -> Global}
 
                 let impl_trait_ref = self
-                    .tcx()
-                    .impl_trait_ref(impl_def_id)
+                    .genv
+                    .impl_trait_ref(impl_def_id)?
                     .unwrap()
                     .skip_binder();
 
                 let generics = self.tcx().generics_of(impl_def_id);
 
-                let mut subst = TVarSubst::new(generics);
-                subst.infer_from_args(impl_trait_ref.args, &obligation.args);
+                let mut subst = Equate::new(generics);
+                for (a, b) in iter::zip(&impl_trait_ref.args, &obligation.args) {
+                    subst.generic_args(a, b);
+                }
                 let args = subst.finish(self.tcx(), generics);
 
                 // 2. Get the associated type in the impl block and apply the substitution to it
@@ -254,12 +259,139 @@ pub enum Candidate {
     TraitDef(ProjectionPredicate),
 }
 
+// #[derive(Debug)]
+// struct TVarSubst {
+//     args: Vec<Option<GenericArg>>,
+// }
+
+// impl TVarSubst {
+//     fn new(generics: &rustc_middle::ty::Generics) -> Self {
+//         Self { args: vec![None; generics.count()] }
+//     }
+
+//     fn finish<'tcx>(
+//         self,
+//         tcx: TyCtxt<'tcx>,
+//         generics: &'tcx rustc_middle::ty::Generics,
+//     ) -> Vec<GenericArg> {
+//         self.args
+//             .into_iter()
+//             .enumerate()
+//             .map(|(idx, arg)| {
+//                 if let Some(arg) = arg {
+//                     arg
+//                 } else {
+//                     let param = generics.param_at(idx, tcx);
+//                     bug!("cannot infer substitution for param {param:?}");
+//                 }
+//             })
+//             .collect()
+//     }
+
+//     fn insert_param_ty(&mut self, pty: ParamTy, ty: &Ty) {
+//         let arg = GenericArg::Ty(ty.clone());
+//         if self.args[pty.index as usize].replace(arg).is_some() {
+//             bug!("duplicate insert");
+//         }
+//     }
+
+//     fn insert_early_bound_region(&mut self, ebr: EarlyBoundRegion, re: Region) {
+//         let arg = GenericArg::Lifetime(re);
+//         if self.args[ebr.index as usize].replace(arg).is_some() {
+//             bug!("duplicate insert");
+//         }
+//     }
+
+//     fn infer_from_args(&mut self, src: rustc_middle::ty::GenericArgsRef, dst: &GenericArgs) {
+//         debug_assert_eq!(src.len(), dst.len());
+//         for (src, dst) in iter::zip(src, dst) {
+//             self.infer_from_arg(src, dst);
+//         }
+//     }
+
+//     fn infer_from_arg(&mut self, src: rustc_middle::ty::GenericArg, dst: &GenericArg) {
+//         match dst {
+//             GenericArg::Ty(dst) => {
+//                 self.infer_from_ty(&src.as_type().unwrap(), dst);
+//             }
+//             GenericArg::Lifetime(dst) => self.infer_from_region(&src.as_region().unwrap(), dst),
+//             GenericArg::Base(ty) => {
+//                 // todo!()
+//                 // self.infer_from_ty(&src.as_type().unwrap(), ty.bty_skipping_binder());
+//             }
+//             _ => (),
+//         }
+//     }
+
+//     fn infer_from_ty(&mut self, src: &rustc_middle::ty::Ty, dst: &Ty) {
+//         use rustc_middle::ty;
+//         match src.kind() {
+//             ty::TyKind::Param(pty) => {
+//                 if !dst.has_escaping_bvars() {
+//                     self.insert_param_ty(*pty, dst);
+//                 }
+//             }
+//             ty::TyKind::Adt(_, src_subst) => {
+//                 // NOTE: see https://github.com/flux-rs/flux/pull/478#issuecomment-1650983695
+//                 if let Some(dst) = dst.as_bty_skipping_existentials()
+//                     && let BaseTy::Adt(_, dst_subst) = dst
+//                 {
+//                     debug_assert_eq!(src_subst.len(), dst_subst.len());
+//                     for (src_arg, dst_arg) in iter::zip(*src_subst, dst_subst) {
+//                         self.infer_from_arg(src_arg, dst_arg);
+//                     }
+//                 } else {
+//                     bug!("unexpected type {dst:?}");
+//                 }
+//             }
+//             ty::TyKind::Array(src, _) => {
+//                 if let Some(BaseTy::Array(dst, _)) = dst.as_bty_skipping_existentials() {
+//                     self.infer_from_ty(src, dst);
+//                 } else {
+//                     bug!("unexpected type {dst:?}");
+//                 }
+//             }
+//             ty::TyKind::Slice(src) => {
+//                 if let Some(BaseTy::Slice(dst)) = dst.as_bty_skipping_existentials() {
+//                     self.infer_from_ty(src, dst);
+//                 } else {
+//                     bug!("unexpected type {dst:?}");
+//                 }
+//             }
+//             ty::TyKind::Tuple(src_tys) => {
+//                 if let Some(BaseTy::Tuple(dst_tys)) = dst.as_bty_skipping_existentials() {
+//                     debug_assert_eq!(src_tys.len(), dst_tys.len());
+//                     iter::zip(src_tys.iter(), dst_tys.iter())
+//                         .for_each(|(src, dst)| self.infer_from_ty(&src, dst));
+//                 } else {
+//                     bug!("unexpected type {dst:?}");
+//                 }
+//             }
+//             ty::TyKind::Ref(src_re, src_ty, _) => {
+//                 if let Some(BaseTy::Ref(dst_re, dst_ty, _)) = dst.as_bty_skipping_existentials() {
+//                     self.infer_from_region(src_re, dst_re);
+//                     self.infer_from_ty(src_ty, dst_ty);
+//                 } else {
+//                     bug!("unexpected type {dst:?}");
+//                 }
+//             }
+//             _ => {}
+//         }
+//     }
+
+//     fn infer_from_region(&mut self, src: &rustc_middle::ty::Region, dst: &Region) {
+//         if let rustc_middle::ty::RegionKind::ReEarlyBound(ebr) = src.kind() {
+//             self.insert_early_bound_region(ebr, *dst);
+//         }
+//     }
+// }
+
 #[derive(Debug)]
-struct TVarSubst {
+struct Equate {
     args: Vec<Option<GenericArg>>,
 }
 
-impl TVarSubst {
+impl Equate {
     fn new(generics: &rustc_middle::ty::Generics) -> Self {
         Self { args: vec![None; generics.count()] }
     }
@@ -283,100 +415,68 @@ impl TVarSubst {
             .collect()
     }
 
-    fn insert_param_ty(&mut self, pty: ParamTy, ty: &Ty) {
-        let arg = GenericArg::Ty(ty.clone());
-        if self.args[pty.index as usize].replace(arg).is_some() {
-            bug!("duplicate insert");
-        }
-    }
-
-    fn insert_early_bound_region(&mut self, ebr: EarlyBoundRegion, re: Region) {
-        let arg = GenericArg::Lifetime(re);
-        if self.args[ebr.index as usize].replace(arg).is_some() {
-            bug!("duplicate insert");
-        }
-    }
-
-    fn infer_from_args(&mut self, src: rustc_middle::ty::GenericArgsRef, dst: &GenericArgs) {
-        debug_assert_eq!(src.len(), dst.len());
-        for (src, dst) in iter::zip(src, dst) {
-            self.infer_from_arg(src, dst);
-        }
-    }
-
-    fn infer_from_arg(&mut self, src: rustc_middle::ty::GenericArg, dst: &GenericArg) {
-        match dst {
-            GenericArg::Ty(dst) => {
-                self.infer_from_ty(&src.as_type().unwrap(), dst);
-            }
-            GenericArg::Lifetime(dst) => self.infer_from_region(&src.as_region().unwrap(), dst),
-            GenericArg::Base(ty) => {
-                // todo!()
-                // self.infer_from_ty(&src.as_type().unwrap(), ty.bty_skipping_binder());
-            }
-            _ => (),
-        }
-    }
-
-    fn infer_from_ty(&mut self, src: &rustc_middle::ty::Ty, dst: &Ty) {
-        use rustc_middle::ty;
-        match src.kind() {
-            ty::TyKind::Param(pty) => {
-                if !dst.has_escaping_bvars() {
-                    self.insert_param_ty(*pty, dst);
-                }
-            }
-            ty::TyKind::Adt(_, src_subst) => {
-                // NOTE: see https://github.com/flux-rs/flux/pull/478#issuecomment-1650983695
-                if let Some(dst) = dst.as_bty_skipping_existentials()
-                    && let BaseTy::Adt(_, dst_subst) = dst
-                {
-                    debug_assert_eq!(src_subst.len(), dst_subst.len());
-                    for (src_arg, dst_arg) in iter::zip(*src_subst, dst_subst) {
-                        self.infer_from_arg(src_arg, dst_arg);
-                    }
-                } else {
-                    bug!("unexpected type {dst:?}");
-                }
-            }
-            ty::TyKind::Array(src, _) => {
-                if let Some(BaseTy::Array(dst, _)) = dst.as_bty_skipping_existentials() {
-                    self.infer_from_ty(src, dst);
-                } else {
-                    bug!("unexpected type {dst:?}");
-                }
-            }
-            ty::TyKind::Slice(src) => {
-                if let Some(BaseTy::Slice(dst)) = dst.as_bty_skipping_existentials() {
-                    self.infer_from_ty(src, dst);
-                } else {
-                    bug!("unexpected type {dst:?}");
-                }
-            }
-            ty::TyKind::Tuple(src_tys) => {
-                if let Some(BaseTy::Tuple(dst_tys)) = dst.as_bty_skipping_existentials() {
-                    debug_assert_eq!(src_tys.len(), dst_tys.len());
-                    iter::zip(src_tys.iter(), dst_tys.iter())
-                        .for_each(|(src, dst)| self.infer_from_ty(&src, dst));
-                } else {
-                    bug!("unexpected type {dst:?}");
-                }
-            }
-            ty::TyKind::Ref(src_re, src_ty, _) => {
-                if let Some(BaseTy::Ref(dst_re, dst_ty, _)) = dst.as_bty_skipping_existentials() {
-                    self.infer_from_region(src_re, dst_re);
-                    self.infer_from_ty(src_ty, dst_ty);
-                } else {
-                    bug!("unexpected type {dst:?}");
-                }
+    fn generic_args(&mut self, a: &GenericArg, b: &GenericArg) {
+        match (a, b) {
+            (GenericArg::Ty(a), GenericArg::Ty(b)) => self.tys(a, b),
+            (GenericArg::Lifetime(a), GenericArg::Lifetime(b)) => self.regions(*a, *b),
+            (GenericArg::Base(a), GenericArg::Base(b)) => {
+                debug_assert_eq!(a.sort(), b.sort());
+                self.btys(a.as_bty_skipping_binder(), b.as_bty_skipping_binder());
             }
             _ => {}
         }
     }
 
-    fn infer_from_region(&mut self, src: &rustc_middle::ty::Region, dst: &Region) {
-        if let rustc_middle::ty::RegionKind::ReEarlyBound(ebr) = src.kind() {
-            self.insert_early_bound_region(ebr, *dst);
+    fn tys(&mut self, a: &Ty, b: &Ty) {
+        if let TyKind::Param(param_ty) = a.kind() {
+            if !b.has_escaping_bvars() {
+                self.insert_generic_arg(param_ty.index, GenericArg::Ty(b.clone()));
+            }
+            return;
+        }
+        let Some(a_bty) = a.as_bty_skipping_existentials() else { return };
+        let Some(b_bty) = b.as_bty_skipping_existentials() else { return };
+        self.btys(a_bty, b_bty);
+    }
+
+    fn btys(&mut self, a: &BaseTy, b: &BaseTy) {
+        match (a, b) {
+            (BaseTy::Param(_), _) => todo!(),
+            (BaseTy::Adt(_, a_args), BaseTy::Adt(_, b_args)) => {
+                debug_assert_eq!(a_args.len(), b_args.len());
+                for (a_arg, b_arg) in iter::zip(a_args, b_args) {
+                    self.generic_args(a_arg, b_arg);
+                }
+            }
+            (BaseTy::Array(a_ty, _), BaseTy::Array(b_ty, _)) => {
+                self.tys(a_ty, b_ty);
+            }
+            (BaseTy::Tuple(a_tys), BaseTy::Tuple(b_tys)) => {
+                debug_assert_eq!(a_tys.len(), b_tys.len());
+                for (a_ty, b_ty) in iter::zip(a_tys, b_tys) {
+                    self.tys(a_ty, b_ty);
+                }
+            }
+            (BaseTy::Ref(a_re, a_ty, _), BaseTy::Ref(b_re, b_ty, _)) => {
+                self.regions(*a_re, *b_re);
+                self.tys(a_ty, b_ty);
+            }
+            (BaseTy::Slice(a_ty), BaseTy::Slice(b_ty)) => {
+                self.tys(a_ty, b_ty);
+            }
+            _ => {}
+        }
+    }
+
+    fn regions(&mut self, a: Region, b: Region) {
+        if let Region::ReEarlyBound(ebr) = a {
+            self.insert_generic_arg(ebr.index, GenericArg::Lifetime(b));
+        }
+    }
+
+    fn insert_generic_arg(&mut self, idx: u32, arg: GenericArg) {
+        if self.args[idx as usize].replace(arg).is_some() {
+            bug!("duplicate insert");
         }
     }
 }

--- a/crates/flux-middle/src/rty/projections.rs
+++ b/crates/flux-middle/src/rty/projections.rs
@@ -124,7 +124,7 @@ impl<'genv, 'tcx, 'cx> Normalizer<'genv, 'tcx, 'cx> {
                     .genv
                     .type_of(assoc_type_id)?
                     .instantiate(&args, &[])
-                    .into_ty())
+                    .to_ty())
             }
         }
     }

--- a/crates/flux-middle/src/rty/projections.rs
+++ b/crates/flux-middle/src/rty/projections.rs
@@ -280,7 +280,7 @@ fn into_rustc_generic_arg<'tcx>(
     use rustc_middle::ty;
     match arg {
         GenericArg::Ty(ty) => ty::GenericArg::from(into_rustc_ty(tcx, ty)),
-        GenericArg::BaseTy(bty) => {
+        GenericArg::Base(ty) => {
             ty::GenericArg::from(into_rustc_ty(tcx, &bty.clone().skip_binder()))
         }
         GenericArg::Lifetime(re) => ty::GenericArg::from(into_rustc_region(tcx, *re)),
@@ -449,7 +449,7 @@ impl TVarSubst {
                 self.infer_from_ty(&src.as_type().unwrap(), dst);
             }
             GenericArg::Lifetime(dst) => self.infer_from_region(&src.as_region().unwrap(), dst),
-            GenericArg::BaseTy(bty) => {
+            GenericArg::Base(bty) => {
                 self.infer_from_ty(&src.as_type().unwrap(), &bty.clone().skip_binder());
             }
             _ => (),

--- a/crates/flux-middle/src/rty/projections.rs
+++ b/crates/flux-middle/src/rty/projections.rs
@@ -311,7 +311,7 @@ impl TVarSubst {
             }
             GenericArg::Lifetime(dst) => self.infer_from_region(&src.as_region().unwrap(), dst),
             GenericArg::Base(ty) => {
-                todo!()
+                // todo!()
                 // self.infer_from_ty(&src.as_type().unwrap(), ty.bty_skipping_binder());
             }
             _ => (),

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -43,14 +43,14 @@ pub(crate) fn refine_generics(generics: &rustc::ty::Generics) -> QueryResult<rty
 pub struct Refiner<'genv, 'tcx> {
     genv: GlobalEnv<'genv, 'tcx>,
     generics: rty::Generics,
-    refine: fn(rty::BaseTy) -> rty::Binder<rty::SimpleTy>,
+    refine: fn(rty::BaseTy) -> rty::Binder<rty::SubsetTy>,
 }
 
 impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
     pub fn new(
         genv: GlobalEnv<'genv, 'tcx>,
         generics: &rty::Generics,
-        refine: fn(rty::BaseTy) -> rty::Binder<rty::SimpleTy>,
+        refine: fn(rty::BaseTy) -> rty::Binder<rty::SubsetTy>,
     ) -> Self {
         Self { genv, generics: generics.clone(), refine }
     }
@@ -65,7 +65,7 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
             generics: generics.clone(),
             refine: |bty| {
                 let sort = bty.sort();
-                let constr = rty::SimpleTy::new(
+                let constr = rty::SubsetTy::new(
                     bty.shift_in_escaping(1),
                     rty::Expr::nu(),
                     rty::Expr::hole(rty::HoleKind::Pred),
@@ -395,7 +395,7 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
 
 enum TyOrBase {
     Ty(rty::Ty),
-    Base(rty::SimpleTyCtor),
+    Base(rty::SubsetTyCtor),
 }
 
 impl TyOrBase {
@@ -407,7 +407,7 @@ impl TyOrBase {
     }
 
     #[track_caller]
-    fn expect_simple(self) -> rty::Binder<rty::SimpleTy> {
+    fn expect_simple(self) -> rty::Binder<rty::SubsetTy> {
         if let TyOrBase::Base(poly_constr) = self {
             poly_constr
         } else {
@@ -416,9 +416,9 @@ impl TyOrBase {
     }
 }
 
-fn refine_default(bty: rty::BaseTy) -> rty::Binder<rty::SimpleTy> {
+fn refine_default(bty: rty::BaseTy) -> rty::Binder<rty::SubsetTy> {
     let sort = bty.sort();
-    let constr = rty::SimpleTy::indexed(bty.shift_in_escaping(1), rty::Expr::nu());
+    let constr = rty::SubsetTy::indexed(bty.shift_in_escaping(1), rty::Expr::nu());
     rty::Binder::with_sort(constr, sort)
 }
 

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -418,7 +418,7 @@ impl TyOrBase {
 
 fn refine_default(bty: rty::BaseTy) -> rty::Binder<rty::SubsetTy> {
     let sort = bty.sort();
-    let constr = rty::SubsetTy::indexed(bty.shift_in_escaping(1), rty::Expr::nu());
+    let constr = rty::SubsetTy::trivial(bty.shift_in_escaping(1), rty::Expr::nu());
     rty::Binder::with_sort(constr, sort)
 }
 

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -116,12 +116,12 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
                         &rustc::ty::AliasKind::Projection,
                         &proj_pred.projection_ty,
                     )?,
-                    term: self.as_default().refine_ty(&proj_pred.term)?,
+                    term: self.refine_ty(&proj_pred.term)?,
                 };
                 rty::ClauseKind::Projection(pred)
             }
             rustc::ty::ClauseKind::TypeOutlives(pred) => {
-                let pred = rty::OutlivesPredicate(self.as_default().refine_ty(&pred.0)?, pred.1);
+                let pred = rty::OutlivesPredicate(self.refine_ty(&pred.0)?, pred.1);
                 rty::ClauseKind::TypeOutlives(pred)
             }
         };
@@ -156,14 +156,13 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
         Ok(rty::ClauseKind::FnTrait(pred))
     }
 
-    fn refine_trait_ref(&self, trait_ref: &rustc::ty::TraitRef) -> QueryResult<rty::TraitRef> {
+    pub(crate) fn refine_trait_ref(
+        &self,
+        trait_ref: &rustc::ty::TraitRef,
+    ) -> QueryResult<rty::TraitRef> {
         let trait_ref = rty::TraitRef {
             def_id: trait_ref.def_id,
-            args: trait_ref
-                .args
-                .iter()
-                .map(|arg| self.refine_generic_arg_raw(arg))
-                .try_collect()?,
+            args: self.refine_generic_args(trait_ref.def_id, &trait_ref.args)?,
         };
         Ok(trait_ref)
     }
@@ -214,6 +213,20 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
         })
     }
 
+    fn refine_generic_args(
+        &self,
+        def_id: DefId,
+        args: &rustc::ty::GenericArgs,
+    ) -> QueryResult<rty::GenericArgs> {
+        let generics = self.generics_of(def_id)?;
+        let mut result = vec![];
+        for (idx, arg) in args.iter().enumerate() {
+            let param = generics.param_at(idx, self.genv)?;
+            result.push(self.refine_generic_arg(&param, arg)?);
+        }
+        Ok(List::from_vec(result))
+    }
+
     pub fn refine_generic_arg(
         &self,
         param: &rty::GenericParamDef,
@@ -240,26 +253,13 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
         }
     }
 
-    pub(crate) fn refine_generic_arg_raw(
-        &self,
-        arg: &rustc::ty::GenericArg,
-    ) -> QueryResult<rty::GenericArg> {
-        match arg {
-            rustc::ty::GenericArg::Ty(ty) => Ok(rty::GenericArg::Ty(self.refine_ty(ty)?)),
-            rustc::ty::GenericArg::Lifetime(re) => Ok(rty::GenericArg::Lifetime(*re)),
-            rustc::ty::GenericArg::Const(c) => Ok(rty::GenericArg::Const(c.clone())),
-        }
-    }
-
-    pub(crate) fn refine_alias_ty(
+    fn refine_alias_ty(
         &self,
         alias_kind: &rustc::ty::AliasKind,
         alias_ty: &rustc::ty::AliasTy,
     ) -> QueryResult<rty::AliasTy> {
         let def_id = alias_ty.def_id;
-        let args = self.iter_with_generics_of(def_id, &alias_ty.args, |param, arg| {
-            self.as_default().refine_generic_arg(param, arg)
-        })?;
+        let args = self.refine_generic_args(def_id, &alias_ty.args)?;
 
         let refine_args = self.refine_args_of(def_id, alias_kind)?;
 
@@ -285,7 +285,7 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
         }
     }
 
-    fn refine_ty_inner(&self, ty: &rustc::ty::Ty) -> QueryResult<RefineResult> {
+    fn refine_ty_inner(&self, ty: &rustc::ty::Ty) -> QueryResult<TyOrSimple> {
         let bty = match ty.kind() {
             rustc::ty::TyKind::Closure(did, args) => {
                 let args = args.as_closure();
@@ -323,7 +323,7 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
             rustc::ty::TyKind::Param(param_ty) => {
                 match self.param(*param_ty)?.kind {
                     rty::GenericParamDefKind::Type { .. } | rty::GenericParamDefKind::SplTy => {
-                        return Ok(RefineResult::Ty(rty::Ty::param(*param_ty)));
+                        return Ok(TyOrSimple::Ty(rty::Ty::param(*param_ty)));
                     }
                     rty::GenericParamDefKind::BaseTy => rty::BaseTy::Param(*param_ty),
                     rty::GenericParamDefKind::Lifetime | rty::GenericParamDefKind::Const { .. } => {
@@ -333,15 +333,13 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
             }
             rustc::ty::TyKind::Adt(adt_def, args) => {
                 let adt_def = self.genv.adt_def(adt_def.did())?;
-                let args = self.iter_with_generics_of(adt_def.did(), args, |param, arg| {
-                    self.refine_generic_arg(param, arg)
-                })?;
+                let args = self.refine_generic_args(adt_def.did(), args)?;
                 rty::BaseTy::adt(adt_def, args)
             }
             rustc::ty::TyKind::Alias(alias_kind, alias_ty) => {
                 let kind = Self::refine_alias_kind(alias_kind);
-                let alias_ty = self.refine_alias_ty(alias_kind, alias_ty)?;
-                return Ok(RefineResult::Ty(rty::Ty::alias(kind, alias_ty)));
+                let alias_ty = self.as_default().refine_alias_ty(alias_kind, alias_ty)?;
+                return Ok(TyOrSimple::Ty(rty::Ty::alias(kind, alias_ty)));
             }
             rustc::ty::TyKind::Bool => rty::BaseTy::Bool,
             rustc::ty::TyKind::Int(int_ty) => rty::BaseTy::Int(*int_ty),
@@ -354,7 +352,7 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
                 rty::BaseTy::RawPtr(self.as_default().refine_ty(ty)?, *mu)
             }
         };
-        Ok(RefineResult::Simple((self.refine)(bty)))
+        Ok(TyOrSimple::Simple((self.refine)(bty)))
     }
 
     fn as_default(&self) -> Self {
@@ -385,51 +383,27 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
         }
     }
 
-    fn iter_with_generics_of(
-        &self,
-        def_id: DefId,
-        args: &[rustc::ty::GenericArg],
-        f: impl FnMut(&rty::GenericParamDef, &rustc::ty::GenericArg) -> QueryResult<rty::GenericArg>,
-    ) -> QueryResult<rty::GenericArgs> {
-        let generics = self.generics_of(def_id)?;
-        self.iter_with_generic_params(&generics, args, f)
-    }
-
-    fn iter_with_generic_params(
-        &self,
-        generics: &rty::Generics,
-        args: &[rustc::ty::GenericArg],
-        mut f: impl FnMut(&rty::GenericParamDef, &rustc::ty::GenericArg) -> QueryResult<rty::GenericArg>,
-    ) -> QueryResult<rty::GenericArgs> {
-        args.iter()
-            .enumerate()
-            .map(|(idx, arg)| {
-                let param = generics.param_at(idx, self.genv)?;
-                f(&param, arg)
-            })
-            .try_collect()
-    }
-
     fn param(&self, param_ty: ParamTy) -> QueryResult<rty::GenericParamDef> {
         self.generics.param_at(param_ty.index as usize, self.genv)
     }
 }
 
-enum RefineResult {
+enum TyOrSimple {
     Ty(rty::Ty),
     Simple(rty::Binder<rty::SimpleConstrTy>),
 }
 
-impl RefineResult {
+impl TyOrSimple {
     fn into_ty(self) -> rty::Ty {
         match self {
-            RefineResult::Ty(ty) => ty,
-            RefineResult::Simple(poly_constr) => rty::SimpleTy::Exists(poly_constr).to_ty(),
+            TyOrSimple::Ty(ty) => ty,
+            TyOrSimple::Simple(poly_constr) => rty::SimpleTy::Exists(poly_constr).to_ty(),
         }
     }
 
+    #[track_caller]
     fn expect_simple(self) -> rty::Binder<rty::SimpleConstrTy> {
-        if let RefineResult::Simple(poly_constr) = self {
+        if let TyOrSimple::Simple(poly_constr) = self {
             poly_constr
         } else {
             bug!("unexpected ty")

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -236,10 +236,7 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
             (rty::GenericParamDefKind::Type { .. }, rustc::ty::GenericArg::Ty(ty)) => {
                 Ok(rty::GenericArg::Ty(self.refine_ty(ty)?))
             }
-            (rty::GenericParamDefKind::SplTy, rustc::ty::GenericArg::Ty(ty)) => {
-                Ok(rty::GenericArg::Ty(self.refine_ty(ty)?))
-            }
-            (rty::GenericParamDefKind::BaseTy, rustc::ty::GenericArg::Ty(ty)) => {
+            (rty::GenericParamDefKind::Base, rustc::ty::GenericArg::Ty(ty)) => {
                 let poly_constr = self.refine_ty_inner(ty)?.expect_simple();
                 Ok(rty::GenericArg::Base(poly_constr))
             }
@@ -322,10 +319,10 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
             }
             rustc::ty::TyKind::Param(param_ty) => {
                 match self.param(*param_ty)?.kind {
-                    rty::GenericParamDefKind::Type { .. } | rty::GenericParamDefKind::SplTy => {
+                    rty::GenericParamDefKind::Type { .. } => {
                         return Ok(TyOrBase::Ty(rty::Ty::param(*param_ty)));
                     }
-                    rty::GenericParamDefKind::BaseTy => rty::BaseTy::Param(*param_ty),
+                    rty::GenericParamDefKind::Base => rty::BaseTy::Param(*param_ty),
                     rty::GenericParamDefKind::Lifetime | rty::GenericParamDefKind::Const { .. } => {
                         bug!()
                     }

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -224,7 +224,7 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
                 Ok(rty::GenericArg::Ty(self.refine_ty(ty)?))
             }
             (rty::GenericParamDefKind::BaseTy, rustc::ty::GenericArg::Ty(ty)) => {
-                Ok(rty::GenericArg::BaseTy(self.refine_poly_ty(ty)?))
+                Ok(rty::GenericArg::Base(self.refine_poly_ty(ty)?))
             }
             (rty::GenericParamDefKind::Lifetime, rustc::ty::GenericArg::Lifetime(re)) => {
                 Ok(rty::GenericArg::Lifetime(*re))

--- a/crates/flux-middle/src/rty/subst.rs
+++ b/crates/flux-middle/src/rty/subst.rs
@@ -71,7 +71,7 @@ impl RegionSubst {
                 debug_assert_eq!(args1.len(), args2.len());
                 for (arg1, arg2) in iter::zip(args1, args2) {
                     match (arg1, arg2) {
-                        (GenericArg::BaseTy(ty_con), ty::GenericArg::Ty(ty2)) => {
+                        (GenericArg::Base(ty_con), ty::GenericArg::Ty(ty2)) => {
                             self.infer_from_ty(ty_con.as_ref().skip_binder(), ty2);
                         }
                         (GenericArg::Ty(ty1), ty::GenericArg::Ty(ty2)) => {
@@ -303,7 +303,7 @@ impl GenericsSubstDelegate for GenericArgsDelegate<'_> {
 
     fn bty_for_param(&mut self, param_ty: ParamTy, idx: &Expr) -> Ty {
         match self.0.get(param_ty.index as usize) {
-            Some(GenericArg::BaseTy(arg)) => arg.replace_bound_reft(idx),
+            Some(GenericArg::Base(arg)) => arg.replace_bound_reft(idx),
             Some(arg) => {
                 bug!("expected base type for generic parameter, found `{:?}`", arg)
             }

--- a/crates/flux-middle/src/rty/subst.rs
+++ b/crates/flux-middle/src/rty/subst.rs
@@ -253,7 +253,7 @@ pub(crate) struct GenericsSubstFolder<'a, D> {
 trait GenericsSubstDelegate {
     fn sort_for_param(&mut self, param_ty: ParamTy) -> Sort;
     fn ty_for_param(&mut self, param_ty: ParamTy) -> Ty;
-    fn ctor_for_param(&mut self, param_ty: ParamTy) -> SimpleTyCtor;
+    fn ctor_for_param(&mut self, param_ty: ParamTy) -> SubsetTyCtor;
     fn region_for_param(&mut self, ebr: EarlyBoundRegion) -> Region;
 }
 
@@ -273,9 +273,9 @@ impl GenericsSubstDelegate for IdentitySubstDelegate {
         Ty::param(param_ty)
     }
 
-    fn ctor_for_param(&mut self, param_ty: ParamTy) -> SimpleTyCtor {
+    fn ctor_for_param(&mut self, param_ty: ParamTy) -> SubsetTyCtor {
         Binder::with_sort(
-            SimpleTy::indexed(BaseTy::Param(param_ty), Expr::nu()),
+            SubsetTy::indexed(BaseTy::Param(param_ty), Expr::nu()),
             Sort::Param(param_ty),
         )
     }
@@ -304,7 +304,7 @@ impl GenericsSubstDelegate for GenericArgsDelegate<'_> {
         }
     }
 
-    fn ctor_for_param(&mut self, param_ty: ParamTy) -> SimpleTyCtor {
+    fn ctor_for_param(&mut self, param_ty: ParamTy) -> SubsetTyCtor {
         match self.0.get(param_ty.index as usize) {
             Some(GenericArg::Base(ctor)) => ctor.clone(),
             Some(arg) => {
@@ -353,7 +353,7 @@ where
         bug!("unexpected type param {param_ty:?}");
     }
 
-    fn ctor_for_param(&mut self, param_ty: ParamTy) -> SimpleTyCtor {
+    fn ctor_for_param(&mut self, param_ty: ParamTy) -> SubsetTyCtor {
         bug!("unexpected base type param {param_ty:?}");
     }
 
@@ -398,7 +398,7 @@ impl<D: GenericsSubstDelegate> TypeFolder for GenericsSubstFolder<'_, D> {
         }
     }
 
-    fn fold_simple_ty(&mut self, constr: &SimpleTy) -> SimpleTy {
+    fn fold_subset_ty(&mut self, constr: &SubsetTy) -> SubsetTy {
         if let BaseTy::Param(param_ty) = &constr.bty {
             self.delegate
                 .ctor_for_param(*param_ty)

--- a/crates/flux-middle/src/rty/subst.rs
+++ b/crates/flux-middle/src/rty/subst.rs
@@ -275,7 +275,7 @@ impl GenericsSubstDelegate for IdentitySubstDelegate {
 
     fn ctor_for_param(&mut self, param_ty: ParamTy) -> SubsetTyCtor {
         Binder::with_sort(
-            SubsetTy::indexed(BaseTy::Param(param_ty), Expr::nu()),
+            SubsetTy::trivial(BaseTy::Param(param_ty), Expr::nu()),
             Sort::Param(param_ty),
         )
     }

--- a/crates/flux-middle/src/rustc/lowering.rs
+++ b/crates/flux-middle/src/rustc/lowering.rs
@@ -865,10 +865,7 @@ fn lower_clause<'tcx>(
     let kind = match kind {
         rustc_ty::ClauseKind::Trait(trait_pred) => {
             ClauseKind::Trait(TraitPredicate {
-                trait_ref: TraitRef {
-                    def_id: trait_pred.trait_ref.def_id,
-                    args: lower_generic_args(tcx, trait_pred.trait_ref.args)?,
-                },
+                trait_ref: lower_trait_ref(tcx, trait_pred.trait_ref)?,
             })
         }
         rustc_ty::ClauseKind::Projection(proj_pred) => {
@@ -892,6 +889,13 @@ fn lower_clause<'tcx>(
         }
     };
     Ok(Clause::new(kind))
+}
+
+pub(crate) fn lower_trait_ref<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    trait_ref: rustc_ty::TraitRef<'tcx>,
+) -> Result<TraitRef, UnsupportedReason> {
+    Ok(TraitRef { def_id: trait_ref.def_id, args: lower_generic_args(tcx, trait_ref.args)? })
 }
 
 fn lower_type_outlives<'tcx>(

--- a/crates/flux-middle/src/sort_of.rs
+++ b/crates/flux-middle/src/sort_of.rs
@@ -57,9 +57,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
     fn sort_of_generic_param(self, def_id: LocalDefId) -> Option<rty::Sort> {
         let param = self.get_generic_param(def_id);
         match &param.kind {
-            fhir::GenericParamKind::BaseTy | fhir::GenericParamKind::SplTy => {
-                Some(rty::Sort::Param(self.def_id_to_param_ty(def_id)))
-            }
+            fhir::GenericParamKind::Base => Some(rty::Sort::Param(self.def_id_to_param_ty(def_id))),
             fhir::GenericParamKind::Type { .. } | fhir::GenericParamKind::Lifetime => None,
         }
     }
@@ -68,9 +66,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         let generics = self.map().get_generics(owner.expect_local()).unwrap();
         let kind = generics.self_kind.as_ref()?;
         match kind {
-            fhir::GenericParamKind::BaseTy | fhir::GenericParamKind::SplTy => {
-                Some(rty::Sort::Param(rty::SELF_PARAM_TY))
-            }
+            fhir::GenericParamKind::Base => Some(rty::Sort::Param(rty::SELF_PARAM_TY)),
             fhir::GenericParamKind::Type { .. } | fhir::GenericParamKind::Lifetime => None,
         }
     }
@@ -82,7 +78,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         }
     }
 
-    pub fn sort_of_ty(self, ty: &fhir::Ty) -> Option<rty::Sort> {
+    fn sort_of_ty(self, ty: &fhir::Ty) -> Option<rty::Sort> {
         match &ty.kind {
             fhir::TyKind::BaseTy(bty) | fhir::TyKind::Indexed(bty, _) => self.sort_of_bty(bty),
             fhir::TyKind::Exists(_, ty) | fhir::TyKind::Constr(_, ty) => self.sort_of_ty(ty),

--- a/crates/flux-refineck/locales/en-US.ftl
+++ b/crates/flux-refineck/locales/en-US.ftl
@@ -28,9 +28,6 @@ refineck_assert_error =
 refineck_param_inference_error =
     parameter inference error at function call
 
-refineck_invalid_generic_arg =
-    cannot instantiate base or spl generic with opaque type
-
 refineck_fold_error =
     type invariant may not hold (when place is folded)
 

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1425,7 +1425,6 @@ pub(crate) mod errors {
         Inference,
         OpaqueStruct(DefId),
         Query(QueryErr),
-        InvalidGenericArg,
     }
 
     impl CheckerError {
@@ -1444,12 +1443,6 @@ pub(crate) mod errors {
                 CheckerErrKind::Inference => {
                     handler.struct_err_with_code(
                         fluent::refineck_param_inference_error,
-                        flux_errors::diagnostic_id(),
-                    )
-                }
-                CheckerErrKind::InvalidGenericArg => {
-                    handler.struct_err_with_code(
-                        fluent::refineck_invalid_generic_arg,
                         flux_errors::diagnostic_id(),
                     )
                 }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1147,9 +1147,13 @@ fn instantiate_args_for_fun_call(
 
     let refiner = Refiner::new(genv, caller_generics, |bty| {
         let sort = bty.sort();
-        let pred =
-            if !sort.is_unit() { rty::Expr::hole(rty::HoleKind::Pred) } else { rty::Expr::tt() };
-        rty::SimpleTy::new(bty.shift_in_escaping(1), pred)
+        let bty = bty.shift_in_escaping(1);
+        let constr = if !sort.is_unit() {
+            rty::SimpleConstrTy::new(bty, Expr::nu(), Expr::hole(rty::HoleKind::Pred))
+        } else {
+            rty::SimpleConstrTy::indexed(bty, Expr::nu())
+        };
+        Binder::with_sort(constr, sort)
     });
 
     args.iter()

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1149,9 +1149,9 @@ fn instantiate_args_for_fun_call(
         let sort = bty.sort();
         let bty = bty.shift_in_escaping(1);
         let constr = if !sort.is_unit() {
-            rty::SimpleTy::new(bty, Expr::nu(), Expr::hole(rty::HoleKind::Pred))
+            rty::SubsetTy::new(bty, Expr::nu(), Expr::hole(rty::HoleKind::Pred))
         } else {
-            rty::SimpleTy::indexed(bty, Expr::nu())
+            rty::SubsetTy::indexed(bty, Expr::nu())
         };
         Binder::with_sort(constr, sort)
     });

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1149,9 +1149,9 @@ fn instantiate_args_for_fun_call(
         let sort = bty.sort();
         let bty = bty.shift_in_escaping(1);
         let constr = if !sort.is_unit() {
-            rty::SimpleConstrTy::new(bty, Expr::nu(), Expr::hole(rty::HoleKind::Pred))
+            rty::SimpleTy::new(bty, Expr::nu(), Expr::hole(rty::HoleKind::Pred))
         } else {
-            rty::SimpleConstrTy::indexed(bty, Expr::nu())
+            rty::SimpleTy::indexed(bty, Expr::nu())
         };
         Binder::with_sort(constr, sort)
     });

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1151,7 +1151,7 @@ fn instantiate_args_for_fun_call(
         let constr = if !sort.is_unit() {
             rty::SubsetTy::new(bty, Expr::nu(), Expr::hole(rty::HoleKind::Pred))
         } else {
-            rty::SubsetTy::indexed(bty, Expr::nu())
+            rty::SubsetTy::trivial(bty, Expr::nu())
         };
         Binder::with_sort(constr, sort)
     });

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -693,7 +693,7 @@ impl<'a, 'genv, 'tcx> InferCtxt<'a, 'genv, 'tcx> {
                     Variance::Bivariant => Ok(()),
                 }
             }
-            (GenericArg::BaseTy(_), GenericArg::BaseTy(_)) => {
+            (GenericArg::Base(_), GenericArg::Base(_)) => {
                 tracked_span_bug!("generic argument subtyping for base types is not implemented");
             }
             (GenericArg::Lifetime(_), GenericArg::Lifetime(_)) => Ok(()),

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -1093,7 +1093,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
 /// This function returns a very polymorphic sort for the UIF encoding the alias_pred;
 /// This is ok, as well-formedness in previous phases will ensure the function is always
 /// instantiated with the same sorts. However, the proper thing is to compute the *actual*
-/// mono-sort at which this alias_pred is being used see [`GlobalEnv::sort_of_alias_pred`] but
+/// mono-sort at which this alias_pred is being used see [`GlobalEnv::sort_of_alias_reft`] but
 /// that is a bit tedious as its done using the `fhir` (not `rty`). Alternatively, we might
 /// stash the computed mono-sort *in* the `rty::AliasPred` during `conv`?
 fn alias_reft_sort(arity: usize) -> rty::PolyFuncSort {

--- a/crates/flux-refineck/src/refine_tree.rs
+++ b/crates/flux-refineck/src/refine_tree.rs
@@ -321,7 +321,7 @@ impl<'a, 'rcx> Unpacker<'a, 'rcx> {
 impl TypeFolder for Unpacker<'_, '_> {
     fn fold_ty(&mut self, ty: &Ty) -> Ty {
         match ty.kind() {
-            TyKind::Indexed(bty, idxs) => Ty::indexed(bty.fold_with(self), idxs.clone()),
+            TyKind::Indexed(bty, idx) => Ty::indexed(bty.fold_with(self), idx.clone()),
             TyKind::Exists(bound_ty) if self.unpack_exists => {
                 // HACK(nilehmann) In general we shouldn't unpack through mutable references because
                 // that makes referent type too specific. We only have this as a workaround to infer

--- a/crates/flux-refineck/src/refine_tree.rs
+++ b/crates/flux-refineck/src/refine_tree.rs
@@ -193,16 +193,17 @@ impl<'rcx> RefineCtxt<'rcx> {
         fresh
     }
 
-    /// Given a [`sort`] that may contain aggregate sorts ([tuples] or [records]), it destructs the sort
-    /// recursively, generating multiple fresh variables and returning the "eta-expanded" tuple of fresh
-    /// variables. This is in contrast to generating a single fresh variable of tuple sort.
+    /// Given a [`sort`] that may contain aggregate sorts ([tuple] or [adt]), it destructs the sort
+    /// recursively, generating multiple fresh variables and returning an "eta-expanded" expression
+    /// of fresh variables. This is in contrast to generating a single fresh variable of aggregate
+    /// sort.
     ///
     /// For example, given the sort `(int, (bool, int))` it returns `(a0, (a1, a2))` for fresh variables
     /// `a0: int`, `a1: bool`, and `a2: int`.
     ///
     /// [`sort`]: Sort
-    /// [tuples]: Sort::Tuple
-    /// [records]: Sort::Adt
+    /// [tuple]: Sort::Tuple
+    /// [adt]: flux_middle::rty::SortCtor::Adt
     pub(crate) fn define_vars(&mut self, sort: &Sort) -> Expr {
         Expr::fold_sort(sort, |sort| Expr::fvar(self.define_var(sort)))
     }

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -373,8 +373,8 @@ impl BasicBlockEnvShape {
     fn pack_generic_arg(scope: &Scope, arg: &GenericArg) -> GenericArg {
         match arg {
             GenericArg::Ty(ty) => GenericArg::Ty(Self::pack_ty(scope, ty)),
-            GenericArg::BaseTy(arg) => {
-                GenericArg::BaseTy(arg.as_ref().map(|ty| Self::pack_ty(scope, ty)))
+            GenericArg::Base(arg) => {
+                GenericArg::Base(arg.as_ref().map(|ty| Self::pack_ty(scope, ty)))
             }
             GenericArg::Lifetime(re) => GenericArg::Lifetime(*re),
             GenericArg::Const(c) => GenericArg::Const(c.clone()),
@@ -529,7 +529,7 @@ impl BasicBlockEnvShape {
     fn join_generic_arg(&self, arg1: &GenericArg, arg2: &GenericArg) -> GenericArg {
         match (arg1, arg2) {
             (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) => GenericArg::Ty(self.join_ty(ty1, ty2)),
-            (GenericArg::BaseTy(_), GenericArg::BaseTy(_)) => {
+            (GenericArg::Base(_), GenericArg::Base(_)) => {
                 tracked_span_bug!("generic argument join for base types is not implemented")
             }
             (GenericArg::Lifetime(re1), GenericArg::Lifetime(re2)) => {

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -12,7 +12,7 @@ use flux_middle::{
         fold::{FallibleTypeFolder, TypeFoldable, TypeVisitable, TypeVisitor},
         subst::RegionSubst,
         BaseTy, Binder, BoundReftKind, Expr, ExprKind, GenericArg, HoleKind, Mutability, Path,
-        PtrKind, Region, SimpleTy, SortCtor, Ty, TyKind, INNERMOST,
+        PtrKind, Region, SortCtor, SubsetTy, Ty, TyKind, INNERMOST,
     },
     rustc::mir::{BasicBlock, Local, LocalDecls, Place, PlaceElem},
 };
@@ -542,7 +542,7 @@ impl BasicBlockEnvShape {
                     sty1.pred.clone()
                 };
                 let sort = bty.sort();
-                let ctor = Binder::with_sort(SimpleTy::new(bty, Expr::nu(), pred), sort);
+                let ctor = Binder::with_sort(SubsetTy::new(bty, Expr::nu(), pred), sort);
                 GenericArg::Base(ctor)
             }
             (GenericArg::Lifetime(re1), GenericArg::Lifetime(re2)) => {

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -7,7 +7,7 @@ use flux_middle::{
     global_env::GlobalEnv,
     intern::List,
     rty::{
-        canonicalize::Hoister,
+        canonicalize::ShallowHoister,
         evars::EVarSol,
         fold::{FallibleTypeFolder, TypeFoldable, TypeVisitable, TypeVisitor},
         subst::RegionSubst,
@@ -556,7 +556,7 @@ impl BasicBlockEnvShape {
     pub fn into_bb_env(self, kvar_store: &mut KVarStore) -> BasicBlockEnv {
         let mut bindings = self.bindings;
 
-        let mut hoister = Hoister::default();
+        let mut hoister = ShallowHoister::default();
         bindings.fmap_mut(|ty| hoister.hoist(ty));
         let (vars, preds) = hoister.into_parts();
 

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -847,7 +847,7 @@ fn fold(
                     .map(|ty| fold(bindings, rcx, gen, ty, is_strg))
                     .try_collect_vec()?;
 
-                let partially_moved = fields.iter().any(|ty| ty.is_uninit());
+                let partially_moved = fields.iter().any(Ty::is_uninit);
                 let ty = if partially_moved {
                     Ty::uninit()
                 } else {
@@ -868,7 +868,7 @@ fn fold(
                 .map(|ty| fold(bindings, rcx, gen, ty, is_strg))
                 .try_collect_vec()?;
 
-            let partially_moved = fields.iter().any(|ty| ty.is_uninit());
+            let partially_moved = fields.iter().any(Ty::is_uninit);
             let ty = if partially_moved { Ty::uninit() } else { Ty::tuple(fields) };
             Ok(ty)
         }

--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -41,7 +41,6 @@ GenericParam: surface::GenericParam = {
         let kind = match kind.as_str() {
             "type" => surface::GenericParamKind::Type,
             "base" => surface::GenericParamKind::Base,
-            "spl"  => surface::GenericParamKind::Spl,
             _ => return Err(ParseError::User { error: UserParseError::UnexpectedToken(lo, hi) })
         };
         Ok(surface::GenericParam { name, kind, node_id: cx.next_node_id() })

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -72,7 +72,6 @@ pub struct GenericParam {
 #[derive(Debug)]
 pub enum GenericParamKind {
     Type,
-    Spl,
     Base,
     Refine { sort: Sort },
 }

--- a/crates/flux-syntax/src/surface/visit.rs
+++ b/crates/flux-syntax/src/surface/visit.rs
@@ -203,7 +203,7 @@ pub fn walk_generic_param<V: Visitor>(vis: &mut V, param: &GenericParam) {
     vis.visit_ident(param.name);
     match &param.kind {
         GenericParamKind::Refine { sort } => vis.visit_sort(sort),
-        GenericParamKind::Type | GenericParamKind::Spl | GenericParamKind::Base => {}
+        GenericParamKind::Type | GenericParamKind::Base => {}
     }
 }
 

--- a/crates/flux-tests/tests/neg/error_messages/wf/kinds00.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/kinds00.rs
@@ -13,3 +13,6 @@ pub fn test00_bad() -> RSet<impl Eq + Hash> {
     //~^ ERROR values of this type cannot be used as base sorted instances
     RSet::<i32>::new()
 }
+
+#[flux::sig(fn(soup:RSet<Tinker>))] //~ ERROR values of this type cannot be used as base sorted instances
+pub fn test01<Tinker: Eq + Hash>(_s: RSet<Tinker>) {}

--- a/crates/flux-tests/tests/neg/error_messages/wf/kinds01.rs
+++ b/crates/flux-tests/tests/neg/error_messages/wf/kinds01.rs
@@ -5,11 +5,12 @@ use std::hash::Hash;
 
 use rset::RSet;
 
-#[flux::sig(fn(soup:RSet<Tinker>))] //~ ERROR values of this type cannot be used as base sorted instances
-pub fn test04<Tinker: Eq + Hash>(_s: RSet<Tinker>) {}
-
+// This error is confusing. The problem is that `RSet` cannot be instantiated with `T` because it is
+// of kind `type`. But we don't know that until after we convert the argument to `rty` and we check if
+// it is a valid simple type. The reason we only know that after conv is that we need to expand type
+// aliases.
 #[flux::sig(fn(RSet<T>[@salt]))] //~ ERROR type cannot be refined
-pub fn test05<T>(_s: RSet<T>)
+pub fn test01<T>(_s: RSet<T>)
 where
     T: Eq + Hash,
 {


### PR DESCRIPTION
Create a simplified version of types that can be used inside generic arguments of kind base. This supersedes the need for arguments of kind `Spl` which have been removed.