### PR TITLE
Make Pretty less magical

### DIFF
--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -877,8 +877,7 @@ mod pretty {
 
     impl Pretty for Tag {
         fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            define_scoped!(cx, f);
-            w!("{:?} at {:?}", ^self.reason, self.src_span)
+            w!(cx, f, "{:?} at {:?}", ^self.reason, self.src_span)
         }
     }
 

--- a/crates/flux-middle/src/rty/canonicalize.rs
+++ b/crates/flux-middle/src/rty/canonicalize.rs
@@ -333,20 +333,18 @@ mod pretty {
 
     impl Pretty for CanonicalConstrTy {
         fn fmt(&self, cx: &PrettyCx, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            define_scoped!(cx, f);
-            w!("{{ {:?} | {:?} }}", &self.ty, &self.pred)
+            w!(cx, f, "{{ {:?} | {:?} }}", &self.ty, &self.pred)
         }
     }
 
     impl Pretty for CanonicalTy {
         fn fmt(&self, cx: &PrettyCx, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            define_scoped!(cx, f);
             match self {
-                CanonicalTy::Constr(constr) => w!("{:?}", constr),
+                CanonicalTy::Constr(constr) => w!(cx, f, "{:?}", constr),
                 CanonicalTy::Exists(poly_constr) => {
                     cx.with_bound_vars(poly_constr.vars(), || {
                         cx.fmt_bound_vars(false, "∃", poly_constr.vars(), ". ", f)?;
-                        w!("{:?}", poly_constr.as_ref().skip_binder())
+                        w!(cx, f, "{:?}", poly_constr.as_ref().skip_binder())
                     })
                 }
             }

--- a/crates/flux-middle/src/rty/evars.rs
+++ b/crates/flux-middle/src/rty/evars.rs
@@ -212,9 +212,8 @@ mod pretty {
     use crate::pretty::*;
 
     impl Pretty for EVar {
-        fn fmt(&self, _cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            define_scoped!(cx, f);
-            w!("?{}e#{}", ^self.id.as_u32(), ^self.cx.0)
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            w!(cx, f, "?{}e#{}", ^self.id.as_u32(), ^self.cx.0)
         }
     }
 

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -832,8 +832,7 @@ mod pretty {
 
     impl Pretty for TypeEnv<'_> {
         fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            define_scoped!(cx, f);
-            w!("{:?}", &self.bindings)
+            w!(cx, f, "{:?}", &self.bindings)
         }
 
         fn default_cx(tcx: TyCtxt) -> PrettyCx {
@@ -843,8 +842,7 @@ mod pretty {
 
     impl Pretty for BasicBlockEnvShape {
         fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            define_scoped!(cx, f);
-            w!("{:?} {:?}", &self.scope, &self.bindings)
+            w!(cx, f, "{:?} {:?}", &self.scope, &self.bindings)
         }
 
         fn default_cx(tcx: TyCtxt) -> PrettyCx {
@@ -854,8 +852,7 @@ mod pretty {
 
     impl Pretty for BasicBlockEnv {
         fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            define_scoped!(cx, f);
-            w!("{:?} ", &self.scope)?;
+            w!(cx, f, "{:?} ", &self.scope)?;
 
             let vars = self.data.vars();
             cx.with_bound_vars(vars, || {
@@ -865,11 +862,13 @@ mod pretty {
                 let data = self.data.as_ref().skip_binder();
                 if !data.constrs.is_empty() {
                     w!(
+                        cx,
+                        f,
                         "{:?} ⇒ ",
                         join!(", ", data.constrs.iter().filter(|pred| !pred.is_trivially_true()))
                     )?;
                 }
-                w!("{:?}", &data.bindings)
+                w!(cx, f, "{:?}", &data.bindings)
             })
         }
 

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -938,15 +938,15 @@ mod pretty {
 
     impl Pretty for PlacesTree {
         fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            define_scoped!(cx, f);
             w!(
+                cx, f,
                 "{{{}}}",
                 ^self
                     .iter()
                     .filter(|(_, binding)| !cx.hide_uninit || !binding.ty.is_uninit())
                     .sorted_by(|(loc1, _), (loc2, _)| loc1.cmp(loc2))
                     .format_with(", ", |(loc, binding), f| {
-                        f(&format_args_cx!("{:?}:{:?} {:?}", loc, &binding.kind, &binding.ty))
+                        f(&format_args_cx!(cx, "{:?}:{:?} {:?}", loc, &binding.kind, &binding.ty))
                     })
             )
         }
@@ -957,12 +957,11 @@ mod pretty {
     }
 
     impl Pretty for LocKind {
-        fn fmt(&self, _cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            define_scoped!(cx, f);
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
                 LocKind::Local | LocKind::Universal => Ok(()),
-                LocKind::Box(_) => w!("[box]"),
-                LocKind::LocalPtr(ty) => w!("[local-ptr({ty:?})]"),
+                LocKind::Box(_) => w!(cx, f, "[box]"),
+                LocKind::LocalPtr(ty) => w!(cx, f, "[local-ptr({:?})]", ty),
             }
         }
     }


### PR DESCRIPTION
The old behavior was too magical so this removes the `define_scoped` macro and makes all pretty macros take the context and formatter explicitly.