### PR TITLE
Basic support for `union`

### DIFF
--- a/crates/flux-desugar/src/lib.rs
+++ b/crates/flux-desugar/src/lib.rs
@@ -94,6 +94,18 @@ pub fn desugar<'genv>(
                         ),
                     );
                 }
+                hir::ItemKind::Union(..) => {
+                    let union_def = &specs.structs[&owner_id];
+                    nodes.insert(
+                        def_id,
+                        fhir::Node::Item(
+                            genv.alloc(
+                                cx.as_rust_item_ctxt(owner_id, None)
+                                    .desugar_struct_def(union_def)?,
+                            ),
+                        ),
+                    );
+                }
                 hir::ItemKind::Struct(..) => {
                     let struct_def = &specs.structs[&owner_id];
                     nodes.insert(

--- a/crates/flux-driver/src/collector/mod.rs
+++ b/crates/flux-driver/src/collector/mod.rs
@@ -6,6 +6,7 @@ use extern_specs::ExternSpecCollector;
 use flux_common::{
     iter::IterExt,
     result::{ErrorCollector, ResultExt},
+    tracked_span_assert_eq,
 };
 use flux_config::{self as config, CrateConfig};
 use flux_errors::{Errors, FluxSession};
@@ -104,6 +105,11 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
                 self.collect_fn_spec(owner_id, attrs)?;
             }
             ItemKind::Struct(variant, ..) => {
+                self.collect_struct_def(owner_id, attrs, variant)?;
+            }
+            ItemKind::Union(variant, ..) => {
+                // currently no refinements on unions
+                tracked_span_assert_eq!(attrs.items().is_empty(), true);
                 self.collect_struct_def(owner_id, attrs, variant)?;
             }
             ItemKind::Enum(enum_def, ..) => {

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1318,7 +1318,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
             fhir::Res::PrimTy(PrimTy::Float(float_ty)) => {
                 rty::BaseTy::Float(rustc_middle::ty::float_ty(float_ty))
             }
-            fhir::Res::Def(DefKind::Struct | DefKind::Enum, did) => {
+            fhir::Res::Def(DefKind::Struct | DefKind::Enum | DefKind::Union, did) => {
                 let adt_def = self.genv.adt_def(did)?;
                 let args = self.conv_generic_args(env, did, path.last_segment())?;
                 rty::BaseTy::adt(adt_def, args)
@@ -1367,9 +1367,6 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
                         refine_args: List::from(refine_args),
                     })
                 }
-            }
-            fhir::Res::Def(DefKind::Union, def_id) => {
-                span_bug!(path.span, "TODO: union types: {def_id:?}")
             }
             fhir::Res::Def(..) | fhir::Res::Err => {
                 span_bug!(path.span, "unexpected resolution in conv_ty_ctor: {:?}", path.res)

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -314,6 +314,7 @@ fn generics_of(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::Generics
         DefKind::Impl { .. }
         | DefKind::Struct
         | DefKind::Enum
+        | DefKind::Union
         | DefKind::TyAlias { .. }
         | DefKind::OpaqueTy
         | DefKind::AssocFn

--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -50,9 +50,10 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
     pub fn lift_refined_by<'fhir>(&self) -> fhir::RefinedBy<'fhir> {
         let item = self.genv.hir().expect_item(self.local_id());
         match item.kind {
-            hir::ItemKind::TyAlias(..) | hir::ItemKind::Struct(..) | hir::ItemKind::Enum(..) => {
-                fhir::RefinedBy::trivial()
-            }
+            hir::ItemKind::TyAlias(..)
+            | hir::ItemKind::Struct(..)
+            | hir::ItemKind::Enum(..)
+            | hir::ItemKind::Union(..) => fhir::RefinedBy::trivial(),
             _ => {
                 bug!("expected struct, enum, or type alias");
             }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1978,6 +1978,10 @@ impl AdtDef {
         self.0.rustc.is_struct()
     }
 
+    pub fn is_union(&self) -> bool {
+        self.0.rustc.is_union()
+    }
+
     pub fn variants(&self) -> &IndexSlice<VariantIdx, VariantDef> {
         self.0.rustc.variants()
     }

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -2055,18 +2055,19 @@ impl<T, E> Opaqueness<Result<T, E>> {
 }
 
 impl EarlyBinder<PolyVariant> {
-    pub fn to_poly_fn_sig(&self) -> EarlyBinder<PolyFnSig> {
+    // The field_idx is `Some(i)` when we have the `i`-th field of a `union`, in which case,
+    // the `inputs` are _just_ the `i`-th type (and not all the types...)
+    pub fn to_poly_fn_sig(&self, field_idx: Option<crate::FieldIdx>) -> EarlyBinder<PolyFnSig> {
         self.as_ref().map(|poly_variant| {
             poly_variant.as_ref().map(|variant| {
                 let ret = variant.ret().shift_in_escaping(1);
                 let output = Binder::bind_with_vars(FnOutput::new(ret, vec![]), List::empty());
-                FnSig::new(
-                    Safety::Safe,
-                    abi::Abi::Rust,
-                    List::empty(),
-                    variant.fields.clone(),
-                    output,
-                )
+                let inputs = match field_idx {
+                    None => variant.fields.clone(),
+                    Some(i) => List::singleton(variant.fields[i.index()].clone()),
+                };
+                let requires = List::empty();
+                FnSig::new(Safety::Safe, abi::Abi::Rust, requires, inputs, output)
             })
         })
     }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1007,13 +1007,17 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                     .expect_adt();
                 Ok(Ty::discr(adt_def.clone(), place.clone()))
             }
-            Rvalue::Aggregate(AggregateKind::Adt(def_id, variant_idx, args, _), operands) => {
+            Rvalue::Aggregate(
+                AggregateKind::Adt(def_id, variant_idx, args, _, field_idx),
+                operands,
+            ) => {
                 let actuals = self.check_operands(infcx, env, stmt_span, operands)?;
                 let sig = genv
-                    .variant_sig(*def_id, *variant_idx)
+                    .variant_sig(*def_id, *variant_idx /* FIXME, *field_idx */)
                     .with_span(stmt_span)?
                     .ok_or_else(|| CheckerError::opaque_struct(*def_id, stmt_span))?
-                    .to_poly_fn_sig();
+                    .to_poly_fn_sig(*field_idx);
+
                 let args = instantiate_args_for_constructor(genv, &self.generics, *def_id, args)
                     .with_span(stmt_span)?;
                 self.check_call(infcx, env, stmt_span, *def_id, sig, &args, &actuals)

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1013,7 +1013,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             ) => {
                 let actuals = self.check_operands(infcx, env, stmt_span, operands)?;
                 let sig = genv
-                    .variant_sig(*def_id, *variant_idx /* FIXME, *field_idx */)
+                    .variant_sig(*def_id, *variant_idx)
                     .with_span(stmt_span)?
                     .ok_or_else(|| CheckerError::opaque_struct(*def_id, stmt_span))?
                     .to_poly_fn_sig(*field_idx);

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -815,7 +815,8 @@ fn struct_variant(
     genv: GlobalEnv,
     def_id: DefId,
 ) -> CheckerResult<EarlyBinder<Binder<VariantSig>>> {
-    debug_assert!(genv.adt_def(def_id)?.is_struct());
+    let adt_def = genv.adt_def(def_id)?;
+    debug_assert!(adt_def.is_struct() || adt_def.is_union());
     genv.variant_sig(def_id, VariantIdx::from_u32(0))?
         .ok_or_else(|| CheckerErrKind::OpaqueStruct(def_id))
 }

--- a/crates/flux-rustc-bridge/src/lowering.rs
+++ b/crates/flux-rustc-bridge/src/lowering.rs
@@ -491,12 +491,19 @@ impl<'sess, 'tcx> MirLoweringCtxt<'_, 'sess, 'tcx> {
         aggregate_kind: &rustc_mir::AggregateKind<'tcx>,
     ) -> Result<AggregateKind, UnsupportedReason> {
         match aggregate_kind {
-            rustc_mir::AggregateKind::Adt(def_id, variant_idx, args, user_type_annot_idx, None) => {
+            rustc_mir::AggregateKind::Adt(
+                def_id,
+                variant_idx,
+                args,
+                user_type_annot_idx,
+                field_idx,
+            ) => {
                 Ok(AggregateKind::Adt(
                     *def_id,
                     *variant_idx,
                     args.lower(self.tcx)?,
                     *user_type_annot_idx,
+                    *field_idx,
                 ))
             }
             rustc_mir::AggregateKind::Array(ty) => Ok(AggregateKind::Array(ty.lower(self.tcx)?)),
@@ -510,7 +517,6 @@ impl<'sess, 'tcx> MirLoweringCtxt<'_, 'sess, 'tcx> {
                 Ok(AggregateKind::Coroutine(*did, args))
             }
             rustc_mir::AggregateKind::RawPtr(_, _)
-            | rustc_mir::AggregateKind::Adt(..)
             | rustc_mir::AggregateKind::CoroutineClosure(..) => {
                 Err(UnsupportedReason::new(format!(
                     "unsupported aggregate kind `{aggregate_kind:?}`"

--- a/crates/flux-rustc-bridge/src/mir.rs
+++ b/crates/flux-rustc-bridge/src/mir.rs
@@ -218,7 +218,7 @@ pub enum PointerCast {
 
 #[derive(Debug)]
 pub enum AggregateKind {
-    Adt(DefId, VariantIdx, GenericArgs, Option<UserTypeAnnotationIndex>),
+    Adt(DefId, VariantIdx, GenericArgs, Option<UserTypeAnnotationIndex>, Option<FieldIdx>),
     Array(Ty),
     Tuple,
     Closure(DefId, GenericArgs),
@@ -637,7 +637,7 @@ impl fmt::Debug for Rvalue {
             Rvalue::BinaryOp(bin_op, op1, op2) => write!(f, "{bin_op:?}({op1:?}, {op2:?})"),
             Rvalue::NullaryOp(null_op, ty) => write!(f, "{null_op:?}({ty:?})"),
             Rvalue::UnaryOp(un_op, op) => write!(f, "{un_op:?}({op:?})"),
-            Rvalue::Aggregate(AggregateKind::Adt(def_id, variant_idx, args, _), operands) => {
+            Rvalue::Aggregate(AggregateKind::Adt(def_id, variant_idx, args, _, _), operands) => {
                 let (fname, variant_name) = rustc_middle::ty::tls::with(|tcx| {
                     let variant_name = tcx.adt_def(*def_id).variant(*variant_idx).name;
                     let fname = tcx.def_path(*def_id).data.iter().join("::");

--- a/tests/tests/pos/structs/union00.rs
+++ b/tests/tests/pos/structs/union00.rs
@@ -1,13 +1,15 @@
+#![allow(unused)]
+
 pub union Silly {
     this: i32,
-    that: u32,
+    that: bool,
 }
 
 pub fn bob(s: Silly) -> i32 {
     unsafe { s.this }
 }
 
-pub fn glob(s: Silly) -> u32 {
+pub fn glob(s: Silly) -> bool {
     unsafe { s.that }
 }
 
@@ -15,6 +17,6 @@ pub fn new_this(v: i32) -> Silly {
     Silly { this: v }
 }
 
-pub fn new_that(v: u32) -> Silly {
-    Silly { that: v }
+pub fn new_that(b: bool) -> Silly {
+    Silly { that: b }
 }

--- a/tests/tests/pos/structs/union00.rs
+++ b/tests/tests/pos/structs/union00.rs
@@ -10,3 +10,11 @@ pub fn bob(s: Silly) -> i32 {
 pub fn glob(s: Silly) -> u32 {
     unsafe { s.that }
 }
+
+pub fn new_this(v: i32) -> Silly {
+    Silly { this: v }
+}
+
+pub fn new_that(v: u32) -> Silly {
+    Silly { that: v }
+}


### PR DESCRIPTION
1. No refinements allowed,
2. Otherwise, treated just like `struct`