### PR TITLE
Hack to not crash when matching on a &mut Option<T> with a refinement

### DIFF
--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -20,7 +20,7 @@ pub use expr::{
     AggregateKind, AliasReft, BinOp, BoundReft, Constant, ESpan, EarlyReftParam, Expr, ExprKind,
     FieldProj, HoleKind, KVar, KVid, Lambda, Loc, Name, Path, UnOp, Var,
 };
-use flux_common::bug;
+use flux_common::{bug, tracked_span_bug};
 use itertools::Itertools;
 pub use normalize::SpecFuncDefns;
 use rustc_data_structures::unord::UnordMap;
@@ -1321,7 +1321,7 @@ impl TyS {
         if let TyKind::Indexed(BaseTy::Adt(adt_def, args), idx) = self.kind() {
             (adt_def, args, idx)
         } else {
-            bug!("expected adt")
+            tracked_span_bug!("expected adt `{self:?}`")
         }
     }
 
@@ -1557,6 +1557,15 @@ impl BaseTy {
             | BaseTy::Coroutine(..)
             | BaseTy::Dynamic(_, _)
             | BaseTy::Never => Sort::unit(),
+        }
+    }
+
+    #[track_caller]
+    pub fn expect_adt(&self) -> (&AdtDef, &[GenericArg]) {
+        if let BaseTy::Adt(adt_def, args) = self {
+            (adt_def, args)
+        } else {
+            tracked_span_bug!("expected adt `{self:?}`")
         }
     }
 }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -910,7 +910,8 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 let ty = env
                     .lookup_place(&mut infcx.at(stmt_span), place)
                     .with_span(stmt_span)?;
-                let (adt_def, ..) = ty.expect_adt();
+                // HACK(nilehmann, mut-ref-unfolding) place should be unfolded here.
+                let (adt_def, ..) = ty.as_bty_skipping_existentials().unwrap().expect_adt();
                 Ok(Ty::discr(adt_def.clone(), place.clone()))
             }
             Rvalue::Aggregate(AggregateKind::Adt(def_id, variant_idx, args, _), operands) => {


### PR DESCRIPTION
Hack to fix the CI after adding extern specs to `Option<T>`

See https://github.com/flux-rs/flux/issues/782