### PR TITLE
Basic support for function pointers

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -568,7 +568,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
             };
             // Fix up the span in asyncness
             if let surface::Async::Yes { span, .. } = fn_sig.asyncness {
-                header.asyncness = hir::IsAsync::Async(span)
+                header.asyncness = hir::IsAsync::Async(span);
             }
             (generics, decl)
         } else {

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -16,8 +16,7 @@ use hir::{def::DefKind, ItemKind};
 use rustc_data_structures::{fx::FxIndexSet, unord::UnordMap};
 use rustc_errors::{Diagnostic, ErrorGuaranteed};
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_hir as hir;
-use rustc_hir::OwnerId;
+use rustc_hir::{self as hir, OwnerId, ParamName};
 use rustc_span::{
     def_id::{DefId, LocalDefId},
     sym,
@@ -256,7 +255,10 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
                     }
                     surface::GenericParamKind::Base => fhir::GenericParamKind::Base,
                 };
-                surface_params.insert(def_id, fhir::GenericParam { def_id, kind });
+                surface_params.insert(
+                    def_id,
+                    fhir::GenericParam { def_id, name: ParamName::Plain(param.name), kind },
+                );
             }
         }
 

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -103,7 +103,7 @@ fhir_analysis_refined_unrefinable_type =
 fhir_analysis_incompatible_refinement =
     {$def_descr} has an incompatible refinement annotation
     .label = expected a refinement of `{$expected_ty}`
-    .expected_label = corresponding to the unrefined definition
+    .expected_label = unrefined {$def_descr} defined here
 
 fhir_analysis_incompatible_param_count =
     {$def_descr} has an incompatible refinement annotation

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -821,7 +821,7 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             }
             fhir::TyKind::BareFn(bare_fn) => {
                 let mut env = Env::empty();
-                env.push_layer(Layer::list(&self, bare_fn.generic_params.len() as u32, &[])?);
+                env.push_layer(Layer::list(self, bare_fn.generic_params.len() as u32, &[])?);
                 let fn_sig =
                     self.conv_fn_decl(&mut env, bare_fn.safety, bare_fn.abi, bare_fn.decl)?;
                 let vars = bare_fn

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -8,6 +8,7 @@ extern crate rustc_hir;
 extern crate rustc_hir_pretty;
 extern crate rustc_middle;
 extern crate rustc_span;
+extern crate rustc_target;
 extern crate rustc_trait_selection;
 extern crate rustc_type_ir;
 
@@ -407,7 +408,7 @@ fn fn_sig(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<r
     let fn_sig = genv.desugar(def_id.local_id())?.fn_sig().unwrap();
     let wfckresults = genv.check_wf(def_id.local_id())?;
     let defns = genv.spec_func_defns()?;
-    let fn_sig = conv::conv_fn_decl(genv, def_id, fn_sig.decl, &wfckresults)?
+    let fn_sig = conv::conv_fn_sig(genv, def_id, fn_sig, &wfckresults)?
         .map(|fn_sig| fn_sig.normalize(defns));
 
     if config::dump_rty() {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -353,7 +353,7 @@ pub struct TyAlias<'fhir> {
     pub span: Span,
     /// Whether this alias was [lifted] from a `hir` alias
     ///
-    /// [lifted]: lift::lift_type_alias
+    /// [lifted]: lift::LiftCtxt::lift_type_alias
     pub lifted: bool,
 }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -495,7 +495,7 @@ pub struct MutTy<'fhir> {
 }
 
 /// Our surface syntax doesn't have lifetimes. To deal with them we create a *hole* for every lifetime
-/// which we then resolve during `annot_check` when zipping against the lifted version.
+/// which we then resolve when we check for structural compatibility against the rust type.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Lifetime {
     /// A lifetime hole created during desugaring.
@@ -733,7 +733,7 @@ pub enum ParamKind {
     /// A location declared with `x: &strg T` syntax.
     Loc,
     /// A parameter introduced with `x: T` syntax that we know *syntactically* is always and error
-    /// to used inside a refinement. For example, consider the following:
+    /// to use inside a refinement. For example, consider the following:
     /// ```ignore
     /// fn(x: {v. i32[v] | v > 0}) -> i32[x]
     /// ```
@@ -1136,18 +1136,6 @@ impl fmt::Debug for FnSig<'_> {
 
 impl fmt::Debug for FnDecl<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // if !self.generics.refinement_params.is_empty() {
-        //     write!(
-        //         f,
-        //         "for<{}> ",
-        //         self.generics
-        //             .refinement_params
-        //             .iter()
-        //             .format_with(", ", |param, f| {
-        //                 f(&format_args!("{}: {:?}", param.name, param.sort))
-        //             })
-        //     )?;
-        // }
         if !self.requires.is_empty() {
             write!(f, "[{:?}] ", self.requires.iter().format(", "))?;
         }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -29,7 +29,7 @@ pub use rustc_hir::PrimTy;
 use rustc_hir::{
     def::DefKind,
     def_id::{DefId, LocalDefId},
-    ItemId, OwnerId, ParamName,
+    FnHeader, ItemId, OwnerId, ParamName, Safety,
 };
 use rustc_index::newtype_index;
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
@@ -37,6 +37,7 @@ pub use rustc_middle::mir::Mutability;
 use rustc_middle::{middle::resolve_bound_vars::ResolvedArg, ty::TyCtxt};
 use rustc_span::{symbol::Ident, Span, Symbol};
 pub use rustc_target::abi::VariantIdx;
+use rustc_target::spec::abi;
 
 use crate::{global_env::GlobalEnv, pretty, MaybeExternId};
 
@@ -428,6 +429,7 @@ pub struct Requires<'fhir> {
 
 #[derive(Clone, Copy)]
 pub struct FnSig<'fhir> {
+    pub header: FnHeader,
     //// List of local qualifiers for this function
     pub qualifiers: &'fhir [Ident],
     pub decl: &'fhir FnDecl<'fhir>,
@@ -483,6 +485,8 @@ pub enum TyKind<'fhir> {
 }
 
 pub struct BareFnTy<'fhir> {
+    pub safety: Safety,
+    pub abi: abi::Abi,
     pub generic_params: &'fhir [GenericParam<'fhir>],
     pub decl: &'fhir FnDecl<'fhir>,
     pub param_names: &'fhir [Ident],

