### PR TITLE
Add support for polymorphic bit-vector sizes

### DIFF
--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1676,7 +1676,7 @@ fn conv_sort_path(
     let args = path
         .args
         .iter()
-        .map(|t| conv_sort(genv, t, next_infer_sort).map(rty::SortArg::Sort))
+        .map(|t| conv_sort(genv, t, next_infer_sort))
         .try_collect()?;
     Ok(rty::Sort::app(ctor, args))
 }

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -461,8 +461,8 @@ impl<'genv> InferCtxt<'genv, '_> {
                     return None;
                 }
                 let mut args = vec![];
-                for (t1, t2) in args1.iter().zip(args2.iter()) {
-                    args.push(self.try_equate_sort_args(t1, t2)?);
+                for (s1, s2) in args1.iter().zip(args2.iter()) {
+                    args.push(self.try_equate_inner(s1, s2)?);
                 }
             }
             (rty::Sort::BitVec(size1), rty::Sort::BitVec(size2)) => {
@@ -472,23 +472,6 @@ impl<'genv> InferCtxt<'genv, '_> {
             _ => return None,
         }
         Some(sort1.clone())
-    }
-
-    fn try_equate_sort_args(
-        &mut self,
-        arg1: &rty::SortArg,
-        arg2: &rty::SortArg,
-    ) -> Option<rty::SortArg> {
-        match (arg1, arg2) {
-            (rty::SortArg::Sort(sort1), rty::SortArg::Sort(sort2)) => {
-                self.try_equate_inner(sort1, sort2).map(rty::SortArg::Sort)
-            }
-            (rty::SortArg::BvSize(size1), rty::SortArg::BvSize(size2)) => {
-                self.try_equate_bv_sizes(*size1, *size2)
-                    .map(rty::SortArg::BvSize)
-            }
-            _ => None,
-        }
     }
 
     fn try_equate_bv_sizes(

--- a/crates/flux-fixpoint/src/constraint.rs
+++ b/crates/flux-fixpoint/src/constraint.rs
@@ -48,7 +48,8 @@ pub enum Sort<T: Types> {
     Int,
     Bool,
     Real,
-    BitVec(usize),
+    BitVec(Box<Sort<T>>),
+    BvSize(usize),
     Var(usize),
     Func(Box<[Self; 2]>),
     Abs(usize, Box<Self>),
@@ -280,7 +281,8 @@ impl<T: Types> fmt::Display for Sort<T> {
             Sort::Bool => write!(f, "bool"),
             Sort::Real => write!(f, "real"),
             Sort::Var(i) => write!(f, "@({i})"),
-            Sort::BitVec(size) => write!(f, "(BitVec Size{})", size),
+            Sort::BitVec(size) => write!(f, "(BitVec {size})"),
+            Sort::BvSize(size) => write!(f, "Size{size}"),
             Sort::Abs(..) => {
                 let (params, sort) = self.peel_out_abs();
                 fmt_func(params, sort, f)

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -70,7 +70,6 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
         use rty::{
             BvSize, ParamSort,
             Sort::{self, *},
-            SortArg,
             SortCtor::*,
             SortParamKind,
         };
@@ -185,10 +184,7 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                 fixpoint_name: Symbol::intern("Set_empty"),
                 sort: rty::PolyFuncSort::new(
                     List::from_arr([SortParamKind::Sort]),
-                    rty::FuncSort::new(
-                        vec![Int],
-                        Sort::app(Set, List::from_arr([SortArg::Sort(Var(param0))])),
-                    ),
+                    rty::FuncSort::new(vec![Int], Sort::app(Set, List::singleton(Var(param0)))),
                 ),
             },
             TheoryFunc {
@@ -198,7 +194,7 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                     List::from_arr([SortParamKind::Sort]),
                     rty::FuncSort::new(
                         vec![Var(param0)],
-                        Sort::app(Set, List::from_arr([SortArg::Sort(Var(param0))])),
+                        Sort::app(Set, List::singleton(Var(param0))),
                     ),
                 ),
             },
@@ -209,10 +205,10 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                     List::from_arr([SortParamKind::Sort]),
                     rty::FuncSort::new(
                         vec![
-                            Sort::app(Set, List::from_arr([SortArg::Sort(Var(param0))])),
-                            Sort::app(Set, List::from_arr([SortArg::Sort(Var(param0))])),
+                            Sort::app(Set, List::singleton(Var(param0))),
+                            Sort::app(Set, List::singleton(Var(param0))),
                         ],
-                        Sort::app(Set, List::from_arr([SortArg::Sort(Var(param0))])),
+                        Sort::app(Set, List::singleton(Var(param0))),
                     ),
                 ),
             },
