### PR TITLE
Add sections specifying use of flux:: and flux_rs:: for files vs. crates

### DIFF
--- a/book/src/blog/01-introducing-flux.md
+++ b/book/src/blog/01-introducing-flux.md
@@ -40,7 +40,7 @@ code. For example we can write the following specification which says that
 the value *returned* by `mk_ten` must in fact be `10`
 
 ```rust
-#[flux::sig(fn() -> i32[10])]
+#[flux_rs::sig(fn() -> i32[10])]
 pub fn mk_ten() -> i32 {
     5 + 4
 }
@@ -69,7 +69,7 @@ Here's a second example that shows how you can use an index to restrict
 the space of *inputs* that a function expects.
 
 ```rust
-#[flux::sig(fn (b:bool[true]))]
+#[flux_rs::sig(fn (b:bool[true]))]
 pub fn assert(b:bool) {
   if !b { panic!("assertion failed") }
 }
@@ -108,7 +108,7 @@ like `10` or `true`. To be more useful, `flux` lets you index
 types by refinement *parameters*. For example, you can write
 
 ```rust
-#[flux::sig(fn(n:i32) -> bool[0 < n])]
+#[flux_rs::sig(fn(n:i32) -> bool[0 < n])]
 pub fn is_pos(n: i32) -> bool {
     if 0 < n {
         true
@@ -154,7 +154,7 @@ with *assertions* [^1] that constrain the value. For example, we can rewrite
 the value returned by `mk_ten` is positive.
 
 ```rust
-#[flux::sig(fn() -> i32{v: 0 < v})]
+#[flux_rs::sig(fn() -> i32{v: 0 < v})]
 pub fn mk_ten() -> i32 {
     5 + 5
 }
@@ -165,7 +165,7 @@ value of an `i32` with a type which says the result is non-negative *and*
 exceeds the input `n`.
 
 ```rust
-#[flux::sig(fn (n:i32) -> i32{v:0<=v && n<=v})]
+#[flux_rs::sig(fn (n:i32) -> i32{v:0<=v && n<=v})]
 pub fn abs(n: i32) -> i32 {
     if 0 <= n {
         n
@@ -178,7 +178,7 @@ pub fn abs(n: i32) -> i32 {
 As a last example, you might write a function to compute the factorial of `n`
 
 ```rust
