### PR TITLE
Implement universal quantification in require clauses

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -501,8 +501,9 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
 
             let mut generics = self.desugar_generics(&fn_sig.generics)?;
 
-            if let Some(expr) = &fn_sig.requires {
-                let pred = self.desugar_expr(expr)?;
+            for require in &fn_sig.requires {
+                let a = &require.params;
+                let pred = self.desugar_expr(&require.pred)?;
                 requires.push(fhir::Constraint::Pred(pred));
             }
 
@@ -589,12 +590,9 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
         Ok(fhir::FnOutput { params, ret: ret?, ensures })
     }
 
-    fn desugar_constraint(
-        &mut self,
-        cstr: &surface::Constraint,
-    ) -> Result<fhir::Constraint<'genv>> {
+    fn desugar_constraint(&mut self, cstr: &surface::Ensures) -> Result<fhir::Constraint<'genv>> {
         match cstr {
-            surface::Constraint::Type(loc, ty, node_id) => {
+            surface::Ensures::Type(loc, ty, node_id) => {
                 let res = self.desugar_loc(*loc, *node_id)?;
                 let path = fhir::PathExpr {
                     segments: self.genv().alloc_slice(&[*loc]),
@@ -605,7 +603,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
                 let ty = self.desugar_ty(ty)?;
                 Ok(fhir::Constraint::Type(path, ty))
             }
-            surface::Constraint::Pred(e) => {
+            surface::Ensures::Pred(e) => {
                 let pred = self.desugar_expr(e)?;
                 Ok(fhir::Constraint::Pred(pred))
             }

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -501,10 +501,10 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
 
             let mut generics = self.desugar_generics(&fn_sig.generics)?;
 
-            for require in &fn_sig.requires {
-                let a = &require.params;
-                let pred = self.desugar_expr(&require.pred)?;
-                requires.push(fhir::Constraint::Pred(pred));
+            for surface_requires in &fn_sig.requires {
+                let params = self.desugar_refine_params(&surface_requires.params);
+                let pred = self.desugar_expr(&surface_requires.pred)?;
+                requires.push(fhir::Constraint::Pred(params, pred));
             }
 
             // Bail out if there's an error in the arguments to avoid confusing error messages
@@ -605,7 +605,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
             }
             surface::Ensures::Pred(e) => {
                 let pred = self.desugar_expr(e)?;
-                Ok(fhir::Constraint::Pred(pred))
+                Ok(fhir::Constraint::Pred(&[], pred))
             }
         }
     }

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -198,11 +198,11 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
         surface::visit::walk_fun_arg(self, arg);
     }
 
-    fn visit_constraint(&mut self, constraint: &surface::Constraint) {
-        if let surface::Constraint::Type(loc, _, node_id) = constraint {
+    fn visit_ensures(&mut self, constraint: &surface::Ensures) {
+        if let surface::Ensures::Type(loc, _, node_id) = constraint {
             self.on_loc(*loc, *node_id);
         }
-        surface::visit::walk_constraint(self, constraint);
+        surface::visit::walk_ensures(self, constraint);
     }
 
     fn visit_refine_arg(&mut self, arg: &surface::RefineArg) {

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -642,7 +642,9 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                     Local::from_usize(idx + 1),
                 ))
             }
-            fhir::Constraint::Pred(pred) => Ok(rty::Constraint::Pred(self.conv_expr(env, pred)?)),
+            fhir::Constraint::Pred(params, pred) => {
+                Ok(rty::Constraint::Pred(self.conv_expr(env, pred)?))
+            }
         }
     }
 

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -206,7 +206,7 @@ impl fhir::visit::Visitor for Wf<'_, '_, '_> {
                 self.infcx.check_loc(loc).collect_err(&mut self.errors);
                 self.visit_ty(ty);
             }
