### PR TITLE
Resolve holes in rty

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -5,7 +5,7 @@ use flux_errors::FluxSession;
 use flux_middle::{
     fhir::{self, lift::LiftCtxt, ExprRes, FhirId, FluxOwnerId, Res},
     global_env::GlobalEnv,
-    try_alloc_slice, ResolverOutput, ScopeId,
+    try_alloc_slice, ResolverOutput,
 };
 use flux_syntax::surface::{self, NodeId};
 use hir::{def::DefKind, ItemKind};
@@ -98,7 +98,7 @@ pub(crate) struct RustItemCtxt<'a, 'genv, 'tcx> {
     local_id_gen: IndexGen<fhir::ItemLocalId>,
     owner: OwnerId,
     extern_id: Option<DefId>,
-    fn_sig_scope: Option<ScopeId>,
+    fn_sig_scope: Option<NodeId>,
     resolver_output: &'genv ResolverOutput,
     opaque_tys: Option<&'a mut UnordMap<LocalDefId, fhir::OpaqueTy<'genv>>>,
 }

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -207,6 +207,10 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
                 }
                 Ok(())
             }
+            DefKind::TyAlias => {
+                self.genv.type_of(def_id).emit(&self.genv)?;
+                Ok(())
+            }
             _ => Ok(()),
         }
     }

--- a/crates/flux-driver/src/collector.rs
+++ b/crates/flux-driver/src/collector.rs
@@ -157,7 +157,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
         if attrs.extern_spec() {
             let extern_id =
                 self.extract_extern_def_id_from_extern_spec_trait(owner_id.def_id, bounds)?;
-            self.specs.extern_specs.insert(extern_id, owner_id.def_id);
+            self.specs.insert_extern_id(owner_id.def_id, extern_id);
         };
 
         Ok(())
@@ -181,7 +181,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
             && let Some(extern_id) =
                 self.extract_extern_def_id_from_extern_spec_impl(owner_id.def_id, impl_.items)
         {
-            self.specs.extern_specs.insert(extern_id, owner_id.def_id);
+            self.specs.insert_extern_id(owner_id.def_id, extern_id);
             Some(extern_id)
         } else {
             None
@@ -230,7 +230,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
             opaque = true;
             let extern_id =
                 self.extract_extern_def_id_from_extern_spec_struct(owner_id.def_id, data)?;
-            self.specs.extern_specs.insert(extern_id, owner_id.def_id);
+            self.specs.insert_extern_id(owner_id.def_id, extern_id);
             Some(extern_id)
         } else {
             None
@@ -304,7 +304,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
         let extern_id = if attrs.extern_spec() {
             let extern_id =
                 self.extract_extern_def_id_from_extern_spec_enum(owner_id.def_id, enum_def)?;
-            self.specs.extern_specs.insert(extern_id, owner_id.def_id);
+            self.specs.insert_extern_id(owner_id.def_id, extern_id);
             Some(extern_id)
         } else {
             None
@@ -361,9 +361,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
                 }));
             }
             let extern_def_id = self.extract_extern_def_id_from_extern_spec_fn(owner_id.def_id)?;
-            self.specs
-                .extern_specs
-                .insert(extern_def_id, owner_id.def_id);
+            self.specs.insert_extern_id(owner_id.def_id, extern_def_id);
             // We should never check an extern spec (it will infinitely recurse)
             Some(extern_def_id)
         } else {

--- a/crates/flux-fhir-analysis/src/annot_check.rs
+++ b/crates/flux-fhir-analysis/src/annot_check.rs
@@ -22,9 +22,9 @@ use rustc_data_structures::unord::UnordMap;
 use rustc_errors::Diagnostic;
 use rustc_hir::OwnerId;
 
-pub(crate) fn check_node<'genv>(
-    genv: GlobalEnv<'genv, '_>,
-    wfckresults: &mut WfckResults<'genv>,
+pub(crate) fn check_node(
+    genv: GlobalEnv,
+    wfckresults: &mut WfckResults,
     node: &fhir::Node,
 ) -> Result<(), ErrorGuaranteed> {
     match node {
@@ -34,9 +34,9 @@ pub(crate) fn check_node<'genv>(
     }
 }
 
-fn check_item<'genv>(
-    genv: GlobalEnv<'genv, '_>,
-    wfckresults: &mut WfckResults<'genv>,
+fn check_item(
+    genv: GlobalEnv,
+    wfckresults: &mut WfckResults,
     item: &fhir::Item,
 ) -> Result<(), ErrorGuaranteed> {
     match &item.kind {
@@ -54,9 +54,9 @@ fn check_item<'genv>(
     }
 }
 
-fn check_trait_item<'genv>(
-    genv: GlobalEnv<'genv, '_>,
-    wfckresults: &mut WfckResults<'genv>,
+fn check_trait_item(
+    genv: GlobalEnv,
+    wfckresults: &mut WfckResults,
     trait_item: &fhir::TraitItem,
 ) -> Result<(), ErrorGuaranteed> {
     match &trait_item.kind {
@@ -67,9 +67,9 @@ fn check_trait_item<'genv>(
     }
 }
 
-fn check_impl_item<'genv>(
-    genv: GlobalEnv<'genv, '_>,
-    wfckresults: &mut WfckResults<'genv>,
+fn check_impl_item(
+    genv: GlobalEnv,
+    wfckresults: &mut WfckResults,
     impl_item: &fhir::ImplItem,
 ) -> Result<(), ErrorGuaranteed> {
     match &impl_item.kind {
@@ -80,9 +80,9 @@ fn check_impl_item<'genv>(
     }
 }
 
-pub(crate) fn check_fn_sig<'genv>(
-    genv: GlobalEnv<'genv, '_>,
-    wfckresults: &mut WfckResults<'genv>,
+pub(crate) fn check_fn_sig(
+    genv: GlobalEnv,
+    wfckresults: &mut WfckResults,
     owner_id: OwnerId,
     fn_sig: &fhir::FnSig,
 ) -> Result<(), ErrorGuaranteed> {
@@ -94,9 +94,9 @@ pub(crate) fn check_fn_sig<'genv>(
     Zipper::new(genv, wfckresults, self_ty).zip_fn_decl(fn_sig.decl, expected_fn_decl)
 }
 
-pub(crate) fn check_ty_alias<'genv>(
-    genv: GlobalEnv<'genv, '_>,
-    wfckresults: &mut WfckResults<'genv>,
+pub(crate) fn check_ty_alias(
+    genv: GlobalEnv,
+    wfckresults: &mut WfckResults,
     owner_id: OwnerId,
     ty_alias: &fhir::TyAlias,
 ) -> Result<(), ErrorGuaranteed> {
@@ -107,9 +107,9 @@ pub(crate) fn check_ty_alias<'genv>(
     Zipper::new(genv, wfckresults, None).zip_ty(&ty_alias.ty, &expected_ty_alias.ty)
 }
 
-pub(crate) fn check_struct_def<'genv>(
-    genv: GlobalEnv<'genv, '_>,
-    wfckresults: &mut WfckResults<'genv>,
+pub(crate) fn check_struct_def(
+    genv: GlobalEnv,
+    wfckresults: &mut WfckResults,
     owner_id: OwnerId,
     struct_def: &fhir::StructDef,
 ) -> Result<(), ErrorGuaranteed> {
@@ -130,9 +130,9 @@ pub(crate) fn check_struct_def<'genv>(
     }
 }
 
