### PR TITLE
extend bitvector ops passthrough api 

### DIFF
--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -110,6 +110,29 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                     rty::FuncSort::new(vec![BitVec(BvSize::Fixed(64))], Int),
                 ),
             },
+            // Bitvector extension
+            TheoryFunc {
+                name: Symbol::intern("bv_zero_extend"),
+                fixpoint_name: Symbol::intern("zero_extend"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![rty::Sort::Int, BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
+            TheoryFunc {
+                name: Symbol::intern("bv_sign_extend"),
+                fixpoint_name: Symbol::intern("sign_extend"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![rty::Sort::Int, BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
             // BitVector arith
             TheoryFunc {
                 name: Symbol::intern("bv_add"),
@@ -118,6 +141,18 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                     List::from_arr([SortParamKind::BvSize]),
                     rty::FuncSort::new(
                         vec![BitVec(bv_param0), BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
+
+            TheoryFunc {
+                name: Symbol::intern("bv_neg"),
+                fixpoint_name: Symbol::intern("bvneg"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![BitVec(bv_param0)],
                         BitVec(bv_param0),
                     ),
                 ),
@@ -177,6 +212,61 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                     ),
                 ),
             },
+            TheoryFunc {
+                name: Symbol::intern("bv_udiv"),
+                fixpoint_name: Symbol::intern("bvudiv"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![BitVec(bv_param0), BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
+            TheoryFunc {
+                name: Symbol::intern("bv_urem"),
+                fixpoint_name: Symbol::intern("bvurem"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![BitVec(bv_param0), BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
+            TheoryFunc {
+                name: Symbol::intern("bv_sdiv"),
+                fixpoint_name: Symbol::intern("bvsdiv"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![BitVec(bv_param0), BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
+            TheoryFunc {
+                name: Symbol::intern("bv_srem"),
+                fixpoint_name: Symbol::intern("bvsrem"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![BitVec(bv_param0), BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
+            TheoryFunc {
+                name: Symbol::intern("bv_smod"),
+                fixpoint_name: Symbol::intern("bvsmod"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![BitVec(bv_param0), BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
             // BitVector bitwise
             TheoryFunc {
                 name: Symbol::intern("bv_and"),
@@ -185,6 +275,39 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                     List::from_arr([SortParamKind::BvSize]),
                     rty::FuncSort::new(
                         vec![BitVec(bv_param0), BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
+            TheoryFunc {
+                name: Symbol::intern("bv_or"),
+                fixpoint_name: Symbol::intern("bvor"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![BitVec(bv_param0), BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
+            TheoryFunc {
+                name: Symbol::intern("bv_xor"),
+                fixpoint_name: Symbol::intern("bvxor"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![BitVec(bv_param0), BitVec(bv_param0)],
+                        BitVec(bv_param0),
+                    ),
+                ),
+            },
+            TheoryFunc {
+                name: Symbol::intern("bv_not"),
+                fixpoint_name: Symbol::intern("bvnot"),
+                sort: rty::PolyFuncSort::new(
+                    List::from_arr([SortParamKind::BvSize]),
+                    rty::FuncSort::new(
+                        vec![BitVec(bv_param0)],
                         BitVec(bv_param0),
                     ),
                 ),

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -76,7 +76,6 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
         let param0 = ParamSort::from(0);
         let param1 = ParamSort::from(1);
         let bv_param0 = BvSize::Param(ParamSort::from(0));
-        let bv_param1 = BvSize::Param(ParamSort::from(1));
         vec![
             // BitVector <-> int
             TheoryFunc {

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -76,6 +76,7 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
         let param0 = ParamSort::from(0);
         let param1 = ParamSort::from(1);
         let bv_param0 = BvSize::Param(ParamSort::from(0));
+        let bv_param1 = BvSize::Param(ParamSort::from(1));
         vec![
             // BitVector <-> int
             TheoryFunc {
@@ -108,23 +109,6 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                 sort: rty::PolyFuncSort::new(
                     List::empty(),
                     rty::FuncSort::new(vec![BitVec(BvSize::Fixed(64))], Int),
-                ),
-            },
-            // Bitvector extension
-            TheoryFunc {
-                name: Symbol::intern("bv_zero_extend"),
-                fixpoint_name: Symbol::intern("zero_extend"),
-                sort: rty::PolyFuncSort::new(
-                    List::from_arr([SortParamKind::BvSize]),
-                    rty::FuncSort::new(vec![rty::Sort::Int, BitVec(bv_param0)], BitVec(bv_param0)),
-                ),
-            },
-            TheoryFunc {
-                name: Symbol::intern("bv_sign_extend"),
-                fixpoint_name: Symbol::intern("sign_extend"),
-                sort: rty::PolyFuncSort::new(
-                    List::from_arr([SortParamKind::BvSize]),
-                    rty::FuncSort::new(vec![rty::Sort::Int, BitVec(bv_param0)], BitVec(bv_param0)),
                 ),
             },
             // BitVector arith

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -116,10 +116,7 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                 fixpoint_name: Symbol::intern("zero_extend"),
                 sort: rty::PolyFuncSort::new(
                     List::from_arr([SortParamKind::BvSize]),
-                    rty::FuncSort::new(
-                        vec![rty::Sort::Int, BitVec(bv_param0)],
-                        BitVec(bv_param0),
-                    ),
+                    rty::FuncSort::new(vec![rty::Sort::Int, BitVec(bv_param0)], BitVec(bv_param0)),
                 ),
             },
             TheoryFunc {
@@ -127,10 +124,7 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                 fixpoint_name: Symbol::intern("sign_extend"),
                 sort: rty::PolyFuncSort::new(
                     List::from_arr([SortParamKind::BvSize]),
-                    rty::FuncSort::new(
-                        vec![rty::Sort::Int, BitVec(bv_param0)],
-                        BitVec(bv_param0),
-                    ),
+                    rty::FuncSort::new(vec![rty::Sort::Int, BitVec(bv_param0)], BitVec(bv_param0)),
                 ),
             },
             // BitVector arith
@@ -145,16 +139,12 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                     ),
                 ),
             },
-
             TheoryFunc {
                 name: Symbol::intern("bv_neg"),
                 fixpoint_name: Symbol::intern("bvneg"),
                 sort: rty::PolyFuncSort::new(
                     List::from_arr([SortParamKind::BvSize]),
-                    rty::FuncSort::new(
-                        vec![BitVec(bv_param0)],
-                        BitVec(bv_param0),
-                    ),
+                    rty::FuncSort::new(vec![BitVec(bv_param0)], BitVec(bv_param0)),
                 ),
             },
             TheoryFunc {
@@ -306,10 +296,7 @@ pub fn theory_funcs() -> &'static [TheoryFunc] {
                 fixpoint_name: Symbol::intern("bvnot"),
                 sort: rty::PolyFuncSort::new(
                     List::from_arr([SortParamKind::BvSize]),
-                    rty::FuncSort::new(
-                        vec![BitVec(bv_param0)],
-                        BitVec(bv_param0),
-                    ),
+                    rty::FuncSort::new(vec![BitVec(bv_param0)], BitVec(bv_param0)),
                 ),
             },
             // Set operations


### PR DESCRIPTION
I extended the fixpoint-passhtrough api with:
- bitvector size extension (bv_sign_extend, bv_zero_extend)
- a now-complete set of arithmetic operations (bv_neg, bv_udiv, bv_urem, bv_sdiv, bv_srem, bv_smod)
- and more bitwise logic (bv_or, bv_xor, bv_not)