### PR TITLE
Add Source Span to TypeEnvTrace

### DIFF
--- a/crates/flux-common/src/dbg.rs
+++ b/crates/flux-common/src/dbg.rs
@@ -75,8 +75,9 @@ macro_rules! _statement{
             let ck = $checker;
             let genv = ck.genv;
             let local_names = &ck.body.local_names;
+            let local_decls = &ck.body.local_decls;
             let rcx_json = RefineCtxtTrace::new(genv, $rcx);
-            let env_json = TypeEnvTrace::new(genv, local_names, $env);
+            let env_json = TypeEnvTrace::new(genv, local_names, local_decls, $env);
             let span_json = SpanTrace::new(genv, $span);
             tracing::info!(event = concat!("statement_", $pos), stmt = ?$stmt, stmt_span = ?$span, rcx = ?$rcx, env = ?$env, rcx_json = ?rcx_json, env_json = ?env_json, stmt_span_json = ?span_json)
         }


### PR DESCRIPTION
To allow hyperlinking TypeEnv and source code.