-pub(crate) fn check_enum_def<'genv>(
-    genv: GlobalEnv<'genv, '_>,
-    wfckresults: &mut WfckResults<'genv>,
+pub(crate) fn check_enum_def(
+    genv: GlobalEnv,
+    wfckresults: &mut WfckResults,
     owner_id: OwnerId,
     enum_def: &fhir::EnumDef,
 ) -> Result<(), ErrorGuaranteed> {
@@ -150,7 +150,7 @@ pub(crate) fn check_enum_def<'genv>(
 
 struct Zipper<'zip, 'genv, 'tcx> {
     genv: GlobalEnv<'genv, 'tcx>,
-    wfckresults: &'zip mut WfckResults<'genv>,
+    wfckresults: &'zip mut WfckResults,
     locs: LocsMap<'genv>,
     self_ty: Option<fhir::Ty<'genv>>,
 }
@@ -160,7 +160,7 @@ type LocsMap<'genv> = UnordMap<fhir::ParamId, fhir::Ty<'genv>>;
 impl<'zip, 'genv, 'tcx> Zipper<'zip, 'genv, 'tcx> {
     fn new(
         genv: GlobalEnv<'genv, 'tcx>,
-        wfckresults: &'zip mut WfckResults<'genv>,
+        wfckresults: &'zip mut WfckResults,
         self_ty: Option<fhir::Ty<'genv>>,
     ) -> Self {
         Self { genv, wfckresults, locs: LocsMap::default(), self_ty }
@@ -291,12 +291,7 @@ impl<'zip, 'genv, 'tcx> Zipper<'zip, 'genv, 'tcx> {
                 self.zip_ty(ty, expected_ty)
             }
             (fhir::TyKind::Never, fhir::TyKind::Never) => Ok(()),
-            (fhir::TyKind::Hole(fhir_id), _) => {
-                self.wfckresults
-                    .type_holes_mut()
-                    .insert(fhir_id, *expected_ty);
-                Ok(())
-            }
+            (fhir::TyKind::Hole(_), _) => Ok(()),
             (
                 fhir::TyKind::OpaqueDef(item_id, args, _, _),
                 fhir::TyKind::OpaqueDef(exp_item_id, exp_args, _, _),

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -16,7 +16,7 @@ use flux_middle::{
     intern::List,
     queries::QueryResult,
     rty::{
-        self,
+        self, fill_holes,
         fold::TypeFoldable,
         refining::{self, Refiner},
         AdtSortDef, ESpan, WfckResults, INNERMOST,
@@ -345,8 +345,10 @@ pub(crate) fn conv_fn_decl(
         .cloned()
         .collect();
 
-    let res = rty::PolyFnSig::new(rty::FnSig::new(requires.into(), inputs.into(), output), vars);
-    Ok(rty::EarlyBinder(res))
+    let fn_sig = rty::PolyFnSig::new(rty::FnSig::new(requires.into(), inputs.into(), output), vars);
+    let fn_sig = fill_holes::fn_sig(genv, fn_sig, def_id)?;
+
+    Ok(rty::EarlyBinder(fn_sig))
 }
 
 pub(crate) fn conv_assoc_reft_def(

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -757,14 +757,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
                     rty::Expr::unit(),
                 ))
             }
-            fhir::TyKind::Hole(fhir_id) => {
-                let ty = self
-                    .wfckresults
-                    .type_holes()
-                    .get(*fhir_id)
-                    .unwrap_or_else(|| span_bug!(ty.span, "unfilled type hole"));
-                self.conv_ty(env, ty)
-            }
+            fhir::TyKind::Hole(fhir_id) => Ok(rty::Ty::hole(*fhir_id)),
             fhir::TyKind::OpaqueDef(item_id, args0, refine_args, _in_trait) => {
                 let def_id = item_id.owner_id.to_def_id();
                 let args = List::from_vec(self.conv_generic_args(env, def_id, args0)?);

--- a/crates/flux-fhir-analysis/src/conv.rs
+++ b/crates/flux-fhir-analysis/src/conv.rs
@@ -43,7 +43,7 @@ use rustc_type_ir::DebruijnIndex;
 
 pub struct ConvCtxt<'a, 'genv, 'tcx> {
     genv: GlobalEnv<'genv, 'tcx>,
-    wfckresults: &'a WfckResults<'genv>,
+    wfckresults: &'a WfckResults,
 }
 
 pub(crate) struct Env {
@@ -131,7 +131,7 @@ pub(crate) fn expand_type_alias<'genv>(
     genv: GlobalEnv<'genv, '_>,
     def_id: DefId,
     alias: &fhir::TyAlias,
-    wfckresults: &WfckResults<'genv>,
+    wfckresults: &WfckResults,
 ) -> QueryResult<rty::Binder<rty::Ty>> {
     let cx = ConvCtxt::new(genv, wfckresults);
 
@@ -142,11 +142,11 @@ pub(crate) fn expand_type_alias<'genv>(
     Ok(rty::Binder::new(ty, env.pop_layer().into_bound_vars(genv)?))
 }
 
-pub(crate) fn conv_generic_predicates<'genv>(
-    genv: GlobalEnv<'genv, '_>,
+pub(crate) fn conv_generic_predicates(
+    genv: GlobalEnv,
     def_id: LocalDefId,
     predicates: &[fhir::WhereBoundPredicate],
-    wfckresults: &WfckResults<'genv>,
+    wfckresults: &WfckResults,
 ) -> QueryResult<rty::EarlyBinder<rty::GenericPredicates>> {
     let cx = ConvCtxt::new(genv, wfckresults);
 
@@ -166,11 +166,11 @@ pub(crate) fn conv_generic_predicates<'genv>(
     Ok(rty::EarlyBinder(rty::GenericPredicates { parent, predicates: List::from_vec(clauses) }))
 }
 
-pub(crate) fn conv_opaque_ty<'genv>(
-    genv: GlobalEnv<'genv, '_>,
+pub(crate) fn conv_opaque_ty(
+    genv: GlobalEnv,
     def_id: LocalDefId,
     opaque_ty: &fhir::OpaqueTy,
-    wfckresults: &WfckResults<'genv>,
+    wfckresults: &WfckResults,
 ) -> QueryResult<List<rty::Clause>> {
     let cx = ConvCtxt::new(genv, wfckresults);
     let parent = genv.tcx().local_parent(def_id);
@@ -247,10 +247,10 @@ pub(crate) fn conv_generics(
     })
 }
 
-pub(crate) fn conv_refinement_generics<'genv>(
-    genv: GlobalEnv<'genv, '_>,
+pub(crate) fn conv_refinement_generics(
+    genv: GlobalEnv,
     params: &[fhir::RefineParam],
-    wfckresults: Option<&WfckResults<'genv>>,
+    wfckresults: Option<&WfckResults>,
 ) -> QueryResult<List<rty::RefineParam>> {
     params
         .iter()
@@ -271,12 +271,12 @@ fn conv_generic_param_kind(kind: &fhir::GenericParamKind) -> rty::GenericParamDe
     }
 }
 
-pub(crate) fn conv_invariants<'genv>(
-    genv: GlobalEnv<'genv, '_>,
+pub(crate) fn conv_invariants(
+    genv: GlobalEnv,
     def_id: LocalDefId,
     params: &[fhir::RefineParam],
     invariants: &[fhir::Expr],
-    wfckresults: &WfckResults<'genv>,
+    wfckresults: &WfckResults,
 ) -> QueryResult<Vec<rty::Invariant>> {
     let cx = ConvCtxt::new(genv, wfckresults);
     let mut env = Env::new(genv, &[], wfckresults)?;
@@ -284,10 +284,10 @@ pub(crate) fn conv_invariants<'genv>(
     cx.conv_invariants(&mut env, invariants)
 }
 
-pub(crate) fn conv_defn<'genv>(
-    genv: GlobalEnv<'genv, '_>,
+pub(crate) fn conv_defn(
+    genv: GlobalEnv,
     func: &fhir::SpecFunc,
-    wfckresults: &WfckResults<'genv>,
+    wfckresults: &WfckResults,
 ) -> QueryResult<Option<rty::SpecFunc>> {
     if let Some(body) = &func.body {
         let cx = ConvCtxt::new(genv, wfckresults);
@@ -301,10 +301,10 @@ pub(crate) fn conv_defn<'genv>(
     }
 }
 
-pub(crate) fn conv_qualifier<'genv>(
-    genv: GlobalEnv<'genv, '_>,
+pub(crate) fn conv_qualifier(
+    genv: GlobalEnv,
     qualifier: &fhir::Qualifier,
-    wfckresults: &WfckResults<'genv>,
+    wfckresults: &WfckResults,
 ) -> QueryResult<rty::Qualifier> {
     let cx = ConvCtxt::new(genv, wfckresults);
     let mut env = Env::new(genv, &[], wfckresults)?;
@@ -314,11 +314,11 @@ pub(crate) fn conv_qualifier<'genv>(
     Ok(rty::Qualifier { name: qualifier.name, body, global: qualifier.global })
 }
 
-pub(crate) fn conv_fn_decl<'genv>(
-    genv: GlobalEnv<'genv, '_>,
+pub(crate) fn conv_fn_decl(
+    genv: GlobalEnv,
     def_id: LocalDefId,
     decl: &fhir::FnDecl,
-    wfckresults: &WfckResults<'genv>,
+    wfckresults: &WfckResults,
 ) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
     let cx = ConvCtxt::new(genv, wfckresults);
 
@@ -349,10 +349,10 @@ pub(crate) fn conv_fn_decl<'genv>(
     Ok(rty::EarlyBinder(res))
 }
 