-            fhir::Constraint::Pred(params, pred) => {
+            fhir::Constraint::Pred(_, pred) => {
                 self.infcx
                     .check_expr(pred, &rty::Sort::Bool)
                     .collect_err(&mut self.errors);

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -206,7 +206,7 @@ impl fhir::visit::Visitor for Wf<'_, '_, '_> {
                 self.infcx.check_loc(loc).collect_err(&mut self.errors);
                 self.visit_ty(ty);
             }
-            fhir::Constraint::Pred(pred) => {
+            fhir::Constraint::Pred(params, pred) => {
                 self.infcx
                     .check_expr(pred, &rty::Sort::Bool)
                     .collect_err(&mut self.errors);

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -482,8 +482,8 @@ pub struct FnOutput<'fhir> {
 pub enum Constraint<'fhir> {
     /// A type constraint on a location
     Type(PathExpr<'fhir>, Ty<'fhir>),
-    /// A predicate that needs to hold
-    Pred(Expr<'fhir>),
+    /// A predicate that needs to hold under an (optional) list of universally quantified parameters
+    Pred(&'fhir [RefineParam<'fhir>], Expr<'fhir>),
 }
 
 #[derive(Clone, Copy)]
@@ -1161,7 +1161,18 @@ impl fmt::Debug for Constraint<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Constraint::Type(loc, ty) => write!(f, "{loc:?}: {ty:?}"),
-            Constraint::Pred(e) => write!(f, "{e:?}"),
+            Constraint::Pred(params, e) => {
+                if !params.is_empty() {
+                    write!(
+                        f,
+                        "forall {}.",
+                        params.iter().format_with(",", |param, f| {
+                            f(&format_args!("{}:{:?}", param.name, param.sort))
+                        })
+                    )?;
+                }
+                write!(f, "{e:?}")
+            }
         }
     }
 }

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -318,7 +318,10 @@ pub fn walk_constraint<V: Visitor>(vis: &mut V, constraint: &Constraint) {
             vis.visit_path_expr(loc);
             vis.visit_ty(ty);
         }
-        Constraint::Pred(p) => vis.visit_expr(p),
+        Constraint::Pred(params, pred) => {
+            walk_list!(vis, visit_refine_param, *params);
+            vis.visit_expr(pred);
+        }
     }
 }
 

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -726,6 +726,20 @@ impl Expr {
             _ => Expr::field_proj(self.clone(), proj, None),
         }
     }
+
+    pub fn flatten_conjs(&self) -> Vec<&Expr> {
+        fn go<'a>(e: &'a Expr, vec: &mut Vec<&'a Expr>) {
+            if let ExprKind::BinaryOp(BinOp::And, e1, e2) = e.kind() {
+                go(e1, vec);
+                go(e2, vec);
+            } else {
+                vec.push(e);
+            }
+        }
+        let mut vec = vec![];
+        go(self, &mut vec);
+        vec
+    }
 }
 
 impl KVar {

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -198,6 +198,7 @@ pub enum ExprKind {
     /// and the places where we generate inference variable for them (where we do need to worry
     /// about the scope).
     Hole(HoleKind),
+    ForAll(Binder<Expr>),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable, Debug)]
@@ -486,6 +487,10 @@ impl Expr {
 
     pub fn alias(alias: AliasReft, args: List<Expr>) -> Expr {
         ExprKind::Alias(alias, args).intern()
+    }
+
+    pub fn forall(expr: Binder<Expr>) -> Expr {
+        ExprKind::ForAll(expr).intern()
     }
 
     pub fn binary_op(
@@ -985,6 +990,15 @@ mod pretty {
                     w!("{:?}", lam)
                 }
                 ExprKind::GlobalFunc(func, _) => w!("{}", ^func),
+                ExprKind::ForAll(expr) => {
+                    let vars = expr.vars();
+                    cx.with_bound_vars(vars, || {
+                        if !vars.is_empty() {
+                            cx.fmt_bound_vars("∀", vars, ". ", f)?;
+                        }
+                        w!("{:?}", expr.as_ref().skip_binder())
+                    })
+                }
             }
         }
     }

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -580,7 +580,7 @@ impl Expr {
     /// An expression is an *atom* if it is "self-delimiting", i.e., it has a clear boundary
     /// when printed. This is used to avoid unnecesary parenthesis when pretty printing.
     pub fn is_atom(&self) -> bool {
-        !matches!(self.kind, ExprKind::Abs(..) | ExprKind::BinaryOp(..))
+        !matches!(self.kind, ExprKind::Abs(..) | ExprKind::BinaryOp(..) | ExprKind::ForAll(..))
     }
 
     /// Simple syntactic check to see if the expression is a trivially true predicate. This is used

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -1050,6 +1050,7 @@ impl TypeSuperVisitable for Expr {
                 args.visit_with(visitor)
             }
             ExprKind::Abs(body) => body.visit_with(visitor),
+            ExprKind::ForAll(expr) => expr.visit_with(visitor),
             ExprKind::Constant(_)
             | ExprKind::Hole(_)
             | ExprKind::Local(_)
@@ -1141,6 +1142,7 @@ impl TypeSuperFoldable for Expr {
                 let args = args.try_fold_with(folder)?;
                 Expr::alias(alias, args)
             }
+            ExprKind::ForAll(expr) => Expr::forall(expr.try_fold_with(folder)?),
         };
         Ok(expr)
     }

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -853,6 +853,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                 let var = self.register_const_for_lambda(lam);
                 fixpoint::Expr::Var(var.into())
             }
