### PR TITLE
Move FnTraitPredicate and CoroutineOblig out of Clausekind

### DIFF
--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -674,17 +674,6 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
         for bound in bounds {
             match bound {
                 fhir::GenericBound::Trait(poly_trait_ref, fhir::TraitBoundModifier::None) => {
-                    // let trait_id = poly_trait_ref.trait_def_id();
-                    // if let Some(closure_kind) = self.genv.tcx().fn_trait_kind_from_def_id(trait_id)
-                    // {
-                    //     self.conv_fn_bound(
-                    //         env,
-                    //         &bounded_ty,
-                    //         poly_trait_ref,
-                    //         closure_kind,
-                    //         &mut clauses,
-                    //     )?;
-                    // } else {
                     self.conv_poly_trait_ref(
                         env,
                         bounded_ty_span,
@@ -692,7 +681,6 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
                         poly_trait_ref,
                         &mut clauses,
                     )?;
-                    // }
                 }
                 fhir::GenericBound::Outlives(lft) => {
                     let re = self.conv_lifetime(env, *lft);
@@ -802,37 +790,6 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
             .into();
 
         clauses.push(clause);
-        Ok(())
-    }
-
-    fn conv_fn_bound(
-        &mut self,
-        env: &mut Env,
-        self_ty: &rty::Ty,
-        trait_ref: &fhir::PolyTraitRef,
-        kind: rty::ClosureKind,
-        clauses: &mut Vec<rty::Clause>,
-    ) -> QueryResult {
-        let path = &trait_ref.trait_ref;
-        let layer = Layer::list(self.results(), trait_ref.bound_generic_params.len() as u32, &[]);
-        env.push_layer(layer);
-
-        let fhir::AssocItemConstraintKind::Equality { term } =
-            &path.last_segment().constraints[0].kind;
-
-        let pred = rty::FnTraitPredicate {
-            self_ty: self_ty.clone(),
-            tupled_args: self.conv_ty(env, path.last_segment().args[0].expect_type())?,
-            output: self.conv_ty(env, term)?,
-            kind,
-        };
-        // FIXME(nilehmann) We should use `tcx.late_bound_vars` here instead of trusting our lowering
-        let vars = trait_ref
-            .bound_generic_params
-            .iter()
-            .map(|param| self.param_as_bound_var(param))
-            .try_collect_vec()?;
-        // clauses.push(rty::Clause::new(vars, rty::ClauseKind::FnTrait(pred)));
         Ok(())
     }
 

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -673,25 +673,25 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
         for bound in bounds {
             match bound {
                 fhir::GenericBound::Trait(poly_trait_ref, fhir::TraitBoundModifier::None) => {
-                    let trait_id = poly_trait_ref.trait_def_id();
-                    if let Some(closure_kind) = self.genv.tcx().fn_trait_kind_from_def_id(trait_id)
-                    {
-                        self.conv_fn_bound(
-                            env,
-                            &bounded_ty,
-                            poly_trait_ref,
-                            closure_kind,
-                            &mut clauses,
-                        )?;
-                    } else {
-                        self.conv_poly_trait_ref(
-                            env,
-                            bounded_ty_span,
-                            &bounded_ty,
-                            poly_trait_ref,
-                            &mut clauses,
-                        )?;
-                    }
+                    // let trait_id = poly_trait_ref.trait_def_id();
+                    // if let Some(closure_kind) = self.genv.tcx().fn_trait_kind_from_def_id(trait_id)
+                    // {
+                    //     self.conv_fn_bound(
+                    //         env,
+                    //         &bounded_ty,
+                    //         poly_trait_ref,
+                    //         closure_kind,
+                    //         &mut clauses,
+                    //     )?;
+                    // } else {
+                    self.conv_poly_trait_ref(
+                        env,
+                        bounded_ty_span,
+                        &bounded_ty,
+                        poly_trait_ref,
+                        &mut clauses,
+                    )?;
+                    // }
                 }
                 fhir::GenericBound::Outlives(lft) => {
                     let re = self.conv_lifetime(env, *lft);
@@ -827,7 +827,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
             .iter()
             .map(|param| self.param_as_bound_var(param))
             .try_collect_vec()?;
-        clauses.push(rty::Clause::new(vars, rty::ClauseKind::FnTrait(pred)));
+        // clauses.push(rty::Clause::new(vars, rty::ClauseKind::FnTrait(pred)));
         Ok(())
     }
 
@@ -997,9 +997,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
                     projection_bounds.push(rty::Binder::bind_with_vars(proj, vars));
                 }
                 rty::ClauseKind::TypeOutlives(_) => {}
-                rty::ClauseKind::FnTrait(..)
-                | rty::ClauseKind::ConstArgHasType(..)
-                | rty::ClauseKind::CoroutineOblig(..) => {
+                rty::ClauseKind::ConstArgHasType(..) | rty::ClauseKind::CoroutineOblig(..) => {
                     bug!("did not expect {pred:?} clause in object bounds");
                 }
             }

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -959,7 +959,7 @@ impl<'genv, 'tcx, P: ConvPhase> ConvCtxt<'genv, 'tcx, P> {
                     projection_bounds.push(rty::Binder::bind_with_vars(proj, vars));
                 }
                 rty::ClauseKind::TypeOutlives(_) => {}
-                rty::ClauseKind::ConstArgHasType(..) | rty::ClauseKind::CoroutineOblig(..) => {
+                rty::ClauseKind::ConstArgHasType(..) => {
                     bug!("did not expect {pred:?} clause in object bounds");
                 }
             }

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -760,21 +760,16 @@ impl Sub {
             );
             for clause in &bounds {
                 if let rty::ClauseKind::Projection(pred) = clause.kind_skipping_binder() {
-                    let ty1 = Self::project_ty(infcx, bty, pred.projection_ty.def_id)?;
+                    let alias_ty = pred.projection_ty.with_self_ty(bty.to_subset_ty_ctor());
+                    let ty1 = BaseTy::Alias(AliasKind::Projection, alias_ty)
+                        .to_ty()
+                        .normalize_projections(infcx.genv, infcx.region_infcx, infcx.def_id)?;
                     let ty2 = pred.term.to_ty();
                     self.tys(infcx, &ty1, &ty2)?;
                 }
             }
         }
         Ok(())
-    }
-
-    fn project_ty(infcx: &InferCtxt, self_ty: &BaseTy, assoc_item_id: DefId) -> InferResult<Ty> {
-        let args = List::singleton(GenericArg::Base(self_ty.to_subset_ty_ctor()));
-        let alias_ty = rty::AliasTy::new(assoc_item_id, args, List::empty());
-        Ok(BaseTy::Alias(AliasKind::Projection, alias_ty)
-            .to_ty()
-            .normalize_projections(infcx.genv, infcx.region_infcx, infcx.def_id)?)
     }
 }
 

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -330,7 +330,7 @@ impl<'a, 'infcx, 'genv, 'tcx> InferCtxtAt<'a, 'infcx, 'genv, 'tcx> {
         a: &Ty,
         b: &Ty,
         reason: ConstrReason,
-    ) -> InferResult<Vec<rty::Clause>> {
+    ) -> InferResult<Vec<Binder<rty::CoroutineObligPredicate>>> {
         let mut sub = Sub::new(reason, self.span);
         sub.tys(self.infcx, a, b)?;
         Ok(sub.obligations)
@@ -441,7 +441,7 @@ struct Sub {
     /// FIXME(nilehmann) This is used to store coroutine obligations generated during subtyping when
     /// relating an opaque type. Other obligations related to relating opaque types are resolved
     /// directly here. The implementation is really messy and we may be missing some obligations.
-    obligations: Vec<rty::Clause>,
+    obligations: Vec<Binder<rty::CoroutineObligPredicate>>,
 }
 
 impl Sub {
@@ -784,19 +784,19 @@ fn mk_coroutine_obligations(
     resume_ty: &Ty,
     upvar_tys: &List<Ty>,
     opaque_def_id: &DefId,
-) -> InferResult<Vec<rty::Clause>> {
+) -> InferResult<Vec<Binder<rty::CoroutineObligPredicate>>> {
     let bounds = genv.item_bounds(*opaque_def_id)?.skip_binder();
     for bound in &bounds {
-        if let rty::ClauseKind::Projection(proj) = bound.kind_skipping_binder() {
-            let output = proj.term;
-            let pred = CoroutineObligPredicate {
-                def_id: *generator_did,
-                resume_ty: resume_ty.clone(),
-                upvar_tys: upvar_tys.clone(),
-                output: output.to_ty(),
-            };
-            let clause = rty::Clause::new(vec![], rty::ClauseKind::CoroutineOblig(pred));
-            return Ok(vec![clause]);
+        if let Some(proj_clause) = bound.as_projection_clause() {
+            return Ok(vec![proj_clause.map(|proj_clause| {
+                let output = proj_clause.term;
+                CoroutineObligPredicate {
+                    def_id: *generator_did,
+                    resume_ty: resume_ty.clone(),
+                    upvar_tys: upvar_tys.clone(),
+                    output: output.to_ty(),
+                }
+            })]);
         }
     }
     bug!("no projection predicate")

--- a/crates/flux-middle/src/rty/binder.rs
+++ b/crates/flux-middle/src/rty/binder.rs
@@ -101,8 +101,8 @@ impl<T> Binder<T> {
         self.as_ref().skip_binder()
     }
 
-    pub fn rebind<U>(self, value: U) -> Binder<U> {
-        Binder { vars: self.vars, value }
+    pub fn rebind<U>(&self, value: U) -> Binder<U> {
+        Binder { vars: self.vars.clone(), value }
     }
 
     pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Binder<U> {

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -302,21 +302,12 @@ impl Clause {
                 rest.push(clause.clone());
             }
         }
-        eprintln!("");
-        eprintln!("split off");
-        eprintln!("{clauses:#?}");
-        eprintln!("{rest:#?}");
-        eprintln!("{}", fn_trait_clauses.len());
-        eprintln!("{}", fn_trait_output_clauses.len());
 
         let fn_trait_clauses = fn_trait_clauses
             .into_iter()
             .map(|(kind, fn_trait_clause)| {
                 let mut candidates = vec![];
                 for fn_trait_output_clause in &fn_trait_output_clauses {
-                    eprintln!("");
-                    eprintln!("{:?}", fn_trait_output_clause.self_ty());
-                    eprintln!("{:?}", fn_trait_clause.self_ty());
                     if fn_trait_output_clause.self_ty() == fn_trait_clause.self_ty() {
                         candidates.push(fn_trait_output_clause.clone());
                     }
@@ -327,7 +318,7 @@ impl Clause {
                     FnTraitPredicate {
                         kind,
                         self_ty: fn_trait_clause.self_ty().to_ty(),
-                        tupled_args: fn_trait_clause.trait_ref.args[1].expect_type().clone(),
+                        tupled_args: fn_trait_clause.trait_ref.args[1].expect_base().to_ty(),
                         output: proj_pred.term.to_ty(),
                     }
                 })

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -38,10 +38,12 @@ use flux_rustc_bridge::{
     ty::{self, VariantDef},
     ToRustc,
 };
+use flux_syntax::surface::Trait;
 use itertools::Itertools;
 pub use normalize::SpecFuncDefns;
 use refining::Refiner;
 use rustc_data_structures::unord::UnordMap;
+use rustc_hash::FxHashMap;
 use rustc_hir::{def_id::DefId, LangItem, Safety};
 use rustc_index::{newtype_index, IndexSlice};
 use rustc_macros::{extension, Decodable, Encodable, TyDecodable, TyEncodable};
@@ -247,13 +249,107 @@ pub struct Clause {
     kind: Binder<ClauseKind>,
 }
 
+impl Clause {
+    pub fn new(vars: impl Into<List<BoundVariableKind>>, kind: ClauseKind) -> Self {
+        Clause { kind: Binder::bind_with_vars(kind, vars.into()) }
+    }
+
+    pub fn kind(&self) -> Binder<ClauseKind> {
+        self.kind.clone()
+    }
+
+    fn as_trait_clause(&self) -> Option<Binder<TraitPredicate>> {
+        let clause = self.kind();
+        if let ClauseKind::Trait(trait_clause) = clause.skip_binder_ref() {
+            Some(clause.rebind(trait_clause.clone()))
+        } else {
+            None
+        }
+    }
+
+    pub fn as_projection_clause(&self) -> Option<Binder<ProjectionPredicate>> {
+        let clause = self.kind();
+        if let ClauseKind::Projection(proj_clause) = clause.skip_binder_ref() {
+            Some(clause.rebind(proj_clause.clone()))
+        } else {
+            None
+        }
+    }
+
+    // FIXME(nilehmann) we should deal with the binder in all the places this is used instead of
+    // blindly skipping it here
+    pub fn kind_skipping_binder(&self) -> ClauseKind {
+        self.kind.clone().skip_binder()
+    }
+
+    pub fn split_off_fn_trait_clauses(
+        genv: GlobalEnv,
+        clauses: &Clauses,
+    ) -> (Vec<Clause>, Vec<Binder<FnTraitPredicate>>) {
+        let mut fn_trait_clauses = vec![];
+        let mut fn_trait_output_clauses = vec![];
+        let mut rest = vec![];
+        for clause in clauses {
+            if let Some(trait_clause) = clause.as_trait_clause()
+                && let Some(kind) = genv.tcx().fn_trait_kind_from_def_id(trait_clause.def_id())
+            {
+                fn_trait_clauses.push((kind, trait_clause));
+            } else if let Some(proj_clause) = clause.as_projection_clause()
+                && genv.is_fn_once_output(proj_clause.projection_def_id())
+            {
+                fn_trait_output_clauses.push(proj_clause)
+            } else {
+                rest.push(clause.clone());
+            }
+        }
+        eprintln!("");
+        eprintln!("split off");
+        eprintln!("{clauses:#?}");
+        eprintln!("{rest:#?}");
+        eprintln!("{}", fn_trait_clauses.len());
+        eprintln!("{}", fn_trait_output_clauses.len());
+
+        let fn_trait_clauses = fn_trait_clauses
+            .into_iter()
+            .map(|(kind, fn_trait_clause)| {
+                let mut candidates = vec![];
+                for fn_trait_output_clause in &fn_trait_output_clauses {
+                    eprintln!("");
+                    eprintln!("{:?}", fn_trait_output_clause.self_ty());
+                    eprintln!("{:?}", fn_trait_clause.self_ty());
+                    if fn_trait_output_clause.self_ty() == fn_trait_clause.self_ty() {
+                        candidates.push(fn_trait_output_clause.clone());
+                    }
+                }
+                tracked_span_assert_eq!(candidates.len(), 1);
+                let proj_pred = candidates.pop().unwrap().skip_binder();
+                fn_trait_clause.map(|fn_trait_clause| {
+                    FnTraitPredicate {
+                        kind,
+                        self_ty: fn_trait_clause.self_ty().to_ty(),
+                        tupled_args: fn_trait_clause.trait_ref.args[1].expect_type().clone(),
+                        output: proj_pred.term.to_ty(),
+                    }
+                })
+            })
+            .collect_vec();
+        (rest, fn_trait_clauses)
+    }
+}
+
+impl From<Binder<ClauseKind>> for Clause {
+    fn from(kind: Binder<ClauseKind>) -> Self {
+        Clause { kind }
+    }
+}
+
 pub type Clauses = List<Clause>;
 
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable,
 )]
 pub enum ClauseKind {
-    FnTrait(FnTraitPredicate),
+    // FnTrait(FnTraitPredicate),
     Trait(TraitPredicate),
     Projection(ProjectionPredicate),
     TypeOutlives(TypeOutlivesPredicate),
@@ -270,7 +366,23 @@ pub struct TraitPredicate {
     pub trait_ref: TraitRef,
 }
 
+impl TraitPredicate {
+    fn self_ty(&self) -> SubsetTyCtor {
+        self.trait_ref.self_ty()
+    }
+}
+
 pub type PolyTraitPredicate = Binder<TraitPredicate>;
+
+impl PolyTraitPredicate {
+    fn def_id(&self) -> DefId {
+        self.skip_binder_ref().trait_ref.def_id
+    }
+
+    fn self_ty(&self) -> Binder<SubsetTyCtor> {
+        self.clone().map(|predicate| predicate.self_ty())
+    }
+}
 
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable,
@@ -278,6 +390,12 @@ pub type PolyTraitPredicate = Binder<TraitPredicate>;
 pub struct TraitRef {
     pub def_id: DefId,
     pub args: GenericArgs,
+}
+
+impl TraitRef {
+    pub fn self_ty(&self) -> SubsetTyCtor {
+        self.args[0].expect_base().clone()
+    }
 }
 
 impl<'tcx> ToRustc<'tcx> for TraitRef {
@@ -386,6 +504,28 @@ pub struct ExistentialProjection {
 pub struct ProjectionPredicate {
     pub projection_ty: AliasTy,
     pub term: SubsetTyCtor,
+}
+
+impl ProjectionPredicate {
+    pub fn self_ty(&self) -> SubsetTyCtor {
+        self.projection_ty.self_ty().clone()
+    }
+}
+
+pub type PolyProjectionPredicate = Binder<ProjectionPredicate>;
+
+impl PolyProjectionPredicate {
+    fn projection_def_id(&self) -> DefId {
+        self.skip_binder_ref().projection_ty.def_id
+    }
+
+    fn term(&self) -> Binder<SubsetTyCtor> {
+        self.clone().map(|predicate| predicate.term)
+    }
+
+    pub fn self_ty(&self) -> Binder<SubsetTyCtor> {
+        self.clone().map(|predicate| predicate.self_ty())
+    }
 }
 
 #[derive(
@@ -928,12 +1068,6 @@ pub struct SpecFuncDecl {
     pub name: Symbol,
     pub sort: PolyFuncSort,
     pub kind: SpecFuncKind,
-}
-
-#[derive(Debug)]
-pub struct ClosureOblig {
-    pub oblig_def_id: DefId,
-    pub oblig_sig: PolyFnSig,
 }
 
 pub type TyCtor = Binder<Ty>;
@@ -1539,6 +1673,25 @@ pub struct AliasTy {
     pub refine_args: RefineArgs,
 }
 
+impl AliasTy {
+    pub fn new(def_id: DefId, args: GenericArgs, refine_args: RefineArgs) -> Self {
+        AliasTy { args, refine_args, def_id }
+    }
+
+    /// This method work only with associated type projections (i.e., no opaque tpes)
+    pub fn self_ty(&self) -> SubsetTyCtor {
+        self.args[0].expect_base().clone()
+    }
+}
+
+impl<'tcx> ToRustc<'tcx> for AliasTy {
+    type T = rustc_middle::ty::AliasTy<'tcx>;
+
+    fn to_rustc(&self, tcx: TyCtxt<'tcx>) -> Self::T {
+        rustc_middle::ty::AliasTy::new(tcx, self.def_id, self.args.to_rustc(tcx))
+    }
+}
+
 pub type RefineArgs = List<Expr>;
 
 #[extension(pub trait RefineArgsExt)]
@@ -1687,6 +1840,7 @@ pub enum GenericArg {
 }
 
 impl GenericArg {
+    #[track_caller]
     pub fn expect_type(&self) -> &Ty {
         if let GenericArg::Ty(ty) = self {
             ty
@@ -1695,6 +1849,7 @@ impl GenericArg {
         }
     }
 
+    #[track_caller]
     pub fn expect_base(&self) -> &SubsetTyCtor {
         if let GenericArg::Base(ctor) = self {
             ctor
@@ -1900,28 +2055,6 @@ impl From<TyOrBase> for TyOrCtor {
             TyOrBase::Ty(ty) => TyOrCtor::Ty(ty),
             TyOrBase::Base(ctor) => TyOrCtor::Ctor(ctor.to_ty_ctor()),
         }
-    }
-}
-
-impl Clause {
-    pub fn new(vars: impl Into<List<BoundVariableKind>>, kind: ClauseKind) -> Self {
-        Clause { kind: Binder::bind_with_vars(kind, vars.into()) }
-    }
-
-    pub fn kind(&self) -> Binder<ClauseKind> {
-        self.kind.clone()
-    }
-
-    // FIXME(nilehmann) we should deal with the binder in all the places this is used instead of
-    // blindly skipping it here
-    pub fn kind_skipping_binder(&self) -> ClauseKind {
-        self.kind.clone().skip_binder()
-    }
-}
-
-impl From<Binder<ClauseKind>> for Clause {
-    fn from(kind: Binder<ClauseKind>) -> Self {
-        Clause { kind }
     }
 }
 
@@ -2191,25 +2324,6 @@ impl EarlyBinder<PolyVariant> {
 impl TyKind {
     fn intern(self) -> Ty {
         Ty(Interned::new(self))
-    }
-}
-
-impl AliasTy {
-    pub fn new(def_id: DefId, args: GenericArgs, refine_args: RefineArgs) -> Self {
-        AliasTy { args, refine_args, def_id }
-    }
-
-    /// This method work only with associated type projections (i.e., no opaque tpes)
-    pub fn self_ty(&self) -> &Ty {
-        self.args[0].expect_type()
-    }
-}
-
-impl<'tcx> ToRustc<'tcx> for AliasTy {
-    type T = rustc_middle::ty::AliasTy<'tcx>;
-
-    fn to_rustc(&self, tcx: TyCtxt<'tcx>) -> Self::T {
-        rustc_middle::ty::AliasTy::new(tcx, self.def_id, self.args.to_rustc(tcx))
     }
 }
 

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -281,9 +281,9 @@ impl Clause {
         self.kind.clone().skip_binder()
     }
 
-    /// Match together `Fn` trait clauses with their corresponding `FnOnce::Output` projection
+    /// Group `Fn` trait clauses with their corresponding `FnOnce::Output` projection
     /// predicate. This assumes there's exactly one corresponding projection predicate and will
-    /// crash otherwise
+    /// crash otherwise.
     pub fn split_off_fn_trait_clauses(
         genv: GlobalEnv,
         clauses: &Clauses,
@@ -299,7 +299,7 @@ impl Clause {
             } else if let Some(proj_clause) = clause.as_projection_clause()
                 && genv.is_fn_once_output(proj_clause.projection_def_id())
             {
-                fn_trait_output_clauses.push(proj_clause)
+                fn_trait_output_clauses.push(proj_clause);
             } else {
                 rest.push(clause.clone());
             }
@@ -342,12 +342,10 @@ pub type Clauses = List<Clause>;
     Debug, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable,
 )]
 pub enum ClauseKind {
-    // FnTrait(FnTraitPredicate),
     Trait(TraitPredicate),
     Projection(ProjectionPredicate),
     TypeOutlives(TypeOutlivesPredicate),
     ConstArgHasType(Const, Ty),
-    CoroutineOblig(CoroutineObligPredicate),
 }
 
 pub type TypeOutlivesPredicate = OutlivesPredicate<Ty>;

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -11,7 +11,6 @@ impl Pretty for ClauseKind {
     fn fmt(&self, _cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         define_scoped!(_cx, f);
         match self {
-            ClauseKind::FnTrait(pred) => w!("FnTrait ({pred:?})"),
             ClauseKind::Trait(pred) => w!("Trait ({pred:?})"),
             ClauseKind::Projection(pred) => w!("Projection ({pred:?})"),
             ClauseKind::CoroutineOblig(pred) => w!("Projection ({pred:?})"),

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -13,7 +13,6 @@ impl Pretty for ClauseKind {
         match self {
             ClauseKind::Trait(pred) => w!("Trait ({pred:?})"),
             ClauseKind::Projection(pred) => w!("Projection ({pred:?})"),
-            ClauseKind::CoroutineOblig(pred) => w!("Projection ({pred:?})"),
             ClauseKind::TypeOutlives(pred) => w!("Outlives ({:?}, {:?})", &pred.0, &pred.1),
             ClauseKind::ConstArgHasType(c, ty) => w!("ConstArgHasType ({:?}, {:?})", c, ty),
         }

--- a/crates/flux-middle/src/rty/projections.rs
+++ b/crates/flux-middle/src/rty/projections.rs
@@ -228,10 +228,6 @@ impl<'genv, 'tcx, 'cx> Normalizer<'genv, 'tcx, 'cx> {
                     .skip_binder();
 
                 let generics = self.tcx().generics_of(impl_def_id);
-                // eprintln!();
-                // eprintln!("{:#?}", generics);
-                // eprintln!("{:?}", impl_trait_ref.args);
-                // eprintln!("{:?}", obligation.args);
 
                 let mut subst = TVarSubst::new(generics);
                 for (a, b) in iter::zip(&impl_trait_ref.args, &obligation.args) {

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -123,8 +123,9 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
     fn refine_clause(&self, clause: &ty::Clause) -> QueryResult<Option<rty::Clause>> {
         let kind = match &clause.kind.as_ref().skip_binder() {
             ty::ClauseKind::Trait(trait_pred) => {
-                let trait_ref = &trait_pred.trait_ref;
-                let pred = rty::TraitPredicate { trait_ref: self.refine_trait_ref(trait_ref)? };
+                let pred = rty::TraitPredicate {
+                    trait_ref: self.refine_trait_ref(&trait_pred.trait_ref)?,
+                };
                 rty::ClauseKind::Trait(pred)
             }
             ty::ClauseKind::Projection(proj_pred) => {

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -120,6 +120,7 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
         Ok(clauses)
     }
 
+    /// https://www.google.com
     fn refine_clause(
         &self,
         clauses: &[ty::Clause],
@@ -128,17 +129,17 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
         let kind = match &clause.kind.as_ref().skip_binder() {
             ty::ClauseKind::Trait(trait_pred) => {
                 let trait_ref = &trait_pred.trait_ref;
-                if let Some(kind) = self.genv.tcx().fn_trait_kind_from_def_id(trait_ref.def_id) {
-                    self.refine_fn_trait_pred(clauses, kind, trait_ref)?
-                } else {
-                    let pred = rty::TraitPredicate { trait_ref: self.refine_trait_ref(trait_ref)? };
-                    rty::ClauseKind::Trait(pred)
-                }
+                // if let Some(kind) = self.genv.tcx().fn_trait_kind_from_def_id(trait_ref.def_id) {
+                //     self.refine_fn_trait_pred(clauses, kind, trait_ref)?
+                // } else {
+                let pred = rty::TraitPredicate { trait_ref: self.refine_trait_ref(trait_ref)? };
+                rty::ClauseKind::Trait(pred)
+                // }
             }
             ty::ClauseKind::Projection(proj_pred) => {
-                if self.genv.is_fn_once_output(proj_pred.projection_ty.def_id) {
-                    return Ok(None);
-                }
+                // if self.genv.is_fn_once_output(proj_pred.projection_ty.def_id) {
+                //     return Ok(None);
+                // }
                 let rty::TyOrBase::Base(term) = self.refine_ty_or_base(&proj_pred.term)? else {
                     return Err(query_bug!(
                         self.def_id,
@@ -164,31 +165,31 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
         Ok(Some(rty::Clause { kind }))
     }
 
-    fn refine_fn_trait_pred(
-        &self,
-        clauses: &[ty::Clause],
-        kind: ClosureKind,
-        trait_ref: &ty::TraitRef,
-    ) -> QueryResult<rty::ClauseKind> {
-        let mut candidates = vec![];
-        for clause in clauses {
-            if let ty::ClauseKind::Projection(trait_pred) = &clause.kind.as_ref().skip_binder()
-                && self.genv.is_fn_once_output(trait_pred.projection_ty.def_id)
-                && trait_pred.projection_ty.self_ty() == trait_ref.self_ty()
-            {
-                candidates.push(trait_pred);
-            }
-        }
-        tracked_span_assert_eq!(candidates.len(), 1);
-        let pred = candidates.first().unwrap();
-        let pred = rty::FnTraitPredicate {
-            kind,
-            self_ty: self.refine_ty(trait_ref.args[0].expect_type())?,
-            tupled_args: self.refine_ty(trait_ref.args[1].expect_type())?,
-            output: self.refine_ty(&pred.term)?,
-        };
-        Ok(rty::ClauseKind::FnTrait(pred))
-    }
+    // fn refine_fn_trait_pred(
+    //     &self,
+    //     clauses: &[ty::Clause],
+    //     kind: ClosureKind,
+    //     trait_ref: &ty::TraitRef,
+    // ) -> QueryResult<rty::ClauseKind> {
+    //     let mut candidates = vec![];
+    //     for clause in clauses {
+    //         if let ty::ClauseKind::Projection(trait_pred) = &clause.kind.as_ref().skip_binder()
+    //             && self.genv.is_fn_once_output(trait_pred.projection_ty.def_id)
+    //             && trait_pred.projection_ty.self_ty() == trait_ref.self_ty()
+    //         {
+    //             candidates.push(trait_pred);
+    //         }
+    //     }
+    //     tracked_span_assert_eq!(candidates.len(), 1);
+    //     let pred = candidates.first().unwrap();
+    //     let pred = rty::FnTraitPredicate {
+    //         kind,
+    //         self_ty: self.refine_ty(trait_ref.args[0].expect_type())?,
+    //         tupled_args: self.refine_ty(trait_ref.args[1].expect_type())?,
+    //         output: self.refine_ty(&pred.term)?,
+    //     };
+    //     Ok(rty::ClauseKind::FnTrait(pred))
+    // }
 
     pub fn refine_existential_predicate(
         &self,

--- a/tests/tests/pos/surface/issue-808.rs
+++ b/tests/tests/pos/surface/issue-808.rs
@@ -1,0 +1,9 @@
+#[flux_rs::trusted]
+pub fn get_filter_map(
+) -> core::iter::FilterMap<core::slice::Iter<'static, Option<()>>, fn(&Option<()>) -> Option<()>> {
+    unimplemented!()
+}
+
+fn use_filter_map() {
+    let found = get_filter_map().find(|_| true);
+}


### PR DESCRIPTION
Compute the `FnTraitPredicates` when checking a function call instead of doing it during `conv` and `refining` fixes #808 for real. Ping @enjhnsn2 