### PR TITLE
Save `QueryResult` in crate metadata

### DIFF
--- a/crates/flux-metadata/src/encoder.rs
+++ b/crates/flux-metadata/src/encoder.rs
@@ -1,7 +1,6 @@
 use std::collections::hash_map::Entry;
 
 use flux_middle::global_env::GlobalEnv;
-use rustc_data_structures::{fx::FxIndexSet, sync::Lrc};
 use rustc_hash::FxHashMap;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_metadata::errors::FailCreateFileEncoder;
@@ -14,23 +13,17 @@ use rustc_session::config::CrateType;
 use rustc_span::{
     def_id::{CrateNum, DefIndex},
     hygiene::{ExpnIndex, HygieneEncodeContext},
-    ExpnId, ExternalSource, SourceFile, Span, SpanData, SpanEncoder, Symbol, SyntaxContext,
+    ExpnId, Span, SpanEncoder, Symbol, SyntaxContext,
 };
 use rustc_type_ir::TyEncoder;
 
-use crate::{
-    CrateMetadata, SpanKind, SpanTag, METADATA_HEADER, SYMBOL_OFFSET, SYMBOL_PREINTERNED,
-    SYMBOL_STR,
-};
+use crate::{CrateMetadata, METADATA_HEADER, SYMBOL_OFFSET, SYMBOL_PREINTERNED, SYMBOL_STR};
 
 struct EncodeContext<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     opaque: opaque::FileEncoder,
-    span_shorthands: FxHashMap<Span, usize>,
     type_shorthands: FxHashMap<ty::Ty<'tcx>, usize>,
     predicate_shorthands: FxHashMap<ty::PredicateKind<'tcx>, usize>,
-    source_file_cache: (Lrc<SourceFile>, usize),
-    required_source_files: Option<FxIndexSet<usize>>,
     is_proc_macro: bool,
     hygiene_ctxt: &'a HygieneEncodeContext,
     symbol_table: FxHashMap<Symbol, usize>, // interpret_allocs: FxIndexSet<interpret::AllocId>,
