### PR TITLE
Merge unpacker and hoister

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,18 @@ tests = { path = "./tests", version = "0.1.0" }
 
 liquid-fixpoint = { path = "./lib/liquid-fixpoint", version = "0.1.0" }
 
+bon = "2.3.0"
+bumpalo = "3.14.0"
 dashmap = { version = "5.5.3", features = ["raw-api"] }
 derive-where = "1.2.7"
+ena = "0.14.2"
 hashbrown = "0.14.3"
 home = "0.5.9"
 itertools = "0.13.0"
 pad-adapter = "0.1.1"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
+toposort-scc = "0.5.4"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(flux_sysroot)'] }

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -427,10 +427,10 @@ impl Sub {
 
         match (a.kind(), b.kind()) {
             (TyKind::Exists(..), _) => {
-                bug!("existentials should be removed by the unpack");
+                bug!("existentials should be removed by the unpacking");
             }
             (TyKind::Constr(..), _) => {
-                bug!("constraint types should removed by the unpack");
+                bug!("constraint types should removed by the unpacking");
             }
             (_, TyKind::Exists(ty_b)) => {
                 infcx.push_scope();

--- a/crates/flux-middle/Cargo.toml
+++ b/crates/flux-middle/Cargo.toml
@@ -17,13 +17,13 @@ flux-syntax.workspace = true
 
 liquid-fixpoint.workspace = true
 
+bumpalo.workspace = true
 dashmap.workspace = true
+ena.workspace = true
 hashbrown.workspace = true
 itertools.workspace = true
+toposort-scc.workspace = true
 
-bumpalo = "3.14.0"
-ena = "0.14.2"
-toposort-scc = "0.5.4"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/crates/flux-middle/src/rty/canonicalize.rs
+++ b/crates/flux-middle/src/rty/canonicalize.rs
@@ -6,11 +6,11 @@
 //! not permitted to hoist an existential out of a generic argument. For example, in `Vec<∃v. i32[v]>`
 //! the existential inside the `Vec` cannot be hoisted out.
 //!
-//! However, some type constructors are more lenient with respect to howsint. Consider the tuple
+//! However, some type constructors are more lenient with respect to hoisting. Consider the tuple
 //! `(∃a. i32[a], ∃b. i32[b])`. Hoisting the existentials results in `∃a,b. (i32[a], i32[b])` which
 //! is an equivalent type (in the sense that subtyping holds both ways). The same applies to shared
 //! references: `&∃a. i32[a]` is equivalent to `∃a. &i32[a]`. We refer to this class of type
-//! constructors *transparent*. Hoisting existential out of transparent type constructors is useful
+//! constructors as *transparent*. Hoisting existential out of transparent type constructors is useful
 //! as it allows the logical information to be extracted from the type. We try to eagerly do so as
 //! much as possible.
 //!
@@ -20,9 +20,9 @@
 //! reference is alive). However, this may result in a type that is *too specific* because the index
 //! `a` cannot be updated anymore.
 //!
-//! By default, we do *shallow* hoisting, i.e., we stop at the first type constructor. This enough
-//! in cases where we need to inspect a type structurally one level. The amount of hoisting
-//! can be controlled by configuring the [`Hoister`] struct.
+//! By default, we do *shallow* hoisting, i.e., we stop at the first type constructor. This is enough
+//! for cases where we need to inspect a type structurally one level. The amount of hoisting can be
+//! controlled by configuring the [`Hoister`] struct.
 //!
 //! It's also important to note that canonizalization doesn't imply any form of semantic equality
 //! and it is just a best effort to facilitate syntactic manipulation. For example, the types

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -645,7 +645,8 @@ impl BasicBlockEnvShape {
         let mut hoister = Hoister::with_delegate(&mut delegate)
             .hoist_inside_tuples(true)
             .hoist_inside_shr_refs(true)
-            .hoist_inside_boxes(true);
+            .hoist_inside_boxes(true)
+            .hoist_inside_downcast(true);
 
         let mut bindings = self.bindings;
         bindings.fmap_mut(|ty| hoister.hoist(ty));

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -12,7 +12,7 @@ use flux_middle::{
     global_env::GlobalEnv,
     queries::QueryResult,
     rty::{
-        canonicalize::{BoundedHoister, Hoister},
+        canonicalize::{Hoister, LocalHoister},
         evars::EVarSol,
         fold::{FallibleTypeFolder, TypeFoldable, TypeVisitable, TypeVisitor},
         subst, BaseTy, Binder, BoundReftKind, Expr, ExprKind, FnSig, GenericArg, HoleKind, Lambda,
@@ -640,7 +640,7 @@ impl BasicBlockEnvShape {
     }
 
     pub fn into_bb_env(self, kvar_gen: &mut KVarGen) -> BasicBlockEnv {
-        let mut delegate = BoundedHoister::default();
+        let mut delegate = LocalHoister::default();
         let mut hoister = Hoister::with_delegate(&mut delegate).transparent();
 
         let mut bindings = self.bindings;


### PR DESCRIPTION
The root cause of https://github.com/flux-rs/flux/issues/841 was a divergence between the `Unpacker` and the `Hoister`. This PR generalizes the `Hoister` so it can replace the `Unpacker`.