### PR TITLE
Collapse FHIR

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -978,13 +978,8 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                             fhir_id: self.next_fhir_id(),
                             span: ident.span,
                         };
-                        let inner = fhir::Expr {
-                            kind: fhir::ExprKind::Var(path, Some(kind)),
-                            fhir_id: self.next_fhir_id(),
-                            span,
-                        };
                         fhir::Expr {
-                            kind: fhir::ExprKind::RefineArgExpr(self.genv().alloc(inner)),
+                            kind: fhir::ExprKind::Var(path, Some(kind)),
                             fhir_id: self.next_fhir_id(),
                             span,
                         }
@@ -1106,13 +1101,8 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                     fhir_id: self.next_fhir_id(),
                     span: bind.span,
                 };
-                let inner = fhir::Expr {
-                    kind: fhir::ExprKind::Var(path, None),
-                    span: bind.span,
-                    fhir_id: self.next_fhir_id(),
-                };
                 let idx = fhir::Expr {
-                    kind: fhir::ExprKind::RefineArgExpr(self.genv().alloc(inner)),
+                    kind: fhir::ExprKind::Var(path, None),
                     span: bind.span,
                     fhir_id: self.next_fhir_id(),
                 };
@@ -1295,14 +1285,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                     .implicit_param_into_refine_arg(*ident, *node_id)
                     .unwrap())
             }
-            surface::RefineArg::Expr(expr) => {
-                let inner = self.genv().alloc(self.desugar_expr(expr)?);
-                Ok(fhir::Expr {
-                    kind: fhir::ExprKind::RefineArgExpr(inner),
-                    fhir_id: self.next_fhir_id(),
-                    span: expr.span,
-                })
-            }
+            surface::RefineArg::Expr(expr) => self.desugar_expr(expr),
             surface::RefineArg::Abs(params, body, span, _) => {
                 let body = self.genv().alloc(self.desugar_expr(body)?);
                 let params = self.desugar_refine_params(params);
@@ -1327,15 +1310,10 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
             fhir_id: self.next_fhir_id(),
             span: ident.span,
         };
-        let inner = self.genv().alloc(fhir::Expr {
+        Some(fhir::Expr {
             kind: fhir::ExprKind::Var(path, Some(kind)),
             span: ident.span,
             fhir_id: self.next_fhir_id(),
-        });
-        Some(fhir::Expr {
-            kind: fhir::ExprKind::RefineArgExpr(inner),
-            fhir_id: self.next_fhir_id(),
-            span: ident.span,
         })
     }
 

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -966,7 +966,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
             })
     }
 