--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -368,7 +368,7 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
         let generic_params = try_alloc_slice!(self.genv, bare_fn.generic_params, |param| {
             self.lift_generic_param(param)
         })?;
-        let decl = self.lift_fn_decl_inner(span, &bare_fn.decl)?;
+        let decl = self.lift_fn_decl_inner(span, bare_fn.decl)?;
         Ok(fhir::BareFnTy {
             safety: bare_fn.safety,
             abi: bare_fn.abi,

--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -76,7 +76,7 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
                 fhir::GenericParamKind::Const { ty, is_host_effect }
             }
         };
-        Ok(fhir::GenericParam { def_id: param.def_id, kind })
+        Ok(fhir::GenericParam { def_id: param.def_id, name: param.name, kind })
     }
 
     fn lift_generics_inner(&mut self, generics: &hir::Generics) -> Result<fhir::Generics<'genv>> {

--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -5,8 +5,8 @@ use flux_errors::ErrorGuaranteed;
 use hir::OwnerId;
 use rustc_data_structures::unord::UnordMap;
 use rustc_errors::Diagnostic;
-use rustc_hir as hir;
-use rustc_hir::def_id::LocalDefId;
+use rustc_hir::{self as hir, def_id::LocalDefId, FnHeader};
+use rustc_span::Span;
 
 use super::{FhirId, FluxOwnerId};
 use crate::{
@@ -166,6 +166,16 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
         })
     }
 
+    pub fn lift_fn_header(&mut self) -> FnHeader {
+        let def_id = self.owner.def_id;
+        let hir_id = self.genv.tcx().local_def_id_to_hir_id(def_id);
+        self.genv
+            .hir()
+            .fn_sig_by_hir_id(hir_id)
+            .expect("item does not have a `FnDecl`")
+            .header
+    }
+
     pub fn lift_fn_decl(&mut self) -> Result<fhir::FnDecl<'genv>> {
         let def_id = self.owner.def_id;
         let hir_id = self.genv.tcx().local_def_id_to_hir_id(def_id);
@@ -175,15 +185,20 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
             .fn_sig_by_hir_id(hir_id)
             .expect("item does not have a `FnDecl`");
 
-        let inputs = try_alloc_slice!(self.genv, &fn_sig.decl.inputs, |ty| self.lift_ty(ty))?;
+        self.lift_fn_decl_inner(fn_sig.span, fn_sig.decl)
+    }
 
