### PR TITLE
Parse Array ConstArg

### DIFF
--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -369,15 +369,20 @@ pub Ty: surface::Ty = {
 }
 
 ConstArg: surface::ConstArg = {
-   <lo:@L> <lit:Lit> <hi:@R> => {
+   <lo:@L> <lit:Lit> <hi:@R> =>? {
        let span = cx.map_span(lo, hi);
-       // TODO(RJ): hack to avoid having to resolve the generic DefId
        let mut kind = surface::ConstArgKind::Infer;
        if let surface::LitKind::Integer = lit.kind {
         if let Ok(val) = lit.symbol.as_str().parse::<usize>() {
-            kind = surface::ConstArgKind::Lit(val);
+            let kind = surface::ConstArgKind::Lit(val);
+            return Ok(surface::ConstArg { kind, span });
         }
        }
+       Err( ParseError::User { error: UserParseError::UnexpectedToken(lo, hi) })
+   },
+   <lo:@L> <id:Ident> <hi:@R> => {
+       let span = cx.map_span(lo, hi);
+       let kind = surface::ConstArgKind::Infer; // TODO(RJ): hack to avoid having to resolve the generic DefId
        surface::ConstArg { kind, span }
    },
    <lo:@L> "_" <hi:@R> => {

--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -368,6 +368,25 @@ pub Ty: surface::Ty = {
     }
 }
 
+ConstArg: surface::ConstArg = {
+   <lo:@L> <lit:Lit> <hi:@R> => {
+       let span = cx.map_span(lo, hi);
+       // TODO(RJ): hack to avoid having to resolve the generic DefId
+       let mut kind = surface::ConstArgKind::Infer;
+       if let surface::LitKind::Integer = lit.kind {
+        if let Ok(val) = lit.symbol.as_str().parse::<usize>() {
+            kind = surface::ConstArgKind::Lit(val);
+        }
+       }
+       surface::ConstArg { kind, span }
+   },
+   <lo:@L> "_" <hi:@R> => {
+       let span = cx.map_span(lo, hi);
+       let kind = surface::ConstArgKind::Infer;
+       surface::ConstArg { kind, span }
+   }
+}
+
 TyKind: surface::TyKind = {
     "_"                                               => surface::TyKind::Hole,
     <bty:BaseTy>                                      => surface::TyKind::Base(<>),
@@ -381,14 +400,8 @@ TyKind: surface::TyKind = {
     "&" <ty:Ty>                     => surface::TyKind::Ref(surface::Mutability::Not, Box::new(ty)),
     "&" "mut" <ty:Ty>               => surface::TyKind::Ref(surface::Mutability::Mut, Box::new(ty)),
 
-    "[" <ty:Ty> ";" <lo:@L> <lit:Lit> <hi:@R> "]" =>? {
-        let span = cx.map_span(lo, hi);
-        if let surface::LitKind::Integer = lit.kind {
-            if let Ok(val) = lit.symbol.as_str().parse::<usize>() {
-                return Ok(surface::TyKind::Array(Box::new(ty), surface::ArrayLen { val, span }));
-            }
-        }
-        Err(ParseError::User { error: UserParseError::UnexpectedToken(lo, hi) })
+    "[" <ty:Ty> ";" <len:ConstArg> "]" =>? {
+        return Ok(surface::TyKind::Array(Box::new(ty), len));
     },
 
     "impl" <bounds:GenericBounds> => surface::TyKind::ImplTrait(cx.next_node_id(), bounds),

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -337,7 +337,7 @@ pub enum TyKind {
     /// Constrained type: an exists without binder
     Constr(Expr, Box<Ty>),
     Tuple(Vec<Ty>),
-    Array(Box<Ty>, ArrayLen),
+    Array(Box<Ty>, ConstArg),
     /// The `NodeId` is used to resolve the type to a corresponding `OpaqueTy`
     ImplTrait(NodeId, GenericBounds),
     Hole,
@@ -385,10 +385,17 @@ pub enum BaseTyKind {
     Slice(Box<Ty>),
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct ArrayLen {
-    pub val: usize,
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
+pub struct ConstArg {
+    pub kind: ConstArgKind,
     pub span: Span,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
+pub enum ConstArgKind {
+    Lit(usize),
+    // Param(DefId),
+    Infer,
 }
 
 #[derive(Debug)]

--- a/crates/flux-syntax/src/surface/visit.rs
+++ b/crates/flux-syntax/src/surface/visit.rs
@@ -1,7 +1,7 @@
 use rustc_span::symbol::Ident;
 
 use super::{
-    AliasReft, ArrayLen, Async, BaseSort, BaseTy, BaseTyKind, Ensures, EnumDef, Expr, ExprKind,
+    AliasReft, Async, BaseSort, BaseTy, BaseTyKind, ConstArg, Ensures, EnumDef, Expr, ExprKind,
     ExprPath, ExprPathSegment, FnInput, FnOutput, FnRetTy, FnSig, GenericArg, GenericArgKind,
     GenericParam, Generics, Impl, ImplAssocReft, Indices, Lit, Path, PathSegment, Qualifier,
     RefineArg, RefineParam, Sort, SortPath, SpecFunc, StructDef, Trait, TraitAssocReft, TraitRef,
@@ -135,7 +135,7 @@ pub trait Visitor: Sized {
         walk_ty(self, ty);
     }
 
-    fn visit_array_len(&mut self, _array_len: &ArrayLen) {}
+    fn visit_const_arg(&mut self, _const_arg: &ConstArg) {}
 
     fn visit_bty(&mut self, bty: &BaseTy) {
         walk_bty(self, bty);
@@ -426,7 +426,7 @@ pub fn walk_ty<V: Visitor>(vis: &mut V, ty: &Ty) {
             walk_list!(vis, visit_ty, tys);
         }
         TyKind::Array(ty, len) => {
-            vis.visit_array_len(len);
+            vis.visit_const_arg(len);
             vis.visit_ty(ty);
         }
         TyKind::ImplTrait(_node_id, trait_ref) => {

--- a/tests/tests/lib/rvec.rs
+++ b/tests/tests/lib/rvec.rs
@@ -79,6 +79,26 @@ impl<T> RVec<T> {
         self.inner.as_mut_slice()
     }
 
+
+    #[flux::trusted]
+    #[flux::sig(fn(arr:_) -> RVec<T>[N])]
+    pub fn from_array<const N: usize>(arr: [T; N]) -> Self {
+        Self {
+            inner: Vec::from(arr),
+        }
+    }
+
+    #[flux::trusted]
+    #[flux::sig(fn(xs:&[T][@n]) -> RVec<T>[n])]
+    pub fn from_slice(xs: &[T]) -> Self
+    where
+        T: Clone,
+    {
+        Self {
+            inner: Vec::from(xs),
+        }
+    }
+
     #[flux::trusted]
     #[flux::sig(fn(T, n: usize) -> RVec<T>[n])]
     pub fn from_elem_n(elem: T, n: usize) -> Self

--- a/tests/tests/pos/surface/const06.rs
+++ b/tests/tests/pos/surface/const06.rs
@@ -1,5 +1,5 @@
 #[flux::sig(fn (head: [i32; N]))]
-fn test1<const N: usize>(head: [i32; N]) {}
+pub fn test1<const N: usize>(head: [i32; N]) {}
 
 #[flux::sig(fn (head: [i32; _]))]
-fn test2<const N: usize>(head: [i32; N]) {}
+pub fn test2<const N: usize>(head: [i32; N]) {}

--- a/tests/tests/pos/surface/const06.rs
+++ b/tests/tests/pos/surface/const06.rs
@@ -1,0 +1,5 @@
+#[flux::sig(fn (head: [i32; N]))]
+fn test1<const N: usize>(head: [i32; N]) {}
+
+#[flux::sig(fn (head: [i32; _]))]
+fn test2<const N: usize>(head: [i32; N]) {}


### PR DESCRIPTION
To allow writing specs like

```rust
#[flux::sig(fn (head: [i32; N]))]
pub fn test1<const N: usize>(head: [i32; N]) {}

#[flux::sig(fn (head: [i32; _]))]
pub fn test2<const N: usize>(head: [i32; N]) {}
```