-    fn implicit_params_to_args(&self, scope: NodeId) -> &'genv [fhir::RefineArg<'genv>] {
+    fn implicit_params_to_args(&self, scope: NodeId) -> &'genv [fhir::Expr<'genv>] {
         self.genv()
             .alloc_slice_fill_iter(
                 self.resolve_implicit_params(scope)
@@ -978,12 +978,13 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                             fhir_id: self.next_fhir_id(),
                             span: ident.span,
                         };
-                        fhir::RefineArg {
-                            kind: fhir::RefineArgKind::Expr(fhir::Expr {
-                                kind: fhir::ExprKind::Var(path, Some(kind)),
-                                fhir_id: self.next_fhir_id(),
-                                span,
-                            }),
+                        let inner = fhir::Expr {
+                            kind: fhir::ExprKind::Var(path, Some(kind)),
+                            fhir_id: self.next_fhir_id(),
+                            span,
+                        };
+                        fhir::Expr {
+                            kind: fhir::ExprKind::RefineArgExpr(self.genv().alloc(inner)),
                             fhir_id: self.next_fhir_id(),
                             span,
                         }
@@ -1105,12 +1106,13 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                     fhir_id: self.next_fhir_id(),
                     span: bind.span,
                 };
-                let idx = fhir::RefineArg {
-                    kind: fhir::RefineArgKind::Expr(fhir::Expr {
-                        kind: fhir::ExprKind::Var(path, None),
-                        span: bind.span,
-                        fhir_id: self.next_fhir_id(),
-                    }),
+                let inner = fhir::Expr {
+                    kind: fhir::ExprKind::Var(path, None),
+                    span: bind.span,
+                    fhir_id: self.next_fhir_id(),
+                };
+                let idx = fhir::Expr {
+                    kind: fhir::ExprKind::RefineArgExpr(self.genv().alloc(inner)),
                     span: bind.span,
                     fhir_id: self.next_fhir_id(),
                 };
@@ -1271,22 +1273,22 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
         fhir::Lifetime::Hole(self.next_fhir_id())
     }
 
-    fn desugar_indices(&mut self, idxs: &surface::Indices) -> Result<fhir::RefineArg<'genv>> {
+    fn desugar_indices(&mut self, idxs: &surface::Indices) -> Result<fhir::Expr<'genv>> {
         if let [arg] = &idxs.indices[..] {
             self.desugar_refine_arg(arg)
         } else {
             let flds = try_alloc_slice!(self.genv(), &idxs.indices, |arg| {
                 self.desugar_refine_arg(arg)
             })?;
-            Ok(fhir::RefineArg {
-                kind: fhir::RefineArgKind::Record(flds),
+            Ok(fhir::Expr {
+                kind: fhir::ExprKind::RefineRecord(flds),
                 fhir_id: self.next_fhir_id(),
                 span: idxs.span,
             })
         }
     }
 
-    fn desugar_refine_arg(&mut self, arg: &surface::RefineArg) -> Result<fhir::RefineArg<'genv>> {
+    fn desugar_refine_arg(&mut self, arg: &surface::RefineArg) -> Result<fhir::Expr<'genv>> {
         match arg {
             surface::RefineArg::Bind(ident, .., node_id) => {
                 Ok(self
@@ -1294,17 +1296,18 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                     .unwrap())
             }
             surface::RefineArg::Expr(expr) => {
-                Ok(fhir::RefineArg {
-                    kind: fhir::RefineArgKind::Expr(self.desugar_expr(expr)?),
+                let inner = self.genv().alloc(self.desugar_expr(expr)?);
+                Ok(fhir::Expr {
+                    kind: fhir::ExprKind::RefineArgExpr(inner),
                     fhir_id: self.next_fhir_id(),
                     span: expr.span,
                 })
             }
             surface::RefineArg::Abs(params, body, span, _) => {
-                let body = self.desugar_expr(body)?;
+                let body = self.genv().alloc(self.desugar_expr(body)?);
                 let params = self.desugar_refine_params(params);
-                Ok(fhir::RefineArg {
-                    kind: fhir::RefineArgKind::Abs(params, body),
+                Ok(fhir::Expr {
+                    kind: fhir::ExprKind::RefineAbs(params, body),
                     fhir_id: self.next_fhir_id(),
                     span: *span,
                 })
@@ -1316,7 +1319,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
         &self,
         ident: surface::Ident,
         node_id: NodeId,
-    ) -> Option<fhir::RefineArg<'genv>> {
+    ) -> Option<fhir::Expr<'genv>> {
         let (id, kind) = self.resolve_implicit_param(node_id)?;
         let path = fhir::PathExpr {
             segments: self.genv().alloc_slice(&[ident]),
@@ -1324,12 +1327,13 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
             fhir_id: self.next_fhir_id(),
             span: ident.span,
         };
-        Some(fhir::RefineArg {
-            kind: fhir::RefineArgKind::Expr(fhir::Expr {
-                kind: fhir::ExprKind::Var(path, Some(kind)),
-                span: ident.span,
-                fhir_id: self.next_fhir_id(),
-            }),
+        let inner = self.genv().alloc(fhir::Expr {
+            kind: fhir::ExprKind::Var(path, Some(kind)),
+            span: ident.span,
+            fhir_id: self.next_fhir_id(),
+        });
+        Some(fhir::Expr {
+            kind: fhir::ExprKind::RefineArgExpr(inner),
             fhir_id: self.next_fhir_id(),
             span: ident.span,
         })

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1281,7 +1281,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                 self.desugar_refine_arg(arg)
             })?;
             Ok(fhir::Expr {
-                kind: fhir::ExprKind::RefineRecord(flds),
+                kind: fhir::ExprKind::Record(flds),
                 fhir_id: self.next_fhir_id(),
                 span: idxs.span,
             })
@@ -1307,7 +1307,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                 let body = self.genv().alloc(self.desugar_expr(body)?);
                 let params = self.desugar_refine_params(params);
                 Ok(fhir::Expr {
-                    kind: fhir::ExprKind::RefineAbs(params, body),
+                    kind: fhir::ExprKind::Abs(params, body),
                     fhir_id: self.next_fhir_id(),
                     span: *span,
                 })

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1603,7 +1603,6 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
                 let proj = self.results().field_proj(fhir_id);
                 rty::Expr::field_proj(env.lookup(var).to_expr(), proj)
             }
-            fhir::ExprKind::RefineArgExpr(expr) => self.conv_expr(env, expr)?,
             fhir::ExprKind::Abs(params, body) => {
                 let layer = Layer::list(self.results(), 0, params);
                 env.push_layer(layer);

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1604,7 +1604,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
                 rty::Expr::field_proj(env.lookup(var).to_expr(), proj)
             }
             fhir::ExprKind::RefineArgExpr(expr) => self.conv_expr(env, expr)?,
-            fhir::ExprKind::RefineAbs(params, body) => {
+            fhir::ExprKind::Abs(params, body) => {
                 let layer = Layer::list(self.results(), 0, params);
                 env.push_layer(layer);
                 let pred = self.conv_expr(env, body)?;
@@ -1613,7 +1613,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
                 let lam = rty::Lambda::bind_with_vars(pred, inputs, output);
                 rty::Expr::abs(lam)
             }
-            fhir::ExprKind::RefineRecord(flds) => {
+            fhir::ExprKind::Record(flds) => {
                 let def_id = self.results().record_ctor(expr.fhir_id);
                 let flds = flds
                     .iter()

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -426,7 +426,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
             .try_collect()?;
 
         let adt_def = self.genv.adt_def(enum_id)?;
-        let idxs = self.conv_refine_arg(&mut env, &variant.ret.idx)?;
+        let idxs = self.conv_expr(&mut env, &variant.ret.idx)?;
         let variant = rty::VariantSig::new(
             adt_def,
             rty::GenericArg::identity_for_item(self.genv, enum_id.resolved_id())?,
@@ -835,7 +835,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
             fhir::TyKind::BaseTy(bty) => self.conv_bty(env, bty),
             fhir::TyKind::Indexed(bty, idx) => {
                 let fhir_id = bty.fhir_id;
-                let idx = self.conv_refine_arg(env, idx)?;
+                let idx = self.conv_expr(env, idx)?;
                 match &bty.kind {
                     fhir::BaseTyKind::Path(fhir::QPath::Resolved(qself, path)) => {
                         debug_assert!(qself.is_none());
@@ -929,7 +929,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
         env: &mut Env,
         item_id: hir::ItemId,
         lifetimes: &[fhir::GenericArg],
-        reft_args: &[fhir::RefineArg],
+        reft_args: &[fhir::Expr],
     ) -> QueryResult<rty::Ty> {
         let def_id = item_id.owner_id.to_def_id();
         let generics = self.genv.generics_of(def_id)?;
@@ -957,7 +957,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
         })?;
         let reft_args = reft_args
             .iter()
-            .map(|arg| self.conv_refine_arg(env, arg))
+            .map(|arg| self.conv_expr(env, arg))
             .try_collect()?;
         let alias_ty = rty::AliasTy::new(def_id, args, reft_args);
         Ok(rty::Ty::alias(rty::AliasKind::Opaque, alias_ty))
@@ -1352,7 +1352,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
                 let refine_args = path
                     .refine
                     .iter()
-                    .map(|arg| self.conv_refine_arg(env, arg))
+                    .map(|expr| self.conv_expr(env, expr))
                     .try_collect_vec()?;
                 if P::EXPAND_TYPE_ALIASES {
                     let tcx = self.genv.tcx();
@@ -1603,32 +1603,26 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
                 let proj = self.results().field_proj(fhir_id);
                 rty::Expr::field_proj(env.lookup(var).to_expr(), proj)
             }
-        };
-        Ok(self.add_coercions(expr, fhir_id))
-    }
-
-    fn conv_refine_arg(&mut self, env: &mut Env, arg: &fhir::RefineArg) -> QueryResult<rty::Expr> {
-        match &arg.kind {
-            fhir::RefineArgKind::Expr(expr) => self.conv_expr(env, expr),
-            fhir::RefineArgKind::Abs(params, body) => {
+            fhir::ExprKind::RefineArgExpr(expr) => self.conv_expr(env, expr)?,
+            fhir::ExprKind::RefineAbs(params, body) => {
                 let layer = Layer::list(self.results(), 0, params);
-
                 env.push_layer(layer);
                 let pred = self.conv_expr(env, body)?;
                 let inputs = env.pop_layer().into_bound_vars(self.genv)?;
-                let output = self.results().lambda_output(arg.fhir_id);
+                let output = self.results().lambda_output(expr.fhir_id);
                 let lam = rty::Lambda::bind_with_vars(pred, inputs, output);
-                Ok(self.add_coercions(rty::Expr::abs(lam), arg.fhir_id))
+                rty::Expr::abs(lam)
             }
-            fhir::RefineArgKind::Record(flds) => {
-                let def_id = self.results().record_ctor(arg.fhir_id);
+            fhir::ExprKind::RefineRecord(flds) => {
+                let def_id = self.results().record_ctor(expr.fhir_id);
                 let flds = flds
                     .iter()
-                    .map(|arg| self.conv_refine_arg(env, arg))
+                    .map(|expr| self.conv_expr(env, expr))
                     .try_collect()?;
-                Ok(rty::Expr::adt(def_id, flds))
+                rty::Expr::adt(def_id, flds)
             }
-        }
+        };
+        Ok(self.add_coercions(expr, fhir_id))
     }
 
     fn conv_exprs(&mut self, env: &mut Env, exprs: &[fhir::Expr]) -> QueryResult<List<rty::Expr>> {

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -291,7 +291,7 @@ impl<'genv> fhir::visit::Visitor<'genv> for Wf<'_, 'genv, '_> {
         };
         let expected = adt_sort_def.to_sort(&args);
         self.infcx
-            .check_refine_arg(&ret.idx, &expected)
+            .check_expr(&ret.idx, &expected)
             .collect_err(&mut self.errors);
     }
 
@@ -325,7 +325,7 @@ impl<'genv> fhir::visit::Visitor<'genv> for Wf<'_, 'genv, '_> {
             fhir::TyKind::Indexed(bty, idx) => {
                 let expected = self.infcx.sort_of_bty(bty.fhir_id);
                 self.infcx
-                    .check_refine_arg(idx, &expected)
+                    .check_expr(idx, &expected)
                     .collect_err(&mut self.errors);
                 self.visit_bty(bty);
             }
@@ -363,9 +363,9 @@ impl<'genv> fhir::visit::Visitor<'genv> for Wf<'_, 'genv, '_> {
                 ));
             }
 
-            for (arg, param) in iter::zip(path.refine, &generics.params) {
+            for (expr, param) in iter::zip(path.refine, &generics.params) {
                 self.infcx
-                    .check_refine_arg(arg, &param.sort)
+                    .check_expr(expr, &param.sort)
                     .collect_err(&mut self.errors);
             }
         }

--- a/crates/flux-fhir-analysis/src/wf/param_usage.rs
+++ b/crates/flux-fhir-analysis/src/wf/param_usage.rs
@@ -109,8 +109,8 @@ impl<'a, 'genv, 'tcx> ParamUsesChecker<'a, 'genv, 'tcx> {
                     self.check_func_params_uses(&expr, false);
                 }
             }
-            fhir::ExprKind::RefineAbs(_, body) => self.check_func_params_uses(&body, true),
-            fhir::ExprKind::RefineRecord(fields) => {
+            fhir::ExprKind::Abs(_, body) => self.check_func_params_uses(&body, true),
+            fhir::ExprKind::Record(fields) => {
                 for field in fields {
                     self.check_func_params_uses(field, is_top_level_conj);
                 }

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -138,7 +138,6 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
                     return Err(self.emit_sort_mismatch(expr.span, &expected, &found));
                 }
             }
-            fhir::ExprKind::RefineArgExpr(expr) => self.check_expr(expr, expected)?,
             fhir::ExprKind::Abs(refine_params, body) => {
                 self.check_abs(expr, refine_params, body, expected)?
             }
@@ -640,12 +639,10 @@ impl<'a, 'genv, 'tcx> ImplicitParamInferer<'a, 'genv, 'tcx> {
 
     fn infer_implicit_params(&mut self, idx: &fhir::Expr, expected: &rty::Sort) {
         match idx.kind {
-            fhir::ExprKind::RefineArgExpr(expr) => {
-                if let fhir::ExprKind::Var(var, Some(_)) = &expr.kind {
-                    let (_, id) = var.res.expect_param();
-                    let found = self.infcx.param_sort(id);
-                    self.infcx.equate(&found, expected);
-                }
+            fhir::ExprKind::Var(var, Some(_)) => {
+                let (_, id) = var.res.expect_param();
+                let found = self.infcx.param_sort(id);
+                self.infcx.equate(&found, expected);
             }
             fhir::ExprKind::Record(flds) => {
                 if let rty::Sort::App(rty::SortCtor::Adt(sort_def), sort_args) = expected {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -139,10 +139,10 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
                 }
             }
             fhir::ExprKind::RefineArgExpr(expr) => self.check_expr(expr, expected)?,
-            fhir::ExprKind::RefineAbs(refine_params, body) => {
+            fhir::ExprKind::Abs(refine_params, body) => {
                 self.check_abs(expr, refine_params, body, expected)?
             }
-            fhir::ExprKind::RefineRecord(fields) => self.check_record(expr, fields, expected)?,
+            fhir::ExprKind::Record(fields) => self.check_record(expr, fields, expected)?,
         }
         Ok(())
     }
@@ -647,7 +647,7 @@ impl<'a, 'genv, 'tcx> ImplicitParamInferer<'a, 'genv, 'tcx> {
                     self.infcx.equate(&found, expected);
                 }
             }
-            fhir::ExprKind::RefineRecord(flds) => {
+            fhir::ExprKind::Record(flds) => {
                 if let rty::Sort::App(rty::SortCtor::Adt(sort_def), sort_args) = expected {
                     let sorts = sort_def.field_sorts(sort_args);
                     if flds.len() != sorts.len() {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -49,21 +49,9 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
         }
     }
 
-    pub(super) fn check_refine_arg(
-        &mut self,
-        arg: &fhir::RefineArg,
-        expected: &rty::Sort,
-    ) -> Result {
-        match &arg.kind {
-            fhir::RefineArgKind::Expr(expr) => self.check_expr(expr, expected),
-            fhir::RefineArgKind::Abs(params, body) => self.check_abs(arg, params, body, expected),
-            fhir::RefineArgKind::Record(flds) => self.check_record(arg, flds, expected),
-        }
-    }
-
     fn check_abs(
         &mut self,
-        arg: &fhir::RefineArg,
+        arg: &fhir::Expr,
         params: &[fhir::RefineParam],
         body: &fhir::Expr,
         expected: &rty::Sort,
@@ -98,8 +86,8 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
 
     fn check_record(
         &mut self,
-        arg: &fhir::RefineArg,
-        flds: &[fhir::RefineArg],
+        arg: &fhir::Expr,
+        flds: &[fhir::Expr],
         expected: &rty::Sort,
     ) -> Result {
         if let rty::Sort::App(rty::SortCtor::Adt(sort_def), sort_args) = expected {
@@ -117,7 +105,7 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
                 .insert(arg.fhir_id, sort_def.did());
 
             izip!(flds, &sorts)
-                .map(|(arg, expected)| self.check_refine_arg(arg, expected))
+                .map(|(arg, expected)| self.check_expr(arg, expected))
                 .try_collect_exhaust()
         } else {
             Err(self.emit_err(errors::ArgCountMismatch::new(
@@ -150,6 +138,11 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
                     return Err(self.emit_sort_mismatch(expr.span, &expected, &found));
                 }
             }
+            fhir::ExprKind::RefineArgExpr(expr) => self.check_expr(expr, expected)?,
+            fhir::ExprKind::RefineAbs(refine_params, body) => {
+                self.check_abs(expr, refine_params, body, expected)?
+            }
+            fhir::ExprKind::RefineRecord(fields) => self.check_record(expr, fields, expected)?,
         }
         Ok(())
     }
@@ -199,6 +192,10 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
                     _ => Err(self.emit_field_not_found(&sort, *fld)),
                 }
             }
+            // TODO (VR): Pretty sure we don't synthesize these?
+            fhir::ExprKind::RefineArgExpr(_) => todo!(),
+            fhir::ExprKind::RefineAbs(_, _) => todo!(),
+            fhir::ExprKind::RefineRecord(_) => todo!(),
         }
     }
 
@@ -643,17 +640,16 @@ impl<'a, 'genv, 'tcx> ImplicitParamInferer<'a, 'genv, 'tcx> {
         vis.errors.into_result()
     }
 
-    fn infer_implicit_params(&mut self, idx: &fhir::RefineArg, expected: &rty::Sort) {
+    fn infer_implicit_params(&mut self, idx: &fhir::Expr, expected: &rty::Sort) {
         match idx.kind {
-            fhir::RefineArgKind::Expr(expr) => {
+            fhir::ExprKind::RefineArgExpr(expr) => {
                 if let fhir::ExprKind::Var(var, Some(_)) = &expr.kind {
                     let (_, id) = var.res.expect_param();
                     let found = self.infcx.param_sort(id);
                     self.infcx.equate(&found, expected);
                 }
             }
-            fhir::RefineArgKind::Abs(_, _) => {}
-            fhir::RefineArgKind::Record(flds) => {
+            fhir::ExprKind::RefineRecord(flds) => {
                 if let rty::Sort::App(rty::SortCtor::Adt(sort_def), sort_args) = expected {
                     let sorts = sort_def.field_sorts(sort_args);
                     if flds.len() != sorts.len() {
@@ -677,6 +673,7 @@ impl<'a, 'genv, 'tcx> ImplicitParamInferer<'a, 'genv, 'tcx> {
                     ));
                 }
             }
+            _ => {}
         }
     }
 }

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -192,10 +192,8 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
                     _ => Err(self.emit_field_not_found(&sort, *fld)),
                 }
             }
-            // TODO (VR): Pretty sure we don't synthesize these?
-            fhir::ExprKind::RefineArgExpr(_) => todo!(),
-            fhir::ExprKind::RefineAbs(_, _) => todo!(),
-            fhir::ExprKind::RefineRecord(_) => todo!(),
+            // (VR): Pretty sure we don't synthesize these?
+            _ => span_bug!(expr.span, "unexpected expr `{expr:?}` in synth expr"),
         }
     }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -919,8 +919,8 @@ pub enum ExprKind<'fhir> {
     Alias(AliasReft<'fhir>, &'fhir [Expr<'fhir>]),
     IfThenElse(&'fhir Expr<'fhir>, &'fhir Expr<'fhir>, &'fhir Expr<'fhir>),
     RefineArgExpr(&'fhir Expr<'fhir>),
-    RefineAbs(&'fhir [RefineParam<'fhir>], &'fhir Expr<'fhir>),
-    RefineRecord(&'fhir [Expr<'fhir>]),
+    Abs(&'fhir [RefineParam<'fhir>], &'fhir Expr<'fhir>),
+    Record(&'fhir [Expr<'fhir>]),
 }
 
 impl<'fhir> Expr<'fhir> {
@@ -1422,7 +1422,7 @@ impl fmt::Debug for Expr<'_> {
             ExprKind::RefineArgExpr(expr) => {
                 write!(f, "{expr:?}")
             }
-            ExprKind::RefineAbs(params, body) => {
+            ExprKind::Abs(params, body) => {
                 write!(
                     f,
                     "|{}| {body:?}",
@@ -1431,7 +1431,7 @@ impl fmt::Debug for Expr<'_> {
                     })
                 )
             }
-            ExprKind::RefineRecord(flds) => {
+            ExprKind::Record(flds) => {
                 write!(f, "{{ {:?} }}", flds.iter().format(", "))
             }
         }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -918,15 +918,13 @@ pub enum ExprKind<'fhir> {
     App(PathExpr<'fhir>, &'fhir [Expr<'fhir>]),
     Alias(AliasReft<'fhir>, &'fhir [Expr<'fhir>]),
     IfThenElse(&'fhir Expr<'fhir>, &'fhir Expr<'fhir>, &'fhir Expr<'fhir>),
-    RefineArgExpr(&'fhir Expr<'fhir>),
     Abs(&'fhir [RefineParam<'fhir>], &'fhir Expr<'fhir>),
     Record(&'fhir [Expr<'fhir>]),
 }
 
 impl<'fhir> Expr<'fhir> {
     pub fn is_colon_param(&self) -> Option<ParamId> {
-        if let ExprKind::RefineArgExpr(expr) = &self.kind
-            && let ExprKind::Var(path, Some(ParamKind::Colon)) = &expr.kind
+        if let ExprKind::Var(path, Some(ParamKind::Colon)) = &self.kind
             && let ExprRes::Param(kind, id) = path.res
         {
             debug_assert_eq!(kind, ParamKind::Colon);
@@ -1419,9 +1417,6 @@ impl fmt::Debug for Expr<'_> {
                 write!(f, "(if {p:?} {{ {e1:?} }} else {{ {e2:?} }})")
             }
             ExprKind::Dot(var, fld) => write!(f, "{var:?}.{fld}"),
-            ExprKind::RefineArgExpr(expr) => {
-                write!(f, "{expr:?}")
-            }
             ExprKind::Abs(params, body) => {
                 write!(
                     f,

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -455,7 +455,7 @@ pub struct VariantDef<'fhir> {
 #[derive(Debug, Clone, Copy)]
 pub struct VariantRet<'fhir> {
     pub enum_id: DefId,
-    pub idx: RefineArg<'fhir>,
+    pub idx: Expr<'fhir>,
 }
 
 #[derive(Clone, Copy)]
@@ -518,7 +518,7 @@ pub enum TyKind<'fhir> {
     /// [existential]: crate::rty::TyKind::Exists
     /// [type]: GenericParamKind::Type
     BaseTy(BaseTy<'fhir>),
-    Indexed(BaseTy<'fhir>, RefineArg<'fhir>),
+    Indexed(BaseTy<'fhir>, Expr<'fhir>),
     Exists(&'fhir [RefineParam<'fhir>], &'fhir Ty<'fhir>),
     /// Constrained types `{T | p}` are like existentials but without binders, and are useful
     /// for specifying constraints on indexed values e.g. `{i32[@a] | 0 <= a}`
@@ -529,7 +529,7 @@ pub enum TyKind<'fhir> {
     Tuple(&'fhir [Ty<'fhir>]),
     Array(&'fhir Ty<'fhir>, ConstArg),
     RawPtr(&'fhir Ty<'fhir>, Mutability),
-    OpaqueDef(ItemId, &'fhir [GenericArg<'fhir>], &'fhir [RefineArg<'fhir>], bool),
+    OpaqueDef(ItemId, &'fhir [GenericArg<'fhir>], &'fhir [Expr<'fhir>], bool),
     TraitObject(&'fhir [PolyTraitRef<'fhir>], Lifetime, TraitObjectSyntax),
     Never,
     Infer,