-        let output = fhir::FnOutput {
-            params: &[],
-            ensures: &[],
-            ret: self.lift_fn_ret_ty(&fn_sig.decl.output)?,
-        };
+    fn lift_fn_decl_inner(
+        &mut self,
+        span: Span,
+        decl: &hir::FnDecl,
+    ) -> Result<fhir::FnDecl<'genv>> {
+        let inputs = try_alloc_slice!(self.genv, &decl.inputs, |ty| self.lift_ty(ty))?;
 
-        Ok(fhir::FnDecl { requires: &[], inputs, output, span: fn_sig.span, lifted: true })
+        let output =
+            fhir::FnOutput { params: &[], ensures: &[], ret: self.lift_fn_ret_ty(&decl.output)? };
+
+        Ok(fhir::FnDecl { requires: &[], inputs, output, span, lifted: true })
     }
 
     fn lift_fn_ret_ty(&mut self, ret_ty: &hir::FnRetTy) -> Result<fhir::Ty<'genv>> {
@@ -293,6 +308,10 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
             hir::TyKind::Ref(lft, mut_ty) => {
                 fhir::TyKind::Ref(self.lift_lifetime(lft)?, self.lift_mut_ty(mut_ty)?)
             }
+            hir::TyKind::BareFn(bare_fn) => {
+                let bare_fn = self.lift_bare_fn(ty.span, bare_fn)?;
+                fhir::TyKind::BareFn(self.genv.alloc(bare_fn))
+            }
             hir::TyKind::Never => fhir::TyKind::Never,
             hir::TyKind::Tup(tys) => {
                 let tys = try_alloc_slice!(self.genv, tys, |ty| self.lift_ty(ty))?;
@@ -339,6 +358,24 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
             }
         };
         Ok(fhir::Ty { kind, span: ty.span })