-#[flux::sig(fn (n:i32) -> i32{v:1<=v && n<=v})]
+#[flux_rs::sig(fn (n:i32) -> i32{v:1<=v && n<=v})]
 pub fn factorial(n: i32) -> i32 {
     let mut i = 0;
     let mut res = 1;

--- a/book/src/blog/02-ownership.md
+++ b/book/src/blog/02-ownership.md
@@ -24,7 +24,7 @@ to it, which lets flux *update* the type whenever the location
 is changed. For example, consider the program
 
 ```rust
-#[flux::sig(fn () -> i32[3])]
+#[flux_rs::sig(fn () -> i32[3])]
 pub fn mk_three() -> i32 {
     let mut r = 0;  // r: i32[0]
     r += 1;
@@ -47,7 +47,7 @@ This exclusive ownership mechanism is at work in the `factorial` example
 we signed off with [previously][blog-intro]
 
 ```rust
-#[flux::sig(fn (n:i32{0 <= n}) -> i32{v:n <= v})]
+#[flux_rs::sig(fn (n:i32{0 <= n}) -> i32{v:n <= v})]
 pub fn factorial(n: i32) -> i32 {
     let mut i = 0;  // i: i32[0]
     let mut r = 1;  // r: i32[1]
@@ -83,7 +83,7 @@ access to a value of type `T`. For example, we might write `abs` to take
 a shared reference to an `i32`
 
 ```rust
-#[flux::sig(fn (p: &i32[@n]) -> i32{v:0<=v && n<=v})]
+#[flux_rs::sig(fn (p: &i32[@n]) -> i32{v:0<=v && n<=v})]
 pub fn abs(p: &i32) -> i32 {
     let n = *p;
     if 0 <= n {
@@ -151,7 +151,7 @@ that *decrements* the value of a mutable reference while ensuring the
 data is non-negative:
 
 ```rust
-#[flux::sig(fn(p: &mut i32{v:0 <= v}))]
+#[flux_rs::sig(fn(p: &mut i32{v:0 <= v}))]
 pub fn decr(p: &mut i32) {
     *p = *p - 1;
 }
@@ -173,7 +173,7 @@ code by guarding the update with a test that ensures the
 original contents are in fact *non-zero*
 
 ```rust
-#[flux::sig(fn(p: &mut i32{v:0 <= v}))]
+#[flux_rs::sig(fn(p: &mut i32{v:0 <= v}))]
 pub fn decr(p: &mut i32) {
     let n = *p;
     if n != 0 {
@@ -193,7 +193,7 @@ Flux uses Rust's borrowing rules to track invariants even when
 there may be aliasing. As an example, consider the function
 
 ```rust
-#[flux::sig(fn (bool) -> i32{v:0 <= v})]
+#[flux_rs::sig(fn (bool) -> i32{v:0 <= v})]
 fn test_alias(z: bool) -> i32 {
     let mut x = 1;  // x: i32[1]
     let mut y = 2;  // y: i32[2]
@@ -221,7 +221,7 @@ For example, consider the following function to increment a reference
 to a non-negative `i32`
 
 ```rust
-#[flux::sig(fn (p: &mut i32{v:0 <= v}))]
+#[flux_rs::sig(fn (p: &mut i32{v:0 <= v}))]
 fn incr(p: &mut i32) {
   *p += 1
 }
@@ -247,7 +247,7 @@ the function exits[^3]. Thus, we can use strong references to
 type `incr` as
 
 ```rust
-#[flux::sig(fn(p: &strg i32[@n]) ensures p:i32[n+1])]
+#[flux_rs::sig(fn(p: &strg i32[@n]) ensures p:i32[n+1])]
 fn incr(p: &mut i32) {
   *p += 1
 }

--- a/book/src/blog/03-vectors.md
+++ b/book/src/blog/03-vectors.md
@@ -21,13 +21,13 @@ To begin with, we will defined a *refined* vector type which is simply a wrapper
 around the standard `Vec` type
 
 ```rust
-#[flux::refined_by(len: int)]
+#[flux_rs::refined_by(len: int)]
 pub struct RVec<T> {
     inner: Vec<T>,
 }
 ```
 
-The `#[flux::refined_by(len: int)]` attribute tells flux that the type `RVec<T>` struct
+The `#[flux_rs::refined_by(len: int)]` attribute tells flux that the type `RVec<T>` struct
 is indexed by a `len` refinement which tracks the *size* of the underlying vector, just
 like the indices for `i32` and `bool` tracked the actual *value* of the underlying
 [integer or boolean][blog-intro]). The idea is that the type
@@ -44,8 +44,8 @@ manipulating vectors. I suppose one must start with nothing: an empty vector.
 
 ```rust
 impl<T> RVec<T> {
-    #[flux::trusted]
-    #[flux::sig(fn() -> RVec<T>[0])]
+    #[flux_rs::trusted]
+    #[flux_rs::sig(fn() -> RVec<T>[0])]
     pub fn new() -> Self {
         Self { inner: Vec::new() }
     }
@@ -53,7 +53,7 @@ impl<T> RVec<T> {
 ```
 
 The above implements `RVec::new` as a wrapper around `Vec::new`.
-The `#[flux::trusted]` attribute tells Flux there is nothing to
+The `#[flux_rs::trusted]` attribute tells Flux there is nothing to
 "check" here, as we are *defining* the API itself and trusting
 that the implementation (using `vec` is correct).
 However, the signature says that *callers* of the `RVec::new` get
@@ -66,8 +66,8 @@ An empty vector is a rather desolate thing.
 To be of any use, we need to be able to `push` values into the container, like so
 
 ```rust
-#[flux::trusted]
-#[flux::sig(fn(self: &strg RVec<T>[@n], T)
+#[flux_rs::trusted]
+#[flux_rs::sig(fn(self: &strg RVec<T>[@n], T)
             ensures self: RVec<T>[n+1])]
 pub fn push(&mut self, item: T) {
     self.inner.push(item);
@@ -90,8 +90,8 @@ of the vector. Aha, but what if the vector is empty? You could return an
 only be called with non-empty vectors.
 
 ```rust
-#[flux::trusted]
-#[flux::sig(fn(self: &strg {RVec<T>[@n] | 0 < n}) -> T
+#[flux_rs::trusted]
+#[flux_rs::sig(fn(self: &strg {RVec<T>[@n] | 0 < n}) -> T
             ensures self: RVec<T>[n-1])]
 pub fn pop(&mut self) -> T {
   self.inner.pop().unwrap()
@@ -120,7 +120,7 @@ error[FLUX]: precondition might not hold
 note: this is the condition that cannot be proved
   --> src/rvec.rs:78:47
    |
-78 |     #[flux::sig(fn(self: &strg {RVec<T>[@n] | 0 < n}) -> T
+78 |     #[flux_rs::sig(fn(self: &strg {RVec<T>[@n] | 0 < n}) -> T
    |                                               ^^^^^
 ```
 <!--
@@ -137,8 +137,8 @@ we `pop` it. We can do that with a `len` method whose type says that the returne
 is, in fact, the size of the input vector
 
 ```rust
-#[flux::trusted]
-#[flux::sig(fn(&RVec<T>[@n]) -> usize[n])]
+#[flux_rs::trusted]
+#[flux_rs::sig(fn(&RVec<T>[@n]) -> usize[n])]
 pub fn len(&self) -> usize {
     self.inner.len()
 }
@@ -160,12 +160,12 @@ called with a *valid index* that is between `0` and the
 vector's size
 
 ```rust
-#[flux::sig(fn(&RVec<T>[@n], i: usize{i < n}) -> &T)]
+#[flux_rs::sig(fn(&RVec<T>[@n], i: usize{i < n}) -> &T)]
 pub fn get(&self, i: usize) -> &T {
     &self.inner[i]
 }
 
-#[flux::sig(fn(&mut RVec<T>[@n], i: usize{i < n}) -> &mut T)]
+#[flux_rs::sig(fn(&mut RVec<T>[@n], i: usize{i < n}) -> &mut T)]
 pub fn get_mut(&mut self, i: usize) -> &mut T {
     &mut self.inner[i]
 }
@@ -184,14 +184,14 @@ the `Index` and `IndexMut` traits for `RVec` which allows us to use the
 ```rust
 impl<T> std::ops::Index<usize> for RVec<T> {
     type Output = T;
-    #[flux::sig(fn(&RVec<T>[@n], i:usize{i < n}) -> &T)]
+    #[flux_rs::sig(fn(&RVec<T>[@n], i:usize{i < n}) -> &T)]
     fn index(&self, index: usize) -> &T {
         self.get(index)
     }
 }
 
 impl<T> std::ops::IndexMut<usize> for RVec<T> {
-    #[flux::sig(fn(&mut RVec<T>[@n], i:usize{i < n}) -> &mut T)]
+    #[flux_rs::sig(fn(&mut RVec<T>[@n], i:usize{i < n}) -> &mut T)]
     fn index_mut(&mut self, index: usize) -> &mut T {
         self.get_mut(index)
     }
@@ -286,7 +286,7 @@ error[FLUX]: precondition might not hold
 note: this is the condition that cannot be proved
    --> src/rvec.rs:189:44
     |
-189 |     #[flux::sig(fn(&RVec<T>[@n], usize{v : v < n}) -> &T)]
+189 |     #[flux_rs::sig(fn(&RVec<T>[@n], usize{v : v < n}) -> &T)]
     |                                            ^^^^^
 
 error[FLUX]: arithmetic operation may overflow

--- a/book/src/guide/run.md
+++ b/book/src/guide/run.md
@@ -47,19 +47,21 @@ To do so add the following to `Cargo.toml`:
 enabled = true
 ```
 
-### Refinement Annotations on a Package
+### Refinement Annotations on a Cargo Projects
 
-Adding refinement annotations to packages is simple. You can add `flux-rs` as a dependency in `Cargo.toml`
+Adding refinement annotations to cargo projects is simple. You can add `flux-rs` as a dependency in `Cargo.toml`
 
 ```toml
 [dependencies]
 flux-rs = { git  = "https://github.com/flux-rs/flux.git" }
 ```
 
-Then, add refinement annoations using the fully qualified path `flux_rs::`.
+Then, import attributes from `flux_rs` and add the appropriate refinement annoations.
 
 ```rust
-#[flux_rs::sig(fn(x: i32) -> i32{v: x < v)]
+use flux_rs::*
+
+#[sig(fn(x: i32) -> i32{v: x < v)]
 fn inc(x: i32) -> i32 {
     x - 1
 }
@@ -186,13 +188,13 @@ was overridden by setting the environment variable `FLUX_DUMP_MIR=0`.
 
 ### Crate Config
 
-Some flags can be configured on a per-crate basis using the custom inner attribute `#![flux::cfg]`.
+Some flags can be configured on a per-crate basis using the custom inner attribute `#![flux_rs::cfg]`.
 This annotation relies on the unstable custom inner attributes feature. To be able to use with a
 non-nightly compiler you have to put it under a `cfg_attr`.
 For example, to enable overflow checking:
 
 ```rust
-#![cfg_attr(flux, flux::cfg(check_overflow = true))]
+#![cfg_attr(flux, flux_rs::cfg(check_overflow = true))]
 ```
 
 The only flag supported now is overflow checking.

--- a/book/src/guide/run.md
+++ b/book/src/guide/run.md
@@ -18,6 +18,19 @@ You could for example check a file as a library instead of a binary like so
 rustc-flux --crate-type=lib path/to/test.rs
 ```
 
+### Refinement Annotations on a File
+
+When running flux on a file with `rustc-flux path/to/test.rs`, refinement annotations should be prefixed with `flux::`. 
+
+For example, the refinement below will only work when running `rustc-flux` which is intended for use on a single file.
+
+```rust
+#[flux::sig(fn(x: i32) -> i32{v: x < v)]
+fn inc(x: i32) -> i32 {
+    x - 1
+}
+```
+
 ## Running on a package: `cargo-flux`
 
 Flux is integrated with `cargo` and can be invoked in a package as follows:
@@ -32,6 +45,24 @@ To do so add the following to `Cargo.toml`:
 ```toml
 [package.metadata.flux]
 enabled = true
+```
+
+### Refinement Annotations on a Package
+
+Adding refinement annotations to packages is simple. You can add `flux-rs` as a dependency in `Cargo.toml`
+
+```toml
+[dependencies]
+flux-rs = { git  = "https://github.com/flux-rs/flux.git" }
+```
+
+Then, add refinement annoations using the fully qualified path `flux_rs::`.
+
+```rust
+#[flux_rs::sig(fn(x: i32) -> i32{v: x < v)]
+fn inc(x: i32) -> i32 {
+    x - 1
+}
 ```
 
 ## A tiny example

--- a/book/src/guide/specs.md
+++ b/book/src/guide/specs.md
@@ -86,7 +86,7 @@ happen to correspond to each of the below lines.
 
 ```
 #[extern_spec(std::mem)]
-#[flux::sig(fn(&mut i32[@a], &mut i32{v : a < v }) -> ())]
+#[flux_rs::sig(fn(&mut i32[@a], &mut i32{v : a < v }) -> ())]
 fn swap(a: &mut i32, b: &mut i32);
 ```
 
@@ -94,8 +94,8 @@ fn swap(a: &mut i32, b: &mut i32);
    in the above example, this is `std::mem`. You can use this path to qualify
    the function. So in the above example, the function we are targeting has the
    full path of `std::mem::swap`.
-2. Add a `#[flux::sig(...)]` attribute. This is required for any extern spec on
-   a function. This signature behaves as if the `#[flux::trusted]` attribute was
+2. Add a `#[flux_rs::sig(...)]` attribute. This is required for any extern spec on
+   a function. This signature behaves as if the `#[flux_rs::trusted]` attribute was
    added, because we can't actually check the implementation. We just verify
    some simple things, like that the function arguments have compatible types.
 3. Write a function stub that matches the external function.
@@ -107,8 +107,8 @@ You shouldn't need to know the details, but here's how the macro works. It
 parses the `std::mem` into a module path and then transforms the function into
 
 ```
-#[flux::extern_spec]
-#[flux::sig(fn(&mut i32[@a], &mut i32{v : a < v }) -> ())]
+#[flux_rs::extern_spec]
+#[flux_rs::sig(fn(&mut i32[@a], &mut i32{v : a < v }) -> ())]
 #[allow(unused, dead_code)]
 fn __flux_extern_spec_swap(a: &mut i32, b: &mut i32) {
     std::mem::swap(a, b)
@@ -131,7 +131,7 @@ function. Once again, each line in the example happens to correspond to a step.
 
 ```
 #[extern_spec(std::string)]
-#[flux::refined_by(len: int)]
+#[flux_rs::refined_by(len: int)]
 struct String;
 ```
 
@@ -139,9 +139,9 @@ struct String;
    in the above example, this is `std::string`. You can use this path to qualify
    the function. So in the above example, the struct we are targeting has the
    full path of `std::string::String`.
-2. Add a `#[flux::refined_by(...)]` attribute. This is required for any extern
+2. Add a `#[flux_rs::refined_by(...)]` attribute. This is required for any extern
    spec on a struct. Right now these attributes behave as if they were opaque
-   (`#[flux::opaque]`), although we may support non-opaque extern structs.
+   (`#[flux_rs::opaque]`), although we may support non-opaque extern structs.
 3. Write a stub for the extern struct.
 
 If you do the above, you can use `std::string::String` as if it were refined by
@@ -153,10 +153,10 @@ structs.
 ```
 #[extern_spec(std::string)]
 impl String {
-    #[flux::sig(fn() -> String[0])]
+    #[flux_rs::sig(fn() -> String[0])]
     fn new() -> String;
 
-    #[flux::sig(fn(&String[@n]) -> usize[n])]
+    #[flux_rs::sig(fn(&String[@n]) -> usize[n])]
     fn len(s: &String) -> usize;
 }
 ```
@@ -179,9 +179,9 @@ You shouldn't need to know the details, but here's how the above two macros expa
 
 For structs:
 ```
-#[flux::extern_spec]
+#[flux_rs::extern_spec]
 #[allow(unused, dead_code)]
-#[flux::refined_by(len: int)]
+#[flux_rs::refined_by(len: int)]
 struct __FluxExternSpecString(std::string::String);
 ```
 
@@ -192,14 +192,14 @@ struct __FluxExternImplStructString;
 
 #[allow(unused, dead_code)]
 impl __FluxExternImplStructString {
-    #[flux::extern_spec]
-    #[flux::sig(fn() -> String[0])]
+    #[flux_rs::extern_spec]
+    #[flux_rs::sig(fn() -> String[0])]
     #[allow(unused, dead_code)]
     fn __flux_extern_spec_new() -> String {
        std::string::String::new::<>()
     }
-    #[flux::extern_spec]
-    #[flux::sig(fn(&String[@n]) -> usize[n])]
+    #[flux_rs::extern_spec]
+    #[flux_rs::sig(fn(&String[@n]) -> usize[n])]
     #[allow(unused, dead_code)]
     fn __flux_extern_spec_len(s: &String) -> usize {
        std::string::String::len::<>(s)
@@ -233,23 +233,23 @@ r ::= n                     // numbers 1,2,3...
 
 ## Ignored and trusted code
 
-Flux offers two attributes for controlling which parts of your code it analyzes: `#[flux::ignore]` and `#[flux::trusted]`.
+Flux offers two attributes for controlling which parts of your code it analyzes: `#[flux_rs::ignore]` and `#[flux_rs::trusted]`.
 
-* `#[flux::ignore]`: This attribute is applicable to any item, and it instructs Flux to completely skip some code. Flux won't even look at it.
-* `#[flux::trusted]`: This attribute affects whether Flux checks the body of a function. If a function is marked as trusted, Flux won't verify its body against its signature. However, it will still be able to reason about its signature when used elsewhere.
+* `#[flux_rs::ignore]`: This attribute is applicable to any item, and it instructs Flux to completely skip some code. Flux won't even look at it.
+* `#[flux_rs::trusted]`: This attribute affects whether Flux checks the body of a function. If a function is marked as trusted, Flux won't verify its body against its signature. However, it will still be able to reason about its signature when used elsewhere.
 
 The above means that an *ignored* function can only be called from ignored or trusted code, while a *trusted* function can also be called from analyzed code.
 
-Both attributes apply recursively. For instance, if a module is marked as `#[flux::ignore]`, all its nested elements will also be ignored. This transitive behavior can be disabled by marking an item with `#[flux::ignore(no)]`[^ignore-shorthand], which will include all nested elements for analysis. Similarly,
-the action of `#[flux::trusted]` can be reverted using `#[flux::trusted(no)]`.
+Both attributes apply recursively. For instance, if a module is marked as `#[flux_rs::ignore]`, all its nested elements will also be ignored. This transitive behavior can be disabled by marking an item with `#[flux_rs::ignore(no)]`[^ignore-shorthand], which will include all nested elements for analysis. Similarly,
+the action of `#[flux_rs::trusted]` can be reverted using `#[flux_rs::trusted(no)]`.
 
 Consider the following example:
 
 ```rust
-#[flux::ignore]
+#[flux_rs::ignore]
 mod A {
 
-   #[flux::ignore(no)]
+   #[flux_rs::ignore(no)]
    mod B {
       mod C {
          fn f1() {}
@@ -266,6 +266,6 @@ mod A {
 
 In this scenario, functions `f2` and `f3` will be ignored, while `f1` will be analyzed.
 
-A typical pattern when retroactively adding Flux annotations to existing code is to ignore an entire crate (using the inner attribute `#![flux::ignore]` at the top of the crate) and then selectively include specific sections for analysis.
+A typical pattern when retroactively adding Flux annotations to existing code is to ignore an entire crate (using the inner attribute `#![flux_rs::ignore]` at the top of the crate) and then selectively include specific sections for analysis.
 
-[^ignore-shorthand]: `#[flux::ignore]` (resp. `#[flux::trusted]`) is shorthand for `#[flux::ignore(yes)]` (resp. `#[flux::trusted(yes)]`).
+[^ignore-shorthand]: `#[flux_rs::ignore]` (resp. `#[flux_rs::trusted]`) is shorthand for `#[flux_rs::ignore(yes)]` (resp. `#[flux_rs::trusted(yes)]`).


### PR DESCRIPTION
@nilehmann, do we want to replace subsequent examples of refinement annotations using `flux::` with `flux_rs::`?