### PR TITLE
Erase regions before normalization

### DIFF
--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -17,8 +17,7 @@ use flux_middle::{
 };
 use itertools::{izip, Itertools};
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_infer::infer::{BoundRegionConversionTime, RegionVariableOrigin};
-use rustc_middle::ty::{BoundRegionKind, TyCtxt, Variance};
+use rustc_middle::ty::{TyCtxt, Variance};
 use rustc_span::Span;
 
 use crate::{
@@ -168,19 +167,6 @@ impl<'infcx, 'genv, 'tcx> InferCtxt<'infcx, 'genv, 'tcx> {
         args.iter()
             .map(|a| a.replace_holes(|binders, kind| self.fresh_infer_var_for_hole(binders, kind)))
             .collect_vec()
-    }
-
-    fn next_region_var(&self, origin: RegionVariableOrigin) -> rty::Region {
-        rty::ReVar(self.region_infcx.next_region_var(origin).as_var())
-    }
-
-    pub fn next_bound_region_var(
-        &self,
-        span: Span,
-        kind: BoundRegionKind,
-        conversion_time: BoundRegionConversionTime,
-    ) -> rty::Region {
-        self.next_region_var(RegionVariableOrigin::BoundRegion(span, kind, conversion_time))
     }
 
     pub fn fresh_infer_var(&self, sort: &Sort, mode: InferMode) -> Expr {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -275,11 +275,6 @@ pub struct SortDecl {
 
 pub type SortDecls = FxHashMap<Symbol, SortDecl>;
 
-#[derive(Debug)]
-pub struct GenericPredicates<'fhir> {
-    pub predicates: &'fhir [WhereBoundPredicate<'fhir>],
-}
-
 #[derive(Debug, Clone, Copy)]
 pub struct WhereBoundPredicate<'fhir> {
     pub span: Span,

--- a/crates/flux-middle/src/rustc/ty.rs
+++ b/crates/flux-middle/src/rustc/ty.rs
@@ -364,6 +364,7 @@ pub enum Region {
     ReStatic,
     ReVar(RegionVid),
     ReLateParam(LateParamRegion),
+    ReErased,
 }
 
 impl<'tcx> ToRustc<'tcx> for Region {
@@ -380,6 +381,7 @@ impl<'tcx> ToRustc<'tcx> for Region {
             Region::ReLateParam(LateParamRegion { scope, bound_region }) => {
                 rustc_middle::ty::Region::new_late_param(tcx, scope, bound_region)
             }
+            Region::ReErased => tcx.lifetimes.re_erased,
         }
     }
 }
@@ -990,5 +992,6 @@ pub(crate) fn region_to_string(region: Region) -> String {
         Region::ReStatic => "'static".to_string(),
         Region::ReVar(rvid) => format!("{rvid:?}"),
         Region::ReLateParam(..) => "'<free>".to_string(),
+        Region::ReErased => "'_".to_string(),
     }
 }

