### PR TITLE
Make vscode-extension work on vtock

### DIFF
--- a/book/src/guide/run.md
+++ b/book/src/guide/run.md
@@ -113,7 +113,7 @@ driver](https://rustc-dev-guide.rust-lang.org/rustc-driver.html?highlight=driver
 (similar to how clippy works) meaning it uses rustc as a library to "drive"
 compilation performing additional analysis along the way. Running the binary
 requires dynamically linking a correct version of `librustc`. Thus, to avoid the
-hassle you should never execute it directly.  Instead, use `rustc-flux` or `cargo-flux`.
+hassle you should never execute it directly. Instead, use `rustc-flux` or `cargo-flux`.
 
 ## Editor Support
 
@@ -142,21 +142,21 @@ Add this to the workspace settings i.e. `.vscode/settings.json`
 
 You can set various `env` variables to customize the behavior of `flux`.
 
-* `FLUX_CONFIG` tells `flux` where to find a config file for these settings.
-  * By default, `flux` searches its directory for a `flux.toml` or `.flux.toml`.
-* `FLUX_SYSROOT` tells `cargo-flux` and `rustc-flux` where to find the `flux-driver` binary.
-  * Defaults to the default installation location in `~/.flux`.
-* `FLUX_LOG_DIR=path/to/log/` sets the directory where constraints, timing and cache are saved. Defaults to `./log/`.
-* `FLUX_DUMP_CONSTRAINT=1` tell `flux` to dump constraints generated for each function.
-* `FLUX_DUMP_CHECKER_TRACE=1` saves the checker's trace (useful for debugging!)
-* `FLUX_DUMP_TIMINGS=1` saves the profile information
-* `FLUX_DUMP_MIR=1` saves the low-level MIR for each analyzed function
-* `FLUX_POINTER_WIDTH=N` the size of (either `32` or `64`), used to determine if an integer cast is lossy (default `64`).
-* `FLUX_CHECK_DEF=name` only checks definitions containing `name` as a substring
-* `FLUX_CHECK_FILES=path/to/file1.rs,path/to/file2.rs` only checks the specified files
-* `FLUX_CACHE=1"` switches on query caching and saves the cache in `FLUX_CACHE_FILE`
-* `FLUX_CACHE_FILE=file.json` customizes the cache file, default `FLUX_LOG_DIR/cache.json`
-* `FLUX_CHECK_OVERFLOW=1` checks for over and underflow on arithmetic integer
+- `FLUX_CONFIG` tells `flux` where to find a config file for these settings.
+  - By default, `flux` searches its directory for a `flux.toml` or `.flux.toml`.
+- `FLUX_SYSROOT` tells `cargo-flux` and `rustc-flux` where to find the `flux-driver` binary.
+  - Defaults to the default installation location in `~/.flux`.
+- `FLUX_LOG_DIR=path/to/log/` sets the directory where constraints, timing and cache are saved. Defaults to `./log/`.
+- `FLUX_DUMP_CONSTRAINT=1` tell `flux` to dump constraints generated for each function.
+- `FLUX_DUMP_CHECKER_TRACE=1` saves the checker's trace (useful for debugging!)
+- `FLUX_DUMP_TIMINGS=1` saves the profile information
+- `FLUX_DUMP_MIR=1` saves the low-level MIR for each analyzed function
+- `FLUX_POINTER_WIDTH=N` the size of (either `32` or `64`), used to determine if an integer cast is lossy (default `64`).
+- `FLUX_CHECK_DEF=name` only checks definitions containing `name` as a substring
+- `FLUX_CHECK_FILES=/absolute/path/to/file1.rs,/absolute/path/to/file2.rs` only checks the specified files
+- `FLUX_CACHE=1"` switches on query caching and saves the cache in `FLUX_CACHE_FILE`
+- `FLUX_CACHE_FILE=file.json` customizes the cache file, default `FLUX_LOG_DIR/cache.json`
+- `FLUX_CHECK_OVERFLOW=1` checks for over and underflow on arithmetic integer
   operations, default `0`. When set to `0`, it still checks for underflow on
   unsigned integer subtraction.
 

--- a/crates/flux-common/src/dbg.rs
+++ b/crates/flux-common/src/dbg.rs
@@ -77,7 +77,8 @@ macro_rules! _statement{
             let local_names = &ck.body.local_names;
             let rcx_json = RefineCtxtTrace::new(genv, $rcx);
             let env_json = TypeEnvTrace::new(genv, local_names, $env);
-            tracing::info!(event = concat!("statement_", $pos), stmt = ?$stmt, stmt_span = ?$span, rcx = ?$rcx, env = ?$env, rcx_json = ?rcx_json, env_json = ?env_json)
+            let span_json = SpanTrace::new(genv, $span);
+            tracing::info!(event = concat!("statement_", $pos), stmt = ?$stmt, stmt_span = ?$span, rcx = ?$rcx, env = ?$env, rcx_json = ?rcx_json, env_json = ?env_json, stmt_span_json = ?span_json)
         }
     }};
 }

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -161,7 +161,6 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
         let sm = tcx.sess.source_map();
         let current_dir = tcx.sess.opts.working_dir.clone();
         if let FileName::Real(file_name) = sm.span_to_filename(span) {
-            // TODO: use span_to_location_info
             if let Some(file_path) = file_name.local_path()
                 && let Some(current_dir_path) = current_dir.local_path()
             {
@@ -169,7 +168,6 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
                     .join(file_path)
                     .to_string_lossy()
                     .to_string();
-                // println!("TRACE: matches_check_file {def_id:?}: file={file:?}");
                 return config::is_checked_file(&file);
             }
         }

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -191,14 +191,9 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
         if self.genv.ignored(def_id.local_id()) || self.genv.is_dummy(def_id.local_id()) {
             return Ok(());
         }
-        let matches = self.matches_check_file(def_id.local_id());
-        println!("TRACE: check_def: {def_id:?} matches = {matches:?}");
-        if !matches {
+        if !self.matches_check_file(def_id.local_id()) {
             return Ok(());
         }
-        // if !self.matches_check_file(def_id.local_id()) {
-        //     return Ok(());
-        // }
 
         match self.genv.def_kind(def_id) {
             DefKind::Fn | DefKind::AssocFn => {

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -51,7 +51,9 @@ use crate::{
     ghost_statements::{GhostStatement, GhostStatements, Point},
     primops,
     queue::WorkQueue,
-    type_env::{BasicBlockEnv, BasicBlockEnvShape, PtrToRefBound, TypeEnv, TypeEnvTrace},
+    type_env::{
+        BasicBlockEnv, BasicBlockEnvShape, PtrToRefBound, SpanTrace, TypeEnv, TypeEnvTrace,
+    },
 };
 
 type Result<T = ()> = std::result::Result<T, CheckerError>;


### PR DESCRIPTION
- Render / parse `Span` as JSON
- Use absolute path instead of relative to vscode-workspace
- Make vscode extension use `FLUX_LOG` to generate `checker` at fixed spot