### PR TITLE
Basic support Self::Assoc

### DIFF
--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -694,8 +694,12 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             fhir::TyKind::Indexed(bty, idx) => {
                 let idx = self.conv_refine_arg(env, idx)?;
                 match &bty.kind {
-                    fhir::BaseTyKind::Path(fhir::QPath::Resolved(_, path)) => {
+                    fhir::BaseTyKind::Path(fhir::QPath::Resolved(qself, path)) => {
+                        debug_assert!(qself.is_none());
                         Ok(self.conv_ty_ctor(env, path)?.replace_bound_reft(&idx))
+                    }
+                    fhir::BaseTyKind::Path(fhir::QPath::TypeRelative(..)) => {
+                        span_bug!(ty.span, "Indexed type relative types are not yet supported");
                     }
                     fhir::BaseTyKind::Slice(ty) => {
                         let bty = rty::BaseTy::Slice(self.conv_ty(env, ty)?);
@@ -767,7 +771,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
 
     fn conv_base_ty(&self, env: &mut Env, bty: &fhir::BaseTy) -> QueryResult<rty::Ty> {
         match &bty.kind {
-            fhir::BaseTyKind::Path(fhir::QPath::Resolved(self_ty, path)) => {
+            fhir::BaseTyKind::Path(fhir::QPath::Resolved(qself, path)) => {
                 match path.res {
                     fhir::Res::Def(DefKind::AssocTy, assoc_id) => {
                         let trait_id = self.genv.tcx().trait_of_item(assoc_id).unwrap();
@@ -776,14 +780,14 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                         };
 
                         let trait_generics = self.genv.generics_of(trait_id)?;
-                        let self_ty = self_ty.as_deref().unwrap();
-                        let self_ty =
+                        let qself = qself.as_deref().unwrap();
+                        let qself =
                             if let rty::GenericParamDefKind::Base = trait_generics.params[0].kind {
-                                rty::GenericArg::Base(self.conv_generic_base(env, self_ty)?)
+                                rty::GenericArg::Base(self.conv_generic_base(env, qself)?)
                             } else {
-                                rty::GenericArg::Ty(self.conv_ty(env, self_ty)?)
+                                rty::GenericArg::Ty(self.conv_ty(env, qself)?)
                             };
-                        let mut args = vec![self_ty];
+                        let mut args = vec![qself];
                         self.conv_generic_args_into(env, trait_id, trait_segment.args, &mut args)?;
                         self.conv_generic_args_into(env, assoc_id, assoc_segment.args, &mut args)?;
                         let args = List::from_vec(args);
@@ -813,6 +817,9 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                 }
                 Ok(self.conv_ty_ctor(env, path)?.to_ty())
             }
+            fhir::BaseTyKind::Path(fhir::QPath::TypeRelative(qself, segment)) => {
+                self.conv_assoc_path(env, qself, segment)
+            }
             fhir::BaseTyKind::Slice(ty) => {
                 let bty = rty::BaseTy::Slice(self.conv_ty(env, ty)?).shift_in_escaping(1);
                 let sort = bty.sort();
@@ -821,6 +828,43 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                     sort,
                 )))
             }
+        }
+    }
+
+    fn conv_assoc_path(
+        &self,
+        env: &mut Env,
+        qself: &fhir::Ty,
+        assoc_segment: &fhir::PathSegment,
+    ) -> QueryResult<rty::Ty> {
+        let assoc_ident = assoc_segment.ident;
+        let qself_res = if let Some(path) = qself.as_path() { path.res } else { fhir::Res::Err };
+
+        if let fhir::Res::SelfTyAlias { alias_to: impl_def_id, is_trait_impl: true } = qself_res {
+            let Some(trait_ref) = self.genv.impl_trait_ref(impl_def_id)? else {
+                // A cycle error ocurred most likely
+                span_bug!(qself.span, "expected cycle error");
+            };
+            let trait_ref = trait_ref.instantiate_identity(&[]);
+
+            let Some(assoc_item) = self.trait_defines_associated_item_named(
+                trait_ref.def_id,
+                AssocKind::Type,
+                assoc_ident,
+            ) else {
+                todo!("report cannot find")
+            };
+            let assoc_id = assoc_item.def_id;
+
+            let mut args = trait_ref.args.to_vec();
+            self.conv_generic_args_into(env, assoc_id, assoc_segment.args, &mut args)?;
+
+            let args = List::from_vec(args);
+            let refine_args = List::empty();
+            let alias_ty = rty::AliasTy { args, refine_args, def_id: assoc_id };
+            Ok(rty::Ty::alias(rty::AliasKind::Projection, alias_ty))
+        } else {
+            todo!("report only supported on `Self`")
         }
     }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -617,6 +617,7 @@ pub enum BaseTyKind<'fhir> {
 #[derive(Clone, Copy)]
 pub enum QPath<'fhir> {
     Resolved(Option<&'fhir Ty<'fhir>>, Path<'fhir>),
+    TypeRelative(&'fhir Ty<'fhir>, &'fhir PathSegment<'fhir>),
 }
 
 #[derive(Clone, Copy)]
@@ -972,6 +973,7 @@ impl<'fhir> QPath<'fhir> {
     pub fn span(&self) -> Span {
         match self {
             QPath::Resolved(_, path) => path.span,
+            QPath::TypeRelative(qself, assoc) => qself.span.to(assoc.ident.span),
         }
     }
 }
@@ -1245,9 +1247,8 @@ impl fmt::Debug for BaseTy<'_> {
 impl fmt::Debug for QPath<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            QPath::Resolved(_self_ty, path) => {
-                write!(f, "{path:?}")
-            }
+            QPath::Resolved(_, path) => write!(f, "{path:?}"),
+            QPath::TypeRelative(qself, assoc) => write!(f, "<{qself:?}>::{assoc:?}"),
         }
     }
 }

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -388,11 +388,15 @@ pub fn walk_bty<V: Visitor>(vis: &mut V, bty: &BaseTy) {
 
 pub fn walk_qpath<V: Visitor>(vis: &mut V, qpath: &QPath) {
     match qpath {
-        QPath::Resolved(self_ty, path) => {
-            if let Some(self_ty) = self_ty {
+        QPath::Resolved(qself, path) => {
+            if let Some(self_ty) = qself {
                 vis.visit_ty(self_ty);
             }
             vis.visit_path(path);
+        }
+        QPath::TypeRelative(qself, assoc) => {
+            vis.visit_ty(qself);
+            vis.visit_path_segment(assoc);
         }
     }
 }

--- a/crates/flux-middle/src/sort_of.rs
+++ b/crates/flux-middle/src/sort_of.rs
@@ -27,6 +27,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
     pub fn sort_of_bty(self, bty: &fhir::BaseTy) -> QueryResult<Option<rty::Sort>> {
         let sort = match &bty.kind {
             fhir::BaseTyKind::Path(fhir::QPath::Resolved(_, path)) => self.sort_of_path(path)?,
+            fhir::BaseTyKind::Path(fhir::QPath::TypeRelative(..)) => None,
             fhir::BaseTyKind::Slice(_) => Some(rty::Sort::Int),
         };
         Ok(sort)

--- a/tests/tests/pos/surface/trait06.rs
+++ b/tests/tests/pos/surface/trait06.rs
@@ -1,0 +1,14 @@
+trait MyTrait {
+    type Assoc;
+
+    fn foo(self) -> <Self as MyTrait>::Assoc;
+}
+
+impl MyTrait for i32 {
+    type Assoc = i32;
+
+    // Test we can lift and convert `Self::Assoc`
+    fn foo(self) -> Self::Assoc {
+        self
+    }
+}


### PR DESCRIPTION
Support `Self::Assoc` in a trait implementation. Only look for `Assoc` in the current trait and not supertraits.