@@ -602,34 +602,6 @@ newtype_index! {
     pub struct ItemLocalId {}
 }
 
-#[derive(Clone, Copy)]
-pub struct RefineArg<'fhir> {
-    pub kind: RefineArgKind<'fhir>,
-    pub fhir_id: FhirId,
-    pub span: Span,
-}
-
-impl<'fhir> RefineArg<'fhir> {
-    pub fn is_colon_param(&self) -> Option<ParamId> {
-        if let RefineArgKind::Expr(expr) = &self.kind
-            && let ExprKind::Var(path, Some(ParamKind::Colon)) = &expr.kind
-            && let ExprRes::Param(kind, id) = path.res
-        {
-            debug_assert_eq!(kind, ParamKind::Colon);
-            Some(id)
-        } else {
-            None
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-pub enum RefineArgKind<'fhir> {
-    Expr(Expr<'fhir>),
-    Abs(&'fhir [RefineParam<'fhir>], Expr<'fhir>),
-    Record(&'fhir [RefineArg<'fhir>]),
-}
-
 /// These are types of things that may be refined with indices or existentials
 #[derive(Clone, Copy)]
 pub struct BaseTy<'fhir> {
@@ -668,7 +640,7 @@ pub enum QPath<'fhir> {
 pub struct Path<'fhir> {
     pub res: Res,
     pub segments: &'fhir [PathSegment<'fhir>],
-    pub refine: &'fhir [RefineArg<'fhir>],
+    pub refine: &'fhir [Expr<'fhir>],
     pub span: Span,
 }
 
