### PR TITLE
Add support for `SizeOf` and `AlignOf` nullary ops

### DIFF
--- a/crates/flux-middle/src/rustc/mir.rs
+++ b/crates/flux-middle/src/rustc/mir.rs
@@ -184,15 +184,15 @@ pub enum StatementKind {
 
 pub enum Rvalue {
     Use(Operand),
+    Repeat(Operand, Const),
     Ref(Region, BorrowKind, Place),
-    BinaryOp(BinOp, Operand, Operand),
-    CheckedBinaryOp(BinOp, Operand, Operand),
-    UnaryOp(UnOp, Operand),
-    Aggregate(AggregateKind, Vec<Operand>),
-    Discriminant(Place),
     Len(Place),
     Cast(CastKind, Operand, Ty),
-    Repeat(Operand, Const),
+    BinaryOp(BinOp, Operand, Operand),
+    NullaryOp(NullOp, Ty),
+    UnaryOp(UnOp, Operand),
+    Discriminant(Place),
+    Aggregate(AggregateKind, Vec<Operand>),
 }
 
 #[derive(Copy, Clone)]
@@ -239,6 +239,12 @@ pub enum BinOp {
     BitXor,
     Shl,
     Shr,
+}
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub enum NullOp {
+    SizeOf,
+    AlignOf,
 }
 
 pub enum Operand {
@@ -645,9 +651,7 @@ impl fmt::Debug for Rvalue {
             }
             Rvalue::Discriminant(place) => write!(f, "discriminant({place:?})"),
             Rvalue::BinaryOp(bin_op, op1, op2) => write!(f, "{bin_op:?}({op1:?}, {op2:?})"),
-            Rvalue::CheckedBinaryOp(bin_op, op1, op2) => {
-                write!(f, "Checked{bin_op:?}({op1:?}, {op2:?})")
-            }
+            Rvalue::NullaryOp(null_op, ty) => write!(f, "{null_op:?}({ty:?})"),
             Rvalue::UnaryOp(un_op, op) => write!(f, "{un_op:?}({op:?})"),
             Rvalue::Aggregate(AggregateKind::Adt(def_id, variant_idx, args, _), operands) => {
                 let (fname, variant_name) = rustc_middle::ty::tls::with(|tcx| {

--- a/crates/flux-refineck/src/ghost_statements/fold_unfold.rs
+++ b/crates/flux-refineck/src/ghost_statements/fold_unfold.rs
@@ -311,7 +311,7 @@ impl<'a, 'genv, 'tcx, M: Mode> FoldUnfoldAnalysis<'a, 'genv, 'tcx, M> {
                             M::projection(self, env, place, ProjKind::Other)?;
                         }
                     }
-                    Rvalue::CheckedBinaryOp(_, op1, op2) | Rvalue::BinaryOp(_, op1, op2) => {
+                    Rvalue::BinaryOp(_, op1, op2) => {
                         self.operand(op1, env)?;
                         self.operand(op2, env)?;
                     }
@@ -330,6 +330,7 @@ impl<'a, 'genv, 'tcx, M: Mode> FoldUnfoldAnalysis<'a, 'genv, 'tcx, M> {
                     Rvalue::Repeat(op, _) => {
                         self.operand(op, env)?;
                     }
+                    Rvalue::NullaryOp(_, _) => {}
                 }
                 M::projection(self, env, place, ProjKind::Other)?;
             }


### PR DESCRIPTION
This adds basic support for `SizeOf` and `AlignOf` nullary ops in mir. We assign them a `usize` with no index, which should suffice for now. If we ever need more precision we could get the layout of the type and index the result with the real size or alignment. This is in preparation for supporting the `vec![..]` macro. I don't know how to write a test whose mir only uses these ops.