### PR TITLE
Factor subtyping out of `InferCtxtAt`

### DIFF
--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -31,7 +31,8 @@ use crate::{
     rustc::ty::{Const, ConstKind},
 };
 
-/// A lambda abstraction with an elaborated output sort
+/// A lambda abstraction with an elaborated output sort. We need the output sort of lambdas for
+/// encoding into fixpoint
 #[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub struct Lambda {
     pub(super) body: Binder<Expr>,

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -513,7 +513,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             .output
             .replace_bound_refts_with(|sort, mode, _| infcx.fresh_infer_var(sort, mode));
 
-        infcx
+        let obligations = infcx
             .at(ConstrReason::Ret)
             .subtyping(rcx, &ret_place_ty, &output.ret)
             .with_span(span)?;
@@ -533,12 +533,10 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             }
         }
 
-        let clauses = infcx.take_obligations();
-
         let evars_sol = infcx.solve().with_span(span)?;
         rcx.replace_evars(&evars_sol);
 
-        self.check_closure_clauses(rcx, rcx.snapshot(), &clauses)
+        self.check_closure_clauses(rcx, rcx.snapshot(), &obligations)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/flux-refineck/src/infer.rs
+++ b/crates/flux-refineck/src/infer.rs
@@ -31,6 +31,7 @@ type Result<T = ()> = std::result::Result<T, CheckerErrKind>;
 pub trait KVarGen {
     fn fresh(&self, binders: &[List<Sort>], kind: KVarEncoding) -> Expr;
 }
+
 pub(crate) struct InferCtxt<'a, 'genv, 'tcx> {
     pub genv: GlobalEnv<'genv, 'tcx>,
     pub region_infcx: &'a rustc_infer::infer::InferCtxt<'tcx>,
@@ -40,7 +41,6 @@ pub(crate) struct InferCtxt<'a, 'genv, 'tcx> {
     evar_gen: RefCell<EVarGen<Scope>>,
     /// The span at which this inference context was created in `Checker`
     span: Span,