--- a/crates/flux-middle/src/rustc/ty/subst.rs
+++ b/crates/flux-middle/src/rustc/ty/subst.rs
@@ -126,6 +126,7 @@ impl Subst for Region {
             Region::ReLateParam(..)
             | Region::ReBound(_, _)
             | Region::ReStatic
+            | Region::ReErased
             | Region::ReVar(_) => *self,
         }
     }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -12,13 +12,9 @@ use flux_middle::{
     queries::QueryResult,
     query_bug,
     rty::{
-        self,
-        fold::TypeFoldable,
-        refining::Refiner,
-        AdtDef, BaseTy, Binder, Bool, Clause, CoroutineObligPredicate, EarlyBinder, Ensures, Expr,
-        FnOutput, FnTraitPredicate, GenericArg, Generics, Int, IntTy, Mutability, PolyFnSig,
-        PtrKind, Ref,
-        Region::{ReErased, ReStatic},
+        self, fold::TypeFoldable, refining::Refiner, AdtDef, BaseTy, Binder, Bool, Clause,
+        CoroutineObligPredicate, EarlyBinder, Ensures, Expr, FnOutput, FnTraitPredicate,
+        GenericArg, Generics, Int, IntTy, Mutability, PolyFnSig, PtrKind, Ref, Region::ReStatic,
         Ty, TyKind, Uint, UintTy, VariantIdx,
     },
     rustc::{

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -12,9 +12,13 @@ use flux_middle::{
     queries::QueryResult,
     query_bug,
     rty::{
-        self, fold::TypeFoldable, refining::Refiner, AdtDef, BaseTy, Binder, Bool, Clause,
-        CoroutineObligPredicate, EarlyBinder, Ensures, Expr, FnOutput, FnTraitPredicate,
-        GenericArg, Generics, Int, IntTy, Mutability, PolyFnSig, PtrKind, Ref, Region::ReStatic,
+        self,
+        fold::TypeFoldable,
+        refining::Refiner,
+        AdtDef, BaseTy, Binder, Bool, Clause, CoroutineObligPredicate, EarlyBinder, Ensures, Expr,
+        FnOutput, FnTraitPredicate, GenericArg, Generics, Int, IntTy, Mutability, PolyFnSig,
+        PtrKind, Ref,
+        Region::{ReErased, ReStatic},
         Ty, TyKind, Uint, UintTy, VariantIdx,
     },
     rustc::{
@@ -219,10 +223,10 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         let body = genv.mir(def_id).with_span(span)?;
         let generics = genv.generics_of(def_id).with_span(span)?;
 
-        // The regions we assign here are not relevant because we would map them to local regions
-        // when assigning to locals. See [`TypeEnv::assign`]. Maybe, we should erase regions instead.
-        let fn_sig =
-            poly_sig.replace_bound_vars(|_| rty::ReErased, |sort, _| infcx.define_vars(sort));
+        let fn_sig = poly_sig
+            .replace_bound_vars(|_| rty::ReErased, |sort, _| infcx.define_vars(sort))
+            .normalize_projections(infcx.genv, infcx.region_infcx, infcx.def_id)
+            .with_span(span)?;
 
         let mut env = TypeEnv::new(&mut infcx, &body, &fn_sig, inherited.config.check_overflow);
 
@@ -627,11 +631,6 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         snapshot: &Snapshot,
         gen_pred: CoroutineObligPredicate,
     ) -> Result {
-        // See comment for [`Checker::check_oblig_fn_trait_pred`]
-        let poly_sig = EarlyBinder(gen_pred.to_poly_fn_sig())
-            .instantiate_identity()
-            .normalize_projections(infcx.genv, infcx.region_infcx, infcx.def_id)
-            .with_span(self.body.span())?;
         let def_id = gen_pred.def_id;
         let span = self.genv.tcx().def_span(def_id);
         let body = self.genv.mir(def_id.expect_local()).with_span(span)?;
@@ -639,7 +638,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             infcx.change_item(def_id.expect_local(), &body.infcx, snapshot),
             gen_pred.def_id.expect_local(),
             self.inherited.reborrow(),
-            poly_sig,
+            gen_pred.to_poly_fn_sig(),
         )
     }
 
@@ -649,28 +648,16 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         snapshot: &Snapshot,
         fn_trait_pred: FnTraitPredicate,
     ) -> Result {
-        if let Some(BaseTy::Closure(def_id, tys)) =
+        if let Some(BaseTy::Closure(closure_id, tys)) =
             fn_trait_pred.self_ty.as_bty_skipping_existentials()
         {
-            // The closure signature may contain region variables generated in the `InferCtxt` of the
-            // current function so we normalize it before passing it to `Checker::run`. After
-            // normalization, the signature could still contain region variables wich haven't been
-            // declared in the closure's `InferCtxt`, but this is fine because we would map them to
-            // local regions when assigning to locals. See [`TypeEnv::assign`]
-            //
-            // After writing this, I realize it may be better to erase regions before normalization.
-            // We should revisit this at some point.
-            let poly_sig = EarlyBinder(fn_trait_pred.to_poly_fn_sig(*def_id, tys.clone()))
-                .instantiate_identity()
-                .normalize_projections(infcx.genv, infcx.region_infcx, infcx.def_id)
-                .with_span(self.body.span())?;
-            let span = self.genv.tcx().def_span(def_id);
-            let body = self.genv.mir(def_id.expect_local()).with_span(span)?;
+            let span = self.genv.tcx().def_span(closure_id);
+            let body = self.genv.mir(closure_id.expect_local()).with_span(span)?;
             Checker::run(
-                infcx.change_item(def_id.expect_local(), &body.infcx, snapshot),
-                def_id.expect_local(),
+                infcx.change_item(closure_id.expect_local(), &body.infcx, snapshot),
+                closure_id.expect_local(),
                 self.inherited.reborrow(),
-                poly_sig,
+                fn_trait_pred.to_poly_fn_sig(*closure_id, tys.clone()),
             )?;
         } else {
             // TODO: When we allow refining closure/fn at the surface level, we would need to do

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -17,7 +17,6 @@ extern crate rustc_errors;
 extern crate rustc_hash;
 extern crate rustc_hir;
 extern crate rustc_index;
-extern crate rustc_infer;
 extern crate rustc_middle;
 extern crate rustc_mir_dataflow;
 extern crate rustc_span;

--- a/tests/tests/pos/surface/issue-792.rs
+++ b/tests/tests/pos/surface/issue-792.rs
@@ -1,0 +1,4 @@
+fn try_get_8_bytes(s: &[u8]) -> &[u8; 8] {
+    let try8 = s.get(0..8).unwrap();
+    try8.try_into().unwrap()
+}


### PR DESCRIPTION
Tracking the exact regions is no longer necessary since we improved how we match regions when doing an assignment. 

Fixes #792 