+            rty::ExprKind::ForAll(_) => todo!(),
             rty::ExprKind::Hole(..)
             | rty::ExprKind::KVar(_)
             | rty::ExprKind::Local(_)

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -290,8 +290,8 @@ impl Env {
         self.layers.push(layer);
     }
 
-    fn last_layer(&self) -> &[fixpoint::LocalVar] {
-        self.layers.last().unwrap()
+    fn pop_layer(&mut self) -> Vec<fixpoint::LocalVar> {
+        self.layers.pop().unwrap()
     }
 
     fn get_var(&self, var: &rty::Var, dbg_span: Span) -> fixpoint::LocalVar {
@@ -352,10 +352,6 @@ pub fn stitch(bindings: Bindings, c: fixpoint::Constraint) -> fixpoint::Constrai
         )
     })
 }
-
-/// An alias for a list of predicate (conjuncts) and their spans, used to give
-/// localized errors when refine checking fails.
-type PredSpans = Vec<(fixpoint::Pred, Option<ESpan>)>;
 
 impl<'genv, 'tcx, Tag> FixpointCtxt<'genv, 'tcx, Tag>
 where
@@ -525,7 +521,7 @@ where
         }
     }
 
-    pub fn tag_idx(&mut self, tag: Tag) -> TagIdx
+    fn tag_idx(&mut self, tag: Tag) -> TagIdx
     where
         Tag: std::fmt::Debug,
     {
@@ -536,33 +532,93 @@ where
         })
     }
 