-pub(crate) fn conv_assoc_reft_def<'genv>(
-    genv: GlobalEnv<'genv, '_>,
+pub(crate) fn conv_assoc_reft_def(
+    genv: GlobalEnv,
     assoc_reft: &fhir::ImplAssocReft,
-    wfckresults: &WfckResults<'genv>,
+    wfckresults: &WfckResults,
 ) -> QueryResult<rty::Lambda> {
     let cx = ConvCtxt::new(genv, wfckresults);
     let mut env = Env::new(genv, &[], wfckresults)?;
@@ -363,10 +363,10 @@ pub(crate) fn conv_assoc_reft_def<'genv>(
     Ok(rty::Lambda::with_vars(expr, inputs, output))
 }
 
-pub(crate) fn conv_ty<'genv>(
-    genv: GlobalEnv<'genv, '_>,
+pub(crate) fn conv_ty(
+    genv: GlobalEnv,
     ty: &fhir::Ty,
-    wfckresults: &WfckResults<'genv>,
+    wfckresults: &WfckResults,
 ) -> QueryResult<rty::Binder<rty::Ty>> {
     let mut env = Env::new(genv, &[], wfckresults)?;
     let ty = ConvCtxt::new(genv, wfckresults).conv_ty(&mut env, ty)?;
@@ -374,7 +374,7 @@ pub(crate) fn conv_ty<'genv>(
 }
 
 impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
