### PR TITLE
Improve error reporting of missing assoc refinements

### DIFF
--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -156,9 +156,6 @@ fhir_analysis_definition_cycle =
     cycle in definitions
     .label = {$msg}
 
-fhir_analysis_undefined_assoc_reft =
-    associated refinement `{$name}` is not defined in this trait implementation
-
 # Conv errors
 
 fhir_analysis_assoc_type_not_found =

--- a/crates/flux-middle/locales/en-US.ftl
+++ b/crates/flux-middle/locales/en-US.ftl
@@ -29,7 +29,7 @@ middle_query_invalid_generic_arg =
     cannot instantiate base generic with opaque type or a type parameter of kind type
 
 middle_query_invalid_assoc_reft =
-    invalid associated refinement for this function call
+    associated refinement `{$name}` is not defined in this trait implementation
 
 middle_query_ignored_item =
     use of ignored item
@@ -43,3 +43,6 @@ middle_query_unsupported_at =
 middle_query_ignored_at =
     use of ignored {$kind} `{$name}`
     .label = help: try ignoring or trusting this code
+
+middle_query_invalid_assoc_reft_at =
+    invalid associated refinement for this function call

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -42,10 +42,10 @@ pub type QueryResult<T = ()> = Result<T, QueryErr>;
 /// We make a distinction between errors reported at def-site and errors reported at use-site.
 ///
 /// For most errors reported at the def-site of an item, it makes little sense to check the definition
-/// of other items that depend on it. For example, if a function signature is ill-formed, checking the
-/// body of another function that calls it, can produce confusing errors. We can even fail to produce
+/// of dependent items. For example, if a function signature is ill-formed, checking the body of another
+/// function that calls it, can produce confusing errors. In some cases, we can even fail to produce
 /// a signature for a function in which case we can't even check its call sites. For these cases, we
-/// emit an error at the definition site and return a [`QueryErr::Emitted`]. When checking a dependant,
+/// emit an error at the definition site and return a [`QueryErr::Emitted`]. When checking a dependent,
 /// we detect this and early return without reporting any errors at the use-site.
 ///
 /// Other errors are better reported at the use-site. For example, if some code calls a function from
@@ -61,7 +61,6 @@ pub type QueryResult<T = ()> = Result<T, QueryErr>;
 /// should consider not implementing [`Diagnostic`] for [`QueryErr`] such that we always make the
 /// distinction between use-site and def-site explicit, e.g., we could have methods `QueryErr::at_use_site`
 /// and `QueryErr::at_def_site` returning types with different implementations of [`Diagnostic`].
-///
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub enum QueryErr {
     Unsupported { def_id: DefId, err: UnsupportedErr },

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -56,11 +56,11 @@ pub type QueryResult<T = ()> = Result<T, QueryErr>;
 ///
 /// Both [`QueryErr`] and [`QueryErrAt`] implement [`Diagnostic`]. The implementation for [`QueryErr`]
 /// reports the error at the definition site, while the implementation for [`QueryErrAt`] reports it at
-/// the (attached) use-site span. This allows to play a bit lose because we don't need to attach a span
-/// every time an error is raised, but this means we may forget to attach spans at some places. We
-/// should consider not implementing [`Diagnostic`] for [`QueryErr`] such that we always make the
-/// distinction between use-site and def-site explicit, e.g., we could have methods `QueryErr::at_use_site`
-/// and `QueryErr::at_def_site` returning types with different implementations of [`Diagnostic`].
+/// the (attached) use-site span. This allows to play a bit lose because we can emit an error without
+/// attatching an span, but this means we may forget to attach spans at some places. We should consider
+/// not implementing [`Diagnostic`] for [`QueryErr`] such that we always make the distinction between
+/// use-site and def-site explicit, e.g., we could have methods `QueryErr::at_use_site` and
+/// `QueryErr::at_def_site` returning types with different implementations of [`Diagnostic`].
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub enum QueryErr {
     Unsupported { def_id: DefId, err: UnsupportedErr },

--- a/crates/flux-refineck/src/constraint_gen.rs
+++ b/crates/flux-refineck/src/constraint_gen.rs
@@ -4,7 +4,6 @@ use flux_common::{bug, tracked_span_bug};
 use flux_middle::{
     global_env::GlobalEnv,
     intern::List,
-    queries::QueryErr::InvalidAssocReft,
     rty::{
         self, evars::EVarSol, fold::TypeFoldable, AliasTy, BaseTy, Binder, CoroutineObligPredicate,
         ESpan, EVarGen, EarlyBinder, Ensures, Expr, ExprKind, FnOutput, GenericArg, HoleKind,
@@ -168,15 +167,7 @@ impl<'a, 'genv, 'tcx> ConstrGen<'a, 'genv, 'tcx> {
                 |br| infcx.next_bound_region_var(span, br.kind, BoundRegionConversionTime::FnCall),
                 |sort, mode| infcx.fresh_infer_var(sort, mode),
             )
-            .normalize_projections(genv, infcx.region_infcx, infcx.def_id, infcx.refparams);
-
-        let fn_sig = match fn_sig {
-            Ok(fn_sig) => fn_sig,
-            Err(err) => {
-                let err = InvalidAssocReft { span };
-                return Err(CheckerErrKind::Query(err));
-            }
-        };
+            .normalize_projections(genv, infcx.region_infcx, infcx.def_id, infcx.refparams)?;
 
         let obligs = if let Some(did) = callee_def_id {
             mk_obligations(genv, did, &generic_args, &refine_args)?

--- a/tests/tests/neg/error_messages/check_impl/issue-649.rs
+++ b/tests/tests/neg/error_messages/check_impl/issue-649.rs
@@ -9,7 +9,6 @@ impl MyTrait for Foo {}
 struct Bar;
 
 impl MyTrait for Bar {} //~ ERROR  associated refinement `eval` is not defined in implementation of trait `MyTrait`
-                        //~^ ERROR associated refinement `eval` is not defined in this trait implementation
 
 #[flux::sig(fn(x: i32) -> i32[<T as MyTrait>::eval(x)])]
 fn test01<T: MyTrait>(x: i32) -> i32 {


### PR DESCRIPTION
We now only report two errors in the following

```rust
#[flux::assoc(fn eval(x: int) -> int)]
pub trait MyTrait {}

impl MyTrait for i32 {}

#[flux::trusted]
#[flux::sig(fn(x: i32) -> i32[<T as MyTrait>::eval(x)])]
fn test01<T: MyTrait>(_x: i32) -> i32 {
    todo!()
}

pub fn test02() {
    test01::<i32>(0);
}
```

```
error[E0999]: associated refinement `eval` is not defined in implementation of trait `MyTrait`
 --> attic/playground.rs:4:1
  |
4 | impl MyTrait for i32 {}
  | ^^^^^^^^^^^^^^^^^^^^
-Ztrack-diagnostics: created at crates/flux-fhir-analysis/src/compare_impl_item.rs:21:36

error[E0999]: invalid associated refinement for this function call
  --> attic/playground.rs:13:5
   |
13 |     test01::<i32>(0);
   |     ^^^^^^^^^^^^^^^^
-Ztrack-diagnostics: created at crates/flux-middle/src/queries.rs:726:29
```

Also, add some documentation for `QueryErr` (ping @ranjitjhala)