### PR TITLE
Simplify serialization of fixpoint constraint

### DIFF
--- a/crates/flux-fixpoint/src/constraint.rs
+++ b/crates/flux-fixpoint/src/constraint.rs
@@ -347,55 +347,40 @@ impl<T: Types> Expr<T> {
     }
 }
 
-struct FmtParens<'a, T: Types>(&'a Expr<T>);
-
-impl<T: Types> fmt::Display for FmtParens<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Avoid some obvious unnecesary parentheses
-        let should_parenthesize =
-            !matches!(&self.0, Expr::Var(_) | Expr::Constant(_) | Expr::App(..));
-        if should_parenthesize {
-            write!(f, "({})", self.0)
-        } else {
-            write!(f, "{}", self.0)
-        }
-    }
-}
-
 impl<T: Types> fmt::Display for Expr<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Expr::Constant(c) => write!(f, "{c}"),
             Expr::Var(x) => write!(f, "{x}"),
             Expr::App(func, args) => {
-                write!(f, "({func} {})", args.iter().map(FmtParens).format(" "),)
+                write!(f, "({func} {})", args.iter().format(" "))
             }
             Expr::Neg(e) => {
-                write!(f, "(- {})", FmtParens(e))
+                write!(f, "(- {e})")
             }
             Expr::BinaryOp(op, box [e1, e2]) => {
-                write!(f, "({op} {} {})", FmtParens(e1), FmtParens(e2))
+                write!(f, "({op} {e1} {e2})")
             }
             Expr::IfThenElse(box [p, e1, e2]) => {
-                write!(f, "(if {} {} {})", FmtParens(p), FmtParens(e1), FmtParens(e2))
+                write!(f, "(if {p} {e1} {e2})")
             }
             Expr::And(exprs) => {
-                write!(f, "(and {})", exprs.iter().map(FmtParens).format(" "))
+                write!(f, "(and {})", exprs.iter().format(" "))
             }
             Expr::Or(exprs) => {
-                write!(f, "(or {})", exprs.iter().map(FmtParens).format(" "))
+                write!(f, "(or {})", exprs.iter().format(" "))
             }
             Expr::Not(e) => {
-                write!(f, "(not {})", FmtParens(e))
+                write!(f, "(not {e})")
             }
             Expr::Imp(box [e1, e2]) => {
-                write!(f, "(=> {} {})", FmtParens(e1), FmtParens(e2))
+                write!(f, "(=> {e1} {e2})")
             }
             Expr::Iff(box [e1, e2]) => {
-                write!(f, "(<=> {} {})", FmtParens(e1), FmtParens(e2))
+                write!(f, "(<=> {e1} {e2})")
             }
             Expr::Atom(rel, box [e1, e2]) => {
-                write!(f, "({rel} {} {})", FmtParens(e1), FmtParens(e2))
+                write!(f, "({rel} {e1} {e2})")
             }
         }
     }

--- a/crates/flux-fixpoint/src/lib.rs
+++ b/crates/flux-fixpoint/src/lib.rs
@@ -232,7 +232,7 @@ impl<T: Types> fmt::Display for Task<T> {
 
 impl<T: Types> fmt::Display for KVar<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(var ${} ({})) ;; {}", self.kvid, self.sorts.iter().join(" "), self.comment)
+        write!(f, "(var ${} ({})) ;; {}", self.kvid, self.sorts.iter().format(" "), self.comment)
     }
 }
 

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -110,6 +110,7 @@ pub mod fixpoint {
 
     use rustc_index::newtype_index;
     use rustc_middle::ty::ParamConst;
+    use rustc_span::Symbol;
     newtype_index! {
         pub struct KVid {}
     }
@@ -189,7 +190,6 @@ pub mod fixpoint {
         type Tag = super::TagIdx;
     }
     pub use fixpoint_generated::*;
-    use rustc_span::Symbol;
 }
 
 type ConstMap<'tcx> = FxIndexMap<Key<'tcx>, ConstInfo>;


### PR DESCRIPTION
We were adding a bunch of unnecessary parentheses