-    obligs: Vec<rty::Clause>,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
@@ -94,20 +94,11 @@ impl<'a, 'genv, 'tcx> InferCtxt<'a, 'genv, 'tcx> {
             kvar_gen: Box::new(kvar_gen),
             evar_gen: RefCell::new(evar_gen),
             span,
-            obligs: Vec::new(),
         }
     }
 
     pub(crate) fn at(&mut self, reason: ConstrReason) -> InferCtxtAt<'_, 'a, 'genv, 'tcx> {
         InferCtxtAt { infcx: self, reason }
-    }
-
-    pub(crate) fn take_obligations(&mut self) -> Vec<rty::Clause> {
-        std::mem::take(&mut self.obligs)
-    }
-
-    fn insert_obligations(&mut self, obligs: Vec<rty::Clause>) {
-        self.obligs.extend(obligs);
     }
 
     pub(crate) fn instantiate_refine_args(&mut self, callee_def_id: DefId) -> Result<Vec<Expr>> {
@@ -249,264 +240,17 @@ impl<'a, 'b, 'genv, 'tcx> InferCtxtAt<'a, 'b, 'genv, 'tcx> {
         Ok(())
     }
 
-    pub(crate) fn subtyping(&mut self, rcx: &mut RefineCtxt, ty1: &Ty, ty2: &Ty) -> Result {
-        let rcx = &mut rcx.branch();
-
-        // We *fully* unpack the lhs before continuing to be able to prove goals like this
-        // ∃a. (i32[a], ∃b. {i32[b] | a > b})} <: ∃a,b. ({i32[a] | b < a}, i32[b])
-        // See S4.5 in https://arxiv.org/pdf/2209.13000v1.pdf
-        let ty1 = rcx.unpack(ty1);
-
-        match (ty1.kind(), ty2.kind()) {
-            (TyKind::Exists(..), _) => {
-                bug!("existentials should be removed by the unpack");
-            }
-            (TyKind::Constr(..), _) => {
-                bug!("constraint types should removed by the unpack");
-            }
-            (_, TyKind::Exists(ty2)) => {
-                self.infcx.push_scope(rcx);
-                let ty2 = ty2.replace_bound_refts_with(|sort, mode, _| {
-                    self.infcx.fresh_infer_var(sort, mode)
-                });
-                self.subtyping(rcx, &ty1, &ty2)?;
-                self.infcx.pop_scope();
-                Ok(())
-            }
-            (TyKind::Indexed(bty1, idx1), TyKind::Indexed(bty2, idx2)) => {
-                self.bty_subtyping(rcx, bty1, bty2)?;
-                self.idx_eq(rcx, idx1, idx2);
-                Ok(())
-            }
-            (TyKind::Ptr(pk1, path1), TyKind::Ptr(pk2, path2)) => {
-                debug_assert_eq!(pk1, pk2);
-                debug_assert_eq!(path1, path2);
-                Ok(())
-            }
-            (TyKind::Param(param_ty1), TyKind::Param(param_ty2)) => {
-                debug_assert_eq!(param_ty1, param_ty2);
-                Ok(())
-            }
-            (_, TyKind::Uninit) => {
-                // FIXME: we should rethink in which situation this is sound.
-                Ok(())
-            }
-            (_, TyKind::Constr(p2, ty2)) => {
-                self.check_pred(rcx, p2);
-                self.subtyping(rcx, &ty1, ty2)
-            }
-            (TyKind::Downcast(.., fields1), TyKind::Downcast(.., fields2)) => {
-                debug_assert_eq!(fields1.len(), fields2.len());
-                for (field1, field2) in iter::zip(fields1, fields2) {
-                    self.subtyping(rcx, field1, field2)?;
-                }
-                Ok(())
-            }
-            (_, TyKind::Alias(rty::AliasKind::Opaque, alias_ty)) => {
-                if let TyKind::Alias(rty::AliasKind::Opaque, alias_ty1) = ty1.kind() {
-                    debug_assert_eq!(alias_ty1.refine_args.len(), alias_ty.refine_args.len());
-                    iter::zip(alias_ty1.refine_args.iter(), alias_ty.refine_args.iter())
-                        .for_each(|(e1, e2)| self.infcx.unify_exprs(e1, e2));
-                }
-
-                self.opaque_subtyping(rcx, &ty1, alias_ty)
-            }
-            (
-                TyKind::Alias(rty::AliasKind::Projection, alias_ty1),
-                TyKind::Alias(rty::AliasKind::Projection, alias_ty2),
-            ) => {
-                debug_assert_eq!(alias_ty1, alias_ty2);
-                Ok(())
-            }
-            _ => Err(QueryErr::bug(format!("incompatible types: `{ty1:?}` - `{ty2:?}`")))?,
-        }
-    }
-
-    fn bty_subtyping(&mut self, rcx: &mut RefineCtxt, bty1: &BaseTy, bty2: &BaseTy) -> Result {
-        match (bty1, bty2) {
-            (BaseTy::Int(int_ty1), BaseTy::Int(int_ty2)) => {
-                debug_assert_eq!(int_ty1, int_ty2);
-                Ok(())
-            }
-            (BaseTy::Uint(uint_ty1), BaseTy::Uint(uint_ty2)) => {
-                debug_assert_eq!(uint_ty1, uint_ty2);
-                Ok(())
-            }
-            (BaseTy::Adt(adt1, args1), BaseTy::Adt(adt2, args2)) => {
-                debug_assert_eq!(adt1.did(), adt2.did());
-                debug_assert_eq!(args1.len(), args2.len());
-                let variances = self.infcx.genv.variances_of(adt1.did());
-                for (variance, ty1, ty2) in izip!(variances, args1.iter(), args2.iter()) {
-                    self.generic_arg_subtyping(rcx, *variance, ty1, ty2)?;
-                }
-                Ok(())
-            }
-            (BaseTy::Float(float_ty1), BaseTy::Float(float_ty2)) => {
-                debug_assert_eq!(float_ty1, float_ty2);
-                Ok(())
-            }
-
-            (BaseTy::Slice(ty1), BaseTy::Slice(ty2)) => self.subtyping(rcx, ty1, ty2),
-            (BaseTy::Ref(_, ty1, Mutability::Mut), BaseTy::Ref(_, ty2, Mutability::Mut)) => {
-                self.subtyping(rcx, ty1, ty2)?;
-                self.subtyping(rcx, ty2, ty1)
-            }
-            (BaseTy::Ref(_, ty1, Mutability::Not), BaseTy::Ref(_, ty2, Mutability::Not)) => {
-                self.subtyping(rcx, ty1, ty2)
-            }
-            (BaseTy::Tuple(tys1), BaseTy::Tuple(tys2)) => {
-                debug_assert_eq!(tys1.len(), tys2.len());
-                for (ty1, ty2) in iter::zip(tys1, tys2) {
-                    self.subtyping(rcx, ty1, ty2)?;
-                }
-                Ok(())
-            }
-            (BaseTy::Array(ty1, len1), BaseTy::Array(ty2, len2)) => {
-                debug_assert_eq!(len1, len2);
-                self.subtyping(rcx, ty1, ty2)
-            }
-            (BaseTy::Param(param1), BaseTy::Param(param2)) => {
-                debug_assert_eq!(param1, param2);
-                Ok(())
-            }
-            (BaseTy::Bool, BaseTy::Bool)
-            | (BaseTy::Str, BaseTy::Str)
-            | (BaseTy::Char, BaseTy::Char)
-            | (BaseTy::RawPtr(_, _), BaseTy::RawPtr(_, _)) => Ok(()),
-            (BaseTy::Dynamic(preds1, _), BaseTy::Dynamic(preds2, _)) => {
-                assert_eq!(preds1, preds2);
-                Ok(())
-            }
-            (BaseTy::Closure(did1, tys1), BaseTy::Closure(did2, tys2)) if did1 == did2 => {
-                debug_assert_eq!(tys1.len(), tys2.len());
-                for (ty1, ty2) in iter::zip(tys1, tys2) {
-                    self.subtyping(rcx, ty1, ty2)?;
-                }
-                Ok(())
-            }
-            _ => Err(QueryErr::bug(format!("incompatible base types: `{bty1:?}` - `{bty2:?}`")))?,
-        }
-    }
-
-    fn project_bty(&mut self, self_ty: &Ty, def_id: DefId) -> Result<Ty> {
-        let args = List::singleton(GenericArg::Ty(self_ty.clone()));
-        let alias_ty = rty::AliasTy::new(def_id, args, List::empty());
-        Ok(Ty::projection(alias_ty).normalize_projections(
-            self.infcx.genv,
-            self.infcx.region_infcx,
-            self.infcx.def_id,
-            self.infcx.refparams,
-        )?)
-    }
-
-    fn opaque_subtyping(&mut self, rcx: &mut RefineCtxt, ty: &Ty, alias_ty: &AliasTy) -> Result {
-        if let Some(BaseTy::Coroutine(def_id, resume_ty, upvar_tys)) =
-            ty.as_bty_skipping_existentials()
-        {
-            let obligs = mk_generator_obligations(
-                self.infcx.genv,
-                def_id,
-                resume_ty,
-                upvar_tys,
-                &alias_ty.def_id,
-            )?;
-            self.infcx.insert_obligations(obligs);
-        } else {
-            let bounds = self
-                .infcx
-                .genv
-                .item_bounds(alias_ty.def_id)?
-                .instantiate_identity(self.infcx.refparams);
-            for clause in &bounds {
-                if let rty::ClauseKind::Projection(pred) = clause.kind() {
-                    let ty1 = self.project_bty(ty, pred.projection_ty.def_id)?;
-                    let ty2 = pred.term;
-                    self.subtyping(rcx, &ty1, &ty2)?;
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn generic_arg_subtyping(
+    /// Relate types via subtyping and returns coroutine obligations. See comment for
+    /// [`Sub::obligations`].
+    pub(crate) fn subtyping(
         &mut self,
         rcx: &mut RefineCtxt,
-        variance: Variance,
-        arg1: &GenericArg,
-        arg2: &GenericArg,
-    ) -> Result {
-        let (ty1, ty2) = match (arg1, arg2) {
-            (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) => (ty1.clone(), ty2.clone()),
-            (GenericArg::Base(ctor1), GenericArg::Base(ctor2)) => {
-                debug_assert_eq!(ctor1.sort(), ctor2.sort());
-                (ctor1.to_ty(), ctor2.to_ty())
-            }
-            (GenericArg::Lifetime(_), GenericArg::Lifetime(_)) => return Ok(()),
-            (GenericArg::Const(c1), GenericArg::Const(c2)) => {
-                debug_assert_eq!(c1, c2);
-                return Ok(());
-            }
-            _ => {
-                let note = format!("incompatible generic args: `{arg1:?}` `{arg2:?}`");
-                return Err(QueryErr::bug(note).into());
-            }
-        };
-        match variance {
-            Variance::Covariant => self.subtyping(rcx, &ty1, &ty2),
-            Variance::Invariant => {
-                self.subtyping(rcx, &ty1, &ty2)?;
-                self.subtyping(rcx, &ty2, &ty1)
-            }
-            Variance::Contravariant => self.subtyping(rcx, &ty2, &ty1),
-            Variance::Bivariant => Ok(()),
-        }
-    }
-
-    fn idx_eq(&mut self, rcx: &mut RefineCtxt, e1: &Expr, e2: &Expr) {
-        if e1 == e2 {
-            return;
-        }
-
-        match (e1.kind(), e2.kind()) {
-            (ExprKind::Aggregate(kind1, flds1), ExprKind::Aggregate(kind2, flds2)) => {
-                debug_assert_eq!(kind1, kind2);
-                for (e1, e2) in iter::zip(flds1, flds2) {
-                    self.idx_eq(rcx, e1, e2);
-                }
-            }
-            (_, ExprKind::Aggregate(kind2, flds2)) => {
-                for (f, e2) in flds2.iter().enumerate() {
-                    let e1 = e1.proj_and_reduce(kind2.to_proj(f as u32));
-                    self.idx_eq(rcx, &e1, e2);
-                }
-            }
-            (ExprKind::Aggregate(kind1, flds1), _) => {
-                self.infcx.unify_exprs(e1, e2);
-                for (f, e1) in flds1.iter().enumerate() {
-                    let e2 = e2.proj_and_reduce(kind1.to_proj(f as u32));
-                    self.idx_eq(rcx, e1, &e2);
-                }
-            }
-            (ExprKind::Abs(p1), ExprKind::Abs(p2)) => {
-                self.abs_eq(rcx, p1, p2);
-            }
-            (_, ExprKind::Abs(p)) => {
-                self.abs_eq(rcx, &e1.eta_expand_abs(&p.inputs(), p.output()), p);
-            }
-            (ExprKind::Abs(p), _) => {
-                self.infcx.unify_exprs(e1, e2);
-                self.abs_eq(rcx, p, &e2.eta_expand_abs(&p.inputs(), p.output()));
-            }
-            (ExprKind::KVar(_), _) | (_, ExprKind::KVar(_)) => {
-                rcx.check_impl(e1, e2, self.tag());
-                rcx.check_impl(e2, e1, self.tag());
-            }
-            _ => {
-                self.infcx.unify_exprs(e1, e2);
-                let span = e2.span();
-                self.check_pred(rcx, Expr::eq_at(e1, e2, span));
-            }
-        }
+        ty1: &Ty,
+        ty2: &Ty,
+    ) -> Result<Vec<rty::Clause>> {
+        let mut sub = Sub { infcx: self.infcx, reason: self.reason, obligations: vec![] };
+        sub.tys(rcx, ty1, ty2)?;
+        Ok(sub.obligations)
     }
 
     // FIXME(nilehmann) this is similar to `Checker::check_call`, but since is used from
@@ -540,17 +284,291 @@ impl<'a, 'b, 'genv, 'tcx> InferCtxtAt<'a, 'b, 'genv, 'tcx> {
 
         Ok(variant.ret().replace_evars(&evars_sol))
     }
+}
+
+/// Context to relate two types `a` and `b` via subtyping
+struct Sub<'a, 'b, 'genv, 'tcx> {
+    infcx: &'a mut InferCtxt<'b, 'genv, 'tcx>,
+    reason: ConstrReason,
+    /// FIXME(nilehmann) This is used to store coroutine obligations generated during subtyping when
+    /// relating an opaque type. Other obligations related to relating opaque types are resolved
+    /// directly here. The implementation is a really messy and we may be missing some obligations.
+    /// We should revisit at some point.
+    obligations: Vec<rty::Clause>,
+}
+
+impl<'a, 'b, 'genv, 'tcx> Sub<'a, 'b, 'genv, 'tcx> {
+    fn tag(&self) -> Tag {
+        Tag::new(self.reason, self.infcx.span)
+    }
+
+    fn tys(&mut self, rcx: &mut RefineCtxt, ty1: &Ty, ty2: &Ty) -> Result {
+        let rcx = &mut rcx.branch();
+
+        // We *fully* unpack the lhs before continuing to be able to prove goals like this
+        // ∃a. (i32[a], ∃b. {i32[b] | a > b})} <: ∃a,b. ({i32[a] | b < a}, i32[b])
+        // See S4.5 in https://arxiv.org/pdf/2209.13000v1.pdf
+        let ty1 = rcx.unpack(ty1);
+
+        match (ty1.kind(), ty2.kind()) {
+            (TyKind::Exists(..), _) => {
+                bug!("existentials should be removed by the unpack");
+            }
+            (TyKind::Constr(..), _) => {
+                bug!("constraint types should removed by the unpack");
+            }
+            (_, TyKind::Exists(ty2)) => {
+                self.infcx.push_scope(rcx);
+                let ty2 = ty2.replace_bound_refts_with(|sort, mode, _| {
+                    self.infcx.fresh_infer_var(sort, mode)
+                });
+                self.tys(rcx, &ty1, &ty2)?;
+                self.infcx.pop_scope();
+                Ok(())
+            }
+            (TyKind::Indexed(bty1, idx1), TyKind::Indexed(bty2, idx2)) => {
+                self.btys(rcx, bty1, bty2)?;
+                self.idxs_eq(rcx, idx1, idx2);
+                Ok(())
+            }
+            (TyKind::Ptr(pk1, path1), TyKind::Ptr(pk2, path2)) => {
+                debug_assert_eq!(pk1, pk2);
+                debug_assert_eq!(path1, path2);
+                Ok(())
+            }
+            (TyKind::Param(param_ty1), TyKind::Param(param_ty2)) => {
+                debug_assert_eq!(param_ty1, param_ty2);
+                Ok(())
+            }
+            (_, TyKind::Uninit) => Ok(()),
+            (_, TyKind::Constr(p2, ty2)) => {
+                rcx.check_pred(p2, self.tag());
+                self.tys(rcx, &ty1, ty2)
+            }
+            (TyKind::Downcast(.., fields1), TyKind::Downcast(.., fields2)) => {
+                debug_assert_eq!(fields1.len(), fields2.len());
+                for (field1, field2) in iter::zip(fields1, fields2) {
+                    self.tys(rcx, field1, field2)?;
+                }
+                Ok(())
+            }
+            (_, TyKind::Alias(rty::AliasKind::Opaque, alias_ty)) => {
+                if let TyKind::Alias(rty::AliasKind::Opaque, alias_ty1) = ty1.kind() {
+                    debug_assert_eq!(alias_ty1.refine_args.len(), alias_ty.refine_args.len());
+                    iter::zip(alias_ty1.refine_args.iter(), alias_ty.refine_args.iter())
+                        .for_each(|(e1, e2)| self.infcx.unify_exprs(e1, e2));
+                }
+
+                self.handle_opaque_type(rcx, &ty1, alias_ty)
+            }
+            (
+                TyKind::Alias(rty::AliasKind::Projection, alias_ty1),
+                TyKind::Alias(rty::AliasKind::Projection, alias_ty2),
+            ) => {
+                debug_assert_eq!(alias_ty1, alias_ty2);
+                Ok(())
+            }
+            _ => Err(QueryErr::bug(format!("incompatible types: `{ty1:?}` - `{ty2:?}`")))?,
+        }
+    }
+
+    fn btys(&mut self, rcx: &mut RefineCtxt, bty1: &BaseTy, bty2: &BaseTy) -> Result {
+        match (bty1, bty2) {
+            (BaseTy::Int(int_ty1), BaseTy::Int(int_ty2)) => {
+                debug_assert_eq!(int_ty1, int_ty2);
+                Ok(())
+            }
+            (BaseTy::Uint(uint_ty1), BaseTy::Uint(uint_ty2)) => {
+                debug_assert_eq!(uint_ty1, uint_ty2);
+                Ok(())
+            }
+            (BaseTy::Adt(adt1, args1), BaseTy::Adt(adt2, args2)) => {
+                debug_assert_eq!(adt1.did(), adt2.did());
+                debug_assert_eq!(args1.len(), args2.len());
+                let variances = self.infcx.genv.variances_of(adt1.did());
+                for (variance, ty1, ty2) in izip!(variances, args1.iter(), args2.iter()) {
+                    self.generic_args(rcx, *variance, ty1, ty2)?;
+                }
+                Ok(())
+            }
+            (BaseTy::Float(float_ty1), BaseTy::Float(float_ty2)) => {
+                debug_assert_eq!(float_ty1, float_ty2);
+                Ok(())
+            }
+
+            (BaseTy::Slice(ty1), BaseTy::Slice(ty2)) => self.tys(rcx, ty1, ty2),
+            (BaseTy::Ref(_, ty1, Mutability::Mut), BaseTy::Ref(_, ty2, Mutability::Mut)) => {
+                self.tys(rcx, ty1, ty2)?;
+                self.tys(rcx, ty2, ty1)
+            }
+            (BaseTy::Ref(_, ty1, Mutability::Not), BaseTy::Ref(_, ty2, Mutability::Not)) => {
+                self.tys(rcx, ty1, ty2)
+            }
+            (BaseTy::Tuple(tys1), BaseTy::Tuple(tys2)) => {
+                debug_assert_eq!(tys1.len(), tys2.len());
+                for (ty1, ty2) in iter::zip(tys1, tys2) {
+                    self.tys(rcx, ty1, ty2)?;
+                }
+                Ok(())
+            }
+            (BaseTy::Array(ty1, len1), BaseTy::Array(ty2, len2)) => {
+                debug_assert_eq!(len1, len2);
+                self.tys(rcx, ty1, ty2)
+            }
+            (BaseTy::Param(param1), BaseTy::Param(param2)) => {
+                debug_assert_eq!(param1, param2);
+                Ok(())
+            }
+            (BaseTy::Bool, BaseTy::Bool)
+            | (BaseTy::Str, BaseTy::Str)
+            | (BaseTy::Char, BaseTy::Char)
+            | (BaseTy::RawPtr(_, _), BaseTy::RawPtr(_, _)) => Ok(()),
+            (BaseTy::Dynamic(preds1, _), BaseTy::Dynamic(preds2, _)) => {
+                assert_eq!(preds1, preds2);
+                Ok(())
+            }
+            (BaseTy::Closure(did1, tys1), BaseTy::Closure(did2, tys2)) if did1 == did2 => {
+                debug_assert_eq!(tys1.len(), tys2.len());
+                for (ty1, ty2) in iter::zip(tys1, tys2) {
+                    self.tys(rcx, ty1, ty2)?;
+                }
+                Ok(())
+            }
+            _ => Err(QueryErr::bug(format!("incompatible base types: `{bty1:?}` - `{bty2:?}`")))?,
+        }
+    }
+
+    fn generic_args(
+        &mut self,
+        rcx: &mut RefineCtxt,
+        variance: Variance,
+        arg1: &GenericArg,
+        arg2: &GenericArg,
+    ) -> Result {
+        let (ty1, ty2) = match (arg1, arg2) {
+            (GenericArg::Ty(ty1), GenericArg::Ty(ty2)) => (ty1.clone(), ty2.clone()),
+            (GenericArg::Base(ctor1), GenericArg::Base(ctor2)) => {
+                debug_assert_eq!(ctor1.sort(), ctor2.sort());
+                (ctor1.to_ty(), ctor2.to_ty())
+            }
+            (GenericArg::Lifetime(_), GenericArg::Lifetime(_)) => return Ok(()),
+            (GenericArg::Const(c1), GenericArg::Const(c2)) => {
+                debug_assert_eq!(c1, c2);
+                return Ok(());
+            }
+            _ => {
+                let note = format!("incompatible generic args: `{arg1:?}` `{arg2:?}`");
+                return Err(QueryErr::bug(note).into());
+            }
+        };
+        match variance {
+            Variance::Covariant => self.tys(rcx, &ty1, &ty2),
+            Variance::Invariant => {
+                self.tys(rcx, &ty1, &ty2)?;
+                self.tys(rcx, &ty2, &ty1)
+            }
+            Variance::Contravariant => self.tys(rcx, &ty2, &ty1),
+            Variance::Bivariant => Ok(()),
+        }
+    }
+
+    fn idxs_eq(&mut self, rcx: &mut RefineCtxt, e1: &Expr, e2: &Expr) {
+        if e1 == e2 {
+            return;
+        }
+
+        match (e1.kind(), e2.kind()) {
+            (ExprKind::Aggregate(kind1, flds1), ExprKind::Aggregate(kind2, flds2)) => {
+                debug_assert_eq!(kind1, kind2);
+                for (e1, e2) in iter::zip(flds1, flds2) {
+                    self.idxs_eq(rcx, e1, e2);
+                }
+            }
+            (_, ExprKind::Aggregate(kind2, flds2)) => {
+                for (f, e2) in flds2.iter().enumerate() {
+                    let e1 = e1.proj_and_reduce(kind2.to_proj(f as u32));
+                    self.idxs_eq(rcx, &e1, e2);
+                }
+            }
+            (ExprKind::Aggregate(kind1, flds1), _) => {
+                self.infcx.unify_exprs(e1, e2);
+                for (f, e1) in flds1.iter().enumerate() {
+                    let e2 = e2.proj_and_reduce(kind1.to_proj(f as u32));
+                    self.idxs_eq(rcx, e1, &e2);
+                }
+            }
+            (ExprKind::Abs(p1), ExprKind::Abs(p2)) => {
+                self.abs_eq(rcx, p1, p2);
+            }
+            (_, ExprKind::Abs(p)) => {
+                self.abs_eq(rcx, &e1.eta_expand_abs(&p.inputs(), p.output()), p);
+            }
+            (ExprKind::Abs(p), _) => {
+                self.infcx.unify_exprs(e1, e2);
+                self.abs_eq(rcx, p, &e2.eta_expand_abs(&p.inputs(), p.output()));
+            }
+            (ExprKind::KVar(_), _) | (_, ExprKind::KVar(_)) => {
+                rcx.check_impl(e1, e2, self.tag());
+                rcx.check_impl(e2, e1, self.tag());
+            }
+            _ => {
+                self.infcx.unify_exprs(e1, e2);
+                let span = e2.span();
+                rcx.check_pred(Expr::eq_at(e1, e2, span), self.tag());
+            }
+        }
+    }
 
     fn abs_eq(&mut self, rcx: &mut RefineCtxt, f1: &Lambda, f2: &Lambda) {
         debug_assert_eq!(f1.inputs(), f2.inputs());
         let vars = f1.inputs().iter().map(|s| rcx.define_vars(s)).collect_vec();
         let e1 = f1.apply(&vars);
         let e2 = f2.apply(&vars);
-        self.idx_eq(rcx, &e1, &e2);
+        self.idxs_eq(rcx, &e1, &e2);
+    }
+
+    fn handle_opaque_type(&mut self, rcx: &mut RefineCtxt, ty: &Ty, alias_ty: &AliasTy) -> Result {
+        if let Some(BaseTy::Coroutine(def_id, resume_ty, upvar_tys)) =
+            ty.as_bty_skipping_existentials()
+        {
+            let obligs = mk_coroutine_obligations(
+                self.infcx.genv,
+                def_id,
+                resume_ty,
+                upvar_tys,
+                &alias_ty.def_id,
+            )?;
+            self.obligations.extend(obligs);
+        } else {
+            let bounds = self
+                .infcx
+                .genv
+                .item_bounds(alias_ty.def_id)?
+                .instantiate_identity(self.infcx.refparams);
+            for clause in &bounds {
+                if let rty::ClauseKind::Projection(pred) = clause.kind() {
+                    let ty1 = self.project_bty(ty, pred.projection_ty.def_id)?;
+                    let ty2 = pred.term;
+                    self.tys(rcx, &ty1, &ty2)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn project_bty(&mut self, self_ty: &Ty, def_id: DefId) -> Result<Ty> {
+        let args = List::singleton(GenericArg::Ty(self_ty.clone()));
+        let alias_ty = rty::AliasTy::new(def_id, args, List::empty());
+        Ok(Ty::projection(alias_ty).normalize_projections(
+            self.infcx.genv,
+            self.infcx.region_infcx,
+            self.infcx.def_id,
+            self.infcx.refparams,
+        )?)
     }
 }
 
-fn mk_generator_obligations(
+fn mk_coroutine_obligations(
     genv: GlobalEnv,
     generator_did: &DefId,
     resume_ty: &Ty,


### PR DESCRIPTION
Such that we can remove `obligations` from `InferCtxt`. In preparation for having a unique `InferCtxt` per function