### PR TITLE
Support `&strg` , `requires` and `ensures` in function subtyping

### DIFF
--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -48,6 +48,14 @@ impl Tag {
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash, Debug)]
+pub enum SubtypeReason {
+    Input,
+    Output,
+    Requires,
+    Ensures,
+}
+
+#[derive(PartialEq, Eq, Clone, Copy, Hash, Debug)]
 pub enum ConstrReason {
     Call,
     Assign,
@@ -58,11 +66,8 @@ pub enum ConstrReason {
     Rem,
     Goto(BasicBlock),
     Overflow,
+    Subtype(SubtypeReason),
     Other,
-    SubtypeIn,
-    SubtypeReq,
-    SubtypeOut,
-    SubtypeEns,
 }
 
 pub struct InferCtxtRoot<'genv, 'tcx> {

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -59,6 +59,10 @@ pub enum ConstrReason {
     Goto(BasicBlock),
     Overflow,
     Other,
+    SubtypeIn,
+    SubtypeReq,
+    SubtypeOut,
+    SubtypeEns,
 }
 
 pub struct InferCtxtRoot<'genv, 'tcx> {

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -235,7 +235,7 @@ fn find_trait_item(
 ///  fn g(x1:T1,...,xn:Tn) -> T {
 ///      f(x1,...,xn)
 ///  }
-/// TODO: copy rules from SLACK.
+#[expect(clippy::too_many_arguments)]
 fn check_fn_subtyping(
     infcx: &mut InferCtxt,
     def_id: &DefId,

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -327,15 +327,16 @@ fn check_fn_subtyping(
     infcx
         .subtyping(&output.ret, &super_output.ret, ConstrReason::Ret)
         .with_span(span)?;
-    let evars_sol = infcx.pop_scope().with_span(span)?;
-    infcx.replace_evars(&evars_sol);
 
     // println!("TRACE: check_fn_subtyping (0): {env:?}");
     // // 6. Update state with Output "ensures"
-    // update_ensures(&mut infcx, &mut env, &output, overflow_checking)?;
+    update_ensures(&mut infcx, &mut env, &output, overflow_checking)?;
     // println!("TRACE: check_fn_subtyping (1): {env:?}");
     // // 7. Check ensures predicates
-    // check_ensures(&mut infcx, &mut env, &super_output, span)?;
+    check_ensures(&mut infcx, &mut env, &super_output, span)?;
+
+    let evars_sol = infcx.pop_scope().with_span(span)?;
+    infcx.replace_evars(&evars_sol);
 
     Ok(())
 }
@@ -869,16 +870,6 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             .replace_bound_refts_with(|sort, _, _| infcx.define_vars(sort));
 
         update_ensures(infcx, env, &output, self.check_overflow())?;
-        // for ensures in &output.ensures {
-        //     match ensures {
-        //         Ensures::Type(path, updated_ty) => {
-        //             let updated_ty = infcx.unpack(updated_ty);
-        //             infcx.assume_invariants(&updated_ty, self.check_overflow());
-        //             env.update_path(path, updated_ty);
-        //         }
-        //         Ensures::Pred(e) => infcx.assume_pred(e),
-        //     }
-        // }
 
         fold_local_ptrs(infcx, env, span)?;
 

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -318,7 +318,7 @@ fn check_fn_subtyping(
         .with_span(span)?;
 
     // 6. Update state with Output "ensures" and check super ensures
-    update_ensures(&mut infcx, &mut env, &output, overflow_checking)?;
+    update_ensures(&mut infcx, &mut env, &output, overflow_checking);
     fold_local_ptrs(&mut infcx, &mut env, span)?;
     check_ensures(
         &mut infcx,
@@ -339,7 +339,7 @@ fn update_ensures(
     env: &mut TypeEnv,
     output: &FnOutput,
     overflow_checking: bool,
-) -> Result {
+) {
     for ensure in &output.ensures {
         match ensure {
             Ensures::Type(path, updated_ty) => {
@@ -350,7 +350,6 @@ fn update_ensures(
             Ensures::Pred(e) => infcx.assume_pred(e),
         }
     }
-    Ok(())
 }
 
 fn check_ensures(
@@ -867,7 +866,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             .replace_evars(&evars_sol)
             .replace_bound_refts_with(|sort, _, _| infcx.define_vars(sort));
 
-        update_ensures(infcx, env, &output, self.check_overflow())?;
+        update_ensures(infcx, env, &output, self.check_overflow());
 
         fold_local_ptrs(infcx, env, span)?;
 

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -207,9 +207,13 @@ fn report_errors(genv: GlobalEnv, errors: Vec<Tag>) -> Result<(), ErrorGuarantee
     for err in errors {
         let span = err.src_span;
         e = Some(match err.reason {
-            ConstrReason::Call => call_error(genv, span, err.dst_span),
+            ConstrReason::Call | ConstrReason::SubtypeIn | ConstrReason::SubtypeReq => {
+                call_error(genv, span, err.dst_span)
+            }
             ConstrReason::Assign => genv.sess().emit_err(errors::AssignError { span }),
-            ConstrReason::Ret => ret_error(genv, span, err.dst_span),
+            ConstrReason::Ret | ConstrReason::SubtypeOut | ConstrReason::SubtypeEns => {
+                ret_error(genv, span, err.dst_span)
+            }
             ConstrReason::Div => genv.sess().emit_err(errors::DivError { span }),
             ConstrReason::Rem => genv.sess().emit_err(errors::RemError { span }),
             ConstrReason::Goto(_) => genv.sess().emit_err(errors::GotoError { span }),

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -37,7 +37,7 @@ use flux_common::{cache::QueryCache, dbg, result::ResultExt as _};
 use flux_config as config;
 use flux_infer::{
     fixpoint_encoding::{FixpointCtxt, KVarGen},
-    infer::{ConstrReason, Tag},
+    infer::{ConstrReason, SubtypeReason, Tag},
     refine_tree::RefineTree,
 };
 use flux_macros::fluent_messages;
@@ -207,13 +207,15 @@ fn report_errors(genv: GlobalEnv, errors: Vec<Tag>) -> Result<(), ErrorGuarantee
     for err in errors {
         let span = err.src_span;
         e = Some(match err.reason {
-            ConstrReason::Call | ConstrReason::SubtypeIn | ConstrReason::SubtypeReq => {
+            ConstrReason::Call
+            | ConstrReason::Subtype(SubtypeReason::Input)
+            | ConstrReason::Subtype(SubtypeReason::Requires) => {
                 call_error(genv, span, err.dst_span)
             }
             ConstrReason::Assign => genv.sess().emit_err(errors::AssignError { span }),
-            ConstrReason::Ret | ConstrReason::SubtypeOut | ConstrReason::SubtypeEns => {
-                ret_error(genv, span, err.dst_span)
-            }
+            ConstrReason::Ret
+            | ConstrReason::Subtype(SubtypeReason::Output)
+            | ConstrReason::Subtype(SubtypeReason::Ensures) => ret_error(genv, span, err.dst_span),
             ConstrReason::Div => genv.sess().emit_err(errors::DivError { span }),
             ConstrReason::Rem => genv.sess().emit_err(errors::RemError { span }),
             ConstrReason::Goto(_) => genv.sess().emit_err(errors::GotoError { span }),

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -169,7 +169,8 @@ pub fn check_fn(
 
         // PHASE 4: subtyping check for trait-method implementations
         if let Some((refine_tree, kvars)) =
-            trait_impl_subtyping(genv, local_id, span).map_err(|err| err.emit_err(&genv, def_id))?
+            trait_impl_subtyping(genv, local_id, config.check_overflow, span)
+                .map_err(|err| err.emit_err(&genv, def_id))?
         {
             tracing::info!("check_fn::refine-subtyping");
             let errors =

--- a/tests/tests/neg/surface/impl01.rs
+++ b/tests/tests/neg/surface/impl01.rs
@@ -1,0 +1,14 @@
+pub trait Mono {
+    #[flux::sig(fn (zing: &strg i32[@n]) ensures zing: i32{v:n < v})]
+    fn foo(z: &mut i32);
+}
+
+pub struct Horse;
+
+impl Mono for Horse {
+    #[flux::sig(fn (z: &strg i32[@n]) ensures z: i32{v:v < n})]
+    fn foo(z: &mut i32) {
+        //~^ ERROR refinement type
+        *z -= 1;
+    }
+}

--- a/tests/tests/neg/surface/impl02.rs
+++ b/tests/tests/neg/surface/impl02.rs
@@ -1,0 +1,29 @@
+pub trait Mono {
+    #[flux::sig(fn (zing: &strg i32[@n])
+                  requires 0 < n
+                  ensures zing: i32{v:n < v})]
+    fn foo(z: &mut i32);
+}
+
+pub struct Tiger;
+
+impl Mono for Tiger {
+    #[flux::sig(fn (pig: &strg i32[@m])
+                  requires 100 < m
+                  ensures pig: i32{v:m < v})]
+    fn foo(pig: &mut i32) {
+        //~^ ERROR refinement type
+        *pig += 1;
+    }
+}
+
+pub struct Snake;
+
+impl Mono for Snake {
+    #[flux::sig(fn (pig: &strg {i32[@m] | 100 < m})
+                ensures pig: i32[m+1])]
+    fn foo(pig: &mut i32) {
+        //~^ ERROR refinement type
+        *pig += 1;
+    }
+}

--- a/tests/tests/neg/surface/impl03.rs
+++ b/tests/tests/neg/surface/impl03.rs
@@ -1,0 +1,14 @@
+pub trait Mono {
+    #[flux::sig(fn (zing: &mut i32{v: 0 <= v}))]
+    fn foo(z: &mut i32);
+}
+
+pub struct Snake;
+
+impl Mono for Snake {
+    #[flux::sig(fn (hog: &strg i32[@m]) ensures hog: i32[m-1])]
+    fn foo(hog: &mut i32) {
+        //~^ ERROR: type invariant may not hold
+        *hog -= 1;
+    }
+}

--- a/tests/tests/pos/surface/impl01.rs
+++ b/tests/tests/pos/surface/impl01.rs
@@ -1,0 +1,22 @@
+pub trait Mono {
+    #[flux::sig(fn (zing: &strg i32[@n]) ensures zing: i32{v:n < v})]
+    fn foo(z: &mut i32);
+}
+
+pub struct Tiger;
+
+impl Mono for Tiger {
+    #[flux::sig(fn (pig: &strg i32[@m]) ensures pig: i32{v:m < v})]
+    fn foo(pig: &mut i32) {
+        *pig += 1;
+    }
+}
+
+pub struct Snake;
+
+impl Mono for Snake {
+    #[flux::sig(fn (pig: &strg i32[@m]) ensures pig: i32[m+1])]
+    fn foo(pig: &mut i32) {
+        *pig += 1;
+    }
+}

--- a/tests/tests/pos/surface/impl02.rs
+++ b/tests/tests/pos/surface/impl02.rs
@@ -1,0 +1,27 @@
+pub trait Mono {
+    #[flux::sig(fn (zing: &strg i32[@n])
+                  requires 100 < n
+                  ensures zing: i32{v:n < v})]
+    fn foo(z: &mut i32);
+}
+
+pub struct Tiger;
+
+impl Mono for Tiger {
+    #[flux::sig(fn (pig: &strg i32[@m])
+                  requires 0 < m
+                  ensures pig: i32{v:m < v})]
+    fn foo(pig: &mut i32) {
+        *pig += 1;
+    }
+}
+
+pub struct Snake;
+
+impl Mono for Snake {
+    #[flux::sig(fn (pig: &strg {i32[@m] | 0 < m})
+                ensures pig: i32[m+1])]
+    fn foo(pig: &mut i32) {
+        *pig += 1;
+    }
+}

--- a/tests/tests/pos/surface/impl03.rs
+++ b/tests/tests/pos/surface/impl03.rs
@@ -1,0 +1,13 @@
+pub trait Mono {
+    #[flux::sig(fn (zing: &mut i32{v: 0 <= v}))]
+    fn foo(z: &mut i32);
+}
+
+pub struct Tiger;
+
+impl Mono for Tiger {
+    #[flux::sig(fn (pig: &strg i32[@m]) ensures pig: i32[m+1])]
+    fn foo(pig: &mut i32) {
+        *pig += 1;
+    }
+}


### PR DESCRIPTION
fixes #890 