-    pub(crate) fn new(genv: GlobalEnv<'genv, 'tcx>, wfckresults: &'a WfckResults<'genv>) -> Self {
+    pub(crate) fn new(genv: GlobalEnv<'genv, 'tcx>, wfckresults: &'a WfckResults) -> Self {
         Self { genv, wfckresults }
     }
 
@@ -576,10 +576,10 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
     }
 
     pub(crate) fn conv_enum_def_variants(
-        genv: GlobalEnv<'genv, '_>,
+        genv: GlobalEnv,
         adt_def_id: DefId,
         enum_def: &fhir::EnumDef,
-        wfckresults: &WfckResults<'genv>,
+        wfckresults: &WfckResults,
     ) -> QueryResult<Vec<rty::PolyVariant>> {
         enum_def
             .variants
@@ -591,10 +591,10 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
     }
 
     fn conv_enum_variant(
-        genv: GlobalEnv<'genv, '_>,
+        genv: GlobalEnv,
         adt_def_id: DefId,
         variant: &fhir::VariantDef,
-        wfckresults: &WfckResults<'genv>,
+        wfckresults: &WfckResults,
     ) -> QueryResult<rty::PolyVariant> {
         let cx = ConvCtxt::new(genv, wfckresults);
 
@@ -622,7 +622,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
         genv: GlobalEnv<'genv, '_>,
         adt_def_id: DefId,
         struct_def: &fhir::StructDef,
-        wfckresults: &WfckResults<'genv>,
+        wfckresults: &WfckResults,
     ) -> QueryResult<rty::Opaqueness<rty::PolyVariant>> {
         let cx = ConvCtxt::new(genv, wfckresults);
         let mut env = Env::new(genv, &[], wfckresults)?;

--- a/crates/flux-fhir-analysis/src/conv/fill_holes.rs
+++ b/crates/flux-fhir-analysis/src/conv/fill_holes.rs
@@ -28,7 +28,7 @@ pub(crate) fn fn_sig(
     // signature to evaluate constants before lowering it. This also normalizes projections which
     // we don't want here because we need the signatures to match syntactically.
     // FIXME(nilehmann) we should check against the extern signature if this is an extern spec.
-    // Unfortunately, doing this makes `neg/vec01.rs` fail because checking against the real 
+    // Unfortunately, doing this makes `neg/vec01.rs` fail because checking against the real
     // signature of `<Vec as Index<usize>>::index` requires deep normalization.
     let rust_fn_sig = lowering::lower_fn_sig(genv.tcx(), genv.tcx().fn_sig(def_id).skip_binder())
         .map_err(UnsupportedReason::into_err)
@@ -40,7 +40,7 @@ pub(crate) fn fn_sig(
         zipper.zip_fn_sig(fn_sig, rust_fn_sig)
     })?;
 
-    Ok(zipper.replace_holes(&fn_sig))
+    Ok(zipper.replace_holes(fn_sig))
 }
 
 pub(crate) fn variants(
@@ -128,7 +128,7 @@ impl<'genv, 'tcx> Zipper<'genv, 'tcx> {
                 self.zip_bty(bty, b)?;
             }
             (rty::TyKind::Exists(ctor), _) => {
-                self.enter_rty_binder(ctor, |this, ty| this.zip_ty(ty, b))?
+                self.enter_rty_binder(ctor, |this, ty| this.zip_ty(ty, b))?;
             }
             (rty::TyKind::Constr(_, ty), _) => self.zip_ty(ty, b)?,
             (
@@ -163,7 +163,7 @@ impl<'genv, 'tcx> Zipper<'genv, 'tcx> {
                 bug!("unexpected type {a:?}");
             }
             _ => {
-                bug!("incompatible types `{a:?}` `{b:?}`")
+                bug!("incompatible types `{a:?}` `{b:?}`");
             }
         }
         Ok(())
@@ -172,10 +172,10 @@ impl<'genv, 'tcx> Zipper<'genv, 'tcx> {
     fn zip_bty(&mut self, a: &rty::BaseTy, b: &ty::Ty) -> QueryResult {
         match (a, b.kind()) {
             (rty::BaseTy::Int(ity_a), ty::TyKind::Int(ity_b)) => {
-                debug_assert_eq!(ity_a, ity_b)
+                debug_assert_eq!(ity_a, ity_b);
             }
             (rty::BaseTy::Uint(uity_a), ty::TyKind::Uint(uity_b)) => {
-                debug_assert_eq!(uity_a, uity_b)
+                debug_assert_eq!(uity_a, uity_b);
             }
             (rty::BaseTy::Bool, ty::TyKind::Bool) => {}
             (rty::BaseTy::Str, ty::TyKind::Str) => {}
@@ -217,13 +217,13 @@ impl<'genv, 'tcx> Zipper<'genv, 'tcx> {
                 debug_assert_eq!(pty_a, pty_b);
             }
             (rty::BaseTy::Closure(..), _) => {
-                bug!("unexpected closure {a:?}")
+                bug!("unexpected closure {a:?}");
             }
             (rty::BaseTy::Coroutine(..), _) => {
-                bug!("unexpected coroutine {a:?}")
+                bug!("unexpected coroutine {a:?}");
             }
             _ => {
-                bug!("incompatible types `{a:?}` `{b:?}`")
+                bug!("incompatible types `{a:?}` `{b:?}`");
             }
         }
         Ok(())
@@ -242,7 +242,7 @@ impl<'genv, 'tcx> Zipper<'genv, 'tcx> {
                 debug_assert_eq!(ct_a, ct_b);
             }
             _ => {
-                bug!("incompatible generic args `{a:?}` `{b:?}`")
+                bug!("incompatible generic args `{a:?}` `{b:?}`");
             }
         }
         Ok(())

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -128,8 +128,8 @@ pub(crate) fn conv_adt_sort_def(
     Ok(rty::AdtSortDef::new(def_id, params, fields))
 }
 
-pub(crate) fn expand_type_alias<'genv>(
-    genv: GlobalEnv<'genv, '_>,
+pub(crate) fn expand_type_alias(
+    genv: GlobalEnv,
     def_id: DefId,
     alias: &fhir::TyAlias,
     wfckresults: &WfckResults,

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -7,6 +7,9 @@
 //!    refinement predicates, aka abstract refinements, since the syntax in [`rty`] has
 //!    syntactic restrictions on predicates.
 //! 3. Refinements are well-sorted.
+
+mod fill_holes;
+
 use std::{borrow::Borrow, iter};
 
 use flux_common::{bug, iter::IterExt, span_bug};
@@ -16,7 +19,7 @@ use flux_middle::{
     intern::List,
     queries::QueryResult,
     rty::{
-        self, fill_holes,
+        self,
         fold::TypeFoldable,
         refining::{self, Refiner},
         AdtSortDef, ESpan, WfckResults, INNERMOST,

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -397,8 +397,8 @@ fn check_wf(genv: GlobalEnv, flux_id: FluxLocalDefId) -> QueryResult<Rc<WfckResu
         }
         FluxLocalDefId::Rust(def_id) => {
             let node = genv.desugar(def_id)?;
-            let mut wfckresults = wf::check_node(genv, &node)?;
-            annot_check::check_node(genv, &mut wfckresults, &node)?;
+            let wfckresults = wf::check_node(genv, &node)?;
+            annot_check::check_node(genv, &node)?;
             wfckresults
         }
     };

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -391,10 +391,7 @@ fn fn_sig(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<r
     Ok(fn_sig)
 }
 
-fn check_wf<'genv>(
-    genv: GlobalEnv<'genv, '_>,
-    flux_id: FluxLocalDefId,
-) -> QueryResult<Rc<WfckResults<'genv>>> {
+fn check_wf(genv: GlobalEnv, flux_id: FluxLocalDefId) -> QueryResult<Rc<WfckResults>> {
     let wfckresults = match flux_id {
         FluxLocalDefId::Flux(sym) => {
             wf::check_flux_item(genv, genv.map().get_flux_item(sym).unwrap())?

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -26,7 +26,7 @@ use flux_middle::{
     global_env::GlobalEnv,
     intern::List,
     queries::{Providers, QueryResult},
-    rty::{self, fill_holes, fold::TypeFoldable, refining::Refiner, WfckResults},
+    rty::{self, fold::TypeFoldable, refining::Refiner, WfckResults},
     rustc::lowering,
 };
 use itertools::Itertools;
@@ -380,7 +380,6 @@ fn fn_sig(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<r
     let defns = genv.spec_func_defns()?;
     let fn_sig = conv::conv_fn_decl(genv, def_id, fn_sig.decl, &wfckresults)?
         .map(|fn_sig| fn_sig.normalize(defns));
-    let fn_sig = fill_holes::fn_sig(genv, fn_sig, def_id)?;
 
     if config::dump_rty() {
         let generics = genv.generics_of(def_id)?;

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_private, let_chains, box_patterns, if_let_guard, once_cell_try)]
 
+extern crate rustc_ast;
 extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate rustc_hash;

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -362,7 +362,7 @@ fn variants_of(
                         .try_collect()
                 })
                 .transpose()?
-                .map(|variants| rty::EarlyBinder(variants))
+                .map(rty::EarlyBinder)
         }
         _ => bug!("expected struct or enum"),
     };

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -26,7 +26,7 @@ use flux_middle::{
     global_env::GlobalEnv,
     intern::List,
     queries::{Providers, QueryResult},
-    rty::{self, fold::TypeFoldable, refining::Refiner, WfckResults},
+    rty::{self, fill_holes, fold::TypeFoldable, refining::Refiner, WfckResults},
     rustc::lowering,
 };
 use itertools::Itertools;
@@ -380,6 +380,7 @@ fn fn_sig(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<r
     let defns = genv.spec_func_defns()?;
     let fn_sig = conv::conv_fn_decl(genv, def_id, fn_sig.decl, &wfckresults)?
         .map(|fn_sig| fn_sig.normalize(defns));
+    let fn_sig = fill_holes::fn_sig(genv, fn_sig, def_id)?;
 
     if config::dump_rty() {
         let generics = genv.generics_of(def_id)?;

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -29,10 +29,7 @@ use crate::conv::{self, bug_on_infer_sort};
 
 type Result<T = ()> = std::result::Result<T, ErrorGuaranteed>;
 
-pub(crate) fn check_flux_item<'genv>(
-    genv: GlobalEnv<'genv, '_>,
-    item: &fhir::FluxItem,
-) -> Result<WfckResults<'genv>> {
+pub(crate) fn check_flux_item(genv: GlobalEnv, item: &fhir::FluxItem) -> Result<WfckResults> {
     let owner = FluxOwnerId::Flux(item.name());
     let mut infcx = InferCtxt::new(genv, owner);
     match item {
@@ -55,7 +52,7 @@ pub(crate) fn check_flux_item<'genv>(
 pub(crate) fn check_node<'genv>(
     genv: GlobalEnv<'genv, '_>,
     node: &fhir::Node<'genv>,
-) -> Result<WfckResults<'genv>> {
+) -> Result<WfckResults> {
     let mut infcx = InferCtxt::new(genv, node.owner_id().into());
 
     insert_params(&mut infcx, node)?;

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -27,7 +27,7 @@ pub(super) struct InferCtxt<'genv, 'tcx> {
     pub params: UnordMap<fhir::ParamId, (rty::Sort, fhir::ParamKind)>,
     pub(super) sort_unification_table: InPlaceUnificationTable<rty::SortVid>,
     num_unification_table: InPlaceUnificationTable<rty::NumVid>,
-    pub wfckresults: WfckResults<'genv>,
+    pub wfckresults: WfckResults,
 }
 
 impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
@@ -517,7 +517,7 @@ impl<'genv> InferCtxt<'genv, '_> {
         }
     }
 
-    pub(crate) fn into_results(self) -> WfckResults<'genv> {
+    pub(crate) fn into_results(self) -> WfckResults {
         self.wfckresults
     }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -572,7 +572,7 @@ pub enum FluxLocalDefId {
 }
 
 /// Owner version of [`FluxLocalDefId`]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Encodable, Decodable)]
 pub enum FluxOwnerId {
     Flux(Symbol),
     Rust(OwnerId),
@@ -585,7 +585,7 @@ pub enum FluxOwnerId {
 ///
 /// [`rty`]: crate::rty
 /// [`HirId`]: rustc_hir::HirId
-#[derive(Debug, Hash, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Copy, Clone, Encodable, Decodable)]
 pub struct FhirId {
     pub owner: FluxOwnerId,
     pub local_id: ItemLocalId,
@@ -593,6 +593,7 @@ pub struct FhirId {
 
 newtype_index! {
     /// An `ItemLocalId` uniquely identifies something within a given "item-like".
+    #[encodable]
     pub struct ItemLocalId {}
 }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -549,7 +549,7 @@ pub struct MutTy<'fhir> {
 
 /// Our surface syntax doesn't have lifetimes. To deal with them we create a *hole* for every lifetime
 /// which we then resolve during `annot_check` when zipping against the lifted version.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Lifetime {
     /// A lifetime hole created during desugaring.
     Hole(FhirId),

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -206,10 +206,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         self.inner.queries.adt_sort_def_of(self, def_id.into())
     }
 
-    pub fn check_wf(
-        self,
-        flux_id: impl Into<FluxLocalDefId>,
-    ) -> QueryResult<Rc<rty::WfckResults<'genv>>> {
+    pub fn check_wf(self, flux_id: impl Into<FluxLocalDefId>) -> QueryResult<Rc<rty::WfckResults>> {
         self.inner.queries.check_wf(self, flux_id.into())
     }
 

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -191,8 +191,11 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         self.inner.queries.lower_type_of(self, def_id.into())
     }
 
-    pub fn lower_fn_sig(self, def_id: DefId) -> QueryResult<ty::EarlyBinder<ty::PolyFnSig>> {
-        self.inner.queries.lower_fn_sig(self, def_id)
+    pub fn lower_fn_sig(
+        self,
+        def_id: impl Into<DefId>,
+    ) -> QueryResult<ty::EarlyBinder<ty::PolyFnSig>> {
+        self.inner.queries.lower_fn_sig(self, def_id.into())
     }
 
     pub fn adt_def(self, def_id: impl Into<DefId>) -> QueryResult<rty::AdtDef> {

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -236,7 +236,7 @@ pub struct ResolverOutput {
     pub path_res_map: UnordMap<NodeId, fhir::Res>,
     pub impl_trait_res_map: UnordMap<NodeId, hir::ItemId>,
     /// Resolution of explicit and implicit parameters. The [`fhir::ParamId`] is unique per item.
-    /// The [`NodeId`] used as the key correspond to the node introducing the parameter. When explicit,
+    /// The [`NodeId`] used as the key corresponds to the node introducing the parameter. When explicit,
     /// this is the id of the [`surface::GenericArg`] or [`surface::RefineParam`], when implicit, this
     /// is the id of the [`surface::RefineArg::Bind`] or [`surface::FnInput`].
     pub param_res_map: UnordMap<NodeId, (fhir::ParamId, fhir::ParamKind)>,

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -69,10 +69,7 @@ pub struct Providers {
     pub spec_func_defns: fn(GlobalEnv) -> QueryResult<rty::SpecFuncDefns>,
     pub spec_func_decls: fn(GlobalEnv) -> QueryResult<FxHashMap<Symbol, rty::SpecFuncDecl>>,
     pub adt_sort_def_of: fn(GlobalEnv, LocalDefId) -> QueryResult<rty::AdtSortDef>,
-    pub check_wf: for<'genv> fn(
-        GlobalEnv<'genv, '_>,
-        FluxLocalDefId,
-    ) -> QueryResult<Rc<rty::WfckResults<'genv>>>,
+    pub check_wf: for<'genv> fn(GlobalEnv, FluxLocalDefId) -> QueryResult<Rc<rty::WfckResults>>,
     pub adt_def: fn(GlobalEnv, LocalDefId) -> QueryResult<rty::AdtDef>,
     pub type_of: fn(GlobalEnv, LocalDefId) -> QueryResult<rty::EarlyBinder<rty::TyCtor>>,
     pub variants_of: fn(
@@ -140,7 +137,7 @@ pub struct Queries<'genv, 'tcx> {
     func_decls: OnceCell<QueryResult<FxHashMap<Symbol, rty::SpecFuncDecl>>>,
     qualifiers: OnceCell<QueryResult<Vec<rty::Qualifier>>>,
     adt_sort_def_of: Cache<DefId, QueryResult<rty::AdtSortDef>>,
-    check_wf: Cache<FluxLocalDefId, QueryResult<Rc<rty::WfckResults<'genv>>>>,
+    check_wf: Cache<FluxLocalDefId, QueryResult<Rc<rty::WfckResults>>>,
     adt_def: Cache<DefId, QueryResult<rty::AdtDef>>,
     generics_of: Cache<DefId, QueryResult<rty::Generics>>,
     refinement_generics_of: Cache<DefId, QueryResult<rty::RefinementGenerics>>,
@@ -351,7 +348,7 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
         &self,
         genv: GlobalEnv<'genv, '_>,
         flux_id: FluxLocalDefId,
-    ) -> QueryResult<Rc<rty::WfckResults<'genv>>> {
+    ) -> QueryResult<Rc<rty::WfckResults>> {
         run_with_cache(&self.check_wf, flux_id, || (self.providers.check_wf)(genv, flux_id))
     }
 

--- a/crates/flux-middle/src/rty/fill_holes.rs
+++ b/crates/flux-middle/src/rty/fill_holes.rs
@@ -23,11 +23,9 @@ use crate::{
 
 pub fn fn_sig(
     genv: GlobalEnv,
-    fn_sig: rty::EarlyBinder<rty::PolyFnSig>,
+    fn_sig: rty::PolyFnSig,
     def_id: LocalDefId,
-) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
-    let fn_sig = fn_sig.skip_binder();
-
+) -> QueryResult<rty::PolyFnSig> {
     // FIXME(nilehmann) we should call `genv.lower_fn_sig`, but that function normalizes
     // the signature before lowering it such that constants are evaluated. This is not what we want
     // here because we need the signatures to match syntactically.
@@ -59,7 +57,7 @@ pub fn fn_sig(
         })
     });
 
-    Ok(rty::EarlyBinder(fn_sig))
+    Ok(fn_sig)
 }
 
 struct Zipper<'genv, 'tcx> {

--- a/crates/flux-middle/src/rty/fill_holes.rs
+++ b/crates/flux-middle/src/rty/fill_holes.rs
@@ -1,0 +1,127 @@
+use std::iter;
+
+use flux_common::bug;
+use rustc_ast::Mutability;
+
+use crate::{rty, rustc::ty};
+
+struct Zipper {}
+
+impl Zipper {
+    fn zip_ty(&mut self, a: &rty::Ty, b: &ty::Ty) {
+        match (a.kind(), b.kind()) {
+            (rty::TyKind::Indexed(bty, _), _) => {
+                self.zip_bty(bty, b);
+            }
+            (rty::TyKind::Exists(ctor), _) => self.zip_ty(ctor.as_ref().skip_binder(), b),
+            (rty::TyKind::Constr(_, ty), _) => self.zip_ty(ty, b),
+            (rty::TyKind::StrgRef(re_a, _, ty_a), ty::TyKind::Ref(re_b, ty_b, Mutability::Mut)) => {
+                self.zip_region(re_a, re_b);
+                self.zip_ty(ty_a, ty_b);
+            }
+            (rty::TyKind::Param(pty_a), ty::TyKind::Param(pty_b)) => {
+                debug_assert_eq!(pty_a, pty_b);
+            }
+            (rty::TyKind::Alias(kind_a, aty_a), ty::TyKind::Alias(kind_b, aty_b)) => {
+                debug_assert_eq!(kind_a, kind_b);
+                debug_assert_eq!(aty_a.def_id, aty_b.def_id);
+                debug_assert_eq!(aty_a.args.len(), aty_b.args.len());
+                for (arg_a, arg_b) in iter::zip(&aty_a.args, &aty_b.args) {
+                    self.zip_generic_arg(arg_a, arg_b);
+                }
+            }
+            (
+                rty::TyKind::Ptr(_, _)
+                | rty::TyKind::Discr(_, _)
+                | rty::TyKind::Downcast(_, _, _, _, _)
+                | rty::TyKind::Blocked(_)
+                | rty::TyKind::Uninit,
+                _,
+            ) => {
+                bug!("unexpected type {a:?}");
+            }
+            _ => {
+                bug!("incompatible types `{a:?}` `{b:?}`")
+            }
+        }
+    }
+
+    fn zip_bty(&mut self, a: &rty::BaseTy, b: &ty::Ty) {
+        match (a, b.kind()) {
+            (rty::BaseTy::Int(ity_a), ty::TyKind::Int(ity_b)) => {
+                debug_assert_eq!(ity_a, ity_b)
+            }
+            (rty::BaseTy::Uint(uity_a), ty::TyKind::Uint(uity_b)) => {
+                debug_assert_eq!(uity_a, uity_b)
+            }
+            (rty::BaseTy::Bool, ty::TyKind::Bool) => {}
+            (rty::BaseTy::Str, ty::TyKind::Str) => {}
+            (rty::BaseTy::Char, ty::TyKind::Char) => {}
+            (rty::BaseTy::Float(fty_a), ty::TyKind::Float(fty_b)) => {
+                debug_assert_eq!(fty_a, fty_b);
+            }
+            (rty::BaseTy::Slice(ty_a), ty::TyKind::Slice(ty_b)) => {
+                self.zip_ty(ty_a, ty_b);
+            }
+            (rty::BaseTy::Adt(adt_def_a, args_a), ty::TyKind::Adt(adt_def_b, args_b)) => {
+                debug_assert_eq!(adt_def_a.did(), adt_def_b.did());
+                debug_assert_eq!(args_a.len(), args_b.len());
+                for (arg_a, arg_b) in iter::zip(args_a, args_b) {
+                    self.zip_generic_arg(arg_a, arg_b);
+                }
+            }
+            (rty::BaseTy::RawPtr(ty_a, mutbl_a), ty::TyKind::RawPtr(ty_b, mutbl_b)) => {
+                debug_assert_eq!(mutbl_a, mutbl_b);
+                self.zip_ty(ty_a, ty_b);
+            }
+            (rty::BaseTy::Ref(re_a, ty_a, mutbl_a), ty::TyKind::Ref(re_b, ty_b, mutbl_b)) => {
+                debug_assert_eq!(mutbl_a, mutbl_b);
+                self.zip_ty(ty_a, ty_b);
+                self.zip_region(re_a, re_b);
+            }
+            (rty::BaseTy::Tuple(tys_a), ty::TyKind::Tuple(tys_b)) => {
+                debug_assert_eq!(tys_a.len(), tys_b.len());
+                for (ty_a, ty_b) in iter::zip(tys_a, tys_b) {
+                    self.zip_ty(ty_a, ty_b);
+                }
+            }
+            (rty::BaseTy::Array(ty_a, len_a), ty::TyKind::Array(ty_b, len_b)) => {
+                debug_assert_eq!(len_a, len_b);
+                self.zip_ty(ty_a, ty_b);
+            }
+            (rty::BaseTy::Never, ty::TyKind::Never) => {}
+            (rty::BaseTy::Closure(..), _) => {
+                bug!("unexpected closure {a:?}")
+            }
+            (rty::BaseTy::Coroutine(..), _) => {
+                bug!("unexpected coroutine {a:?}")
+            }
+            (rty::BaseTy::Param(pty_a), ty::TyKind::Param(pty_b)) => {
+                debug_assert_eq!(pty_a, pty_b);
+            }
+            _ => {
+                bug!("incompatible types `{a:?}` `{b:?}`")
+            }
+        }
+    }
+
+    fn zip_generic_arg(&mut self, a: &rty::GenericArg, b: &ty::GenericArg) {
+        match (a, b) {
+            (rty::GenericArg::Ty(ty_a), ty::GenericArg::Ty(ty_b)) => self.zip_ty(ty_a, ty_b),
+            (rty::GenericArg::Base(ctor_a), ty::GenericArg::Ty(ty_b)) => {
+                self.zip_bty(ctor_a.as_bty_skipping_binder(), ty_b);
+            }
+            (rty::GenericArg::Lifetime(re_a), ty::GenericArg::Lifetime(re_b)) => {
+                self.zip_region(re_a, re_b);
+            }
+            (rty::GenericArg::Const(ct_a), ty::GenericArg::Const(ct_b)) => {
+                debug_assert_eq!(ct_a, ct_b);
+            }
+            _ => {
+                bug!("incompatible generic args `{a:?}` `{b:?}`")
+            }
+        }
+    }
+
+    fn zip_region(&mut self, a: &rty::Region, b: &ty::Region) {}
+}

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -14,7 +14,7 @@ use super::{
     normalize::{Normalizer, SpecFuncDefns},
     projections,
     subst::EVarSubstFolder,
-    AliasReft, AliasTy, BaseTy, BinOp, Binder, BoundVariableKind, Clause, ClauseKind,
+    AliasReft, AliasTy, BaseTy, BinOp, Binder, BoundVariableKind, Clause, ClauseKind, Const,
     CoroutineObligPredicate, Ensures, Expr, ExprKind, FnOutput, FnSig, FnTraitPredicate, FuncSort,
     GenericArg, Invariant, KVar, Lambda, Name, Opaqueness, OutlivesPredicate, PolyFuncSort,
     ProjectionPredicate, PtrKind, Qualifier, ReLateBound, Region, Sort, SubsetTy, TraitPredicate,
@@ -806,7 +806,9 @@ impl TypeSuperVisitable for Ty {
             }
             TyKind::Blocked(ty) => ty.visit_with(visitor),
             TyKind::Alias(_, alias_ty) => alias_ty.visit_with(visitor),
-            TyKind::Param(_) | TyKind::Discr(..) | TyKind::Uninit => ControlFlow::Continue(()),
+            TyKind::Hole(_) | TyKind::Param(_) | TyKind::Discr(..) | TyKind::Uninit => {
+                ControlFlow::Continue(())
+            }
         }
     }
 }
@@ -863,7 +865,7 @@ impl TypeSuperFoldable for Ty {
             }
             TyKind::Blocked(ty) => Ty::blocked(ty.try_fold_with(folder)?),
             TyKind::Alias(kind, alias_ty) => Ty::alias(*kind, alias_ty.try_fold_with(folder)?),
-            TyKind::Param(_) | TyKind::Uninit | TyKind::Discr(..) => self.clone(),
+            TyKind::Hole(_) | TyKind::Param(_) | TyKind::Uninit | TyKind::Discr(..) => self.clone(),
         };
         Ok(ty)
     }
@@ -1270,4 +1272,38 @@ impl TypeFoldable for Invariant {
         let pred = self.pred.try_fold_with(folder)?;
         Ok(Invariant { pred })
     }
+}
+
+pub struct BottomUpFolder<F, G, H>
+where
+    F: FnMut(Ty) -> Ty,
+    G: FnMut(Region) -> Region,
+    H: FnMut(Const) -> Const,
+{
+    pub ty_op: F,
+    pub lt_op: G,
+    pub ct_op: H,
+}
+
+impl<F, G, H> TypeFolder for BottomUpFolder<F, G, H>
+where
+    F: FnMut(Ty) -> Ty,
+    G: FnMut(Region) -> Region,
+    H: FnMut(Const) -> Const,
+{
+    fn fold_ty(&mut self, ty: &Ty) -> Ty {
+        let t = ty.super_fold_with(self);
+        (self.ty_op)(t)
+    }
+
+    fn fold_region(&mut self, r: &Region) -> Region {
+        // This one is a little different, because `super_fold_with` is not
+        // implemented on non-recursive `Region`.
+        (self.lt_op)(*r)
+    }
+
+    // fn fold_const(&mut self, ct: &Const) -> Const {
+    //     let ct = ct.super_fold_with(self);
+    //     (self.ct_op)(ct)
+    // }
 }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -51,6 +51,7 @@ pub use crate::{
     rustc::ty::{
         AliasKind, BoundRegion, BoundRegionKind, BoundVar, Const, EarlyParamRegion, FreeRegion,
         Region::{self, *},
+        RegionVid,
     },
 };
 use crate::{

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -7,7 +7,7 @@
 pub mod canonicalize;
 pub mod evars;
 mod expr;
-mod fill_holes;
+pub mod fill_holes;
 pub mod fold;
 pub(crate) mod normalize;
 mod pretty;
@@ -704,6 +704,10 @@ impl Ty {
         BaseTy::Never.into_ty()
     }
 
+    pub fn hole(fhir_id: FhirId) -> Ty {
+        TyKind::Hole(fhir_id).intern()
+    }
+
     pub fn unconstr(&self) -> (Ty, Expr) {
         fn go(this: &Ty, preds: &mut Vec<Expr>) -> Ty {
             if let TyKind::Constr(pred, ty) = this.kind() {
@@ -745,7 +749,8 @@ impl Ty {
             | TyKind::Ptr(_, _)
             | TyKind::Discr(_, _)
             | TyKind::Downcast(_, _, _, _, _)
-            | TyKind::Blocked(_) => todo!(),
+            | TyKind::Blocked(_)
+            | TyKind::Hole(_) => bug!(),
         }
     }
 
@@ -825,6 +830,7 @@ pub enum TyKind {
     Downcast(AdtDef, GenericArgs, Ty, VariantIdx, List<Ty>),
     Blocked(Ty),
     Alias(AliasKind, AliasTy),
+    Hole(FhirId),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -7,6 +7,7 @@
 pub mod canonicalize;
 pub mod evars;
 mod expr;
+mod fill_holes;
 pub mod fold;
 pub(crate) mod normalize;
 mod pretty;
@@ -48,7 +49,7 @@ use self::{
 pub use crate::{
     fhir::InferMode,
     rustc::ty::{
-        BoundRegion, BoundRegionKind, BoundVar, Const, EarlyParamRegion, FreeRegion,
+        AliasKind, BoundRegion, BoundRegionKind, BoundVar, Const, EarlyParamRegion, FreeRegion,
         Region::{self, *},
     },
 };
@@ -858,22 +859,6 @@ pub struct AliasTy {
     /// Holds the refinement-arguments for opaque-types; empty for projections
     pub refine_args: RefineArgs,
     pub def_id: DefId,
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, TyEncodable, TyDecodable)]
-pub enum AliasKind {
-    Projection,
-    Opaque,
-}
-
-impl AliasKind {
-    fn to_rustc(self) -> rustc_middle::ty::AliasKind {
-        use rustc_middle::ty;
-        match self {
-            AliasKind::Opaque => ty::AliasKind::Opaque,
-            AliasKind::Projection => ty::AliasKind::Projection,
-        }
-    }
 }
 
 pub type RefineArgs = List<Expr>;

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -29,10 +29,7 @@ use rustc_data_structures::unord::UnordMap;
 use rustc_hir::def_id::DefId;
 use rustc_index::{newtype_index, IndexSlice};
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
-use rustc_middle::{
-    middle::resolve_bound_vars::ResolvedArg,
-    ty::{ParamConst, TyCtxt},
-};
+use rustc_middle::ty::{ParamConst, TyCtxt};
 pub use rustc_middle::{
     mir::Mutability,
     ty::{AdtFlags, ClosureKind, FloatTy, IntTy, OutlivesPredicate, ParamTy, ScalarInt, UintTy},
@@ -1986,7 +1983,6 @@ pub struct WfckResults {
     node_sorts: ItemLocalMap<Sort>,
     bin_rel_sorts: ItemLocalMap<Sort>,
     coercions: ItemLocalMap<Vec<Coercion>>,
-    lifetime_holes: ItemLocalMap<ResolvedArg>,
 }
 
 #[derive(Debug)]
@@ -2016,7 +2012,6 @@ impl WfckResults {
             node_sorts: ItemLocalMap::default(),
             bin_rel_sorts: ItemLocalMap::default(),
             coercions: ItemLocalMap::default(),
-            lifetime_holes: ItemLocalMap::default(),
         }
     }
 
@@ -2050,14 +2045,6 @@ impl WfckResults {
 
     pub fn coercions(&self) -> LocalTableInContext<Vec<Coercion>> {
         LocalTableInContext { owner: self.owner, data: &self.coercions }
-    }
-
-    pub fn lifetime_holes_mut(&mut self) -> LocalTableInContextMut<ResolvedArg> {
-        LocalTableInContextMut { owner: self.owner, data: &mut self.lifetime_holes }
-    }
-
-    pub fn lifetime_holes(&self) -> LocalTableInContext<ResolvedArg> {
-        LocalTableInContext { owner: self.owner, data: &self.lifetime_holes }
     }
 }
 

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1422,7 +1422,7 @@ where
     pub fn replace_bound_refts(&self, exprs: &[Expr]) -> T {
         let delegate = FnMutDelegate::new(
             |var| exprs[var.index as usize].clone(),
-            |_| bug!("unexpected escaping region"),
+            |_| flux_common::tracked_span_bug!("unexpected escaping region"),
         );
         self.value
             .fold_with(&mut BoundVarReplacer::new(delegate))

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -7,7 +7,6 @@
 pub mod canonicalize;
 pub mod evars;
 mod expr;
-pub mod fill_holes;
 pub mod fold;
 pub(crate) mod normalize;
 mod pretty;

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1979,13 +1979,12 @@ macro_rules! _Ref {
 }
 pub use crate::_Ref as Ref;
 
-pub struct WfckResults<'genv> {
+pub struct WfckResults {
     pub owner: FluxOwnerId,
     record_ctors: ItemLocalMap<DefId>,
     node_sorts: ItemLocalMap<Sort>,
     bin_rel_sorts: ItemLocalMap<Sort>,
     coercions: ItemLocalMap<Vec<Coercion>>,
-    type_holes: ItemLocalMap<fhir::Ty<'genv>>,
     lifetime_holes: ItemLocalMap<ResolvedArg>,
 }
 
@@ -2008,7 +2007,7 @@ pub struct LocalTableInContextMut<'a, T> {
     data: &'a mut ItemLocalMap<T>,
 }
 
-impl<'genv> WfckResults<'genv> {
+impl WfckResults {
     pub fn new(owner: impl Into<FluxOwnerId>) -> Self {
         Self {
             owner: owner.into(),
@@ -2016,7 +2015,6 @@ impl<'genv> WfckResults<'genv> {
             node_sorts: ItemLocalMap::default(),
             bin_rel_sorts: ItemLocalMap::default(),
             coercions: ItemLocalMap::default(),
-            type_holes: ItemLocalMap::default(),
             lifetime_holes: ItemLocalMap::default(),
         }
     }
@@ -2051,14 +2049,6 @@ impl<'genv> WfckResults<'genv> {
 
     pub fn coercions(&self) -> LocalTableInContext<Vec<Coercion>> {
         LocalTableInContext { owner: self.owner, data: &self.coercions }
-    }
-
-    pub fn type_holes_mut(&mut self) -> LocalTableInContextMut<fhir::Ty<'genv>> {
-        LocalTableInContextMut { owner: self.owner, data: &mut self.type_holes }
-    }
-
-    pub fn type_holes(&self) -> LocalTableInContext<fhir::Ty> {
-        LocalTableInContext { owner: self.owner, data: &self.type_holes }
     }
 
     pub fn lifetime_holes_mut(&mut self) -> LocalTableInContextMut<ResolvedArg> {

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1419,7 +1419,7 @@ where
     pub fn replace_bound_refts(&self, exprs: &[Expr]) -> T {
         let delegate = FnMutDelegate::new(
             |var| exprs[var.index as usize].clone(),
-            |_| flux_common::tracked_span_bug!("unexpected escaping region"),
+            |_| bug!("unexpected escaping region"),
         );
         self.value
             .fold_with(&mut BoundVarReplacer::new(delegate))

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -290,6 +290,9 @@ impl Pretty for TyS {
                     join!(", ", &alias_ty.refine_args)
                 )
             }
+            TyKind::Hole(_) => {
+                w!("□")
+            }
         }
     }
 

--- a/crates/flux-middle/src/rustc/lowering.rs
+++ b/crates/flux-middle/src/rustc/lowering.rs
@@ -54,7 +54,7 @@ impl UnsupportedReason {
         UnsupportedReason { descr: reason.to_string() }
     }
 
-    pub(crate) fn into_err(self) -> UnsupportedErr {
+    pub fn into_err(self) -> UnsupportedErr {
         UnsupportedErr { descr: self.descr, span: None }
     }
 }
@@ -619,7 +619,7 @@ pub fn lower_place(place: &rustc_mir::Place) -> Result<Place, UnsupportedReason>
     Ok(Place { local: place.local, projection })
 }
 
-pub(crate) fn lower_fn_sig<'tcx>(
+pub fn lower_fn_sig<'tcx>(
     tcx: TyCtxt<'tcx>,
     fn_sig: rustc_ty::PolyFnSig<'tcx>,
 ) -> Result<PolyFnSig, UnsupportedReason> {

--- a/crates/flux-middle/src/rustc/ty.rs
+++ b/crates/flux-middle/src/rustc/ty.rs
@@ -193,6 +193,16 @@ pub enum AliasKind {
     Opaque,
 }
 
+impl AliasKind {
+    pub fn to_rustc(self) -> rustc_middle::ty::AliasKind {
+        use rustc_middle::ty;
+        match self {
+            AliasKind::Opaque => ty::AliasKind::Opaque,
+            AliasKind::Projection => ty::AliasKind::Projection,
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub struct Const {
     pub kind: ConstKind,

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -325,7 +325,8 @@ impl BasicBlockEnvShape {
             | TyKind::Uninit
             | TyKind::Param(_)
             | TyKind::Constr(_, _) => ty.clone(),
-            TyKind::StrgRef(..) => bug!("unexpected strong reference inside function"),
+            TyKind::Hole(_) => bug!("unexpected hole whecn checking function body"),
+            TyKind::StrgRef(..) => bug!("unexpected strong reference when checking function body"),
         }
     }
 

--- a/tests/tests/pos/surface/type_holes01.rs
+++ b/tests/tests/pos/surface/type_holes01.rs
@@ -1,0 +1,21 @@
+// Type holes in structts and enums
+
+pub struct S {
+    #[flux::field(Option<_>)]
+    x: Option<i32>,
+}
+
+pub fn test_s(s: S) -> Option<i32> {
+    s.x
+}
+
+pub enum E {
+    #[flux::variant((_) -> E)]
+    A(i32),
+}
+
+pub fn test_e(e: E) -> i32 {
+    match e {
+        E::A(x) => x,
+    }
+}

--- a/tests/tests/pos/surface/type_holes02.rs
+++ b/tests/tests/pos/surface/type_holes02.rs
@@ -1,0 +1,6 @@
+#[flux::alias(type Test = Vec<_>)]
+type Test = Vec<i32>;
+
+fn test(x: Test) -> Vec<i32> {
+    x
+}


### PR DESCRIPTION
Lower holes all the way down to `rty` and resolve them by matching types against `rustc::ty`. First step towards moving `annot_check` from `fhir` to `rty`.