### PR TITLE
Do not fail on synthetic type parameters

### DIFF
--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -133,17 +133,10 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
     ) -> Result<fhir::GenericParam<'genv>> {
         let kind = match param.kind {
             hir::GenericParamKind::Lifetime { .. } => fhir::GenericParamKind::Lifetime,
-            hir::GenericParamKind::Type { default, synthetic: false } => {
+            hir::GenericParamKind::Type { default, .. } => {
                 fhir::GenericParamKind::Type {
                     default: default.map(|ty| self.lift_ty(ty)).transpose()?,
                 }
-            }
-            hir::GenericParamKind::Type { synthetic: true, .. } => {
-                return self.emit_err(errors::UnsupportedHir::new(
-                    self.genv.tcx(),
-                    param.def_id,
-                    "`impl Trait` in argument position not supported",
-                ))
             }
             hir::GenericParamKind::Const { ty, is_host_effect, .. } => {
                 let ty = self.lift_ty(ty)?;

--- a/crates/flux-middle/src/rustc/lowering.rs
+++ b/crates/flux-middle/src/rustc/lowering.rs
@@ -824,25 +824,22 @@ pub(crate) fn lower_generics(generics: &rustc_ty::Generics) -> Result<Generics, 
             .own_params
             .iter()
             .map(lower_generic_param_def)
-            .try_collect()?,
+            .collect(),
     );
     Ok(Generics { params, orig: generics })
 }
 
-fn lower_generic_param_def(
-    generic: &rustc_ty::GenericParamDef,
-) -> Result<GenericParamDef, UnsupportedReason> {
+fn lower_generic_param_def(generic: &rustc_ty::GenericParamDef) -> GenericParamDef {
     let kind = match generic.kind {
-        rustc_ty::GenericParamDefKind::Type { has_default, synthetic: false } => {
+        rustc_ty::GenericParamDefKind::Type { has_default, .. } => {
             GenericParamDefKind::Type { has_default }
         }
         rustc_ty::GenericParamDefKind::Lifetime => GenericParamDefKind::Lifetime,
         rustc_ty::GenericParamDefKind::Const { has_default, is_host_effect, .. } => {
             GenericParamDefKind::Const { has_default, is_host_effect }
         }
-        _ => return Err(UnsupportedReason::new("unsupported generic param")),
     };
-    Ok(GenericParamDef { def_id: generic.def_id, index: generic.index, name: generic.name, kind })
+    GenericParamDef { def_id: generic.def_id, index: generic.index, name: generic.name, kind }
 }
 
 pub(crate) fn lower_generic_predicates<'tcx>(

--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -343,6 +343,18 @@ pub Ty: surface::Ty = {
         kind,
         node_id: cx.next_node_id(),
         span: cx.map_span(lo, hi)
+    },
+    <lo:@L> "(" <tys:Punctuated<Ty, ",">> ")" <hi:@R> => {
+        if tys.len() == 1 && !tys.trailing_punct() {
+            tys.into_values().pop().unwrap()
+        } else {
+            let kind = surface::TyKind::Tuple(tys.into_values());
+            surface::Ty {
+                kind,
+                node_id: cx.next_node_id(),
+                span: cx.map_span(lo, hi),
+            }
+        }
     }
 }
 
@@ -355,7 +367,6 @@ TyKind: surface::TyKind = {
     "{" <params:Comma1<RefineParam<"?">>> "." <ty:Ty> <pred:("|" <Expr>)?> "}" => {
         surface::TyKind::GeneralExists { params, ty: Box::new(ty), pred }
     },
-    "(" <tys:Comma<Ty>> ")"         => surface::TyKind::Tuple(tys),
 
     "&" <ty:Ty>                     => surface::TyKind::Ref(surface::Mutability::Not, Box::new(ty)),
     "&" "mut" <ty:Ty>               => surface::TyKind::Ref(surface::Mutability::Mut, Box::new(ty)),
@@ -620,19 +631,14 @@ Ident: surface::Ident = {
 }
 
 Sep<S, T>: Vec<T> = {
-    <v:(<T> S)*> <e:T?> => match e {
-        None => v,
-        Some(e) => {
-            let mut v = v;
-            v.push(e);
-            v
-        }
+    <mut v:(<T> S)*> <e:T?> => {
+        if let Some(e) = e { v.push(e); }
+        v
     }
 }
 
 Sep1<S, T>: Vec<T> = {
-    <v:(<T> S)*> <e:T> => {
-        let mut v = v;
+    <mut v:(<T> S)*> <e:T> => {
         v.push(e);
         v
     }
@@ -640,6 +646,15 @@ Sep1<S, T>: Vec<T> = {
 
 Comma<T> = Sep<",", T>;
 Comma1<T> = Sep1<",", T>;
+
+Punctuated<T, S>: surface::Punctuated<T, S> = {
+    <v:(T S)*> <e:T?> => {
+        let mut v = surface::Punctuated::from(v);
+        if let Some(e) = e { v.push_value(e); }
+        v
+    }
+}
+
 
 Binding<A, B>: (A, B) = <A> ":" <B>;
 

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -549,7 +549,7 @@ impl BindKind {
     }
 }
 
-/// A punctuated sequence of vlaues of type `T` separated by punctuation of type `P`
+/// A punctuated sequence of values of type `T` separated by punctuation of type `P`
 pub struct Punctuated<T, P> {
     inner: Vec<(T, P)>,
     last: Option<Box<T>>,

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -366,9 +366,9 @@ impl Ty {
             fn visit_ty(&mut self, ty: &Ty) {
                 match &ty.kind {
                     TyKind::Tuple(_)
-                    | TyKind::Ref(_, _)
-                    | TyKind::Array(_, _)
-                    | TyKind::ImplTrait(_, _)
+                    | TyKind::Ref(..)
+                    | TyKind::Array(..)
+                    | TyKind::ImplTrait(..)
                     | TyKind::Hole
                     | TyKind::Base(_) => {
                         visit::walk_ty(self, ty);
@@ -546,5 +546,72 @@ impl BindKind {
             BindKind::At => "@",
             BindKind::Pound => "#",
         }
+    }
+}
+
+/// A punctuated sequence of vlaues of type `T` separated by punctuation of type `P`
+pub struct Punctuated<T, P> {
+    inner: Vec<(T, P)>,
+    last: Option<Box<T>>,
+}
+
+impl<T, P> From<Vec<(T, P)>> for Punctuated<T, P> {
+    fn from(inner: Vec<(T, P)>) -> Self {
+        Self { inner, last: None }
+    }
+}
+
+impl<T, P> Punctuated<T, P> {
+    pub fn len(&self) -> usize {
+        self.inner.len() + self.last.is_some() as usize
+    }
+
+    /// Determines whether this punctuated sequence is empty, meaning it
+    /// contains no syntax tree nodes or punctuation.
+    pub fn is_empty(&self) -> bool {
+        self.inner.len() == 0 && self.last.is_none()
+    }
+
+    /// Appends a syntax tree node onto the end of this punctuated sequence. The
+    /// sequence must already have a trailing punctuation, or be empty.
+    ///
+    /// Use [`push`] instead if the punctuated sequence may or may not already
+    /// have trailing punctuation.
+    ///
+    /// [`push`]: Punctuated::push
+    ///
+    /// # Panics
+    ///
+    /// Panics if the sequence is nonempty and does not already have a trailing
+    /// punctuation.
+    pub fn push_value(&mut self, value: T) {
+        assert!(
+            self.empty_or_trailing(),
+            "Punctuated::push_value: cannot push value if Punctuated is missing trailing punctuation",
+        );
+
+        self.last = Some(Box::new(value));
+    }
+
+    /// Returns true if either this `Punctuated` is empty, or it has a trailing
+    /// punctuation.
+    ///
+    /// Equivalent to `punctuated.is_empty() || punctuated.trailing_punct()`.
+    pub fn empty_or_trailing(&self) -> bool {
+        self.last.is_none()
+    }
+
+    /// Determines whether this punctuated sequence ends with a trailing
+    /// punctuation.
+    pub fn trailing_punct(&self) -> bool {
+        self.last.is_none() && !self.is_empty()
+    }
+
+    pub fn into_values(self) -> Vec<T> {
+        let mut v: Vec<T> = self.inner.into_iter().map(|(v, _)| v).collect();
+        if let Some(last) = self.last {
+            v.push(*last);
+        }
+        v
     }
 }

--- a/tests/tests/neg/surface/synthetic-param.rs
+++ b/tests/tests/neg/surface/synthetic-param.rs
@@ -1,0 +1,9 @@
+trait MyTrait {
+    #[flux::sig(fn(Self) -> i32{v: v >= 0})]
+    fn method(self) -> i32;
+}
+
+#[flux::sig(fn(_) -> i32{v: v > 0})]
+fn test00(x: impl MyTrait) -> i32 {
+    x.method()
+} //~ ERROR refinement type error

--- a/tests/tests/pos/parse-paren-ty.rs
+++ b/tests/tests/pos/parse-paren-ty.rs
@@ -1,0 +1,9 @@
+#[flux::sig(fn(x: (i32)) -> i32)]
+fn test00(x: (i32)) -> i32 {
+    x
+}
+
+#[flux::sig(fn(x: (i32,)) -> i32)]
+fn test01(x: (i32,)) -> i32 {
+    x.0
+}

--- a/tests/tests/pos/surface/synthetic-param.rs
+++ b/tests/tests/pos/surface/synthetic-param.rs
@@ -1,0 +1,9 @@
+trait MyTrait {
+    #[flux::sig(fn(Self) -> i32{v: v > 0})]
+    fn method(self) -> i32;
+}
+
+#[flux::sig(fn(_) -> i32{v: v > 0})]
+fn test00(x: impl MyTrait) -> i32 {
+    x.method()
+}


### PR DESCRIPTION
* Do not fail on synthetic type parameters during lifting and lowering
* Parse a type surrounded by parentheses without a trailing comma as a type instead of a tuple.