@@ -932,8 +904,8 @@ pub struct AliasReft<'fhir> {
 #[derive(Clone, Copy)]
 pub struct Expr<'fhir> {
     pub kind: ExprKind<'fhir>,
-    pub span: Span,
     pub fhir_id: FhirId,
+    pub span: Span,
 }
 
 #[derive(Clone, Copy)]
@@ -946,6 +918,23 @@ pub enum ExprKind<'fhir> {
     App(PathExpr<'fhir>, &'fhir [Expr<'fhir>]),
     Alias(AliasReft<'fhir>, &'fhir [Expr<'fhir>]),
     IfThenElse(&'fhir Expr<'fhir>, &'fhir Expr<'fhir>, &'fhir Expr<'fhir>),
+    RefineArgExpr(&'fhir Expr<'fhir>),
+    RefineAbs(&'fhir [RefineParam<'fhir>], &'fhir Expr<'fhir>),
+    RefineRecord(&'fhir [Expr<'fhir>]),
+}
+
+impl<'fhir> Expr<'fhir> {
+    pub fn is_colon_param(&self) -> Option<ParamId> {
+        if let ExprKind::RefineArgExpr(expr) = &self.kind
+            && let ExprKind::Var(path, Some(ParamKind::Colon)) = &expr.kind
+            && let ExprRes::Param(kind, id) = path.res
+        {
+            debug_assert_eq!(kind, ParamKind::Colon);
+            Some(id)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -1409,28 +1398,6 @@ impl fmt::Debug for AssocItemConstraint<'_> {
     }
 }
 
-impl fmt::Debug for RefineArg<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.kind {
-            RefineArgKind::Expr(expr) => {
-                write!(f, "{expr:?}")
-            }
-            RefineArgKind::Abs(params, body) => {
-                write!(
-                    f,
-                    "|{}| {body:?}",
-                    params.iter().format_with(", ", |param, f| {
-                        f(&format_args!("{}: {:?}", param.name, param.sort))
-                    })
-                )
-            }
-            RefineArgKind::Record(flds) => {
-                write!(f, "{{ {:?} }}", flds.iter().format(", "))
-            }
-        }
-    }
-}
-
 impl fmt::Debug for AliasReft<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "<{:?} as {:?}>::{}", self.qself, self.path, self.name)
