### PR TITLE
Implement two-phase conversion to avoid computing sorts in `fhir`

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1161,12 +1161,12 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
         match &bty.kind {
             surface::BaseTyKind::Path(qself, path) => {
                 let qpath = self.desugar_qpath(qself.as_deref(), path)?;
-                Ok(fhir::BaseTy::from(qpath))
+                Ok(fhir::BaseTy::from_qpath(qpath, self.next_fhir_id()))
             }
             surface::BaseTyKind::Slice(ty) => {
                 let ty = self.desugar_ty(ty)?;
                 let kind = fhir::BaseTyKind::Slice(self.genv().alloc(ty));
-                Ok(fhir::BaseTy { kind, span: bty.span })
+                Ok(fhir::BaseTy { kind, fhir_id: self.next_fhir_id(), span: bty.span })
             }
         }
     }
@@ -1177,7 +1177,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
         path: &surface::Path,
     ) -> Result<fhir::BaseTy<'genv>> {
         let qpath = self.desugar_qpath(qself, path)?;
-        Ok(fhir::BaseTy::from(qpath))
+        Ok(fhir::BaseTy::from_qpath(qpath, self.next_fhir_id()))
     }
 
     fn desugar_qpath(
@@ -1259,7 +1259,10 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
     }
 
     fn ty_path(&self, qpath: fhir::QPath<'genv>) -> fhir::Ty<'genv> {
-        fhir::Ty { span: qpath.span(), kind: fhir::TyKind::BaseTy(fhir::BaseTy::from(qpath)) }
+        fhir::Ty {
+            span: qpath.span(),
+            kind: fhir::TyKind::BaseTy(fhir::BaseTy::from_qpath(qpath, self.next_fhir_id())),
+        }
     }
 
     fn mk_lft_hole(&self) -> fhir::Lifetime {

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -94,10 +94,6 @@ fhir_analysis_cannot_infer_sort =
     .label = cannot infer sort
     .note = sort must be known at this point
 
-
-fhir_analysis_refined_unrefinable_type =
-    type cannot be refined
-
 # Structural Compatibility
 
 fhir_analysis_incompatible_refinement =
@@ -204,6 +200,9 @@ fhir_analysis_too_many_generic_args =
         [one] argument
         *[other] arguments
     }
+
+fhir_analysis_refined_unrefinable_type =
+    type cannot be refined
 
 # Check impl against trait errors
 

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -48,12 +48,251 @@ use rustc_target::spec::abi;
 use rustc_trait_selection::traits;
 use rustc_type_ir::DebruijnIndex;
 
-pub struct ConvCtxt<'a, 'genv, 'tcx> {
+pub struct ConvCtxt<'genv, 'tcx, M> {
     genv: GlobalEnv<'genv, 'tcx>,
-    wfckresults: &'a WfckResults,
+    mode: M,
     next_type_index: u32,
     next_region_index: u32,
     next_const_index: u32,
+}
+
+pub trait Mode: Sized {
+    fn owner(&self) -> FluxOwnerId;
+
+    fn resolve_param_sort(
+        &self,
+        genv: GlobalEnv,
+        param: &fhir::RefineParam,
+    ) -> QueryResult<rty::Sort>;
+
+    fn conv_expr(
+        cx: &mut ConvCtxt<Self>,
+        env: &mut Env,
+        expr: &fhir::Expr,
+    ) -> QueryResult<rty::Expr>;
+
+    fn conv_refine_arg(
+        cx: &mut ConvCtxt<Self>,
+        env: &mut Env,
+        arg: &fhir::RefineArg,
+    ) -> QueryResult<rty::Expr>;
+}
+
+pub struct A<'a> {
+    wfckresults: &'a WfckResults,
+}
+
+impl<'a> Mode for A<'a> {
+    fn owner(&self) -> FluxOwnerId {
+        self.wfckresults.owner
+    }
+
+    fn resolve_param_sort(
+        &self,
+        genv: GlobalEnv,
+        param: &fhir::RefineParam,
+    ) -> QueryResult<rty::Sort> {
+        resolve_param_sort(genv, param, Some(self.wfckresults))
+    }
+
+    fn conv_expr(
+        cx: &mut ConvCtxt<Self>,
+        env: &mut Env,
+        expr: &fhir::Expr,
+    ) -> QueryResult<rty::Expr> {
+        let fhir_id = expr.fhir_id;
+        let espan = ESpan::new(expr.span);
+        let expr = match &expr.kind {
+            fhir::ExprKind::Var(var, _) => {
+                match var.res {
+                    ExprRes::Param(..) => env.lookup(var).to_expr(),
+                    ExprRes::Const(def_id) => rty::Expr::const_def_id(def_id).at(espan),
+                    ExprRes::ConstGeneric(def_id) => {
+                        rty::Expr::const_generic(def_id_to_param_const(cx.genv, def_id)).at(espan)
+                    }
+                    ExprRes::NumConst(num) => {
+                        rty::Expr::constant(rty::Constant::from(num)).at(espan)
+                    }
+                    ExprRes::GlobalFunc(..) => {
+                        span_bug!(var.span, "unexpected func in var position")
+                    }
+                }
+            }
+            fhir::ExprKind::Literal(lit) => rty::Expr::constant(conv_lit(*lit)).at(espan),
+            fhir::ExprKind::BinaryOp(op, e1, e2) => {
+                rty::Expr::binary_op(
+                    cx.conv_bin_op(*op, expr.fhir_id),
+                    cx.conv_expr(env, e1)?,
+                    cx.conv_expr(env, e2)?,
+                )
+                .at(espan)
+            }
+            fhir::ExprKind::UnaryOp(op, e) => {
+                rty::Expr::unary_op(conv_un_op(*op), cx.conv_expr(env, e)?).at(espan)
+            }
+            fhir::ExprKind::App(func, args) => {
+                rty::Expr::app(cx.conv_func(env, func), cx.conv_exprs(env, args)?).at(espan)
+            }
+            fhir::ExprKind::Alias(alias, args) => {
+                let args = args
+                    .iter()
+                    .map(|arg| cx.conv_expr(env, arg))
+                    .try_collect()?;
+                let alias = cx.conv_alias_reft(env, alias)?;
+                rty::Expr::alias(alias, args).at(espan)
+            }
+            fhir::ExprKind::IfThenElse(p, e1, e2) => {
+                rty::Expr::ite(
+                    cx.conv_expr(env, p)?,
+                    cx.conv_expr(env, e1)?,
+                    cx.conv_expr(env, e2)?,
+                )
+                .at(espan)
+            }
+            fhir::ExprKind::Dot(var, fld) => env.lookup(var).get_field(*fld, espan),
+        };
+        Ok(cx.add_coercions(expr, fhir_id))
+    }
+
+    fn conv_refine_arg(
+        cx: &mut ConvCtxt<Self>,
+        env: &mut Env,
+        arg: &fhir::RefineArg,
+    ) -> QueryResult<rty::Expr> {
+        match &arg.kind {
+            fhir::RefineArgKind::Expr(expr) => cx.conv_expr(env, expr),
+            fhir::RefineArgKind::Abs(params, body) => {
+                let layer = Layer::list(cx, 0, params)?;
+
+                env.push_layer(layer);
+                let pred = cx.conv_expr(env, body)?;
+                let inputs = env.pop_layer().into_bound_vars(cx.genv)?;
+                let output = cx
+                    .mode
+                    .wfckresults
+                    .node_sorts()
+                    .get(arg.fhir_id)
+                    .unwrap_or_else(|| bug!("lambda without elaborated sort"))
+                    .clone();
+                let lam = rty::Lambda::bind_with_vars(pred, inputs, output);
+                Ok(cx.add_coercions(rty::Expr::abs(lam), arg.fhir_id))
+            }
+            fhir::RefineArgKind::Record(flds) => {
+                let def_id = cx.mode.wfckresults.record_ctors().get(arg.fhir_id).unwrap();
+                let flds = flds
+                    .iter()
+                    .map(|arg| cx.conv_refine_arg(env, arg))
+                    .try_collect()?;
+                Ok(rty::Expr::adt(*def_id, flds))
+            }
+        }
+    }
+}
+
+impl<'a, 'genv, 'tcx> ConvCtxt<'genv, 'tcx, A<'a>> {
+    fn conv_exprs(&mut self, env: &mut Env, exprs: &[fhir::Expr]) -> QueryResult<List<rty::Expr>> {
+        exprs.iter().map(|e| A::conv_expr(self, env, e)).collect()
+    }
+
+    fn conv_bin_op(&self, op: fhir::BinOp, fhir_id: FhirId) -> rty::BinOp {
+        match op {
+            fhir::BinOp::Iff => rty::BinOp::Iff,
+            fhir::BinOp::Imp => rty::BinOp::Imp,
+            fhir::BinOp::Or => rty::BinOp::Or,
+            fhir::BinOp::And => rty::BinOp::And,
+            fhir::BinOp::Eq => rty::BinOp::Eq,
+            fhir::BinOp::Ne => rty::BinOp::Ne,
+            fhir::BinOp::Gt => rty::BinOp::Gt(self.bin_rel_sort(fhir_id)),
+            fhir::BinOp::Ge => rty::BinOp::Ge(self.bin_rel_sort(fhir_id)),
+            fhir::BinOp::Lt => rty::BinOp::Lt(self.bin_rel_sort(fhir_id)),
+            fhir::BinOp::Le => rty::BinOp::Le(self.bin_rel_sort(fhir_id)),
+            fhir::BinOp::Add => rty::BinOp::Add,
+            fhir::BinOp::Sub => rty::BinOp::Sub,
+            fhir::BinOp::Mod => rty::BinOp::Mod,
+            fhir::BinOp::Mul => rty::BinOp::Mul,
+            fhir::BinOp::Div => rty::BinOp::Div,
+        }
+    }
+
+    fn bin_rel_sort(&self, fhir_id: FhirId) -> rty::Sort {
+        self.mode
+            .wfckresults
+            .bin_rel_sorts()
+            .get(fhir_id)
+            .unwrap()
+            .clone()
+    }
+
+    fn add_coercions(&self, mut expr: rty::Expr, fhir_id: FhirId) -> rty::Expr {
+        let span = expr.span();
+        if let Some(coercions) = self.mode.wfckresults.coercions().get(fhir_id) {
+            for coercion in coercions {
+                expr = match *coercion {
+                    rty::Coercion::Inject(def_id) => {
+                        rty::Expr::aggregate(rty::AggregateKind::Adt(def_id), List::singleton(expr))
+                            .at_opt(span)
+                    }
+                    rty::Coercion::Project(def_id) => {
+                        rty::Expr::field_proj(expr, rty::FieldProj::Adt { def_id, field: 0 })
+                            .at_opt(span)
+                    }
+                };
+            }
+        }
+        expr
+    }
+
+    fn conv_func(&self, env: &Env, func: &fhir::PathExpr) -> rty::Expr {
+        let expr = match func.res {
+            ExprRes::Param(..) => env.lookup(func).to_expr(),
+            ExprRes::GlobalFunc(kind, sym) => rty::Expr::global_func(sym, kind),
+            _ => span_bug!(func.span, "unexpected path in function position"),
+        };
+        self.add_coercions(expr, func.fhir_id)
+    }
+
+    fn conv_alias_reft(
+        &mut self,
+        env: &mut Env,
+        alias: &fhir::AliasReft,
+    ) -> QueryResult<rty::AliasReft> {
+        let fhir::Res::Def(DefKind::Trait, trait_id) = alias.path.res else {
+            span_bug!(alias.path.span, "expected trait")
+        };
+        let trait_segment = alias.path.last_segment();
+
+        let generics = self.genv.generics_of(trait_id)?;
+        let self_ty =
+            self.conv_ty_to_generic_arg(env, &generics.param_at(0, self.genv)?, alias.qself)?;
+        let mut generic_args = vec![self_ty];
+        self.conv_generic_args_into(env, trait_id, trait_segment, &mut generic_args)?;
+
+        let alias_reft =
+            rty::AliasReft { trait_id, name: alias.name, args: List::from_vec(generic_args) };
+        Ok(alias_reft)
+    }
+
+    fn conv_invariants(
+        &mut self,
+        env: &mut Env,
+        invariants: &[fhir::Expr],
+    ) -> QueryResult<Vec<rty::Invariant>> {
+        invariants
+            .iter()
+            .map(|invariant| self.conv_invariant(env, invariant))
+            .collect()
+    }
+
+    fn conv_invariant(
+        &mut self,
+        env: &mut Env,
+        invariant: &fhir::Expr,
+    ) -> QueryResult<rty::Invariant> {
+        Ok(rty::Invariant::new(rty::Binder::bind_with_vars(
+            self.conv_expr(env, invariant)?,
+            env.top_layer().to_bound_vars(self.genv)?,
+        )))
+    }
 }
 
 pub(crate) struct Env {
@@ -410,11 +649,11 @@ pub(crate) fn conv_ty(
     Ok(rty::Binder::bind_with_vars(ty, List::empty()))
 }
 
-impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
+impl<'a, 'genv, 'tcx> ConvCtxt<'genv, 'tcx, A<'a>> {
     pub(crate) fn new(genv: GlobalEnv<'genv, 'tcx>, wfckresults: &'a WfckResults) -> Self {
         Self {
             genv,
-            wfckresults,
+            mode: A { wfckresults },
             // We start from 1 to skip the trait object dummy self type.
             // See [`rty::Ty::trait_object_dummy_self`]
             next_type_index: 1,
@@ -422,7 +661,27 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             next_const_index: 0,
         }
     }
+}
 
+impl<'genv, 'tcx, M: Mode> ConvCtxt<'genv, 'tcx, M> {
+    fn owner(&self) -> FluxOwnerId {
+        self.mode.owner()
+    }
+
+    fn conv_expr(&mut self, env: &mut Env, expr: &fhir::Expr) -> QueryResult<rty::Expr> {
+        M::conv_expr(self, env, expr)
+    }
+
+    fn conv_refine_arg(&mut self, env: &mut Env, arg: &fhir::RefineArg) -> QueryResult<rty::Expr> {
+        M::conv_refine_arg(self, env, arg)
+    }
+
+    fn resolve_param_sort(&self, param: &fhir::RefineParam) -> QueryResult<rty::Sort> {
+        self.mode.resolve_param_sort(self.genv, param)
+    }
+}
+
+impl<'a, 'genv, 'tcx> ConvCtxt<'genv, 'tcx, A<'a>> {
     fn conv_generic_bounds(
         &mut self,
         env: &mut Env,
@@ -758,27 +1017,6 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
             }
             fhir::Ensures::Pred(pred) => Ok(rty::Ensures::Pred(self.conv_expr(env, pred)?)),
         }
-    }
-
-    fn conv_alias_reft(
-        &mut self,
-        env: &mut Env,
-        alias: &fhir::AliasReft,
-    ) -> QueryResult<rty::AliasReft> {
-        let fhir::Res::Def(DefKind::Trait, trait_id) = alias.path.res else {
-            span_bug!(alias.path.span, "expected trait")
-        };
-        let trait_segment = alias.path.last_segment();
-
-        let generics = self.genv.generics_of(trait_id)?;
-        let self_ty =
-            self.conv_ty_to_generic_arg(env, &generics.param_at(0, self.genv)?, alias.qself)?;
-        let mut generic_args = vec![self_ty];
-        self.conv_generic_args_into(env, trait_id, trait_segment, &mut generic_args)?;
-
-        let alias_reft =
-            rty::AliasReft { trait_id, name: alias.name, args: List::from_vec(generic_args) };
-        Ok(alias_reft)
     }
 
     fn conv_ty(&mut self, env: &mut Env, ty: &fhir::Ty) -> QueryResult<rty::Ty> {
@@ -1459,10 +1697,6 @@ impl<'a, 'genv, 'tcx> ConvCtxt<'a, 'genv, 'tcx> {
         Ok(rty::GenericArg::Base(ctor))
     }
 
-    fn resolve_param_sort(&self, param: &fhir::RefineParam) -> QueryResult<rty::Sort> {
-        resolve_param_sort(self.genv, param, Some(self.wfckresults))
-    }
-
     fn next_type_vid(&mut self) -> rty::TyVid {
         self.next_type_index = self.next_type_index.checked_add(1).unwrap();
         rty::TyVid::from_u32(self.next_type_index - 1)
@@ -1557,180 +1791,14 @@ impl Env {
     }
 }
 
-impl ConvCtxt<'_, '_, '_> {
-    fn owner(&self) -> FluxOwnerId {
-        self.wfckresults.owner
-    }
-
-    fn conv_refine_arg(&mut self, env: &mut Env, arg: &fhir::RefineArg) -> QueryResult<rty::Expr> {
-        match &arg.kind {
-            fhir::RefineArgKind::Expr(expr) => self.conv_expr(env, expr),
-            fhir::RefineArgKind::Abs(params, body) => {
-                let layer = Layer::list(self, 0, params)?;
-
-                env.push_layer(layer);
-                let pred = self.conv_expr(env, body)?;
-                let inputs = env.pop_layer().into_bound_vars(self.genv)?;
-                let output = self
-                    .wfckresults
-                    .node_sorts()
-                    .get(arg.fhir_id)
-                    .unwrap_or_else(|| bug!("lambda without elaborated sort"))
-                    .clone();
-                let lam = rty::Lambda::bind_with_vars(pred, inputs, output);
-                Ok(self.add_coercions(rty::Expr::abs(lam), arg.fhir_id))
-            }
-            fhir::RefineArgKind::Record(flds) => {
-                let def_id = self.wfckresults.record_ctors().get(arg.fhir_id).unwrap();
-                let flds = flds
-                    .iter()
-                    .map(|arg| self.conv_refine_arg(env, arg))
-                    .try_collect()?;
-                Ok(rty::Expr::adt(*def_id, flds))
-            }
-        }
-    }
-
-    fn conv_expr(&mut self, env: &mut Env, expr: &fhir::Expr) -> QueryResult<rty::Expr> {
-        let fhir_id = expr.fhir_id;
-        let espan = ESpan::new(expr.span);
-        let expr = match &expr.kind {
-            fhir::ExprKind::Var(var, _) => {
-                match var.res {
-                    ExprRes::Param(..) => env.lookup(var).to_expr(),
-                    ExprRes::Const(def_id) => rty::Expr::const_def_id(def_id).at(espan),
-                    ExprRes::ConstGeneric(def_id) => {
-                        rty::Expr::const_generic(def_id_to_param_const(self.genv, def_id)).at(espan)
-                    }
-                    ExprRes::NumConst(num) => {
-                        rty::Expr::constant(rty::Constant::from(num)).at(espan)
-                    }
-                    ExprRes::GlobalFunc(..) => {
-                        span_bug!(var.span, "unexpected func in var position")
-                    }
-                }
-            }
-            fhir::ExprKind::Literal(lit) => rty::Expr::constant(conv_lit(*lit)).at(espan),
-            fhir::ExprKind::BinaryOp(op, e1, e2) => {
-                rty::Expr::binary_op(
-                    self.conv_bin_op(*op, expr.fhir_id),
-                    self.conv_expr(env, e1)?,
-                    self.conv_expr(env, e2)?,
-                )
-                .at(espan)
-            }
-            fhir::ExprKind::UnaryOp(op, e) => {
-                rty::Expr::unary_op(conv_un_op(*op), self.conv_expr(env, e)?).at(espan)
-            }
-            fhir::ExprKind::App(func, args) => {
-                rty::Expr::app(self.conv_func(env, func), self.conv_exprs(env, args)?).at(espan)
-            }
-            fhir::ExprKind::Alias(alias, args) => {
-                let args = args
-                    .iter()
-                    .map(|arg| self.conv_expr(env, arg))
-                    .try_collect()?;
-                let alias = self.conv_alias_reft(env, alias)?;
-                rty::Expr::alias(alias, args).at(espan)
-            }
-            fhir::ExprKind::IfThenElse(p, e1, e2) => {
-                rty::Expr::ite(
-                    self.conv_expr(env, p)?,
-                    self.conv_expr(env, e1)?,
-                    self.conv_expr(env, e2)?,
-                )
-                .at(espan)
-            }
-            fhir::ExprKind::Dot(var, fld) => env.lookup(var).get_field(*fld, espan),
-        };
-        Ok(self.add_coercions(expr, fhir_id))
-    }
-
-    fn conv_bin_op(&self, op: fhir::BinOp, fhir_id: FhirId) -> rty::BinOp {
-        match op {
-            fhir::BinOp::Iff => rty::BinOp::Iff,
-            fhir::BinOp::Imp => rty::BinOp::Imp,
-            fhir::BinOp::Or => rty::BinOp::Or,
-            fhir::BinOp::And => rty::BinOp::And,
-            fhir::BinOp::Eq => rty::BinOp::Eq,
-            fhir::BinOp::Ne => rty::BinOp::Ne,
-            fhir::BinOp::Gt => rty::BinOp::Gt(self.bin_rel_sort(fhir_id)),
-            fhir::BinOp::Ge => rty::BinOp::Ge(self.bin_rel_sort(fhir_id)),
-            fhir::BinOp::Lt => rty::BinOp::Lt(self.bin_rel_sort(fhir_id)),
-            fhir::BinOp::Le => rty::BinOp::Le(self.bin_rel_sort(fhir_id)),
-            fhir::BinOp::Add => rty::BinOp::Add,
-            fhir::BinOp::Sub => rty::BinOp::Sub,
-            fhir::BinOp::Mod => rty::BinOp::Mod,
-            fhir::BinOp::Mul => rty::BinOp::Mul,
-            fhir::BinOp::Div => rty::BinOp::Div,
-        }
-    }
-
-    fn bin_rel_sort(&self, fhir_id: FhirId) -> rty::Sort {
-        self.wfckresults
-            .bin_rel_sorts()
-            .get(fhir_id)
-            .unwrap()
-            .clone()
-    }
-
-    fn conv_func(&self, env: &Env, func: &fhir::PathExpr) -> rty::Expr {
-        let expr = match func.res {
-            ExprRes::Param(..) => env.lookup(func).to_expr(),
-            ExprRes::GlobalFunc(kind, sym) => rty::Expr::global_func(sym, kind),
-            _ => span_bug!(func.span, "unexpected path in function position"),
-        };
-        self.add_coercions(expr, func.fhir_id)
-    }
-
-    fn conv_exprs(&mut self, env: &mut Env, exprs: &[fhir::Expr]) -> QueryResult<List<rty::Expr>> {
-        exprs.iter().map(|e| self.conv_expr(env, e)).collect()
-    }
-
-    fn conv_invariants(
-        &mut self,
-        env: &mut Env,
-        invariants: &[fhir::Expr],
-    ) -> QueryResult<Vec<rty::Invariant>> {
-        invariants
-            .iter()
-            .map(|invariant| self.conv_invariant(env, invariant))
-            .collect()
-    }
-
-    fn conv_invariant(
-        &mut self,
-        env: &mut Env,
-        invariant: &fhir::Expr,
-    ) -> QueryResult<rty::Invariant> {
-        Ok(rty::Invariant::new(rty::Binder::bind_with_vars(
-            self.conv_expr(env, invariant)?,
-            env.top_layer().to_bound_vars(self.genv)?,
-        )))
-    }
-
-    fn add_coercions(&self, mut expr: rty::Expr, fhir_id: FhirId) -> rty::Expr {
-        let span = expr.span();
-        if let Some(coercions) = self.wfckresults.coercions().get(fhir_id) {
-            for coercion in coercions {
-                expr = match *coercion {
-                    rty::Coercion::Inject(def_id) => {
-                        rty::Expr::aggregate(rty::AggregateKind::Adt(def_id), List::singleton(expr))
-                            .at_opt(span)
-                    }
-                    rty::Coercion::Project(def_id) => {
-                        rty::Expr::field_proj(expr, rty::FieldProj::Adt { def_id, field: 0 })
-                            .at_opt(span)
-                    }
-                };
-            }
-        }
-        expr
-    }
-}
+impl<M: Mode> ConvCtxt<'_, '_, M> {}
 
 impl Layer {
-    fn new(cx: &ConvCtxt, params: &[fhir::RefineParam], kind: LayerKind) -> QueryResult<Self> {
+    fn new<M: Mode>(
+        cx: &ConvCtxt<M>,
+        params: &[fhir::RefineParam],
+        kind: LayerKind,
+    ) -> QueryResult<Self> {
         let map = params
             .iter()
             .map(|param| -> QueryResult<_> {
@@ -1743,11 +1811,19 @@ impl Layer {
         Ok(Self { map, kind })
     }
 
-    fn list(cx: &ConvCtxt, bound_regions: u32, params: &[fhir::RefineParam]) -> QueryResult<Self> {
+    fn list<M: Mode>(
+        cx: &ConvCtxt<M>,
+        bound_regions: u32,
+        params: &[fhir::RefineParam],
+    ) -> QueryResult<Self> {
         Self::new(cx, params, LayerKind::List { bound_regions })
     }
 
-    fn coalesce(cx: &ConvCtxt, def_id: DefId, params: &[fhir::RefineParam]) -> QueryResult<Self> {
+    fn coalesce<M: Mode>(
+        cx: &ConvCtxt<M>,
+        def_id: DefId,
+        params: &[fhir::RefineParam],
+    ) -> QueryResult<Self> {
         Self::new(cx, params, LayerKind::Coalesce(def_id))
     }
 

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -271,7 +271,7 @@ fn sort_of_assoc_reft(
             let inputs = assoc_reft
                 .params
                 .iter()
-                .map(|p| conv::resolve_param_sort(genv, p, None))
+                .map(|p| conv::conv_sort(genv, &p.sort, &mut bug_on_infer_sort))
                 .try_collect_vec()?;
             let output = conv::conv_sort(genv, &assoc_reft.output, &mut bug_on_infer_sort)?;
             Ok(Some(rty::EarlyBinder(rty::FuncSort::new(inputs, output))))
@@ -281,7 +281,7 @@ fn sort_of_assoc_reft(
             let inputs = assoc_reft
                 .params
                 .iter()
-                .map(|p| conv::resolve_param_sort(genv, p, None))
+                .map(|p| conv::conv_sort(genv, &p.sort, &mut bug_on_infer_sort))
                 .try_collect_vec()?;
             let output = conv::conv_sort(genv, &assoc_reft.output, &mut bug_on_infer_sort)?;
             Ok(Some(rty::EarlyBinder(rty::FuncSort::new(inputs, output))))

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -490,7 +490,7 @@ fn fn_sig(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<r
     let fhir_fn_sig = genv.desugar(def_id.local_id())?.fn_sig().unwrap();
     let wfckresults = genv.check_wf(def_id.local_id())?;
     let fn_sig = ConvCtxt::new(genv, &*wfckresults).conv_fn_sig(def_id, fhir_fn_sig)?;
-    let fn_sig = struct_compat::fn_sig(genv, &fhir_fn_sig.decl, &fn_sig, def_id)?;
+    let fn_sig = struct_compat::fn_sig(genv, fhir_fn_sig.decl, &fn_sig, def_id)?;
     let fn_sig = normalize(genv, fn_sig)?;
 
     if config::dump_rty() {

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -17,7 +17,7 @@ mod wf;
 
 use std::rc::Rc;
 
-use conv::bug_on_infer_sort;
+use conv::{bug_on_infer_sort, ConvCtxt};
 use flux_common::{bug, dbg, iter::IterExt, result::ResultExt};
 use flux_config as config;
 use flux_errors::Errors;
@@ -444,16 +444,15 @@ fn variants_of(
     let variants = match &item.kind {
         fhir::ItemKind::Enum(enum_def) => {
             let wfckresults = genv.check_wf(local_id)?;
-            let variants =
-                conv::ConvCtxt::conv_enum_variants(genv, def_id, enum_def, &wfckresults)?
-                    .into_iter()
-                    .map(|variant| normalize(genv, variant))
-                    .try_collect()?;
+            let variants = ConvCtxt::conv_enum_variants(genv, def_id, enum_def, &*wfckresults)?
+                .into_iter()
+                .map(|variant| normalize(genv, variant))
+                .try_collect()?;
             rty::Opaqueness::Transparent(rty::EarlyBinder(variants))
         }
         fhir::ItemKind::Struct(struct_def) => {
             let wfckresults = genv.check_wf(local_id)?;
-            conv::ConvCtxt::conv_struct_variant(genv, def_id, struct_def, &wfckresults)?
+            ConvCtxt::conv_struct_variant(genv, def_id, struct_def, &*wfckresults)?
                 .map(|variants| {
                     variants
                         .into_iter()

--- a/crates/flux-fhir-analysis/src/wf/errors.rs
+++ b/crates/flux-fhir-analysis/src/wf/errors.rs
@@ -226,16 +226,3 @@ impl CannotInferSort {
         Self { span }
     }
 }
-
-#[derive(Diagnostic)]
-#[diag(fhir_analysis_refined_unrefinable_type, code = E0999)]
-pub(super) struct RefinedUnrefinableType {
-    #[primary_span]
-    span: Span,
-}
-
-impl RefinedUnrefinableType {
-    pub(super) fn new(span: Span) -> Self {
-        Self { span }
-    }
-}

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -194,7 +194,7 @@ impl<'genv> fhir::visit::Visitor<'genv> for Wf<'_, 'genv, '_> {
         let Ok(args) = rty::GenericArg::identity_for_item(genv, enum_id).emit(&self.errors) else {
             return;
         };
-        let expected = adt_sort_def.sort(&args);
+        let expected = adt_sort_def.to_sort(&args);
         self.infcx
             .check_refine_arg(&ret.idx, &expected)
             .collect_err(&mut self.errors);

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -110,14 +110,18 @@ pub(crate) fn foo<'genv>(
                 fhir::ItemKind::Impl(_) => {}
                 fhir::ItemKind::Fn(fn_sig) => {
                     cx.conv_fn_sig(def_id, fn_sig)?;
+                    cx.conv_generic_predicates(def_id, &item.generics)?;
                 }
-                fhir::ItemKind::OpaqueTy(_) => {}
+                fhir::ItemKind::OpaqueTy(opaque_ty) => {
+                    cx.conv_opaque_ty(def_id.expect_local(), opaque_ty)?;
+                }
             }
         }
         fhir::Node::TraitItem(trait_item) => {
             match trait_item.kind {
                 fhir::TraitItemKind::Fn(fn_sig) => {
                     cx.conv_fn_sig(def_id, &fn_sig)?;
+                    cx.conv_generic_predicates(def_id, &trait_item.generics)?;
                 }
                 fhir::TraitItemKind::Type => {}
             }
@@ -126,6 +130,7 @@ pub(crate) fn foo<'genv>(
             match impl_item.kind {
                 fhir::ImplItemKind::Fn(fn_sig) => {
                     cx.conv_fn_sig(def_id, &fn_sig)?;
+                    cx.conv_generic_predicates(def_id, &impl_item.generics)?;
                 }
                 fhir::ImplItemKind::Type => {}
             }

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -103,12 +103,28 @@ pub(crate) fn foo<'genv>(genv: GlobalEnv<'genv, '_>, node: &fhir::Node<'genv>) -
                 fhir::ItemKind::TyAlias(_) => {}
                 fhir::ItemKind::Trait(_) => {}
                 fhir::ItemKind::Impl(_) => {}
-                fhir::ItemKind::Fn(_) => {}
+                fhir::ItemKind::Fn(fn_sig) => {
+                    cx.conv_fn_sig(def_id, fn_sig)?;
+                }
                 fhir::ItemKind::OpaqueTy(_) => {}
             }
         }
-        fhir::Node::TraitItem(_) => {}
-        fhir::Node::ImplItem(_) => {}
+        fhir::Node::TraitItem(trait_item) => {
+            match trait_item.kind {
+                fhir::TraitItemKind::Fn(fn_sig) => {
+                    cx.conv_fn_sig(def_id, &fn_sig)?;
+                }
+                fhir::TraitItemKind::Type => {}
+            }
+        }
+        fhir::Node::ImplItem(impl_item) => {
+            match impl_item.kind {
+                fhir::ImplItemKind::Fn(fn_sig) => {
+                    cx.conv_fn_sig(def_id, &fn_sig)?;
+                }
+                fhir::ImplItemKind::Type => {}
+            }
+        }
     }
     Ok(())
 }

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -160,6 +160,7 @@ fn init_infcx<'genv, 'tcx>(
             }
         }
     }
+    infcx.normalize_weak_alias_sorts()?;
     Ok(infcx)
 }
 
@@ -307,20 +308,7 @@ impl<'genv> fhir::visit::Visitor<'genv> for Wf<'_, 'genv, '_> {
     fn visit_ty(&mut self, ty: &fhir::Ty<'genv>) {
         match &ty.kind {
             fhir::TyKind::Indexed(bty, idx) => {
-                // Check if any error reported here should be reportd during conv
-                let a = 0;
-                // let Ok(sort_of_bty) = self.infcx.genv.sort_of_bty(bty).emit(&self.errors) else {
-                //     return;
-                // };
-                // if let Some(expected) = sort_of_bty {
-                //     self.infcx
-                //         .check_refine_arg(idx, &expected)
-                //         .collect_err(&mut self.errors);
-                // } else if idx.is_colon_param().is_none() {
-                //     self.errors
-                //         .emit(errors::RefinedUnrefinableType::new(bty.span));
-                // }
-                let Ok(expected) = self.infcx.sort_of_bty(bty.fhir_id) else { return };
+                let expected = self.infcx.sort_of_bty(bty.fhir_id);
                 self.infcx
                     .check_refine_arg(idx, &expected)
                     .collect_err(&mut self.errors);

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -100,7 +100,9 @@ pub(crate) fn foo<'genv>(genv: GlobalEnv<'genv, '_>, node: &fhir::Node<'genv>) -
                 fhir::ItemKind::Struct(struct_def) => {
                     cx.conv_struct_variant(def_id, struct_def)?;
                 }
-                fhir::ItemKind::TyAlias(_) => {}
+                fhir::ItemKind::TyAlias(ty_alias) => {
+                    cx.conv_type_alias(def_id, ty_alias)?;
+                }
                 fhir::ItemKind::Trait(_) => {}
                 fhir::ItemKind::Impl(_) => {}
                 fhir::ItemKind::Fn(fn_sig) => {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -379,7 +379,7 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
     pub(crate) fn normalize_weak_alias_sorts(&mut self) -> QueryResult {
         for sort in self.sort_of_bty.values_mut() {
             if let rty::Sort::Alias(alias_ty) = sort {
-                *sort = self.genv.normalize_weak_alias_sort(&alias_ty)?;
+                *sort = self.genv.normalize_weak_alias_sort(alias_ty)?;
             }
         }
         Ok(())

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -353,10 +353,6 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
         let mut cx = ConvCtxt::new(self.genv, InSortck { owner: self.wfckresults.owner });
         cx.conv_base_ty(&mut Env::empty(), bty)
     }
-
-    fn conv_ctxt(&self) -> ConvCtxt<'genv, 'tcx, InSortck> {
-        ConvCtxt::new(self.genv, InSortck { owner: self.wfckresults.owner })
-    }
 }
 
 impl<'genv> InferCtxt<'genv, '_> {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -375,7 +375,7 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
 
     // FIXME(nilehmann) this assumes weak aliases appear shallowly and are only created for the
     // sorts associated to base types. We should find a more robust way to do normalization for
-    // sort checkint. If we do so we can stop expanding self aliases in `conv::conv_sort`.
+    // sort checking. If we do so we can stop expanding self aliases in `conv::conv_sort`.
     pub(crate) fn normalize_weak_alias_sorts(&mut self) -> QueryResult {
         for sort in self.sort_of_bty.values_mut() {
             if let rty::Sort::Alias(alias_ty) = sort {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -551,20 +551,16 @@ impl<'genv> InferCtxt<'genv, '_> {
     }
 
     pub(crate) fn resolve_param_sort(&mut self, param: &fhir::RefineParam) -> Result {
-        if let fhir::Sort::Infer = param.sort {
-            let sort = self.param_sort(param.id);
-            match self.fully_resolve(&sort) {
-                Ok(sort) => {
-                    self.wfckresults
-                        .node_sorts_mut()
-                        .insert(param.fhir_id, sort);
-                }
-                Err(_) => {
-                    return Err(self.emit_err(errors::SortAnnotationNeeded::new(param)));
-                }
+        let sort = self.param_sort(param.id);
+        match self.fully_resolve(&sort) {
+            Ok(sort) => {
+                self.wfckresults
+                    .node_sorts_mut()
+                    .insert(param.fhir_id, sort);
+                Ok(())
             }
+            Err(_) => Err(self.emit_err(errors::SortAnnotationNeeded::new(param))),
         }
-        Ok(())
     }
 
     fn ensure_resolved_var(&mut self, path: &fhir::PathExpr) -> Result<rty::Sort> {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -357,6 +357,8 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
     }
 
     pub(crate) fn sort_of_bty(&self, fhir_id: FhirId) -> QueryResult<rty::Sort> {
+        // find a better place to do the normalization
+        let a = 0;
         let sort = self.sort_of_bty[&fhir_id].clone();
         if let rty::Sort::Alias(alias_ty) = sort {
             self.genv.normalize_weak_alias_sort(&alias_ty)
@@ -590,7 +592,11 @@ impl<'genv> InferCtxt<'genv, '_> {
 
     #[track_caller]
     pub(crate) fn param_sort(&self, id: fhir::ParamId) -> rty::Sort {
-        self.params[&id].0.clone()
+        self.params
+            .get(&id)
+            .unwrap_or_else(|| bug!("no entry found for `{id:?}`"))
+            .0
+            .clone()
     }
 
     fn shallow_resolve(&mut self, sort: &rty::Sort) -> rty::Sort {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -373,6 +373,9 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
             .clone()
     }
 
+    // FIXME(nilehmann) this assumes weak aliases appear shallowly and are only created for the
+    // sorts associated to base types. We should find a more robust way to do normalization for
+    // sort checkint. If we do so we can stop expanding self aliases in `conv::conv_sort`.
     pub(crate) fn normalize_weak_alias_sorts(&mut self) -> QueryResult {
         for sort in self.sort_of_bty.values_mut() {
             if let rty::Sort::Alias(alias_ty) = sort {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -350,8 +350,8 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
     }
 
     fn conv_base_ty(&self, bty: &fhir::BaseTy) -> QueryResult<rty::Ty> {
-        let mut cx = ConvCtxt::new(self.genv, InSortck { owner: self.wfckresults.owner });
-        cx.conv_base_ty(&mut Env::empty(), bty)
+        let results = InSortck { owner: self.wfckresults.owner };
+        ConvCtxt::new(self.genv, &results).conv_base_ty(&mut Env::empty(), bty)
     }
 }
 

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -959,14 +959,14 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                     self.expr_to_fixpoint(e2, scx)?,
                 ]))
             }
-            rty::ExprKind::Alias(alias_pred, args) => {
+            rty::ExprKind::Alias(alias_reft, args) => {
                 let sort = self
                     .genv
-                    .sort_of_assoc_reft(alias_pred.trait_id, alias_pred.name)?
+                    .sort_of_assoc_reft(alias_reft.trait_id, alias_reft.name)?
                     .unwrap();
                 let sort = sort.instantiate_identity();
                 let func = fixpoint::Expr::Var(
-                    self.register_const_for_alias_reft(alias_pred, sort, scx)
+                    self.register_const_for_alias_reft(alias_reft, sort, scx)
                         .into(),
                 );
                 let args = args

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -210,8 +210,11 @@ impl SortEncodingCtxt {
             }
             rty::Sort::Func(sort) => self.func_sort_to_fixpoint(sort),
             rty::Sort::Var(k) => fixpoint::Sort::Var(k.index()),
+            rty::Sort::Alias(_) => {
+                tracked_span_bug!("TODO: implementt encoding of `Sort::Alias`: `{sort:?}`")
+            }
             rty::Sort::Err | rty::Sort::Infer(_) | rty::Sort::Loc => {
-                bug!("unexpected sort {sort:?}")
+                tracked_span_bug!("unexpected sort `{sort:?}`")
             }
         }
     }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -1065,14 +1065,20 @@ impl Lit {
 /// Information about the refinement parameters associated with a type alias or an adt (struct/enum).
 #[derive(Clone, Debug)]
 pub struct RefinedBy<'fhir> {
-    /// Tracks the mapping from bound var to generic def ids. e.g. if we have
+    /// When a `#[flux::refined_by(..)]` annotation mentions generic type parameters we implicitly
+    /// generate a *polymorphic* data sort.
     ///
+    /// For example, if we have:
     /// ```ignore
     /// #[refined_by(keys: Set<K>)]
-    /// RMap<K, V> { ...}
+    /// RMap<K, V> { ... }
     /// ```
-    /// then the sort associated to `RMap` is of the form `forall #0. { keys: Set<#0> }`
-    /// and `sort_params` will be `vec![K]`,  i.e., it maps `Var(0)` to `K`.
+    /// we implicitly create a data sort of the form `forall #0. { keys: Set<#0> }`, where `#0` is a
+    /// *sort variable*.
+    ///
+    /// The [`FxIndexSet`] is used to track a mapping between sort varriables and their corresponding
+    /// type parameter. The [`DefId`] is the id of the type parameter and its index in the set is the
+    /// position of the sort variable.
     pub sort_params: FxIndexSet<DefId>,
     /// Fields indexed by their name and in the same order they appear in the definition.
     pub fields: FxIndexMap<Symbol, Sort<'fhir>>,

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -608,7 +608,22 @@ pub enum RefineArgKind<'fhir> {
 #[derive(Clone, Copy)]
 pub struct BaseTy<'fhir> {
     pub kind: BaseTyKind<'fhir>,
+    pub fhir_id: FhirId,
     pub span: Span,
+}
+
+impl<'fhir> BaseTy<'fhir> {
+    pub fn from_qpath(qpath: QPath<'fhir>, fhir_id: FhirId) -> Self {
+        let span = qpath.span();
+        Self { kind: BaseTyKind::Path(qpath), fhir_id, span }
+    }
+
+    fn as_path(&self) -> Option<Path<'fhir>> {
+        match self.kind {
+            BaseTyKind::Path(QPath::Resolved(None, path)) => Some(path),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -998,15 +1013,6 @@ impl<'fhir> Ty<'fhir> {
     }
 }
 
-impl<'fhir> BaseTy<'fhir> {
-    fn as_path(&self) -> Option<Path<'fhir>> {
-        match self.kind {
-            BaseTyKind::Path(QPath::Resolved(None, path)) => Some(path),
-            _ => None,
-        }
-    }
-}
-
 impl Res {
     pub fn descr(&self) -> &'static str {
         match self {
@@ -1049,13 +1055,6 @@ impl<'fhir> QPath<'fhir> {
             QPath::Resolved(_, path) => path.span,
             QPath::TypeRelative(qself, assoc) => qself.span.to(assoc.ident.span),
         }
-    }
-}
-
-impl<'fhir> From<QPath<'fhir>> for BaseTy<'fhir> {
-    fn from(qpath: QPath<'fhir>) -> Self {
-        let span = qpath.span();
-        Self { kind: BaseTyKind::Path(qpath), span }
     }
 }
 

--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -284,7 +284,7 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
             hir::TyKind::Slice(ty) => {
                 let ty = self.lift_ty(ty)?;
                 let kind = fhir::BaseTyKind::Slice(self.genv.alloc(ty));
-                let bty = fhir::BaseTy { kind, span: ty.span };
+                let bty = fhir::BaseTy { kind, fhir_id: self.next_fhir_id(), span: ty.span };
                 return Ok(fhir::Ty { kind: fhir::TyKind::BaseTy(bty), span: ty.span });
             }
             hir::TyKind::Array(ty, len) => {
@@ -305,7 +305,7 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
             }
             hir::TyKind::Path(qpath) => {
                 let qpath = self.lift_qpath(qpath)?;
-                let bty = fhir::BaseTy::from(qpath);
+                let bty = fhir::BaseTy::from_qpath(qpath, self.next_fhir_id());
                 return Ok(fhir::Ty { kind: fhir::TyKind::BaseTy(bty), span: bty.span });
             }
             hir::TyKind::Ptr(mut_ty) => {

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -44,6 +44,7 @@ mod sort_of;
 use std::sync::LazyLock;
 
 use flux_arc_interner::List;
+use flux_common::bug;
 use flux_config as config;
 use flux_macros::fluent_messages;
 pub use flux_rustc_bridge::def_id_to_string;
@@ -480,6 +481,14 @@ impl<Id> MaybeExternId<Id> {
     pub fn local_id(self) -> Id {
         match self {
             MaybeExternId::Local(local_id) | MaybeExternId::Extern(local_id, _) => local_id,
+        }
+    }
+
+    #[track_caller]
+    pub fn expect_local(self) -> Id {
+        match self {
+            MaybeExternId::Local(local_id) => local_id,
+            MaybeExternId::Extern(..) => bug!("expected `MaybeExternId::Local`"),
         }
     }
 

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -306,10 +306,6 @@ newtype_index! {
 }
 
 impl ExprKind {
-    // pub fn intern_at_opt(self, espan: Option<ESpan>) -> Expr {
-    //     Expr { kind: Interned::new(self), espan }
-    // }
-
     fn intern(self) -> Expr {
         Expr { kind: Interned::new(self), espan: None }
     }

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -431,6 +431,7 @@ impl TypeSuperVisitable for Sort {
             Sort::Tuple(sorts) => sorts.visit_with(visitor),
             Sort::App(_, args) => args.visit_with(visitor),
             Sort::Func(fsort) => fsort.visit_with(visitor),
+            Sort::Alias(alias_ty) => alias_ty.visit_with(visitor),
             Sort::Int
             | Sort::Bool
             | Sort::Real
@@ -457,6 +458,7 @@ impl TypeSuperFoldable for Sort {
             Sort::Tuple(sorts) => Sort::tuple(sorts.try_fold_with(folder)?),
             Sort::App(ctor, sorts) => Sort::app(ctor.clone(), sorts.try_fold_with(folder)?),
             Sort::Func(fsort) => Sort::Func(fsort.try_fold_with(folder)?),
+            Sort::Alias(alias_ty) => Sort::Alias(alias_ty.try_fold_with(folder)?),
             Sort::Int
             | Sort::Bool
             | Sort::Real
@@ -721,6 +723,7 @@ impl TypeSuperVisitable for BaseTy {
             BaseTy::Ref(_, ty, _) => ty.visit_with(visitor),
             BaseTy::FnPtr(poly_fn_sig) => poly_fn_sig.visit_with(visitor),
             BaseTy::Tuple(tys) => tys.visit_with(visitor),
+            BaseTy::Alias(alias_ty) => alias_ty.visit_with(visitor),
             BaseTy::Array(ty, _) => ty.visit_with(visitor),
             BaseTy::Coroutine(_, resume_ty, upvars) => {
                 resume_ty.visit_with(visitor)?;
@@ -759,6 +762,7 @@ impl TypeSuperFoldable for BaseTy {
             }
             BaseTy::FnPtr(decl) => BaseTy::FnPtr(decl.try_fold_with(folder)?),
             BaseTy::Tuple(tys) => BaseTy::Tuple(tys.try_fold_with(folder)?),
+            BaseTy::Alias(alias_ty) => BaseTy::Alias(alias_ty.try_fold_with(folder)?),
             BaseTy::Array(ty, c) => {
                 BaseTy::Array(ty.try_fold_with(folder)?, c.try_fold_with(folder)?)
             }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1441,30 +1441,6 @@ impl BaseTy {
         }
     }
 
-    pub fn sort(&self) -> Sort {
-        match self {
-            BaseTy::Int(_) | BaseTy::Uint(_) | BaseTy::Slice(_) => Sort::Int,
-            BaseTy::Bool => Sort::Bool,
-            BaseTy::Adt(adt_def, args) => adt_def.sort(args),
-            BaseTy::Param(param_ty) => Sort::Param(*param_ty),
-            BaseTy::Str => Sort::Str,
-            BaseTy::Alias(alias_ty) => Sort::Alias(alias_ty.clone()),
-            BaseTy::Float(_)
-            | BaseTy::Char
-            | BaseTy::RawPtr(..)
-            | BaseTy::Ref(..)
-            | BaseTy::FnPtr(..)
-            | BaseTy::FnDef(..)
-            | BaseTy::Tuple(_)
-            | BaseTy::Array(_, _)
-            | BaseTy::Closure(..)
-            | BaseTy::Coroutine(..)
-            | BaseTy::Dynamic(_, _)
-            | BaseTy::Never => Sort::unit(),
-            BaseTy::Infer(_) => tracked_span_bug!(),
-        }
-    }
-
     #[track_caller]
     pub fn expect_adt(&self) -> (&AdtDef, &[GenericArg]) {
         if let BaseTy::Adt(adt_def, args) = self {

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -2104,13 +2104,6 @@ impl<'tcx> ToRustc<'tcx> for AliasTy {
     }
 }
 
-impl Binder<Expr> {
-    /// See [`Expr::is_trivially_true`]
-    pub fn is_trivially_true(&self) -> bool {
-        self.skip_binder_ref().is_trivially_true()
-    }
-}
-
 /// returns the same invariants as for `usize` which is the length of a slice
 fn slice_invariants(overflow_checking: bool) -> &'static [Invariant] {
     static DEFAULT: LazyLock<[Invariant; 1]> = LazyLock::new(|| {

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -63,14 +63,27 @@ use crate::{
     rty::subst::SortSubst,
 };
 
+/// The definition of the data sort automatically generated for a struct, enum or type alias.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
 pub struct AdtSortDef(Interned<AdtSortDefData>);
 
 #[derive(Debug, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 struct AdtSortDefData {
+    /// [`DefId`] of the struct, enum or type aliases this data sort is associated to
     def_id: DefId,
+    /// The list of the type parameters used in the `#[flux::refined_by(..)]` annotation.
+    ///
+    /// See [`fhir::RefinedBy::sort_params`] for more details. This is a version of that but using
+    /// [`ParamTy`] instead of [`DefId`].
+    ///
+    /// The length of this list corresponds to the number of sort variables bound by this definition.
     params: Vec<ParamTy>,
+    /// The list of field names as declared in the `#[flux::refined_by(...)]` annotation
     field_names: Vec<Symbol>,
+    /// The sort of each of the fields. Note that these can contain [sort variables]. Methods used
+    /// to access these sorts guarantee they are properly instantiated.
+    ///
+    /// [sort variables]: Sort::Var
     sorts: List<Sort>,
 }
 
@@ -480,8 +493,8 @@ pub enum SortCtor {
 
 newtype_index! {
     /// [ParamSort] is used for polymorphic sorts (Set, Map etc.) and [bit-vector size parameters].
-    /// They should occur "bound" under a [`PolyFuncSort`]; i.e. should be < than the number of params
-    /// in the [`PolyFuncSort`].
+    /// They should occur "bound" under a [`PolyFuncSort`] or an [`AdtSortDef`]; i.e. should be <
+    /// than the number of params.
     ///
     /// [bit-vector size parameters]: BvSize::Param
     #[debug_format = "?{}s"]

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -2255,7 +2255,7 @@ pub struct WfckResults {
     coercions: ItemLocalMap<Vec<Coercion>>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Coercion {
     Inject(DefId),
     Project(DefId),

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -109,6 +109,7 @@ impl Pretty for Sort {
                     w!("({:?})", join!(", ", sorts))
                 }
             }
+            Sort::Alias(alias_ty) => todo!(),
             Sort::App(ctor, sorts) => {
                 if sorts.is_empty() {
                     w!("{:?}", ctor)
@@ -444,6 +445,7 @@ impl Pretty for BaseTy {
                     w!("({:?})", join!(", ", tys))
                 }
             }
+            BaseTy::Alias(alias_ty) => todo!(),
             BaseTy::Array(ty, c) => w!("[{:?}; {:?}]", ty, ^c),
             BaseTy::Never => w!("!"),
             BaseTy::Closure(did, args, _) => {

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -451,7 +451,13 @@ impl Pretty for BaseTy {
                     w!("({:?})", join!(", ", tys))
                 }
             }
-            BaseTy::Alias(alias_ty) => todo!(),
+            BaseTy::Alias(alias_ty) => {
+                w!("{:?}", alias_ty.def_id)?;
+                if !alias_ty.args.is_empty() {
+                    w!("<{:?}>", join!(", ", &alias_ty.args))?;
+                }
+                Ok(())
+            }
             BaseTy::Array(ty, c) => w!("[{:?}; {:?}]", ty, ^c),
             BaseTy::Never => w!("!"),
             BaseTy::Closure(did, args, _) => {

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -109,7 +109,13 @@ impl Pretty for Sort {
                     w!("({:?})", join!(", ", sorts))
                 }
             }
-            Sort::Alias(alias_ty) => todo!(),
+            Sort::Alias(alias_ty) => {
+                w!("{:?}", alias_ty.def_id)?;
+                if !alias_ty.args.is_empty() {
+                    w!("<{:?}>", join!(", ", &alias_ty.args))?;
+                }
+                w!("::sort")
+            }
             Sort::App(ctor, sorts) => {
                 if sorts.is_empty() {
                     w!("{:?}", ctor)

--- a/crates/flux-middle/src/rty/projections.rs
+++ b/crates/flux-middle/src/rty/projections.rs
@@ -333,8 +333,7 @@ impl FallibleTypeFolder for Normalizer<'_, '_, '_> {
     fn try_fold_sort(&mut self, sort: &Sort) -> Result<Sort, Self::Error> {
         if let Sort::Alias(alias_ty) = sort {
             self.genv
-                .adt_sort_def_of(alias_ty.def_id)?
-                .to_sort(&alias_ty.args)
+                .normalize_weak_alias_sort(alias_ty)?
                 .try_fold_with(self)
         } else {
             sort.try_super_fold_with(self)

--- a/crates/flux-middle/src/rty/projections.rs
+++ b/crates/flux-middle/src/rty/projections.rs
@@ -15,7 +15,7 @@ use super::{
     fold::{FallibleTypeFolder, TypeFoldable, TypeSuperFoldable},
     subst::{GenericsSubstDelegate, GenericsSubstFolder},
     AliasKind, AliasReft, AliasTy, BaseTy, Binder, Clause, ClauseKind, Const, EarlyBinder, Expr,
-    ExprKind, GenericArg, ProjectionPredicate, RefineArgs, Region, SubsetTy, Ty, TyKind,
+    ExprKind, GenericArg, ProjectionPredicate, RefineArgs, Region, Sort, SubsetTy, Ty, TyKind,
 };
 use crate::{
     global_env::GlobalEnv,
@@ -330,6 +330,17 @@ fn assemble_candidates_from_predicates(
 impl FallibleTypeFolder for Normalizer<'_, '_, '_> {
     type Error = QueryErr;
 
+    fn try_fold_sort(&mut self, sort: &Sort) -> Result<Sort, Self::Error> {
+        if let Sort::Alias(alias_ty) = sort {
+            self.genv
+                .adt_sort_def_of(alias_ty.def_id)?
+                .to_sort(&alias_ty.args)
+                .try_fold_with(self)
+        } else {
+            sort.try_super_fold_with(self)
+        }
+    }
+
     // As shown in https://github.com/flux-rs/flux/issues/711
     // one round of `normalize_projections` can replace one
     // projection e.g. `<Rev<Iter<[i32]> as Iterator>::Item`
@@ -339,6 +350,13 @@ impl FallibleTypeFolder for Normalizer<'_, '_, '_> {
     // which is what the `changed` is for.
     fn try_fold_ty(&mut self, ty: &Ty) -> Result<Ty, Self::Error> {
         match ty.kind() {
+            TyKind::Indexed(BaseTy::Alias(alias_ty), idx) => {
+                Ok(self
+                    .genv
+                    .type_of(alias_ty.def_id)?
+                    .instantiate(self.genv.tcx(), &alias_ty.args, &alias_ty.refine_args)
+                    .replace_bound_reft(idx))
+            }
             TyKind::Alias(AliasKind::Projection, alias_ty) => {
                 let (changed, ty) = self.normalize_projection_ty(alias_ty)?;
                 if changed {

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -429,9 +429,10 @@ impl BasicBlockEnvShape {
             | BaseTy::Never
             | BaseTy::Closure(..)
             | BaseTy::Dynamic(..)
+            | BaseTy::Alias(..)
             | BaseTy::FnPtr(..)
             | BaseTy::Coroutine(..) => {
-                debug_assert!(!scope.has_free_vars(bty));
+                assert!(!scope.has_free_vars(bty));
                 bty.clone()
             }
             BaseTy::Infer(..) => {

--- a/tests/tests/neg/error_messages/conv/refined_type_var.rs
+++ b/tests/tests/neg/error_messages/conv/refined_type_var.rs
@@ -14,7 +14,12 @@ pub trait MyTrait {
 
 #[flux::sig(fn[hrn q: T -> bool](&T{v:q(v)}) -> T{v: q(v)})]
 //~^ ERROR type cannot be refined
-//~^^ ERROR type cannot be refined
 pub fn baz<T: MyTrait>(x: &T) -> T {
     x.foo()
+}
+
+// This error is confusing, but it should go once we make all types refinable
+#[flux::sig(fn(x: T) -> i32[x])] //~ ERROR type cannot be refined
+fn generic<T>(x: T) -> i32 {
+    0
 }

--- a/tests/tests/neg/error_messages/wf/index_errors.rs
+++ b/tests/tests/neg/error_messages/wf/index_errors.rs
@@ -52,9 +52,3 @@ pub fn use_chair(c: Chair) -> i32 {
 fn ira(f: f32) -> i32 {
     0
 }
-
-// We should improve this error message it currently says expected int but found err
-#[flux::sig(fn(x: T) -> i32[x])] //~ ERROR mismatched sorts
-fn generic<T>(x: T) -> i32 {
-    0
-}

--- a/tests/tests/neg/error_messages/wf/kinds01.rs
+++ b/tests/tests/neg/error_messages/wf/kinds01.rs
@@ -5,11 +5,7 @@ use std::hash::Hash;
 
 use rset::RSet;
 
-// This error is confusing. The problem is that `RSet` cannot be instantiated with `T` because it is
-// of kind `type`. But we don't know that until after we convert the argument to `rty` and we check if
-// it is a valid simple type. The reason we only know that after conv is that we need to expand type
-// aliases.
-#[flux::sig(fn(RSet<T>[@salt]))] //~ ERROR type cannot be refined
+#[flux::sig(fn(RSet<T>[@salt]))] //~ ERROR values of this type cannot be used as base sorted instances
 pub fn test01<T>(_s: RSet<T>)
 where
     T: Eq + Hash,


### PR DESCRIPTION
To check for well-formedness we need to know the sort of base types. For example, to check if the type `i32[e]` is well formed, we need to know that the sort of `i32` is `int` so we can check the expression `e` against it. Computing the sort from a base type is subtle and hard to do in `fhir` and we ought to do it in `rty`. However, to convert from `fhir` to `rty` we need elaborated information from sort checking which we do in `fhir` resulting in a circularity. 

So far we have been able to get away by computing sorts in `fhir`, but the implementation has hard-to-fix bugs and is preventing us from moving associated types to `BaseTy`.

This PR manages to compute sorts in `rty` for sort checking by breaking the circularity with a two-phase conversion. In the first phase, we do conversion without elaborated information. This results in `rty` types with incorrect refinements but with the right *shape* to compute their sorts. We use these sorts for sort checking and then do conversion again with the elaborated information.