### PR TITLE
Use even more MaybeExternId

### DIFF
--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -60,7 +60,8 @@ pub fn provide(providers: &mut Providers) {
 }
 
 fn adt_sort_def_of(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::AdtSortDef> {
-    conv::conv_adt_sort_def(genv, def_id, genv.map().refined_by(def_id)?)
+    let def_id = genv.maybe_extern_id(def_id);
+    conv::conv_adt_sort_def(genv, def_id, genv.map().refined_by(def_id.local_id())?)
 }
 
 fn spec_func_decl(genv: GlobalEnv, name: Symbol) -> QueryResult<rty::SpecFuncDecl> {

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -6,8 +6,7 @@ use flux_infer::{
     infer::{ConstrReason, Tag},
     refine_tree::RefineTree,
 };
-use flux_middle::{fhir, global_env::GlobalEnv, rty};
-use rustc_hir::def_id::LocalDefId;
+use flux_middle::{fhir, global_env::GlobalEnv, rty, MaybeExternId};
 use rustc_span::{Span, DUMMY_SP};
 
 use crate::CheckerConfig;
@@ -15,7 +14,7 @@ use crate::CheckerConfig;
 pub fn check_invariants(
     genv: GlobalEnv,
     cache: &mut QueryCache,
-    def_id: LocalDefId,
+    def_id: MaybeExternId,
     invariants: &[fhir::Expr],
     adt_def: &rty::AdtDef,
     checker_config: CheckerConfig,
@@ -33,13 +32,13 @@ pub fn check_invariants(
 fn check_invariant(
     genv: GlobalEnv,
     cache: &mut QueryCache,
-    def_id: LocalDefId,
+    def_id: MaybeExternId,
     adt_def: &rty::AdtDef,
     span: Span,
     invariant: &rty::Invariant,
     checker_config: CheckerConfig,
 ) -> Result<(), ErrorGuaranteed> {
-    let mut refine_tree = RefineTree::new(genv, def_id).emit(&genv)?;
+    let mut refine_tree = RefineTree::new(genv, def_id.local_id()).emit(&genv)?;
 
     for variant_idx in adt_def.variants().indices() {
         let mut rcx = refine_tree.refine_ctxt_at_root();
@@ -58,9 +57,9 @@ fn check_invariant(
         let pred = invariant.apply(&variant.idx);
         rcx.check_pred(&pred, Tag::new(ConstrReason::Other, DUMMY_SP));
     }
-    let mut fcx = FixpointCtxt::new(genv, def_id, KVarGen::dummy());
+    let mut fcx = FixpointCtxt::new(genv, def_id.local_id(), KVarGen::dummy());
     if config::dump_constraint() {
-        dbg::dump_item_info(genv.tcx(), def_id, "fluxc", &refine_tree).unwrap();
+        dbg::dump_item_info(genv.tcx(), def_id.local_id(), "fluxc", &refine_tree).unwrap();
     }
 
     let cstr = refine_tree.into_fixpoint(&mut fcx).emit(&genv)?;

--- a/tests/tests/lib/iter.rs
+++ b/tests/tests/lib/iter.rs
@@ -25,8 +25,8 @@ trait Iterator {
 
 #[extern_spec(std::slice)]
 #[flux::generics(T as base)]
-#[flux::assoc(fn done(x: Iter<T>) -> bool { x.idx >= x.len })]
-#[flux::assoc(fn step(x: Iter<T>, y: Iter<T>) -> bool { x.idx + 1 == y.idx && x.len == y.len})]
+#[flux::assoc(fn done(x: Iter) -> bool { x.idx >= x.len })]
+#[flux::assoc(fn step(x: Iter, y: Iter) -> bool { x.idx + 1 == y.idx && x.len == y.len})]
 impl<'a, T> Iterator for Iter<'a, T> {
     #[flux::sig(fn(self: &strg Iter<T>[@curr_s]) -> Option<_>[curr_s.idx < curr_s.len] ensures self: Iter<T>{next_s: curr_s.idx + 1 == next_s.idx && curr_s.len == next_s.len})]
     fn next(&mut self) -> Option<&'a T>;

--- a/tests/tests/neg/surface/extern_spec_impl02.rs
+++ b/tests/tests/neg/surface/extern_spec_impl02.rs
@@ -14,8 +14,12 @@ pub fn bob<T: MyTrait>(_x: &T) -> i32 {
 }
 
 // library impl
+// FIXME(nilehmann) having both the item and an extern spec for it in the same
+// crates breaks some of our assumptions. We should disallow it. For now we
+// ignore the item for the test to pass, but we should test this with using
+// multiple crates.
+#[flux::ignore]
 impl MyTrait for usize {
-    #[flux::trusted]
     fn foo() -> i32 {
         10
     }


### PR DESCRIPTION
This uncovered a bug: we weren't checking impls against their traits for extern specs