### PR TITLE
Put early refinements in root of `RefineTree`

### DIFF
--- a/crates/flux-fhir-analysis/src/compare_impl_item.rs
+++ b/crates/flux-fhir-analysis/src/compare_impl_item.rs
@@ -66,7 +66,7 @@ fn check_assoc_reft(genv: GlobalEnv, impl_id: LocalDefId, trait_id: DefId, name:
         .impl_trait_ref(impl_id.to_def_id())
         .emit(&genv)?
         .unwrap()
-        .instantiate_identity(&[]);
+        .instantiate_identity();
 
     let Some(impl_sort) = genv.sort_of_assoc_reft(impl_id, name).emit(genv.sess())? else {
         return Err(genv.sess().emit_err(errors::InvalidAssocReft::new(
@@ -76,7 +76,7 @@ fn check_assoc_reft(genv: GlobalEnv, impl_id: LocalDefId, trait_id: DefId, name:
         )));
     };
 
-    let impl_sort = impl_sort.instantiate_identity(&[]);
+    let impl_sort = impl_sort.instantiate_identity();
 
     let Some(trait_sort) = genv.sort_of_assoc_reft(trait_id, name).emit(genv.sess())? else {
         return Err(genv.sess().emit_err(errors::InvalidAssocReft::new(

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1206,7 +1206,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             }
             fhir::Res::SelfTyParam { .. } => rty::BaseTy::Param(rty::SELF_PARAM_TY),
             fhir::Res::SelfTyAlias { alias_to, .. } => {
-                return Ok(self.genv.type_of(*alias_to)?.instantiate_identity(&[]));
+                return Ok(self.genv.type_of(*alias_to)?.instantiate_identity());
             }
             fhir::Res::Def(DefKind::TyAlias { .. }, def_id) => {
                 let generics = self.conv_generic_args(env, *def_id, path.last_segment())?;

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -266,7 +266,7 @@ pub(crate) fn conv_refinement_generics(
         .map(|param| {
             let sort = resolve_param_sort(genv, param, wfckresults)?;
             let mode = rty::InferMode::from_param_kind(param.kind);
-            Ok(rty::RefineParam { sort, mode })
+            Ok(rty::RefineParam { sort, name: param.name, mode })
         })
         .try_collect()
 }

--- a/crates/flux-fixpoint/src/constraint.rs
+++ b/crates/flux-fixpoint/src/constraint.rs
@@ -118,7 +118,7 @@ impl BinRel {
 pub enum Expr<T: Types> {
     Constant(Constant),
     Var(T::Var),
-    App(T::Var, Vec<Self>),
+    App(Box<Self>, Vec<Self>),
     Neg(Box<Self>),
     BinaryOp(BinOp, Box<[Self; 2]>),
     IfThenElse(Box<[Self; 3]>),

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -110,7 +110,7 @@ pub mod fixpoint {
                     write!(f, "constgen${}${}", param.name, param.index)
                 }
                 Var::Param(param) => {
-                    write!(f, "reftparam${}", param.index)
+                    write!(f, "reftgen${}${}", param.name, param.index)
                 }
             }
         }

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -107,10 +107,10 @@ pub mod fixpoint {
                 Var::UIFRel(BinRel::Ne) => write!(f, "ne"),
                 Var::Underscore => write!(f, "_$"), // To avoid clashing with `_` used for `app (_ bv_op n)` for parametric SMT ops
                 Var::ConstGeneric(param) => {
-                    write!(f, "constgen{}#{}", param.name, param.index)
+                    write!(f, "constgen${}${}", param.name, param.index)
                 }
                 Var::Param(param) => {
-                    write!(f, "reftgen{}#{}", param.name, param.index)
+                    write!(f, "reftparam${}", param.index)
                 }
             }
         }
@@ -933,7 +933,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                     .genv
                     .sort_of_assoc_reft(alias_pred.trait_id, alias_pred.name)?
                     .unwrap();
-                let sort = sort.instantiate_identity(&[]);
+                let sort = sort.instantiate_identity();
                 let func = self.register_const_for_alias_reft(alias_pred, sort, scx);
                 let args = args
                     .iter()

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -1149,7 +1149,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
             }
             rty::ExprKind::FieldProj(e, proj) => {
                 let proj = fixpoint::Expr::Var(self.proj_to_fixpoint(*proj, scx)?);
-                Ok(fixpoint::Expr::App(Box::new(proj), vec![self.expr_to_fixpoint(e, scx)?]))
+                Ok(fixpoint::Expr::App(Box::new(proj), vec![self.func_to_fixpoint(e, scx)?]))
             }
             rty::ExprKind::GlobalFunc(sym, SpecFuncKind::Def) => {
                 span_bug!(self.def_span, "unexpected global function `{sym}`. Function must be normalized away at this point")

--- a/crates/flux-infer/src/refine_tree.rs
+++ b/crates/flux-infer/src/refine_tree.rs
@@ -539,6 +539,9 @@ impl Node {
                 };
                 let mut constr = children;
                 for (var, sort) in params {
+                    if sort.is_loc() {
+                        continue;
+                    }
                     constr = fixpoint::Constraint::ForAll(
                         fixpoint::Bind {
                             name: cx.var_to_fixpoint(var),

--- a/crates/flux-infer/src/refine_tree.rs
+++ b/crates/flux-infer/src/refine_tree.rs
@@ -20,7 +20,6 @@ use flux_middle::{
 };
 use itertools::Itertools;
 use rustc_hir::def_id::LocalDefId;
-use rustc_span::Symbol;
 
 use crate::{
     fixpoint_encoding::{fixpoint, FixpointCtxt},
@@ -184,6 +183,7 @@ impl WeakNodePtr {
 }
 
 enum NodeKind {
+    /// List of const and refinement generics
     Root(List<(Var, Sort)>),
     /// Used for debugging. See [`TypeTrace`]
     Trace(TypeTrace),
@@ -205,10 +205,7 @@ impl RefineTree {
                 .map(|(pcst, sort)| Ok((Var::ConstGeneric(pcst), sort))),
             (0..reft_generics.count()).map(|i| {
                 let param = reft_generics.param_at(i, genv)?;
-                let var = Var::EarlyParam(EarlyReftParam {
-                    index: i as u32,
-                    name: Symbol::intern("hola"),
-                });
+                let var = Var::EarlyParam(EarlyReftParam { index: i as u32, name: param.name });
                 Ok((var, param.sort))
             }),
         )

--- a/crates/flux-infer/src/refine_tree.rs
+++ b/crates/flux-infer/src/refine_tree.rs
@@ -535,7 +535,7 @@ impl Node {
                     return Ok(None);
                 };
                 let mut constr = children;
-                for (var, sort) in params {
+                for (var, sort) in params.iter().rev() {
                     if sort.is_loc() {
                         continue;
                     }

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -242,10 +242,8 @@ pub trait TypeFoldable: TypeVisitable {
         genv: GlobalEnv<'_, 'tcx>,
         infcx: &rustc_infer::infer::InferCtxt<'tcx>,
         callsite_def_id: DefId,
-        refine_params: &[Expr],
     ) -> QueryResult<Self> {
-        let mut normalizer =
-            projections::Normalizer::new(genv, infcx, callsite_def_id, refine_params)?;
+        let mut normalizer = projections::Normalizer::new(genv, infcx, callsite_def_id)?;
         self.try_fold_with(&mut normalizer)
     }
 

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -190,6 +190,7 @@ pub struct RefinementGenerics {
 #[derive(PartialEq, Eq, Debug, Clone, Hash, TyEncodable, TyDecodable)]
 pub struct RefineParam {
     pub sort: Sort,
+    pub name: Symbol,
     pub mode: InferMode,
 }
 

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -17,8 +17,8 @@ use std::{borrow::Cow, cmp::Ordering, hash::Hash, iter, slice, sync::LazyLock};
 
 pub use evars::{EVar, EVarGen};
 pub use expr::{
-    AggregateKind, AliasReft, BinOp, BoundReft, Constant, ESpan, Expr, ExprKind, FieldProj,
-    HoleKind, KVar, KVid, Lambda, Loc, Name, Path, UnOp, Var,
+    AggregateKind, AliasReft, BinOp, BoundReft, Constant, ESpan, EarlyReftParam, Expr, ExprKind,
+    FieldProj, HoleKind, KVar, KVid, Lambda, Loc, Name, Path, UnOp, Var,
 };
 use flux_common::bug;
 use itertools::Itertools;
@@ -163,7 +163,7 @@ impl Generics {
         }
     }
 
-    pub fn const_params(&self, genv: GlobalEnv) -> QueryResult<List<(ParamConst, Sort)>> {
+    pub fn const_params(&self, genv: GlobalEnv) -> QueryResult<Vec<(ParamConst, Sort)>> {
         // FIXME(nilehmann) this shouldn't use the methods in `flux_middle::sort_of` to get the sort
         let mut res = vec![];
         for i in 0..self.count() {
@@ -176,7 +176,7 @@ impl Generics {
                 res.push((param_const, sort));
             }
         }
-        Ok(List::from_vec(res))
+        Ok(res)
     }
 }
 
@@ -2284,7 +2284,7 @@ impl_slice_internable!(
     RefineParam,
     AssocRefinement,
     SortParamKind,
-    (ParamConst, Sort)
+    (Var, Sort)
 );
 
 #[macro_export]

--- a/crates/flux-middle/src/rty/projections.rs
+++ b/crates/flux-middle/src/rty/projections.rs
@@ -18,6 +18,7 @@ use super::{
 };
 use crate::{
     global_env::GlobalEnv,
+    intern::List,
     queries::{QueryErr, QueryResult},
     rty::fold::TypeVisitable,
     rustc::lowering::lower_ty,
@@ -27,7 +28,7 @@ pub(crate) struct Normalizer<'genv, 'tcx, 'cx> {
     genv: GlobalEnv<'genv, 'tcx>,
     selcx: SelectionContext<'cx, 'tcx>,
     def_id: DefId,
-    param_env: Vec<Clause>,
+    param_env: List<Clause>,
 }
 
 impl<'genv, 'tcx, 'cx> Normalizer<'genv, 'tcx, 'cx> {
@@ -35,11 +36,12 @@ impl<'genv, 'tcx, 'cx> Normalizer<'genv, 'tcx, 'cx> {
         genv: GlobalEnv<'genv, 'tcx>,
         infcx: &'cx InferCtxt<'tcx>,
         callsite_def_id: DefId,
-        refine_params: &[Expr],
     ) -> QueryResult<Self> {
         let param_env = genv
             .predicates_of(callsite_def_id)?
-            .instantiate_identity(genv, refine_params)?;
+            .instantiate_identity()
+            .predicates
+            .clone();
         let selcx = SelectionContext::new(infcx);
         Ok(Normalizer { genv, selcx, def_id: callsite_def_id, param_env })
     }

--- a/crates/flux-middle/src/rty/subst.rs
+++ b/crates/flux-middle/src/rty/subst.rs
@@ -321,42 +321,6 @@ pub trait GenericsSubstDelegate {
     fn const_for_param(&mut self, param: &Const) -> Const;
 }
 
-/// The identity substitution used when checking the body of a (polymorphic) function. For example,
-/// consider the function `fn foo<T>(){ .. }`
-///
-/// Outside of `foo`, `T` is bound (represented by the presence of `EarlyBinder`). Inside of the body
-/// of `foo`, we treat `T` as a placeholder.
-pub(crate) struct IdentitySubstDelegate;
-
-impl GenericsSubstDelegate for IdentitySubstDelegate {
-    fn sort_for_param(&mut self, param_ty: ParamTy) -> Result<Sort, !> {
-        Ok(Sort::Param(param_ty))
-    }
-
-    fn ty_for_param(&mut self, param_ty: ParamTy) -> Ty {
-        Ty::param(param_ty)
-    }
-
-    fn ctor_for_param(&mut self, param_ty: ParamTy) -> SubsetTyCtor {
-        Binder::with_sort(
-            SubsetTy::trivial(BaseTy::Param(param_ty), Expr::nu()),
-            Sort::Param(param_ty),
-        )
-    }
-
-    fn region_for_param(&mut self, ebr: EarlyParamRegion) -> Region {
-        ReEarlyParam(ebr)
-    }
-
-    fn const_for_param(&mut self, param: &Const) -> Const {
-        param.clone()
-    }
-
-    fn expr_for_param_const(&self, param_const: ParamConst) -> Expr {
-        Expr::var(Var::ConstGeneric(param_const), None)
-    }
-}
-
 /// A substitution with an explicit list of generic arguments.
 pub(crate) struct GenericArgsDelegate<'a, 'tcx>(
     pub(crate) &'a [GenericArg],

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -558,7 +558,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 |br| infcx.next_bound_region_var(span, br.kind, BoundRegionConversionTime::FnCall),
                 |sort, mode| infcx.fresh_infer_var(sort, mode),
             )
-            .normalize_projections(genv, infcx.region_infcx, infcx.def_id, infcx.refparams)
+            .normalize_projections(genv, infcx.region_infcx, infcx.def_id)
             .with_span(span)?;
 
         let mut at = infcx.at(span);
@@ -1356,9 +1356,11 @@ fn instantiate_and_normalize_fn_sig(
     infcx: &InferCtxt,
     fn_sig: EarlyBinder<PolyFnSig>,
 ) -> QueryResult<PolyFnSig> {
-    fn_sig
-        .instantiate_identity(infcx.refparams)
-        .normalize_projections(infcx.genv, infcx.region_infcx, infcx.def_id, infcx.refparams)
+    fn_sig.instantiate_identity().normalize_projections(
+        infcx.genv,
+        infcx.region_infcx,
+        infcx.def_id,
+    )
 }
 
 fn init_env<'a>(

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -39,9 +39,7 @@ fn check_invariant(
     invariant: &rty::Invariant,
     checker_config: CheckerConfig,
 ) -> Result<(), ErrorGuaranteed> {
-    let generics = genv.generics_of(def_id).emit(&genv)?;
-    let const_params = generics.const_params(genv).emit(&genv)?;
-    let mut refine_tree = RefineTree::new(const_params);
+    let mut refine_tree = RefineTree::new(genv, def_id).emit(&genv)?;
 
     for variant_idx in adt_def.variants().indices() {
         let mut rcx = refine_tree.refine_ctxt_at_root();

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -48,7 +48,7 @@ fn check_invariant(
             .variant_sig(adt_def.did(), variant_idx)
             .emit(&genv)?
             .expect("cannot check opaque structs")
-            .instantiate_identity(&[])
+            .instantiate_identity()
             .replace_bound_refts_with(|sort, _, _| rcx.define_vars(sort));
 
         for ty in variant.fields() {

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -806,7 +806,7 @@ fn downcast_struct(
     Ok(struct_variant(infcx.genv, adt.did())?
         .instantiate(tcx, args, &[])
         .replace_bound_refts(&flds)
-        .normalize_projections(infcx.genv, infcx.region_infcx, infcx.def_id, infcx.refparams)?
+        .normalize_projections(infcx.genv, infcx.region_infcx, infcx.def_id)?
         .fields
         .to_vec())
 }
@@ -842,7 +842,7 @@ fn downcast_enum(
         .expect("enums cannot be opaque")
         .instantiate(tcx, args, &[])
         .replace_bound_refts_with(|sort, _, _| infcx.define_vars(sort))
-        .normalize_projections(infcx.genv, infcx.region_infcx, infcx.def_id, infcx.refparams)?;
+        .normalize_projections(infcx.genv, infcx.region_infcx, infcx.def_id)?;
 
     // FIXME(nilehmann) We could assert idx1 == variant_def.idx directly, but for aggregate sorts there
     // are currently two problems.


### PR DESCRIPTION
* Encode early params in fixpoint
* Put early params in the root node of `RefineTree`
* Remove `reftparams` from `InferCtxt