### PR TITLE
Replace underscores in integer parsing

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1417,6 +1417,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
     }
 
     fn try_parse_int_lit(&self, span: Span, s: &str) -> Result<i128> {
+        let s = s.replace("_", "");
         let parsed_int = if s.len() <= 2 {
             s.parse::<i128>()
         } else {


### PR DESCRIPTION
Adding this so that int values in refinement annotations can be rusty. i.e. annotations like this ([see here for actual code](https://github.com/vrindisbacher/tock-veri-asm-sb/blob/d230a91431c1c2736ba4452781a94e414da86fe7/src/lib.rs#L45)): 

```rust
#[flux_rs::sig(
    fn (self: &strg Armv7m[@old_cpu]) ensures self: Armv7m { new_cpu:
        // r0 = 1 << (ipsr & 31)
        new_cpu.r0 == lshl(1, (and(get_ipsr(old_cpu), 31)))
        &&
        // r2 = (ipsr >> 5) << 2
        new_cpu.r2 == lshl(lshr(get_ipsr(old_cpu), 5), 2)
        &&
        // nvic iser bit for ipsr is correct
        nth_bit(
            get_mem_value(0xE000_E180 + new_cpu.r2, new_cpu.mem), and(get_ipsr(old_cpu), 31)
        ) == 1
        &&
        // nvic icer bit for ipsr is correct
        nth_bit(
            get_mem_value(0xE000_E200 + new_cpu.r2, new_cpu.mem), and(get_ipsr(old_cpu), 31)
        ) == 1
    }
)]
fn my_fn(...) {
    ...
}
```

I did check Rust's convention for ints, and it seems you can add as many underscores as you'd like, it will always ignore them in int type declarations. I.e. all of these are `100`:

```rust
1_0_0
1__0_0
1_00
```

So I think just replacing any underscores should work.

@nilehmann, this one isn't a very big deal but I figured I'd add it as it is nice to use `_` notation when you're dealing with things like memory addresses :). We don't have to merge this if you think it's unnecessary. 