@@ -222,10 +218,7 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                 sort: rty::PolyFuncSort::new(
                     List::from_arr([SortParamKind::Sort]),
                     rty::FuncSort::new(
-                        vec![
-                            Var(param0),
-                            Sort::app(Set, List::from_arr([SortArg::Sort(Var(param0))])),
-                        ],
+                        vec![Var(param0), Sort::app(Set, List::singleton(Var(param0)))],
                         Bool,
                     ),
                 ),
@@ -238,13 +231,7 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                     List::from_arr([SortParamKind::Sort, SortParamKind::Sort]),
                     rty::FuncSort::new(
                         vec![Var(param1)],
-                        Sort::app(
-                            Map,
-                            List::from_arr([
-                                SortArg::Sort(Var(param0)),
-                                SortArg::Sort(Var(param1)),
-                            ]),
-                        ),
+                        Sort::app(Map, List::from_arr([Var(param0), Var(param1)])),
                     ),
                 ),
             },
@@ -255,13 +242,7 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                     List::from_arr([SortParamKind::Sort, SortParamKind::Sort]),
                     rty::FuncSort::new(
                         vec![
-                            Sort::app(
-                                Map,
-                                List::from_arr([
-                                    SortArg::Sort(Var(param0)),
-                                    SortArg::Sort(Var(param1)),
-                                ]),
-                            ),
+                            Sort::app(Map, List::from_arr([Var(param0), Var(param1)])),
                             Var(param0),
                         ],
                         Var(param1),
@@ -275,23 +256,11 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                     List::from_arr([SortParamKind::Sort, SortParamKind::Sort]),
                     rty::FuncSort::new(
                         vec![
-                            Sort::app(
-                                Map,
-                                List::from_arr([
-                                    SortArg::Sort(Var(param0)),
-                                    SortArg::Sort(Var(param1)),
-                                ]),
-                            ),
+                            Sort::app(Map, List::from_arr([Var(param0), Var(param1)])),
                             Var(param0),
                             Var(param1),
                         ],
-                        Sort::app(
-                            Map,
-                            List::from_arr([
-                                SortArg::Sort(Var(param0)),
-                                SortArg::Sort(Var(param1)),
-                            ]),
-                        ),
+                        Sort::app(Map, List::from_arr([Var(param0), Var(param1)])),
                     ),
                 ),
             },

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -94,12 +94,12 @@ impl AdtSortDef {
         (0..self.fields()).map(|i| FieldProj::Adt { def_id: self.did(), field: i as u32 })
     }
 
