### PR TITLE
Delay unfolding

### DIFF
--- a/crates/flux-infer/src/refine_tree.rs
+++ b/crates/flux-infer/src/refine_tree.rs
@@ -235,7 +235,7 @@ impl RefineTree {
     }
 
     pub fn simplify(&mut self, defns: &SpecFuncDefns) {
-        self.root.borrow_mut().simplify(defns)
+        self.root.borrow_mut().simplify(defns);
     }
 
     pub fn into_fixpoint(self, cx: &mut FixpointCtxt<Tag>) -> QueryResult<fixpoint::Constraint> {

--- a/crates/flux-infer/src/refine_tree.rs
+++ b/crates/flux-infer/src/refine_tree.rs
@@ -14,8 +14,8 @@ use flux_middle::{
         canonicalize::{Hoister, HoisterDelegate},
         evars::EVarSol,
         fold::{TypeFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitor},
-        BaseTy, EarlyBinder, EarlyReftParam, Expr, GenericArgs, Name, Sort, Ty, TyCtor, TyKind,
-        Var,
+        BaseTy, EarlyBinder, EarlyReftParam, Expr, GenericArgs, Name, Sort, SpecFuncDefns, Ty,
+        TyCtor, TyKind, Var,
     },
 };
 use itertools::Itertools;
@@ -234,8 +234,8 @@ impl RefineTree {
         Ok(RefineTree { root })
     }
 
-    pub fn simplify(&mut self, genv: GlobalEnv) -> QueryResult {
-        self.root.borrow_mut().simplify(genv)
+    pub fn simplify(&mut self, defns: &SpecFuncDefns) {
+        self.root.borrow_mut().simplify(defns)
     }
 
     pub fn into_fixpoint(self, cx: &mut FixpointCtxt<Tag>) -> QueryResult<fixpoint::Constraint> {
@@ -415,14 +415,14 @@ impl std::ops::Deref for NodePtr {
 }
 
 impl Node {
-    fn simplify(&mut self, genv: GlobalEnv) -> QueryResult {
+    fn simplify(&mut self, defns: &SpecFuncDefns) {
         for child in &self.children {
-            child.borrow_mut().simplify(genv)?;
+            child.borrow_mut().simplify(defns);
         }
 
         match &mut self.kind {
             NodeKind::Head(pred, tag) => {
-                let pred = pred.normalize(genv.spec_func_defns()?).simplify();
+                let pred = pred.normalize(defns).simplify();
                 if pred.is_trivially_true() {
                     self.kind = NodeKind::True;
                 } else {
@@ -431,7 +431,7 @@ impl Node {
             }
             NodeKind::True => {}
             NodeKind::Assumption(pred) => {
-                *pred = pred.normalize(genv.spec_func_defns()?).simplify();
+                *pred = pred.normalize(defns).simplify();
                 self.children
                     .extract_if(|child| {
                         matches!(child.borrow().kind, NodeKind::True)
@@ -448,7 +448,6 @@ impl Node {
         if !self.is_leaf() && self.children.is_empty() {
             self.kind = NodeKind::True;
         }
-        Ok(())
     }
 
     fn is_leaf(&self) -> bool {

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -119,7 +119,9 @@ impl ESpan {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, TypeFoldable, TypeVisitable)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, TypeFoldable, TypeVisitable,
+)]
 pub enum BinOp {
     Iff,
     Imp,
@@ -1144,6 +1146,7 @@ mod pretty {
                 }
             }
             let e = if cx.simplify_exprs { self.simplify() } else { self.clone() };
+            // w!("{:?}@(", ^e.span())?;
             match e.kind() {
                 ExprKind::Var(var) => w!("{:?}", var),
                 ExprKind::Local(local) => w!("{:?}", ^local),
@@ -1221,8 +1224,8 @@ mod pretty {
                     }
                 }
                 ExprKind::App(func, args) => {
-                    w!("({:?})({})",
-                        func,
+                    w!("{:?}({})",
+                        parens!(func, !func.is_atom()),
                         ^args
                             .iter()
                             .format_with(", ", |arg, f| f(&format_args_cx!("{:?}", arg)))
@@ -1253,7 +1256,9 @@ mod pretty {
                         w!("{:?}", expr.as_ref().skip_binder())
                     })
                 }
-            }
+            }?;
+            // w!(")")
+            Ok(())
         }
     }
 

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -119,9 +119,7 @@ impl ESpan {
     }
 }
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, TypeFoldable, TypeVisitable,
-)]
+#[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, TypeFoldable, TypeVisitable)]
 pub enum BinOp {
     Iff,
     Imp,
@@ -1146,7 +1144,6 @@ mod pretty {
                 }
             }
             let e = if cx.simplify_exprs { self.simplify() } else { self.clone() };
-            // w!("{:?}@(", ^e.span())?;
             match e.kind() {
                 ExprKind::Var(var) => w!("{:?}", var),
                 ExprKind::Local(local) => w!("{:?}", ^local),
@@ -1256,9 +1253,7 @@ mod pretty {
                         w!("{:?}", expr.as_ref().skip_binder())
                     })
                 }
-            }?;
-            // w!(")")
-            Ok(())
+            }
         }
     }
 

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1950,7 +1950,7 @@ pub(crate) mod errors {
             Self { kind: CheckerErrKind::OpaqueStruct(def_id), span }
         }
 