-    pub fn pred_to_fixpoint(&mut self, pred: &rty::Expr) -> QueryResult<(Bindings, PredSpans)> {
-        let mut bindings = vec![];
-        let mut preds = vec![];
-        self.pred_to_fixpoint_internal(pred, &mut bindings, &mut preds)?;
-        Ok((bindings, preds))
+    /// Encodes an expression in head position as a constraint "peeling out" implications and foralls.
+    pub fn head_to_fixpoint(
+        &mut self,
+        expr: &rty::Expr,
+        mk_tag: impl Fn(Option<ESpan>) -> Tag + Copy,
+    ) -> QueryResult<fixpoint::Constraint>
+    where
+        Tag: std::fmt::Debug,
+    {
+        match expr.kind() {
+            rty::ExprKind::BinaryOp(rty::BinOp::And, ..) => {
+                // avoid creating nested conjunctions
+                let cstrs = expr
+                    .flatten_conjs()
+                    .into_iter()
+                    .map(|e| self.head_to_fixpoint(e, mk_tag))
+                    .try_collect()?;
+                Ok(fixpoint::Constraint::Conj(cstrs))
+            }
+            rty::ExprKind::BinaryOp(rty::BinOp::Imp, e1, e2) => {
+                let (bindings, assumption) = self.assumption_to_fixpoint(e1)?;
+                let cstr = self.head_to_fixpoint(e2, mk_tag)?;
+                Ok(stitch(bindings, mk_implies(assumption, cstr)))
+            }
+            rty::ExprKind::KVar(kvar) => {
+                let mut bindings = vec![];
+                let pred = self.kvar_to_fixpoint(kvar, &mut bindings)?;
+                Ok(stitch(bindings, fixpoint::Constraint::Pred(pred, None)))
+            }
+            rty::ExprKind::ForAll(pred) => {
+                self.env.push_layer_with_fresh_names(pred.vars().len());
+                let cstr = self.head_to_fixpoint(pred.as_ref().skip_binder(), mk_tag)?;
+                let vars = self.env.pop_layer();
+
+                let bindings = iter::zip(vars, &pred.vars().to_sort_list())
+                    .map(|(var, sort)| (var, sort_to_fixpoint(sort), fixpoint::Expr::TRUE))
+                    .collect_vec();
+
+                Ok(stitch(bindings, cstr))
+            }
+            _ => {
+                let tag_idx = self.tag_idx(mk_tag(expr.span()));
+                let pred = fixpoint::Pred::Expr(self.ecx.expr_to_fixpoint(expr, &self.env)?);
+                Ok(fixpoint::Constraint::Pred(pred, Some(tag_idx)))
+            }
+        }
     }
 
-    fn pred_to_fixpoint_internal(
+    /// Encodes an expression in assumptive position as a [`fixpoint::Pred`]. Returns the encoded
+    /// predicate and a possible list of bindings produced by ANF-fing kvars.
+    ///
+    /// [`fixpoint::Pred`]: flux_fixpoint::Pred
+    pub fn assumption_to_fixpoint(
+        &mut self,
+        pred: &rty::Expr,
+    ) -> QueryResult<(Bindings, fixpoint::Pred)> {
+        let mut bindings = vec![];
+        let mut preds = vec![];
+        self.assumption_to_fixpoint_aux(pred, &mut bindings, &mut preds)?;
+        Ok((bindings, fixpoint::Pred::And(preds)))
+    }
+
+    /// Auxiliary function to avoid creating nested conjunctions
+    fn assumption_to_fixpoint_aux(
         &mut self,
         expr: &rty::Expr,
         bindings: &mut Bindings,
-        preds: &mut PredSpans,
+        preds: &mut Vec<fixpoint::Pred>,
     ) -> QueryResult {
         match expr.kind() {
             rty::ExprKind::BinaryOp(rty::BinOp::And, e1, e2) => {
-                self.pred_to_fixpoint_internal(e1, bindings, preds)?;
-                self.pred_to_fixpoint_internal(e2, bindings, preds)?;
+                self.assumption_to_fixpoint_aux(e1, bindings, preds)?;
+                self.assumption_to_fixpoint_aux(e2, bindings, preds)?;
             }
             rty::ExprKind::KVar(kvar) => {
-                preds.push((self.kvar_to_fixpoint(kvar, bindings)?, None));
+                preds.push(self.kvar_to_fixpoint(kvar, bindings)?);
+            }
+            rty::ExprKind::ForAll(_) => {
+                // If a forall appears in assumptive position replace it with true. This is sound
+                // because we are weakining the context, i.e., anything true without the assumption
+                // should remaing true after adding it. Note that this relies on the predicate
+                // appearing negatively. This is guaranteed by the surface syntax because foralls
+                // can only appear at the top-level in a requires clause.
+                preds.push(fixpoint::Pred::TRUE);
             }
             _ => {
-                let span = expr.span();
-                preds.push((
-                    fixpoint::Pred::Expr(self.ecx.expr_to_fixpoint(expr, &self.env)?),
-                    span,
-                ));
+                preds.push(fixpoint::Pred::Expr(self.ecx.expr_to_fixpoint(expr, &self.env)?));
             }
         }
         Ok(())
@@ -853,12 +909,12 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                 let var = self.register_const_for_lambda(lam);
                 fixpoint::Expr::Var(var.into())
             }
-            rty::ExprKind::ForAll(_) => todo!(),
             rty::ExprKind::Hole(..)
             | rty::ExprKind::KVar(_)
             | rty::ExprKind::Local(_)
             | rty::ExprKind::GlobalFunc(..)
-            | rty::ExprKind::PathProj(..) => {
+            | rty::ExprKind::PathProj(..)
+            | rty::ExprKind::ForAll(_) => {
                 span_bug!(self.dbg_span, "unexpected expr: `{expr:?}`")
             }
         };
@@ -1119,13 +1175,12 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
     ) -> QueryResult<fixpoint::Qualifier> {
         let mut env = Env::new();
         env.push_layer_with_fresh_names(qualifier.body.vars().len());
+        let body = self.expr_to_fixpoint(qualifier.body.as_ref().skip_binder(), &env)?;
 
         let args: Vec<(fixpoint::Var, fixpoint::Sort)> =
-            iter::zip(env.last_layer(), qualifier.body.vars())
-                .map(|(name, var)| ((*name).into(), sort_to_fixpoint(var.expect_sort())))
+            iter::zip(env.pop_layer(), qualifier.body.vars())
+                .map(|(name, var)| (name.into(), sort_to_fixpoint(var.expect_sort())))
                 .collect();
-
-        let body = self.expr_to_fixpoint(qualifier.body.as_ref().skip_binder(), &env)?;
 
         let name = qualifier.name.to_string();
 
@@ -1146,4 +1201,15 @@ fn alias_reft_sort(arity: usize) -> rty::PolyFuncSort {
     }
     sorts.push(rty::Sort::Bool);
     rty::PolyFuncSort::new(arity, rty::FuncSort { inputs_and_output: List::from_vec(sorts) })
+}
+
+fn mk_implies(assumption: fixpoint::Pred, cstr: fixpoint::Constraint) -> fixpoint::Constraint {
+    fixpoint::Constraint::ForAll(
+        fixpoint::Bind {
+            name: fixpoint::Var::Underscore,
+            sort: fixpoint::Sort::Int,
+            pred: assumption,
+        },
+        Box::new(cstr),
+    )
 }

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -95,7 +95,7 @@ pub fn check_fn(
         }
         refine_tree.simplify();
         if config::dump_constraint() {
-            dbg::dump_item_info(genv.tcx(), def_id, ".simp.fluxc", &refine_tree).unwrap();
+            dbg::dump_item_info(genv.tcx(), def_id, "simp.fluxc", &refine_tree).unwrap();
         }
         let mut fcx = fixpoint_encoding::FixpointCtxt::new(genv, def_id, kvars).emit(&genv)?;
         fcx.collect_sorts(&refine_tree);

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -90,9 +90,12 @@ pub fn check_fn(
         tracing::info!("check_fn::refine");
 
         // PHASE 3: invoke fixpoint on the constraint
-        refine_tree.simplify();
         if config::dump_constraint() {
             dbg::dump_item_info(genv.tcx(), def_id, "fluxc", &refine_tree).unwrap();
+        }
+        refine_tree.simplify();
+        if config::dump_constraint() {
+            dbg::dump_item_info(genv.tcx(), def_id, ".simp.fluxc", &refine_tree).unwrap();
         }
         let mut fcx = fixpoint_encoding::FixpointCtxt::new(genv, def_id, kvars).emit(&genv)?;
         fcx.collect_sorts(&refine_tree);

--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -235,12 +235,11 @@ pub FnSig: surface::FnSig = {
     "(" <args:Args> ")"
     <ret_lo:@L> <ret_hi:@R>
     <returns:("->" <Ty>)?>
-    <requires:("requires" <Expr>)?>
-    <ensures:("ensures" <Ensures>)?>
+    <requires:("requires" <Comma1<Requires>>)?>
+    <ensures:("ensures" <Comma1<Ensures>>)?>
     <predicates:("where" <Predicates>)?>
     <hi:@R>
     => {
-        let ensures = ensures.unwrap_or_default();
         let returns = if let Some(ty) = returns {
             surface::FnRetTy::Ty(ty)
         } else {
@@ -249,14 +248,14 @@ pub FnSig: surface::FnSig = {
         generics.predicates = predicates.unwrap_or_default();
         let output = surface::FnOutput {
             returns,
-            ensures,
+            ensures: ensures.unwrap_or_default(),
             node_id: cx.next_node_id(),
         };
         surface::FnSig {
             asyncness,
             generics,
             args,
-            requires,
+            requires: requires.unwrap_or_default(),
             output,
             span: cx.map_span(lo, hi),
             node_id: cx.next_node_id(),
@@ -319,14 +318,21 @@ Fields: Vec<surface::Ty> = {
 }
 
 Args    = <Comma<Arg>>;
-Ensures    = <Comma<Constraint>>;
 Predicates = <Comma<WhereBoundPredicate>>;
 
-Constraint: surface::Constraint = {
-    <ident:Ident> ":" <ty:Ty> => surface::Constraint::Type(ident, ty, cx.next_node_id()),
-    <expr:Expr> => surface::Constraint::Pred(expr),
+Requires: surface::Requires = {
+    <params: ("forall" <RefineParams<"?">> ".")?> <pred:Expr> => {
+        surface::Requires {
+            params: params.unwrap_or_default(),
+            pred,
+        }
+    }
 }
 
+Ensures: surface::Ensures = {
+    <ident:Ident> ":" <ty:Ty> => surface::Ensures::Type(ident, ty, cx.next_node_id()),
+    <expr:Expr>               => surface::Ensures::Pred(expr),
+}
 
 WhereBoundPredicate: surface::WhereBoundPredicate = {
     <lo:@L> <bounded_ty:Ty> ":" <bounds:GenericBounds>  <hi:@R> => {
@@ -664,6 +670,7 @@ extern {
         "requires" => Token::Requires,
         "ensures" => Token::Ensures,
         "where" => Token::Where,
+        "forall" => Token::Forall,
         "impl" => Token::Impl,
         "qualifier" => Token::Qualifier,
         "sort" => Token::Sort,

--- a/crates/flux-syntax/src/lexer.rs
+++ b/crates/flux-syntax/src/lexer.rs
@@ -39,6 +39,7 @@ pub enum Token {
     FatArrow,
     Mut,
     Where,
+    Forall,
     Impl,
     Requires,
     Ensures,
@@ -86,6 +87,7 @@ struct Symbols {
     local: Symbol,
     bitvec: Symbol,
     refine: Symbol,
+    forall: Symbol,
 }
 
 struct Frame<'t> {
@@ -114,6 +116,7 @@ impl<'t> Cursor<'t> {
                 opaque: Symbol::intern("opaque"),
                 local: Symbol::intern("local"),
                 refine: Symbol::intern("refine"),
+                forall: Symbol::intern("forall"),
             },
         }
     }
@@ -155,6 +158,7 @@ impl<'t> Cursor<'t> {
             TokenKind::Ident(symb, _) if symb == self.symbs.local => Token::Local,
             TokenKind::Ident(symb, _) if symb == self.symbs.bitvec => Token::BitVec,
             TokenKind::Ident(symb, _) if symb == self.symbs.refine => Token::Refine,
+            TokenKind::Ident(symb, _) if symb == self.symbs.forall => Token::Forall,
             TokenKind::Ident(symb, _) if symb == kw::Mut => Token::Mut,
             TokenKind::Ident(symb, _) if symb == kw::Where => Token::Where,
             TokenKind::Ident(symb, _) if symb == kw::Impl => Token::Impl,

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -236,7 +236,7 @@ pub struct FnSig {
     pub asyncness: Async,
     pub generics: Generics,
     /// example: `requires n > 0`
-    pub requires: Option<Expr>,
+    pub requires: Vec<Requires>,
     /// example: `i32<@n>`
     pub args: Vec<Arg>,
     pub output: FnOutput,
@@ -246,16 +246,23 @@ pub struct FnSig {
 }
 
 #[derive(Debug)]
+pub struct Requires {
+    /// Optional list of universally quantified parameters
+    pub params: Vec<RefineParam>,
+    pub pred: Expr,
+}
+
+#[derive(Debug)]
 pub struct FnOutput {
     /// example `i32{v:v >= 0}`
     pub returns: FnRetTy,
     /// example: `*x: i32{v. v = n+1}` or just `x > 10`
-    pub ensures: Vec<Constraint>,
+    pub ensures: Vec<Ensures>,
     pub node_id: NodeId,
 }
 
 #[derive(Debug)]
-pub enum Constraint {
+pub enum Ensures {
     /// A type constraint on a location
     Type(Ident, Ty, NodeId),
     /// A predicate that needs to hold

--- a/tests/tests/neg/surface/forall01.rs
+++ b/tests/tests/neg/surface/forall01.rs
@@ -1,0 +1,15 @@
+#[flux::sig(fn(bool[true]))]
+
+fn assert(_: bool) {}
+#[flux::sig(
+    fn(x: i32)
+    requires forall y. y >= 0 => y > x
+)]
+fn requires_negative(x: i32) {
+    // this should be provable, but we are currently dropping the quantified assumption
+    assert(x <= 0); //~ ERROR refinement type
+}
+
+fn test2() {
+    requires_negative(0); //~ ERROR refinement type
+}

--- a/tests/tests/pos/surface/forall01.rs
+++ b/tests/tests/pos/surface/forall01.rs
@@ -1,0 +1,14 @@
+#[flux::sig(fn(bool[true]))]
+
+fn assert(_: bool) {}
+#[flux::sig(
+    fn(x: i32)
+    requires forall y. y >= 0 => y > x
+)]
+fn requires_negative(x: i32) {
+    assert(x + 1 == 1 + x); // make sure there's something to check to avoid optimizing the entire constraint away
+}
+
+fn test2() {
+    requires_negative(-1);
+}


### PR DESCRIPTION
Limited support for universal quantification in requires clauses. Quantification can be used to specify functions, but not to check their body. This is meant to be used in trusted code.