-    pub fn field_sort(&self, args: &[SortArg], name: Symbol) -> Option<Sort> {
+    pub fn field_sort(&self, args: &[Sort], name: Symbol) -> Option<Sort> {
         let idx = self.field_index(name)?;
         Some(self.0.sorts[idx].fold_with(&mut SortSubst::new(args)))
     }
 
-    pub fn sorts(&self, args: &[SortArg]) -> List<Sort> {
+    pub fn sorts(&self, args: &[Sort]) -> List<Sort> {
         self.0.sorts.fold_with(&mut SortSubst::new(args))
     }
 
@@ -109,9 +109,9 @@ impl AdtSortDef {
         self.0.params.iter().map(|p| &args[p.index as usize])
     }
 
-    pub fn identity_args(&self) -> List<SortArg> {
+    pub fn identity_args(&self) -> List<Sort> {
         (0..self.0.params.len())
-            .map(|i| SortArg::Sort(Sort::Var(ParamSort::from(i))))
+            .map(|i| Sort::Var(ParamSort::from(i)))
             .collect()
     }
 
@@ -442,7 +442,7 @@ pub enum Sort {
     Param(ParamTy),
     Tuple(List<Sort>),
     Func(PolyFuncSort),
-    App(SortCtor, List<SortArg>),
+    App(SortCtor, List<Sort>),
     Var(ParamSort),
     Infer(SortInfer),
     Err,
@@ -1569,7 +1569,7 @@ impl Sort {
         Sort::Tuple(sorts.into())
     }
 
-    pub fn app(ctor: SortCtor, sorts: List<SortArg>) -> Self {
+    pub fn app(ctor: SortCtor, sorts: List<Sort>) -> Self {
         Sort::App(ctor, sorts)
     }
 
@@ -1942,7 +1942,7 @@ impl AdtDef {
         let sorts = self
             .sort_def()
             .filter_generic_args(args)
-            .map(|arg| SortArg::Sort(arg.expect_base().sort()))
+            .map(|arg| arg.expect_base().sort())
             .collect();
 
         Sort::App(SortCtor::Adt(self.sort_def().clone()), sorts)
@@ -2161,7 +2161,6 @@ impl_slice_internable!(
     RefineParam,
     AssocRefinement,
     SortParamKind,
-    SortArg,
     (ParamConst, Sort)
 );
 

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -93,7 +93,7 @@ impl Pretty for Sort {
             Sort::Bool => w!("bool"),
             Sort::Int => w!("int"),
             Sort::Real => w!("real"),
-            Sort::BitVec(w) => w!("bitvec({})", ^w),
+            Sort::BitVec(size) => w!("bitvec({:?})", size),
             Sort::Loc => w!("loc"),
             Sort::Var(n) => w!("@{}", ^n.index),
             Sort::Func(sort) => w!("{:?}", sort),
@@ -114,6 +114,27 @@ impl Pretty for Sort {
             Sort::Param(param_ty) => w!("{}::sort", ^param_ty),
             Sort::Infer(svar) => w!("{:?}", svar),
             Sort::Err => w!("err"),
+        }
+    }
+}
+
+impl Pretty for SortArg {
+    fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        define_scoped!(cx, f);
+        match self {
+            SortArg::Sort(sort) => w!("{:?}", sort),
+            SortArg::BvSize(size) => w!("{:?}", size),
+        }
+    }
+}
+
+impl Pretty for BvSize {
+    fn fmt(&self, _cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        define_scoped!(cx, f);
+        match self {
+            BvSize::Fixed(size) => w!("{}", ^size),
+            BvSize::Param(param) => w!("{:?}", ^param),
+            BvSize::Infer(size_vid) => w!("{:?}", ^size_vid),
         }
     }
 }
@@ -141,10 +162,10 @@ impl Pretty for FuncSort {
 impl Pretty for PolyFuncSort {
     fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         define_scoped!(cx, f);
-        if self.params == 0 {
+        if self.params.is_empty() {
             w!("{:?}", &self.fsort)
         } else {
-            w!("for<{}> {:?}", ^self.params, &self.fsort)
+            w!("for<{}> {:?}", ^self.params.len(), &self.fsort)
         }
     }
 }
@@ -467,4 +488,5 @@ impl_debug_with_default_cx!(
     SortCtor,
     SubsetTy,
     Const,
+    BvSize,
 );

--- a/crates/flux-middle/src/sort_of.rs
+++ b/crates/flux-middle/src/sort_of.rs
@@ -46,7 +46,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
                 let generic_args = path.segments.last().unwrap().args;
                 for arg in sort_def.filter_generic_args(generic_args) {
                     let Some(sort) = self.sort_of_ty(arg.expect_type())? else { return Ok(None) };
-                    sort_args.push(sort);
+                    sort_args.push(rty::SortArg::Sort(sort));
                 }
                 let ctor = rty::SortCtor::Adt(self.adt_sort_def_of(def_id)?);
                 Some(rty::Sort::App(ctor, List::from_vec(sort_args)))
@@ -128,7 +128,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
                     let Some(sort) = self.sort_of_self_ty(def_id, arg.expect_ty())? else {
                         return Ok(None);
                     };
-                    sort_args.push(sort);
+                    sort_args.push(rty::SortArg::Sort(sort));
                 }
                 let ctor = rty::SortCtor::Adt(self.adt_sort_def_of(adt_def.did())?);
                 Some(rty::Sort::App(ctor, List::from_vec(sort_args)))

--- a/crates/flux-middle/src/sort_of.rs
+++ b/crates/flux-middle/src/sort_of.rs
@@ -46,7 +46,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
                 let generic_args = path.segments.last().unwrap().args;
                 for arg in sort_def.filter_generic_args(generic_args) {
                     let Some(sort) = self.sort_of_ty(arg.expect_type())? else { return Ok(None) };
-                    sort_args.push(rty::SortArg::Sort(sort));
+                    sort_args.push(sort);
                 }
                 let ctor = rty::SortCtor::Adt(self.adt_sort_def_of(def_id)?);
                 Some(rty::Sort::App(ctor, List::from_vec(sort_args)))
@@ -128,7 +128,7 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
                     let Some(sort) = self.sort_of_self_ty(def_id, arg.expect_ty())? else {
                         return Ok(None);
                     };
-                    sort_args.push(rty::SortArg::Sort(sort));
+                    sort_args.push(sort);
                 }
                 let ctor = rty::SortCtor::Adt(self.adt_sort_def_of(adt_def.did())?);
                 Some(rty::Sort::App(ctor, List::from_vec(sort_args)))

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -866,8 +866,14 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
 fn bv_size_to_fixpoint(size: rty::BvSize) -> fixpoint::Sort {
     match size {
         rty::BvSize::Fixed(size) => fixpoint::Sort::BvSize(size),
-        rty::BvSize::Param(var) => fixpoint::Sort::Var(var.index),
-        rty::BvSize::Infer(_) => bug!("unexpected infer variable for bit vector size"),
+        rty::BvSize::Param(_var) => {
+            // I think we could encode the size as a sort variable, but this would require some care
+            // because smtlib doesn't really support parametric sizes. Fixpoint is probably already
+            // too liberal about this and it'd be easy to make it crash.
+            // fixpoint::Sort::Var(var.index)
+            bug!("unexpected parametric bit-vector size")
+        }
+        rty::BvSize::Infer(_) => bug!("unexpected infer variable for bit-vector size"),
     }
 }
 

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -828,17 +828,17 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
         rty::Sort::Int => fixpoint::Sort::Int,
         rty::Sort::Real => fixpoint::Sort::Real,
         rty::Sort::Bool => fixpoint::Sort::Bool,
-        rty::Sort::BitVec(w) => fixpoint::Sort::BitVec(*w),
+        rty::Sort::BitVec(size) => fixpoint::Sort::BitVec(Box::new(bv_size_to_fixpoint(*size))),
         // There's no way to declare user defined sorts in the fixpoint horn syntax so we encode
         // user declared opaque sorts and type variable sorts as integers. Well-formedness should
         // ensure values of these sorts are properly used.
         rty::Sort::App(rty::SortCtor::User { .. }, _) | rty::Sort::Param(_) => fixpoint::Sort::Int,
         rty::Sort::App(rty::SortCtor::Set, args) => {
-            let args = args.iter().map(sort_to_fixpoint).collect_vec();
+            let args = args.iter().map(sort_arg_to_fixpoint).collect_vec();
             fixpoint::Sort::App(fixpoint::SortCtor::Set, args)
         }
         rty::Sort::App(rty::SortCtor::Map, args) => {
-            let args = args.iter().map(sort_to_fixpoint).collect_vec();
+            let args = args.iter().map(sort_arg_to_fixpoint).collect_vec();
             fixpoint::Sort::App(fixpoint::SortCtor::Map, args)
         }
         rty::Sort::App(rty::SortCtor::Adt(sort_def), args) => {
@@ -863,12 +863,27 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
     }
 }
 
+fn sort_arg_to_fixpoint(arg: &rty::SortArg) -> fixpoint::Sort {
+    match arg {
+        rty::SortArg::Sort(sort) => sort_to_fixpoint(sort),
+        rty::SortArg::BvSize(size) => bv_size_to_fixpoint(*size),
+    }
+}
+
+fn bv_size_to_fixpoint(size: rty::BvSize) -> fixpoint::Sort {
+    match size {
+        rty::BvSize::Fixed(size) => fixpoint::Sort::BvSize(size),
+        rty::BvSize::Param(var) => fixpoint::Sort::Var(var.index),
+        rty::BvSize::Infer(_) => bug!("unexpected infer variable for bit vector size"),
+    }
+}
+
 fn tuple_sort_name(arity: usize) -> String {
     format!("Tuple{arity}")
 }
 
 fn func_sort_to_fixpoint(fsort: &rty::PolyFuncSort) -> fixpoint::Sort {
-    let params = fsort.params();
+    let params = fsort.params().len();
     let fsort = fsort.skip_binders();
     fixpoint::Sort::mk_func(
         params,
@@ -1230,7 +1245,8 @@ fn alias_reft_sort(arity: usize) -> rty::PolyFuncSort {
         sorts.push(rty::Sort::Var(rty::ParamSort::from(i)));
     }
     sorts.push(rty::Sort::Bool);
-    rty::PolyFuncSort::new(arity, rty::FuncSort { inputs_and_output: List::from_vec(sorts) })
+    let params = iter::repeat(rty::SortParamKind::Sort).take(arity).collect();
+    rty::PolyFuncSort::new(params, rty::FuncSort { inputs_and_output: List::from_vec(sorts) })
 }
 
 fn mk_implies(assumption: fixpoint::Pred, cstr: fixpoint::Constraint) -> fixpoint::Constraint {

--- a/crates/flux-refineck/src/fixpoint_encoding.rs
+++ b/crates/flux-refineck/src/fixpoint_encoding.rs
@@ -834,11 +834,11 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
         // ensure values of these sorts are properly used.
         rty::Sort::App(rty::SortCtor::User { .. }, _) | rty::Sort::Param(_) => fixpoint::Sort::Int,
         rty::Sort::App(rty::SortCtor::Set, args) => {
-            let args = args.iter().map(sort_arg_to_fixpoint).collect_vec();
+            let args = args.iter().map(sort_to_fixpoint).collect_vec();
             fixpoint::Sort::App(fixpoint::SortCtor::Set, args)
         }
         rty::Sort::App(rty::SortCtor::Map, args) => {
-            let args = args.iter().map(sort_arg_to_fixpoint).collect_vec();
+            let args = args.iter().map(sort_to_fixpoint).collect_vec();
             fixpoint::Sort::App(fixpoint::SortCtor::Map, args)
         }
         rty::Sort::App(rty::SortCtor::Adt(sort_def), args) => {
@@ -860,13 +860,6 @@ pub fn sort_to_fixpoint(sort: &rty::Sort) -> fixpoint::Sort {
         rty::Sort::Err | rty::Sort::Infer(_) | rty::Sort::Loc => {
             bug!("unexpected sort {sort:?}")
         }
-    }
-}
-
-fn sort_arg_to_fixpoint(arg: &rty::SortArg) -> fixpoint::Sort {
-    match arg {
-        rty::SortArg::Sort(sort) => sort_to_fixpoint(sort),
-        rty::SortArg::BvSize(size) => bv_size_to_fixpoint(*size),
     }
 }
 


### PR DESCRIPTION
Implement polymorphic bit-vector sizes that can be automatically inferred at call sites. This allows us to define bit-vector theory functions for all sizes.