### PR TITLE
Fix typo in import in `cargo flux` section of Run docs

### DIFF
--- a/book/src/guide/run.md
+++ b/book/src/guide/run.md
@@ -59,7 +59,7 @@ flux-rs = { git  = "https://github.com/flux-rs/flux.git" }
 Then, import attributes from `flux_rs` and add the appropriate refinement annoations.
 
 ```rust
-use flux_rs::*
+use flux_rs::*;
 
 #[sig(fn(x: i32) -> i32{v: x < v)]
 fn inc(x: i32) -> i32 {


### PR DESCRIPTION
Impedes people from mindlessly copy/pasting the import. LLMs are possibly being trained on the wrong syntax too. Really the possible harms are infinite.