@@ -1452,6 +1419,21 @@ impl fmt::Debug for Expr<'_> {
                 write!(f, "(if {p:?} {{ {e1:?} }} else {{ {e2:?} }})")
             }
             ExprKind::Dot(var, fld) => write!(f, "{var:?}.{fld}"),
+            ExprKind::RefineArgExpr(expr) => {
+                write!(f, "{expr:?}")
+            }
+            ExprKind::RefineAbs(params, body) => {
+                write!(
+                    f,
+                    "|{}| {body:?}",
+                    params.iter().format_with(", ", |param, f| {
+                        f(&format_args!("{}: {:?}", param.name, param.sort))
+                    })
+                )
+            }
+            ExprKind::RefineRecord(flds) => {
+                write!(f, "{{ {:?} }}", flds.iter().format(", "))
+            }
         }
     }
 }

--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -269,7 +269,7 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
     }
 
     fn lift_variant_ret_inner(&mut self, generics: &hir::Generics) -> fhir::VariantRet<'genv> {
-        let kind = fhir::ExprKind::RefineRecord(&[]);
+        let kind = fhir::ExprKind::Record(&[]);
         fhir::VariantRet {
             enum_id: self.owner.resolved_id(),
             idx: fhir::Expr {

--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -269,10 +269,10 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
     }
 
     fn lift_variant_ret_inner(&mut self, generics: &hir::Generics) -> fhir::VariantRet<'genv> {
-        let kind = fhir::RefineArgKind::Record(&[]);
+        let kind = fhir::ExprKind::RefineRecord(&[]);
         fhir::VariantRet {
             enum_id: self.owner.resolved_id(),
-            idx: fhir::RefineArg {
+            idx: fhir::Expr {
                 kind,
                 fhir_id: self.next_fhir_id(),
                 span: generics.span.shrink_to_hi(),

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -480,11 +480,11 @@ pub fn walk_expr<'v, V: Visitor<'v>>(vis: &mut V, expr: &Expr<'v>) {
         ExprKind::RefineArgExpr(expr) => {
             vis.visit_expr(expr);
         }
-        ExprKind::RefineAbs(refine_params, body) => {
+        ExprKind::Abs(refine_params, body) => {
             walk_list!(vis, visit_refine_param, refine_params);
             vis.visit_expr(body);
         }
-        ExprKind::RefineRecord(fields) => {
+        ExprKind::Record(fields) => {
             walk_list!(vis, visit_expr, fields);
         }
     }

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -477,9 +477,6 @@ pub fn walk_expr<'v, V: Visitor<'v>>(vis: &mut V, expr: &Expr<'v>) {
             vis.visit_expr(e2);
             vis.visit_expr(e3);
         }
-        ExprKind::RefineArgExpr(expr) => {
-            vis.visit_expr(expr);
-        }
         ExprKind::Abs(refine_params, body) => {
             walk_list!(vis, visit_refine_param, refine_params);
             vis.visit_expr(body);

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -2,9 +2,9 @@ use super::{
     AliasReft, AssocItemConstraint, AssocItemConstraintKind, BaseTy, BaseTyKind, Ensures, EnumDef,
     Expr, ExprKind, FieldDef, FnDecl, FnOutput, FnSig, FuncSort, GenericArg, GenericBound,
     Generics, Impl, ImplAssocReft, ImplItem, ImplItemKind, Item, ItemKind, Lifetime, Lit, Node,
-    OpaqueTy, Path, PathExpr, PathSegment, PolyFuncSort, PolyTraitRef, QPath, RefineArg,
-    RefineArgKind, RefineParam, Requires, Sort, SortPath, StructDef, TraitAssocReft, TraitItem,
-    TraitItemKind, Ty, TyAlias, TyKind, VariantDef, VariantRet, WhereBoundPredicate,
+    OpaqueTy, Path, PathExpr, PathSegment, PolyFuncSort, PolyTraitRef, QPath, RefineParam,
+    Requires, Sort, SortPath, StructDef, TraitAssocReft, TraitItem, TraitItemKind, Ty, TyAlias,
+    TyKind, VariantDef, VariantRet, WhereBoundPredicate,
 };
 use crate::fhir::StructKind;
 
@@ -163,10 +163,6 @@ pub trait Visitor<'v>: Sized {
         walk_func_sort(self, func);
     }
 
-    fn visit_refine_arg(&mut self, arg: &RefineArg<'v>) {
-        walk_refine_arg(self, arg);
-    }
-
     fn visit_expr(&mut self, expr: &Expr<'v>) {
         walk_expr(self, expr);
     }
@@ -211,7 +207,7 @@ pub fn walk_field_def<'v, V: Visitor<'v>>(vis: &mut V, field: &FieldDef<'v>) {
 
 pub fn walk_variant_ret<'v, V: Visitor<'v>>(vis: &mut V, ret: &VariantRet<'v>) {
     let VariantRet { idx, enum_id: _ } = ret;
-    vis.visit_refine_arg(idx);
+    vis.visit_expr(idx);
 }
 
 pub fn walk_ty_alias<'v, V: Visitor<'v>>(vis: &mut V, ty_alias: &TyAlias<'v>) {
@@ -347,7 +343,7 @@ pub fn walk_ty<'v, V: Visitor<'v>>(vis: &mut V, ty: &Ty<'v>) {
         TyKind::BaseTy(bty) => vis.visit_bty(&bty),
         TyKind::Indexed(bty, idx) => {
             vis.visit_bty(&bty);
-            vis.visit_refine_arg(&idx);
+            vis.visit_expr(&idx);
         }
         TyKind::Exists(params, ty) => {
             walk_list!(vis, visit_refine_param, params);
@@ -378,7 +374,7 @@ pub fn walk_ty<'v, V: Visitor<'v>>(vis: &mut V, ty: &Ty<'v>) {
         }
         TyKind::OpaqueDef(_item_id, generics, refine, _bool) => {
             walk_list!(vis, visit_generic_arg, generics);
-            walk_list!(vis, visit_refine_arg, refine);
+            walk_list!(vis, visit_expr, refine);
         }
         TyKind::TraitObject(poly_traits, lft, _) => {
             walk_list!(vis, visit_poly_trait_ref, poly_traits);
@@ -412,7 +408,7 @@ pub fn walk_qpath<'v, V: Visitor<'v>>(vis: &mut V, qpath: &QPath<'v>) {
 
 pub fn walk_path<'v, V: Visitor<'v>>(vis: &mut V, path: &Path<'v>) {
     walk_list!(vis, visit_path_segment, path.segments);
-    walk_list!(vis, visit_refine_arg, path.refine);
+    walk_list!(vis, visit_expr, path.refine);
 }
 
 pub fn walk_path_segment<'v, V: Visitor<'v>>(vis: &mut V, segment: &PathSegment<'v>) {
@@ -452,19 +448,6 @@ pub fn walk_func_sort<'v, V: Visitor<'v>>(vis: &mut V, func: &FuncSort<'v>) {
     walk_list!(vis, visit_sort, func.inputs_and_output);
 }
 
-pub fn walk_refine_arg<'v, V: Visitor<'v>>(vis: &mut V, arg: &RefineArg<'v>) {
-    match arg.kind {
-        RefineArgKind::Expr(expr) => vis.visit_expr(&expr),
-        RefineArgKind::Abs(params, body) => {
-            walk_list!(vis, visit_refine_param, params);
-            vis.visit_expr(&body);
-        }
-        RefineArgKind::Record(flds) => {
-            walk_list!(vis, visit_refine_arg, flds);
-        }
-    }
-}
-
 pub fn walk_alias_reft<'v, V: Visitor<'v>>(vis: &mut V, alias: &AliasReft<'v>) {
     vis.visit_ty(alias.qself);
     vis.visit_path(&alias.path);
@@ -493,6 +476,16 @@ pub fn walk_expr<'v, V: Visitor<'v>>(vis: &mut V, expr: &Expr<'v>) {
             vis.visit_expr(e1);
             vis.visit_expr(e2);
             vis.visit_expr(e3);
+        }
+        ExprKind::RefineArgExpr(expr) => {
+            vis.visit_expr(expr);
+        }
+        ExprKind::RefineAbs(refine_params, body) => {
+            walk_list!(vis, visit_refine_param, refine_params);
+            vis.visit_expr(body);
+        }
+        ExprKind::RefineRecord(fields) => {
+            walk_list!(vis, visit_expr, fields);
         }
     }
 }


### PR DESCRIPTION
Collapses stratified FHIR to only deal with `Expr` and not `RefineArg`