+    }
+
+    fn lift_bare_fn(
+        &mut self,
+        span: Span,
+        bare_fn: &hir::BareFnTy,
+    ) -> Result<fhir::BareFnTy<'genv>> {
+        let generic_params = try_alloc_slice!(self.genv, bare_fn.generic_params, |param| {
+            self.lift_generic_param(param)
+        })?;
+        let decl = self.lift_fn_decl_inner(span, &bare_fn.decl)?;
+        Ok(fhir::BareFnTy {
+            safety: bare_fn.safety,
+            abi: bare_fn.abi,
+            generic_params,
+            decl: self.genv.alloc(decl),
+            param_names: self.genv.alloc_slice(bare_fn.param_names),
+        })
     }
 
     fn lift_lifetime(&self, lft: &hir::Lifetime) -> Result<fhir::Lifetime> {

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -363,6 +363,7 @@ pub fn walk_ty<'v, V: Visitor<'v>>(vis: &mut V, ty: &Ty<'v>) {
             vis.visit_lifetime(&lft);
             vis.visit_ty(mty.ty);
         }
+        TyKind::BareFn(bare_fn) => vis.visit_fn_decl(bare_fn.decl),
         TyKind::Tuple(tys) => {
             walk_list!(vis, visit_ty, tys);
         }

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -77,7 +77,7 @@ pub enum QueryErr {
     },
     /// Used to report bugs, typically this means executing an arm in a match we though it was
     /// unreachable. Use this instead of panicking if it is easy to return a [`QueryErr`]. Use
-    /// [`QueryErr::bug`] or [`query_bug!`] to construct this variant to track source location.
+    /// [`QueryErr::bug`] or [`crate::query_bug!`] to construct this variant to track source location.
     Bug {
         def_id: Option<DefId>,
         location: String,

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -793,7 +793,7 @@ impl TypeFoldable for FnSig {
         let requires = self.requires.try_fold_with(folder)?;
         let args = self.inputs.try_fold_with(folder)?;
         let output = self.output.try_fold_with(folder)?;
-        Ok(FnSig::new(requires, args, output))
+        Ok(FnSig::new(self.safety, self.abi, requires, args, output))
     }
 }
 

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -992,6 +992,7 @@ impl TypeSuperVisitable for BaseTy {
             BaseTy::Slice(ty) => ty.visit_with(visitor),
             BaseTy::RawPtr(ty, _) => ty.visit_with(visitor),
             BaseTy::Ref(_, ty, _) => ty.visit_with(visitor),
+            BaseTy::FnPtr(poly_fn_sig) => poly_fn_sig.visit_with(visitor),
             BaseTy::Tuple(tys) => tys.visit_with(visitor),
             BaseTy::Array(ty, _) => ty.visit_with(visitor),
             BaseTy::Coroutine(_, resume_ty, upvars) => {
@@ -1027,6 +1028,7 @@ impl TypeSuperFoldable for BaseTy {
             BaseTy::Ref(re, ty, mutbl) => {
                 BaseTy::Ref(re.try_fold_with(folder)?, ty.try_fold_with(folder)?, *mutbl)
             }
+            BaseTy::FnPtr(decl) => BaseTy::FnPtr(decl.try_fold_with(folder)?),
             BaseTy::Tuple(tys) => BaseTy::Tuple(tys.try_fold_with(folder)?),
             BaseTy::Array(ty, c) => {
                 BaseTy::Array(ty.try_fold_with(folder)?, c.try_fold_with(folder)?)

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -948,14 +948,14 @@ pub struct EarlyBinder<T>(pub T);
 
 pub type PolyFnSig = Binder<FnSig>;
 
-#[derive(Clone, TyEncodable, TyDecodable)]
+#[derive(Clone, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub struct FnSig {
     requires: List<Expr>,
     inputs: List<Ty>,
     output: Binder<FnOutput>,
 }
 
-#[derive(Clone, Debug, TyEncodable, TyDecodable)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, TyEncodable, TyDecodable)]
 pub struct FnOutput {
     pub ret: Ty,
     pub ensures: List<Ensures>,
@@ -1367,6 +1367,7 @@ pub enum BaseTy {
     Float(FloatTy),
     RawPtr(Ty, Mutability),
     Ref(Region, Ty, Mutability),
+    FnPtr(PolyFnSig),
     Tuple(List<Ty>),
     Array(Ty, Const),
     Never,
@@ -1527,6 +1528,7 @@ impl BaseTy {
             | BaseTy::Char
             | BaseTy::RawPtr(..)
             | BaseTy::Ref(..)
+            | BaseTy::FnPtr(..)
             | BaseTy::Tuple(_)
             | BaseTy::Array(_, _)
             | BaseTy::Closure(_, _)
@@ -1556,6 +1558,9 @@ impl BaseTy {
             BaseTy::RawPtr(ty, mutbl) => ty::Ty::new_ptr(tcx, ty.to_rustc(tcx), *mutbl),
             BaseTy::Ref(re, ty, mutbl) => {
                 ty::Ty::new_ref(tcx, re.to_rustc(tcx), ty.to_rustc(tcx), *mutbl)
+            }
+            BaseTy::FnPtr(poly_fn_sig) => {
+                todo!()
             }
             BaseTy::Tuple(tys) => {
                 let ts = tys.iter().map(|ty| ty.to_rustc(tcx)).collect_vec();

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -428,6 +428,9 @@ impl Pretty for BaseTy {
                 }
                 w!("{}{:?}",  ^mutbl.prefix_str(), ty)
             }
+            BaseTy::FnPtr(poly_fn_sig) => {
+                w!("{:?}", poly_fn_sig)
+            }
             BaseTy::Tuple(tys) => {
                 if let [ty] = &tys[..] {
                     w!("({:?},)", ty)

--- a/crates/flux-middle/src/rustc/lowering.rs
+++ b/crates/flux-middle/src/rustc/lowering.rs
@@ -649,7 +649,7 @@ pub fn lower_fn_sig<'tcx>(
                 .map(|ty| lower_ty(tcx, ty))
                 .try_collect()?,
         );
-        Ok(FnSig { inputs_and_output })
+        Ok(FnSig { safety: fn_sig.safety, abi: fn_sig.abi, inputs_and_output })
     })
 }
 

--- a/crates/flux-middle/src/rustc/ty.rs
+++ b/crates/flux-middle/src/rustc/ty.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 use flux_common::bug;
 use itertools::Itertools;
-use rustc_hir::def_id::DefId;
+use rustc_hir::{def_id::DefId, Safety};
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_macros::{TyDecodable, TyEncodable};
 use rustc_middle::ty::{self as rustc_ty, AdtFlags, ParamConst, TyCtxt};
@@ -19,6 +19,7 @@ pub use rustc_middle::{
 };
 use rustc_span::{symbol::kw, Symbol};
 pub use rustc_target::abi::{FieldIdx, VariantIdx, FIRST_VARIANT};
+use rustc_target::spec::abi;
 pub use rustc_type_ir::InferConst;
 
 use self::subst::Subst;
@@ -115,6 +116,8 @@ pub struct ProjectionPredicate {
 }
 #[derive(Clone, Hash, PartialEq, Eq, TyEncodable, TyDecodable)]
 pub struct FnSig {
+    pub safety: Safety,
+    pub abi: abi::Abi,
     pub(crate) inputs_and_output: List<Ty>,
 }
 

--- a/crates/flux-middle/src/rustc/ty/subst.rs
+++ b/crates/flux-middle/src/rustc/ty/subst.rs
@@ -22,7 +22,11 @@ where
 
 impl Subst for FnSig {
     fn subst(&self, args: &[GenericArg]) -> Self {
-        FnSig { inputs_and_output: self.inputs_and_output.subst(args) }
+        FnSig {
+            safety: self.safety,
+            abi: self.abi,
+            inputs_and_output: self.inputs_and_output.subst(args),
+        }
     }
 }
 

--- a/crates/flux-middle/src/sort_of.rs
+++ b/crates/flux-middle/src/sort_of.rs
@@ -106,15 +106,16 @@ impl<'sess, 'tcx> GlobalEnv<'sess, 'tcx> {
         match &ty.kind {
             fhir::TyKind::BaseTy(bty) | fhir::TyKind::Indexed(bty, _) => self.sort_of_bty(bty),
             fhir::TyKind::Exists(_, ty) | fhir::TyKind::Constr(_, ty) => self.sort_of_ty(ty),
-            fhir::TyKind::RawPtr(_, _)
-            | fhir::TyKind::Ref(_, _)
+            fhir::TyKind::RawPtr(..)
+            | fhir::TyKind::Ref(..)
             | fhir::TyKind::Tuple(_)
-            | fhir::TyKind::Array(_, _)
-            | fhir::TyKind::TraitObject(_, _, _)
+            | fhir::TyKind::Array(..)
+            | fhir::TyKind::TraitObject(..)
+            | fhir::TyKind::BareFn(_)
             | fhir::TyKind::Never => Ok(Some(rty::Sort::unit())),
-            fhir::TyKind::Infer
-            | fhir::TyKind::StrgRef(..)
-            | fhir::TyKind::OpaqueDef(_, _, _, _) => Ok(None),
+            fhir::TyKind::Infer | fhir::TyKind::StrgRef(..) | fhir::TyKind::OpaqueDef(..) => {
+                Ok(None)
+            }
         }
     }
 

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -111,6 +111,7 @@ pub fn check_fn(
         let errors = fcx.check(cache, cstr, config.scrape_quals).emit(&genv)?;
 
         tracing::info!("check_fn::fixpoint");
+        #[expect(clippy::collapsible_else_if, reason = "it looks better")]
         if genv.should_fail(def_id) {
             if errors.is_empty() {
                 report_expected_neg(genv, def_id)

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -415,9 +415,13 @@ impl BasicBlockEnvShape {
             | BaseTy::RawPtr(_, _)
             | BaseTy::Char
             | BaseTy::Never
-            | BaseTy::Closure(_, _)
-            | BaseTy::Dynamic(_, _)
-            | BaseTy::Coroutine(..) => bty.clone(),
+            | BaseTy::Closure(..)
+            | BaseTy::Dynamic(..)
+            | BaseTy::FnPtr(..)
+            | BaseTy::Coroutine(..) => {
+                debug_assert!(!scope.has_free_vars(bty));
+                bty.clone()
+            }
         }
     }
 

--- a/tests/tests/pos/fn_ptrs/fn_ptr00.rs
+++ b/tests/tests/pos/fn_ptrs/fn_ptr00.rs
@@ -1,0 +1,9 @@
+// Test that we at least support mentioning function pointers
+
+pub struct Struct {
+    f: fn(i32) -> i32,
+}
+
+pub fn test00(x: fn(i32) -> i32) {}
+
+pub fn test01(x: Vec<fn(i32) -> i32>) {}


### PR DESCRIPTION
This allows us to mention function pointers in signatures and data types. This doesn't implement calling a function pointer or passing function pointers as arguments.

fixes #749 