### PR TITLE
Improve error messages when there's structural mismatch for an extern spec

### DIFF
--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -103,7 +103,8 @@ fhir_analysis_refined_unrefinable_type =
 fhir_analysis_incompatible_refinement =
     {$def_descr} has an incompatible refinement annotation
     .label = expected a refinement of `{$expected_ty}`
-    .expected_label = unrefined {$def_descr} defined here
+    .expected_label = unrefined {$def_descr} found here
+    .note = a refinement annotation must match the unrefined definition structurally
 
 fhir_analysis_incompatible_param_count =
     {$def_descr} has an incompatible refinement annotation

--- a/crates/flux-fhir-analysis/src/conv/struct_compat.rs
+++ b/crates/flux-fhir-analysis/src/conv/struct_compat.rs
@@ -566,14 +566,15 @@ mod errors {
             decl: &fhir::FnDecl,
             pos: usize,
         ) -> Self {
-            let expected_span = if let Some(local_id) = fn_id.as_local() {
-                genv.tcx()
-                    .hir_node_by_def_id(local_id)
-                    .fn_decl()
-                    .and_then(|fn_decl| fn_decl.inputs.get(pos))
-                    .map(|input| input.span)
-            } else {
-                Some(genv.tcx().def_span(fn_id.resolved_id()))
+            let expected_span = match fn_id {
+                MaybeExternId::Local(local_id) => {
+                    genv.tcx()
+                        .hir_node_by_def_id(local_id)
+                        .fn_decl()
+                        .and_then(|fn_decl| fn_decl.inputs.get(pos))
+                        .map(|input| input.span)
+                }
+                MaybeExternId::Extern(_, extern_id) => Some(genv.tcx().def_span(extern_id)),
             };
 
             let expected_ty = genv
@@ -597,13 +598,14 @@ mod errors {
             fn_id: MaybeExternId,
             decl: &fhir::FnDecl,
         ) -> Self {
-            let expected_span = if let Some(local_id) = fn_id.as_local() {
-                genv.tcx()
-                    .hir_node_by_def_id(local_id)
-                    .fn_decl()
-                    .map(|fn_decl| fn_decl.output.span())
-            } else {
-                Some(genv.tcx().def_span(fn_id.resolved_id()))
+            let expected_span = match fn_id {
+                MaybeExternId::Local(local_id) => {
+                    genv.tcx()
+                        .hir_node_by_def_id(local_id)
+                        .fn_decl()
+                        .map(|fn_decl| fn_decl.output.span())
+                }
+                MaybeExternId::Extern(_, extern_id) => Some(genv.tcx().def_span(extern_id)),
             };
 
             let expected_ty = genv

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -5,7 +5,6 @@ extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate rustc_hash;
 extern crate rustc_hir;
-extern crate rustc_hir_pretty;
 extern crate rustc_middle;
 extern crate rustc_span;
 extern crate rustc_target;


### PR DESCRIPTION
Show the type and span of the external definition instead of the local one for extern specs when there's a structural mismatch