### PR TITLE
add fixpoint-passthrough for bv_shl

### DIFF
--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -134,6 +134,17 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                 ),
             },
             TheoryFunc {
+                name: Symbol::intern("bv_shl"),
+                fixpoint_name: Symbol::intern("bvshl"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![BitVec(bv_param0), BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
+            TheoryFunc {
                 name: Symbol::intern("bv_lshr"),
                 fixpoint_name: Symbol::intern("bvlshr"),
                 sort: rty::PolyFuncSort::new(


### PR DESCRIPTION
I need `bv_shl` for a spec I'm writing, so I just went ahead and added it. Let me know if there is anywhere else I need to modify besides adding this line.