@@ -48,20 +41,12 @@ pub fn encode_metadata(genv: &GlobalEnv, path: &std::path::Path) {
 
     let crate_root = CrateMetadata::new(genv);
 
-    let source_map_files = genv.tcx().sess.source_map().files();
-    let source_file_cache = (source_map_files[0].clone(), 0);
-    let required_source_files = Some(FxIndexSet::default());
-    drop(source_map_files);
-
     let hygiene_ctxt = HygieneEncodeContext::default();
     let mut ecx = EncodeContext {
         tcx: genv.tcx(),
         opaque: encoder,
-        span_shorthands: Default::default(),
         type_shorthands: Default::default(),
         predicate_shorthands: Default::default(),
-        source_file_cache,
-        required_source_files,
         is_proc_macro: genv.tcx().crate_types().contains(&CrateType::ProcMacro),
         hygiene_ctxt: &hygiene_ctxt,
         symbol_table: Default::default(),
@@ -105,37 +90,17 @@ impl<'a, 'tcx> SpanEncoder for EncodeContext<'a, 'tcx> {
         expn_id.local_id.encode(self);
     }
 
+    // Code adapted from prusti
     fn encode_span(&mut self, span: Span) {
-        match self.span_shorthands.entry(span) {
-            Entry::Occupied(o) => {
-                // If an offset is smaller than the absolute position, we encode with the offset.
-                // This saves space since smaller numbers encode in less bits.
-                let last_location = *o.get();
-                // This cannot underflow. Metadata is written with increasing position(), so any
-                // previously saved offset must be smaller than the current position.
-                let offset = self.opaque.position() - last_location;
-                if offset < last_location {
-                    let needed = bytes_needed(offset);
-                    SpanTag::indirect(true, needed as u8).encode(self);
-                    self.opaque.write_with(|dest| {
-                        *dest = offset.to_le_bytes();
-                        needed
-                    });
-                } else {
-                    let needed = bytes_needed(last_location);
-                    SpanTag::indirect(false, needed as u8).encode(self);
-                    self.opaque.write_with(|dest| {
-                        *dest = last_location.to_le_bytes();
-                        needed
-                    });
-                }
-            }
-            Entry::Vacant(v) => {
-                let position = self.opaque.position();
-                v.insert(position);
-                // Data is encoded with a SpanTag prefix (see below).
-                span.data().encode(self);
-            }
+        let sm = self.tcx.sess.source_map();
+        for bp in [span.lo(), span.hi()] {
+            let sf = sm.lookup_source_file(bp);
+            sf.stable_id.encode(self);
+            // Not sure if this is the most stable way to encode a BytePos. If it fails
+            // try finding a function in `SourceMap` or `SourceFile` instead. E.g. the
+            // `bytepos_to_file_charpos` fn which returns `CharPos` (though there is
+            // currently no fn mapping back to `BytePos` for decode)
+            (bp - sf.start_pos).encode(self);
         }
     }
 
@@ -221,155 +186,5 @@ impl<'a, 'tcx> Encoder for EncodeContext<'a, 'tcx> {
         emit_char(char);
         emit_str(&str);
         emit_raw_bytes(&[u8]);
-    }
-}
-
-fn bytes_needed(n: usize) -> usize {
-    (usize::BITS - n.leading_zeros()).div_ceil(u8::BITS) as usize
-}
-
-impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for SpanData {
-    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) {
-        // Don't serialize any `SyntaxContext`s from a proc-macro crate,
-        // since we don't load proc-macro dependencies during serialization.
-        // This means that any hygiene information from macros used *within*
-        // a proc-macro crate (e.g. invoking a macro that expands to a proc-macro
-        // definition) will be lost.
-        //
-        // This can show up in two ways:
-        //
-        // 1. Any hygiene information associated with identifier of
-        // a proc macro (e.g. `#[proc_macro] pub fn $name`) will be lost.
-        // Since proc-macros can only be invoked from a different crate,
-        // real code should never need to care about this.
-        //
-        // 2. Using `Span::def_site` or `Span::mixed_site` will not
-        // include any hygiene information associated with the definition
-        // site. This means that a proc-macro cannot emit a `$crate`
-        // identifier which resolves to one of its dependencies,
-        // which also should never come up in practice.
-        //
-        // Additionally, this affects `Span::parent`, and any other
-        // span inspection APIs that would otherwise allow traversing
-        // the `SyntaxContexts` associated with a span.
-        //
-        // None of these user-visible effects should result in any
-        // cross-crate inconsistencies (getting one behavior in the same
-        // crate, and a different behavior in another crate) due to the
-        // limited surface that proc-macros can expose.
-        //
-        // IMPORTANT: If this is ever changed, be sure to update
-        // `rustc_span::hygiene::raw_encode_expn_id` to handle
-        // encoding `ExpnData` for proc-macro crates.
-        let ctxt = if s.is_proc_macro { SyntaxContext::root() } else { self.ctxt };
-
-        if self.is_dummy() {
-            let tag = SpanTag::new(SpanKind::Partial, ctxt, 0);
-            tag.encode(s);
-            if tag.context().is_none() {
-                ctxt.encode(s);
-            }
-            return;
-        }
-
-        // The Span infrastructure should make sure that this invariant holds:
-        debug_assert!(self.lo <= self.hi);
-
-        if !s.source_file_cache.0.contains(self.lo) {
-            let source_map = s.tcx.sess.source_map();
-            let source_file_index = source_map.lookup_source_file_idx(self.lo);
-            s.source_file_cache =
-                (source_map.files()[source_file_index].clone(), source_file_index);
-        }
-        let (ref source_file, source_file_index) = s.source_file_cache;
-        debug_assert!(source_file.contains(self.lo));
-
-        if !source_file.contains(self.hi) {
-            // Unfortunately, macro expansion still sometimes generates Spans
-            // that malformed in this way.
-            let tag = SpanTag::new(SpanKind::Partial, ctxt, 0);
-            tag.encode(s);
-            if tag.context().is_none() {
-                ctxt.encode(s);
-            }
-            return;
-        }
-
-        // There are two possible cases here:
-        // 1. This span comes from a 'foreign' crate - e.g. some crate upstream of the
-        // crate we are writing metadata for. When the metadata for *this* crate gets
-        // deserialized, the deserializer will need to know which crate it originally came
-        // from. We use `TAG_VALID_SPAN_FOREIGN` to indicate that a `CrateNum` should
-        // be deserialized after the rest of the span data, which tells the deserializer
-        // which crate contains the source map information.
-        // 2. This span comes from our own crate. No special handling is needed - we just
-        // write `TAG_VALID_SPAN_LOCAL` to let the deserializer know that it should use
-        // our own source map information.
-        //
-        // If we're a proc-macro crate, we always treat this as a local `Span`.
-        // In `encode_source_map`, we serialize foreign `SourceFile`s into our metadata
-        // if we're a proc-macro crate.
-        // This allows us to avoid loading the dependencies of proc-macro crates: all of
-        // the information we need to decode `Span`s is stored in the proc-macro crate.
-        let (kind, metadata_index) = if source_file.is_imported() && !s.is_proc_macro {
-            // To simplify deserialization, we 'rebase' this span onto the crate it originally came
-            // from (the crate that 'owns' the file it references. These rebased 'lo' and 'hi'
-            // values are relative to the source map information for the 'foreign' crate whose
-            // CrateNum we write into the metadata. This allows `imported_source_files` to binary
-            // search through the 'foreign' crate's source map information, using the
-            // deserialized 'lo' and 'hi' values directly.
-            //
-            // All of this logic ensures that the final result of deserialization is a 'normal'
-            // Span that can be used without any additional trouble.
-            let metadata_index = {
-                // Introduce a new scope so that we drop the 'read()' temporary
-                match &*source_file.external_src.read() {
-                    ExternalSource::Foreign { metadata_index, .. } => *metadata_index,
-                    src => panic!("Unexpected external source {src:?}"),
-                }
-            };
-
-            (SpanKind::Foreign, metadata_index)
-        } else {
-            // Record the fact that we need to encode the data for this `SourceFile`
-            let source_files = s
-                .required_source_files
-                .as_mut()
-                .expect("Already encoded SourceMap!");
-            let (metadata_index, _) = source_files.insert_full(source_file_index);
-            let metadata_index: u32 = metadata_index
-                .try_into()
-                .expect("cannot export more than U32_MAX files");
-
-            (SpanKind::Local, metadata_index)
-        };
-
-        // Encode the start position relative to the file start, so we profit more from the
-        // variable-length integer encoding.
-        let lo = self.lo - source_file.start_pos;
-
-        // Encode length which is usually less than span.hi and profits more
-        // from the variable-length integer encoding that we use.
-        let len = self.hi - self.lo;
-
-        let tag = SpanTag::new(kind, ctxt, len.0 as usize);
-        tag.encode(s);
-        if tag.context().is_none() {
-            ctxt.encode(s);
-        }
-        lo.encode(s);
-        if tag.length().is_none() {
-            len.encode(s);
-        }
-
-        // Encode the index of the `SourceFile` for the span, in order to make decoding faster.
-        metadata_index.encode(s);
-
-        if kind == SpanKind::Foreign {
-            // This needs to be two lines to avoid holding the `s.source_file_cache`
-            // while calling `cnum.encode(s)`
-            let cnum = s.source_file_cache.0.cnum;
-            cnum.encode(s);
-        }
     }
 }

--- a/crates/flux-metadata/src/lib.rs
+++ b/crates/flux-metadata/src/lib.rs
@@ -22,10 +22,10 @@ use std::path::PathBuf;
 use decoder::decode_crate_metadata;
 use flux_errors::FluxSession;
 use flux_macros::fluent_messages;
-use flux_middle::{cstore::CrateStore, global_env::GlobalEnv, intern::List, rty};
+use flux_middle::{cstore::CrateStore, global_env::GlobalEnv, queries::QueryResult, rty};
 use rustc_hash::FxHashMap;
 use rustc_hir::def::DefKind;
-use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
+use rustc_macros::{TyDecodable, TyEncodable};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::{
     config::{OutFileName, OutputType},
@@ -46,16 +46,11 @@ pub struct CStore {
 
 #[derive(TyEncodable, TyDecodable)]
 pub struct CrateMetadata {
-    fn_sigs: FxHashMap<DefIndex, rty::EarlyBinder<rty::PolyFnSig>>,
-    adts: FxHashMap<DefIndex, AdtMetadata>,
-    /// For now it only store type of aliases
-    type_of: FxHashMap<DefIndex, rty::EarlyBinder<rty::TyCtor>>,
-}
-
-#[derive(TyEncodable, TyDecodable)]
-struct AdtMetadata {
-    adt_def: rty::AdtDef,
-    variants: rty::Opaqueness<rty::EarlyBinder<List<rty::PolyVariant>>>,
+    fn_sigs: FxHashMap<DefIndex, QueryResult<rty::EarlyBinder<rty::PolyFnSig>>>,
+    adt_defs: FxHashMap<DefIndex, QueryResult<rty::AdtDef>>,
+    variants:
+        FxHashMap<DefIndex, QueryResult<rty::Opaqueness<rty::EarlyBinder<rty::PolyVariants>>>>,
+    type_of: FxHashMap<DefIndex, QueryResult<rty::EarlyBinder<rty::TyCtor>>>,
 }
 
 impl CStore {
@@ -71,14 +66,10 @@ impl CStore {
             .collect();
         Self { meta }
     }
-
-    fn adt(&self, def_id: DefId) -> Option<&AdtMetadata> {
-        self.meta.get(&def_id.krate)?.adts.get(&def_id.index)
-    }
 }
 
 impl CrateStore for CStore {
-    fn fn_sig(&self, def_id: DefId) -> Option<rty::EarlyBinder<rty::PolyFnSig>> {
+    fn fn_sig(&self, def_id: DefId) -> Option<QueryResult<rty::EarlyBinder<rty::PolyFnSig>>> {
         self.meta
             .get(&def_id.krate)?
             .fn_sigs
@@ -86,20 +77,31 @@ impl CrateStore for CStore {
             .cloned()
     }
 
-    fn adt_def(&self, def_id: DefId) -> Option<&rty::AdtDef> {
-        self.adt(def_id).map(|adt| &adt.adt_def)
+    fn adt_def(&self, def_id: DefId) -> Option<QueryResult<rty::AdtDef>> {
+        self.meta
+            .get(&def_id.krate)?
+            .adt_defs
+            .get(&def_id.index)
+            .cloned()
     }
 
     fn variants(
         &self,
         def_id: DefId,
-    ) -> Option<rty::Opaqueness<rty::EarlyBinder<&[rty::PolyVariant]>>> {
-        self.adt(def_id)
-            .map(|adt| adt.variants.as_ref().map(rty::EarlyBinder::as_deref))
+    ) -> Option<QueryResult<rty::Opaqueness<rty::EarlyBinder<rty::PolyVariants>>>> {
+        self.meta
+            .get(&def_id.krate)?
+            .variants
+            .get(&def_id.index)
+            .cloned()
     }
 
-    fn type_of(&self, def_id: DefId) -> Option<&rty::EarlyBinder<rty::TyCtor>> {
-        self.meta.get(&def_id.krate)?.type_of.get(&def_id.index)
+    fn type_of(&self, def_id: DefId) -> Option<QueryResult<rty::EarlyBinder<rty::TyCtor>>> {
+        self.meta
+            .get(&def_id.krate)?
+            .type_of
+            .get(&def_id.index)
+            .cloned()
     }
 }
 
@@ -107,35 +109,30 @@ impl CrateMetadata {
     fn new(genv: &GlobalEnv) -> Self {
         let tcx = genv.tcx();
         let mut fn_sigs = FxHashMap::default();
-        let mut adts = FxHashMap::default();
+        let mut adt_defs = FxHashMap::default();
+        let mut variants = FxHashMap::default();
         let mut type_of = FxHashMap::default();
 
         for local_id in tcx.iter_local_def_id() {
-            if genv.ignored(local_id) {
-                continue;
-            }
-
             let def_id = local_id.to_def_id();
             let def_kind = tcx.def_kind(local_id);
 
             match def_kind {
                 DefKind::Fn | DefKind::AssocFn => {
-                    fn_sigs.insert(def_id.index, genv.fn_sig(def_id).unwrap());
+                    fn_sigs.insert(def_id.index, genv.fn_sig(def_id));
                 }
                 DefKind::Enum | DefKind::Struct => {
-                    let adt_def = genv.adt_def(def_id).unwrap();
-                    let variants = genv.variants_of(def_id).unwrap();
-                    let meta = AdtMetadata { adt_def, variants };
-                    adts.insert(def_id.index, meta);
-                    type_of.insert(def_id.index, genv.type_of(def_id).unwrap());
+                    adt_defs.insert(def_id.index, genv.adt_def(def_id));
+                    variants.insert(def_id.index, genv.variants_of(def_id));
+                    type_of.insert(def_id.index, genv.type_of(def_id));
                 }
                 DefKind::TyAlias { .. } => {
-                    type_of.insert(def_id.index, genv.type_of(def_id).unwrap());
+                    type_of.insert(def_id.index, genv.type_of(def_id));
                 }
                 _ => {}
             }
         }
-        Self { fn_sigs, adts, type_of }
+        Self { fn_sigs, adt_defs, variants, type_of }
     }
 }
 
@@ -159,83 +156,6 @@ fn flux_metadata_extern_location(tcx: TyCtxt, crate_num: CrateNum) -> Option<Pat
         .map(CanonicalizedPath::canonicalized)
         .find(|path| path.extension().unwrap_or_default() == OutputType::Metadata.extension())?;
     Some(path.with_extension("fluxmeta"))
-}
-
-#[derive(Encodable, Decodable, Copy, Clone)]
-struct SpanTag(u8);
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum SpanKind {
-    Local = 0b00,
-    Foreign = 0b01,
-    Partial = 0b10,
-    // Indicates the actual span contents are elsewhere.
-    // If this is the kind, then the span context bit represents whether it is a relative or
-    // absolute offset.
-    Indirect = 0b11,
-}
-
-impl SpanTag {
-    fn new(kind: SpanKind, context: rustc_span::SyntaxContext, length: usize) -> SpanTag {
-        let mut data = 0u8;
-        data |= kind as u8;
-        if context.is_root() {
-            data |= 0b100;
-        }
-        let all_1s_len = (0xffu8 << 3) >> 3;
-        // strictly less than - all 1s pattern is a sentinel for storage being out of band.
-        if length < all_1s_len as usize {
-            data |= (length as u8) << 3;
-        } else {
-            data |= all_1s_len << 3;
-        }
-
-        SpanTag(data)
-    }
-
-    fn indirect(relative: bool, length_bytes: u8) -> SpanTag {
-        let mut tag = SpanTag(SpanKind::Indirect as u8);
-        if relative {
-            tag.0 |= 0b100;
-        }
-        assert!(length_bytes <= 8);
-        tag.0 |= length_bytes << 3;
-        tag
-    }
-
-    // fn kind(self) -> SpanKind {
-    //     let masked = self.0 & 0b11;
-    //     match masked {
-    //         0b00 => SpanKind::Local,
-    //         0b01 => SpanKind::Foreign,
-    //         0b10 => SpanKind::Partial,
-    //         0b11 => SpanKind::Indirect,
-    //         _ => unreachable!(),
-    //     }
-    // }
-
-    // fn is_relative_offset(self) -> bool {
-    //     debug_assert_eq!(self.kind(), SpanKind::Indirect);
-    //     self.0 & 0b100 != 0
-    // }
-
-    fn context(self) -> Option<rustc_span::SyntaxContext> {
-        if self.0 & 0b100 != 0 {
-            Some(rustc_span::SyntaxContext::root())
-        } else {
-            None
-        }
-    }
-
-    fn length(self) -> Option<rustc_span::BytePos> {
-        let all_1s_len = (0xffu8 << 3) >> 3;
-        let len = self.0 >> 3;
-        if len != all_1s_len {
-            Some(rustc_span::BytePos(u32::from(len)))
-        } else {
-            None
-        }
-    }
 }
 
 // Tags for encoding Symbol's

--- a/crates/flux-middle/src/cstore.rs
+++ b/crates/flux-middle/src/cstore.rs
@@ -1,15 +1,15 @@
 use rustc_span::def_id::DefId;
 
-use crate::rty;
+use crate::{queries::QueryResult, rty};
 
 pub trait CrateStore {
-    fn fn_sig(&self, def_id: DefId) -> Option<rty::EarlyBinder<rty::PolyFnSig>>;
-    fn adt_def(&self, def_id: DefId) -> Option<&rty::AdtDef>;
+    fn fn_sig(&self, def_id: DefId) -> Option<QueryResult<rty::EarlyBinder<rty::PolyFnSig>>>;
+    fn adt_def(&self, def_id: DefId) -> Option<QueryResult<rty::AdtDef>>;
     fn variants(
         &self,
         def_id: DefId,
-    ) -> Option<rty::Opaqueness<rty::EarlyBinder<&[rty::PolyVariant]>>>;
-    fn type_of(&self, def_id: DefId) -> Option<&rty::EarlyBinder<rty::TyCtor>>;
+    ) -> Option<QueryResult<rty::Opaqueness<rty::EarlyBinder<rty::PolyVariants>>>>;
+    fn type_of(&self, def_id: DefId) -> Option<QueryResult<rty::EarlyBinder<rty::TyCtor>>>;
 }
 
 pub type CrateStoreDyn = dyn CrateStore;

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -7,7 +7,7 @@ use rustc_hir::def_id::DefId;
 use rustc_index::newtype_index;
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
 use rustc_middle::{mir::Local, ty::TyCtxt};
-use rustc_span::{BytePos, Span, Symbol, SyntaxContext};
+use rustc_span::{Span, Symbol};
 use rustc_target::abi::FieldIdx;
 use rustc_type_ir::{DebruijnIndex, INNERMOST};
 
@@ -86,45 +86,18 @@ pub struct ExprS {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable, Debug)]
 pub struct ESpan {
     /// The top-level span information
-    span: SpanData,
+    pub span: Span,
     /// The span for the (base) call-site for def-expanded spans
-    base: Option<SpanData>,
+    pub base: Option<Span>,
 }
 
 impl ESpan {
     pub fn new(span: Span) -> Self {
-        Self { span: SpanData::new(span), base: None }
-    }
-
-    pub fn span(&self) -> Span {
-        self.span.span()
-    }
-
-    pub fn base(&self) -> Option<Span> {
-        self.base.as_ref().map(SpanData::span)
+        Self { span, base: None }
     }
 
     pub fn with_base(&self, espan: ESpan) -> Self {
         Self { span: self.span, base: Some(espan.span) }
-    }
-}
-
-// NOTE: we make our own "version" of `rustc`'s SpanData as we cannot `TyEncode/Decode`
-// the original one...
-#[derive(Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable, Debug)]
-pub struct SpanData {
-    pub lo: BytePos,
-    pub hi: BytePos,
-}
-
-impl SpanData {
-    pub fn new(span: Span) -> Self {
-        let data = span.data();
-        Self { lo: data.lo, hi: data.hi }
-    }
-
-    pub fn span(&self) -> Span {
-        Span::new(self.lo, self.hi, SyntaxContext::root(), None)
     }
 }
 

--- a/crates/flux-middle/src/rustc/lowering.rs
+++ b/crates/flux-middle/src/rustc/lowering.rs
@@ -5,6 +5,7 @@ use rustc_borrowck::consumers::BodyWithBorrowckFacts;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::DefId;
 use rustc_infer::{infer::TyCtxtInferExt, traits::Obligation};
+use rustc_macros::{Decodable, Encodable};
 use rustc_middle::{
     mir::{self as rustc_mir, ConstValue},
     traits::{ImplSource, ObligationCause},
@@ -58,7 +59,7 @@ impl UnsupportedReason {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Encodable, Decodable)]
 pub struct UnsupportedErr {
     pub descr: String,
     pub(crate) span: Option<Span>,

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -205,8 +205,8 @@ mod errors {
         fn new(cond: &'static str, span: Span, espan: Option<ESpan>) -> RefineError {
             match espan {
                 Some(dst_span) => {
-                    let span_note = Some(ConditionSpanNote { span: dst_span.span() });
-                    let call_span_note = dst_span.base().map(|span| CallSpanNote { span });
+                    let span_note = Some(ConditionSpanNote { span: dst_span.span });
+                    let call_span_note = dst_span.base.map(|span| CallSpanNote { span });
                     RefineError { span, cond, span_note, call_span_note }
                 }
                 None => RefineError { span, cond, span_note: None, call_span_note: None },


### PR DESCRIPTION
* Save the entire result in case some query fails.
* Eencode spans and remove `rty::SpanData` (this is not working, but `rty::SpanData` wasn't working either)