### PR TITLE
Relax assertion in dyn trait subtyping

### DIFF
--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -534,7 +534,7 @@ impl Sub {
             | (BaseTy::Char, BaseTy::Char)
             | (BaseTy::RawPtr(_, _), BaseTy::RawPtr(_, _)) => Ok(()),
             (BaseTy::Dynamic(preds_a, _), BaseTy::Dynamic(preds_b, _)) => {
-                assert_eq!(preds_a, preds_b);
+                assert_eq!(preds_a.erase_regions(), preds_b.erase_regions());
                 Ok(())
             }
             (BaseTy::Closure(did1, tys_a), BaseTy::Closure(did2, tys_b)) if did1 == did2 => {

--- a/tests/tests/pos/surface/issue-790.rs
+++ b/tests/tests/pos/surface/issue-790.rs
@@ -1,0 +1,8 @@
+pub trait MyTrait<'a> {}
+pub struct MyStruct {
+    t: &'static dyn MyTrait<'static>,
+}
+
+pub fn new(t: &'static dyn MyTrait) -> MyStruct {
+    MyStruct { t }
+}


### PR DESCRIPTION
I think what we really want is for the predicates to be unrefined, but for the moment let's relax the assertion to ignore mismatches between regions.

Fixes #790 