-        pub fn emit_err(self, genv: &GlobalEnv, fn_def_id: MaybeExternId) -> ErrorGuaranteed {
+        pub fn emit(self, genv: GlobalEnv, fn_def_id: MaybeExternId) -> ErrorGuaranteed {
             let dcx = genv.sess().dcx().handle();
             match self.kind {
                 CheckerErrKind::Inference => {

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -1,7 +1,7 @@
-use flux_common::{cache::QueryCache, iter::IterExt, result::ResultExt};
+use flux_common::{iter::IterExt, result::ResultExt};
 use flux_errors::ErrorGuaranteed;
 use flux_infer::{
-    fixpoint_encoding::{FixQueryCache, FixpointCtxt, KVarGen},
+    fixpoint_encoding::{FixQueryCache, KVarGen},
     infer::{ConstrReason, Tag},
     refine_tree::RefineTree,
 };

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -1,5 +1,4 @@
-use flux_common::{dbg, iter::IterExt, result::ResultExt};
-use flux_config as config;
+use flux_common::{cache::QueryCache, iter::IterExt, result::ResultExt};
 use flux_errors::ErrorGuaranteed;
 use flux_infer::{
     fixpoint_encoding::{FixQueryCache, FixpointCtxt, KVarGen},
@@ -9,7 +8,7 @@ use flux_infer::{
 use flux_middle::{fhir, global_env::GlobalEnv, rty, MaybeExternId};
 use rustc_span::{Span, DUMMY_SP};
 
-use crate::CheckerConfig;
+use crate::{invoke_fixpoint, CheckerConfig};
 
 pub fn check_invariants(
     genv: GlobalEnv,
@@ -57,16 +56,17 @@ fn check_invariant(
         let pred = invariant.apply(&variant.idx);
         rcx.check_pred(&pred, Tag::new(ConstrReason::Other, DUMMY_SP));
     }
-    let mut fcx = FixpointCtxt::new(genv, def_id.local_id(), KVarGen::dummy());
-    if config::dump_constraint() {
-        dbg::dump_item_info(genv.tcx(), def_id.local_id(), "fluxc", &refine_tree).unwrap();
-    }
-    refine_tree.simplify(genv).emit(&genv)?;
+    let errors = invoke_fixpoint(
+        genv,
+        cache,
+        def_id,
+        refine_tree,
+        KVarGen::dummy(),
+        checker_config,
+        "fluxc",
+    )
+    .emit(&genv)?;
 
-    let cstr = refine_tree.into_fixpoint(&mut fcx).emit(&genv)?;
-    let errors = fcx
-        .check(cache, cstr, checker_config.scrape_quals)
-        .emit(&genv)?;
     if errors.is_empty() {
         Ok(())
     } else {

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -61,6 +61,7 @@ fn check_invariant(
     if config::dump_constraint() {
         dbg::dump_item_info(genv.tcx(), def_id.local_id(), "fluxc", &refine_tree).unwrap();
     }
+    refine_tree.simplify(genv).emit(&genv)?;
 
     let cstr = refine_tree.into_fixpoint(&mut fcx).emit(&genv)?;
     let errors = fcx

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -89,7 +89,7 @@ fn invoke_fixpoint(
     if config::dump_constraint() {
         dbg::dump_item_info(genv.tcx(), local_id, ext, &refine_tree).unwrap();
     }
-    refine_tree.simplify();
+    refine_tree.simplify(genv).emit(&genv)?;
     let simp_ext = format!("simp.{}", ext);
     if config::dump_constraint() {
         dbg::dump_item_info(genv.tcx(), local_id, simp_ext, &refine_tree).unwrap();

--- a/tests/tests/neg/error_messages/localize02.rs
+++ b/tests/tests/neg/error_messages/localize02.rs
@@ -9,7 +9,7 @@
     }
 
     fn inc1(x: int) -> int {
-        x + 1   //~ NOTE this is the condition
+        x + 1
     }
 }]
 
@@ -21,7 +21,7 @@ fn test() {
                  //~| NOTE a precondition cannot be proved
 }
 
-#[flux::sig(fn() -> i32[inc1(0)])] //~ NOTE inside this call
+#[flux::sig(fn() -> i32[inc1(0)])] //~ NOTE this is the condition
 fn moo() -> i32 {
     2 //~ ERROR refinement type
       //~| NOTE a postcondition cannot be proved


### PR DESCRIPTION
Delay unfolding of definitions until after refinement type checking (and before fixpoint encoding). I tested this in vtock and veriasm, and I didn't notice any changes in performance.

There's one change in behavior. The following code

```rust
#![allow(unused)]
#![flux::defs {
    fn inc1(x: int) -> int {
        x + 1
    }
}]

#[flux::sig(fn() -> i32[inc1(0)])]
fn moo() -> i32 {
    2
}
```

previously produced

```
error[E0999]: refinement type error
  --> attic/playground.rs:10:5
   |
10 |     2
   |     ^ a postcondition cannot be proved
-Ztrack-diagnostics: created at crates/flux-refineck/src/lib.rs:202:10
   |
note: this is the condition that cannot be proved
  --> attic/playground.rs:4:9
   |
4  |         x + 1
   |         ^^^^^
note: inside this call
  --> attic/playground.rs:8:25
   |
8  | #[flux::sig(fn() -> i32[inc1(0)])]
   |                         ^^^^^^^
```

but now it produces

```
error[E0999]: refinement type error
  --> attic/playground.rs:10:5
   |
10 |     2
   |     ^ a postcondition cannot be proved
-Ztrack-diagnostics: created at crates/flux-refineck/src/lib.rs:202:10
   |
note: this is the condition that cannot be proved
  --> attic/playground.rs:8:25
   |
8  | #[flux::sig(fn() -> i32[inc1(0)])]
   |                         ^^^^^^^
   ```
   
   This is because previously we first unfolded `inc1(0)` into `0 + 1` and then generated a head  `2 = 0 + 1` assigning the span of `0 + 1` to the entire head. With this change, we first generate `2 = inc1(0)` assigning it the span of `inc1(0)`. We later unfold it to `2 = 0 + 1`  but the span of the entire head doesn't change. We could recover the behavior by having a different type of head for equalities and adjusting spans accordingly after unfolding. However, I don't think this is objectively worse, I found the old behavior a bit confusing.