### PR TITLE
Use current scope in `InferCtxt` to generate kvars

### DIFF
--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -265,7 +265,7 @@ enum Key<'tcx> {
 pub struct FixpointCtxt<'genv, 'tcx, T: Eq + Hash> {
     comments: Vec<String>,
     genv: GlobalEnv<'genv, 'tcx>,
-    kvars: KVarStore,
+    kvars: KVarGen,
     scx: SortEncodingCtxt,
     kcx: KVarEncodingCtxt,
     ecx: ExprEncodingCtxt<'genv, 'tcx>,
@@ -280,7 +280,7 @@ impl<'genv, 'tcx, Tag> FixpointCtxt<'genv, 'tcx, Tag>
 where
     Tag: std::hash::Hash + Eq + Copy,
 {
-    pub fn new(genv: GlobalEnv<'genv, 'tcx>, def_id: LocalDefId, kvars: KVarStore) -> Self {
+    pub fn new(genv: GlobalEnv<'genv, 'tcx>, def_id: LocalDefId, kvars: KVarGen) -> Self {
         let def_span = genv.tcx().def_span(def_id);
         Self {
             comments: vec![],
@@ -722,12 +722,12 @@ impl FixpointKVar {
 }
 
 #[derive(Default)]
-pub struct KVarStore {
+pub struct KVarGen {
     kvars: IndexVec<rty::KVid, KVarDecl>,
     dummy: bool,
 }
 
-impl KVarStore {
+impl KVarGen {
     pub fn new() -> Self {
         Self { kvars: IndexVec::new(), dummy: false }
     }

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -724,6 +724,10 @@ impl FixpointKVar {
 #[derive(Default)]
 pub struct KVarGen {
     kvars: IndexVec<rty::KVid, KVarDecl>,
+    /// If true generate dummy [holes] instead of kvars. Used during shape mode to avoid generating
+    /// unnecessary kvars.
+    ///
+    /// [holes]: rty::ExprKind::Hole
     dummy: bool,
 }
 
@@ -747,8 +751,11 @@ impl KVarGen {
     /// Note that the returned expression will have escaping variables and it is up to the caller to
     /// put it under an appropriate number of binders.
     ///
+    /// Prefer using [`InferCtxt::fresh_kvar`] when possible.
+    ///
     /// [binders]: rty::Binder
     /// [kvar]: rty::KVar
+    /// [`InferCtxt::fresh_kvar`]: crate::infer::InferCtxt::fresh_kvar
     pub fn fresh(
         &mut self,
         binders: &[List<rty::Sort>],

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -433,6 +433,8 @@ where
 
     /// Encodes an expression in head position as a [`fixpoint::Constraint`] "peeling out"
     /// implications and foralls.
+    ///
+    /// [`fixpoint::Constraint`]: flux_fixpoint::Constraint
     pub(crate) fn head_to_fixpoint(
         &mut self,
         expr: &rty::Expr,
@@ -722,11 +724,16 @@ impl FixpointKVar {
 #[derive(Default)]
 pub struct KVarStore {
     kvars: IndexVec<rty::KVid, KVarDecl>,
+    dummy: bool,
 }
 
 impl KVarStore {
     pub fn new() -> Self {
-        Self { kvars: IndexVec::new() }
+        Self { kvars: IndexVec::new(), dummy: false }
+    }
+
+    pub fn dummy() -> Self {
+        Self { kvars: IndexVec::new(), dummy: true }
     }
 
     fn get(&self, kvid: rty::KVid) -> &KVarDecl {
@@ -748,6 +755,10 @@ impl KVarStore {
         scope: impl IntoIterator<Item = (rty::Var, rty::Sort)>,
         encoding: KVarEncoding,
     ) -> rty::Expr {
+        if self.dummy {
+            return rty::Expr::hole(rty::HoleKind::Pred);
+        }
+
         if binders.is_empty() {
             return self.fresh_inner(0, [], encoding);
         }

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -141,6 +141,7 @@ impl<'a, 'genv, 'tcx> InferCtxt<'a, 'genv, 'tcx> {
         }
     }
 
+    /// Generate a fresh kvar in the current scope. See [`KVarGen::fresh`].
     pub fn fresh_kvar(&self, sorts: &[List<Sort>], encoding: KVarEncoding) -> Expr {
         let evar_gen = self.evar_gen.borrow();
         self.kvar_gen

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -21,22 +21,18 @@ use rustc_middle::ty::{BoundRegionKind, Variance};
 use rustc_span::Span;
 
 use crate::{
-    fixpoint_encoding::KVarEncoding,
+    fixpoint_encoding::{KVarEncoding, KVarGen},
     refine_tree::{RefineCtxt, Scope},
 };
 
 pub type InferResult<T = ()> = std::result::Result<T, InferErr>;
-
-pub trait KVarGen {
-    fn fresh(&self, binders: &[List<Sort>], kind: KVarEncoding) -> Expr;
-}
 
 pub struct InferCtxt<'a, 'genv, 'tcx> {
     pub genv: GlobalEnv<'genv, 'tcx>,
     pub region_infcx: &'a rustc_infer::infer::InferCtxt<'tcx>,
     pub def_id: DefId,
     pub refparams: &'a [Expr],
-    kvar_gen: Box<(dyn KVarGen + 'a)>,
+    kvar_gen: &'a RefCell<KVarGen>,
     evar_gen: RefCell<EVarGen<Scope>>,
     /// The span at which this inference context was created in `Checker`
     span: Span,
@@ -79,7 +75,7 @@ impl<'a, 'genv, 'tcx> InferCtxt<'a, 'genv, 'tcx> {
         region_infcx: &'a rustc_infer::infer::InferCtxt<'tcx>,
         def_id: DefId,
         refparams: &'a [Expr],
-        kvar_gen: impl KVarGen + 'a,
+        kvar_gen: &'a RefCell<KVarGen>,
         span: Span,
     ) -> Self {
         Self {
@@ -87,7 +83,7 @@ impl<'a, 'genv, 'tcx> InferCtxt<'a, 'genv, 'tcx> {
             region_infcx,
             def_id,
             refparams,
-            kvar_gen: Box::new(kvar_gen),
+            kvar_gen,
             evar_gen: RefCell::new(EVarGen::default()),
             span,
         }
@@ -146,7 +142,10 @@ impl<'a, 'genv, 'tcx> InferCtxt<'a, 'genv, 'tcx> {
     }
 
     pub fn fresh_kvar(&self, sorts: &[List<Sort>], encoding: KVarEncoding) -> Expr {
-        self.kvar_gen.fresh(sorts, encoding)
+        let evar_gen = self.evar_gen.borrow();
+        self.kvar_gen
+            .borrow_mut()
+            .fresh(sorts, evar_gen.current_data().iter(), encoding)
     }
 
     fn fresh_evars(&self, sort: &Sort) -> Expr {
@@ -594,15 +593,6 @@ impl From<UnsolvedEvar> for InferErr {
 impl From<QueryErr> for InferErr {
     fn from(v: QueryErr) -> Self {
         Self::Query(v)
-    }
-}
-
-impl<F> KVarGen for F
-where
-    F: Fn(&[List<Sort>], KVarEncoding) -> Expr,
-{
-    fn fresh(&self, binders: &[List<Sort>], kind: KVarEncoding) -> Expr {
-        (self)(binders, kind)
     }
 }
 

--- a/crates/flux-middle/src/rty/evars.rs
+++ b/crates/flux-middle/src/rty/evars.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
 
-use flux_common::index::IndexVec;
+use flux_common::{bug, index::IndexVec};
 use itertools::Itertools;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_hash::FxHashMap;
@@ -127,6 +127,15 @@ impl<T> EVarGen<T> {
             .get(&cxid)
             .or_else(|| self.pending.get(&cxid))
             .unwrap()
+            .data
+    }
+
+    pub fn current_data(&self) -> &T {
+        &self
+            .stack
+            .last()
+            .unwrap_or_else(|| bug!("no context"))
+            .1
             .data
     }
 

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -175,6 +175,8 @@ impl<'ck, 'genv, 'tcx> Checker<'ck, 'genv, 'tcx, ShapeMode> {
             let const_params = generics.const_params(genv).with_span(span)?;
             let mut refine_tree = RefineTree::new(const_params);
             let mut rcx = refine_tree.refine_ctxt_at_root();
+
+            // In shape mode we don't care about kvars
             let kvars = RefCell::new(KVarGen::dummy());
             let inherited =
                 Inherited::new(genv, &mut rcx, def_id, &mut mode, &kvars, ghost_stmts, config)?;

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -2,7 +2,7 @@ use flux_common::{cache::QueryCache, dbg, iter::IterExt, result::ResultExt};
 use flux_config as config;
 use flux_errors::ErrorGuaranteed;
 use flux_infer::{
-    fixpoint_encoding::{FixpointCtxt, KVarStore},
+    fixpoint_encoding::{FixpointCtxt, KVarGen},
     infer::{ConstrReason, Tag},
     refine_tree::RefineTree,
 };
@@ -60,7 +60,7 @@ fn check_invariant(
         let pred = invariant.apply(&variant.idx);
         rcx.check_pred(&pred, Tag::new(ConstrReason::Other, DUMMY_SP));
     }
-    let mut fcx = FixpointCtxt::new(genv, def_id, KVarStore::default());
+    let mut fcx = FixpointCtxt::new(genv, def_id, KVarGen::default());
     if config::dump_constraint() {
         dbg::dump_item_info(genv.tcx(), def_id, "fluxc", &refine_tree).unwrap();
     }

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -4,7 +4,7 @@ use std::{iter, ops::ControlFlow};
 
 use flux_common::{bug, dbg::debug_assert_eq3, tracked_span_bug};
 use flux_infer::{
-    fixpoint_encoding::{KVarEncoding, KVarStore},
+    fixpoint_encoding::{KVarEncoding, KVarGen},
     infer::{ConstrReason, InferCtxt},
     refine_tree::{RefineCtxt, Scope},
 };
@@ -618,7 +618,7 @@ impl BasicBlockEnvShape {
         }
     }
 
-    pub fn into_bb_env(self, kvar_store: &mut KVarStore) -> BasicBlockEnv {
+    pub fn into_bb_env(self, kvar_gen: &mut KVarGen) -> BasicBlockEnv {
         let mut bindings = self.bindings;
 
         let mut hoister = Hoister::default()
@@ -636,7 +636,7 @@ impl BasicBlockEnvShape {
 
         let outter_sorts = vars.to_sort_list();
 
-        let kvar = kvar_store.fresh(&[outter_sorts.clone()], self.scope.iter(), KVarEncoding::Conj);
+        let kvar = kvar_gen.fresh(&[outter_sorts.clone()], self.scope.iter(), KVarEncoding::Conj);
         constrs.push(kvar);
 
         // Replace remaning holes by fresh kvars
@@ -645,7 +645,7 @@ impl BasicBlockEnvShape {
             let sorts = std::iter::once(outter_sorts.clone())
                 .chain(sorts.iter().cloned())
                 .collect_vec();
-            kvar_store.fresh(&sorts, self.scope.iter(), KVarEncoding::Conj)
+            kvar_gen.fresh(&sorts, self.scope.iter(), KVarEncoding::Conj)
         };
         bindings.fmap_mut(|binding| binding.replace_holes(&mut kvar_gen));
 


### PR DESCRIPTION
Also, add a `dummy` configuration boolean to `KVarStore` (renamed to `KVarGen`) so we can use it directly instead of using `Box<dyn KVarGen>`