### PR TITLE
Add check overflow attribute to flux-rs

### DIFF
--- a/lib/flux-rs/src/lib.rs
+++ b/lib/flux-rs/src/lib.rs
@@ -45,6 +45,11 @@ pub fn opaque(attr: TokenStream, tokens: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn check_overflow(attr: TokenStream, tokens: TokenStream) -> TokenStream {
+    attr_impl::check_overflow(attr, tokens)
+}
+
+#[proc_macro_attribute]
 pub fn trusted(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     attr_impl::trusted(attr, tokens)
 }
@@ -123,6 +128,7 @@ mod attr_sysroot {
         constant,
         invariant,
         opaque,
+        check_overflow,
         trusted,
         trusted_impl,
         generics,
@@ -166,6 +172,7 @@ mod attr_dummy {
         invariant,
         constant,
         opaque,
+        check_overflow,
         trusted,
         trusted_impl,
         generics,


### PR DESCRIPTION
I tried to use this attribute in another project and realized that it was non existent in flux-rs. This seems to fix the issue.