### PR TITLE
Do not lift predicates from fhir

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -211,7 +211,11 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
             |hir_param| self.as_lift_cx().lift_generic_param(hir_param)
         )?;
 
-        let predicates = self.desugar_generic_predicates(&generics.predicates)?;
+        let predicates = if let Some(predicates) = &generics.predicates {
+            Some(self.desugar_generic_predicates(predicates)?)
+        } else {
+            None
+        };
         Ok(fhir::Generics { params, refinement_params: &[], predicates })
     }
 

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -272,3 +272,7 @@ fhir_analysis_refine_arg_mismatch =
 
 fhir_analysis_expected_type =
     expected a type, found {$def_descr} `{$name}`
+
+fhir_analysis_fail_to_match_predicates =
+    cannot determine corresponding unrefined predicate
+    .note = you can only add a refined predicate if an corresponding unrefined one exists

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1255,6 +1255,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 rty::ClauseKind::Projection(proj) => {
                     projection_bounds.push(rty::Binder::bind_with_vars(proj, vars));
                 }
+                rty::ClauseKind::RegionOutlives(_) => {}
                 rty::ClauseKind::TypeOutlives(_) => {}
                 rty::ClauseKind::ConstArgHasType(..) => {
                     bug!("did not expect {pred:?} clause in object bounds");

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -25,9 +25,12 @@ use flux_middle::{
     },
     MaybeExternId,
 };
-use flux_rustc_bridge::{lowering::Lower, ToRustc};
+use flux_rustc_bridge::{
+    lowering::{Lower, UnsupportedErr},
+    ToRustc,
+};
 use itertools::Itertools;
-use rustc_data_structures::fx::FxIndexMap;
+use rustc_data_structures::{fx::FxIndexMap, unord::UnordMap};
 use rustc_errors::Diagnostic;
 use rustc_hash::FxHashSet;
 use rustc_hir::{def::DefKind, def_id::DefId, OwnerId, Safety};
@@ -633,22 +636,74 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
     ) -> QueryResult<rty::EarlyBinder<rty::GenericPredicates>> {
         let env = &mut Env::new(generics.refinement_params);
 
-        let predicates = self
-            .genv()
-            .lower_predicates_of(def_id)?
-            .refine(&Refiner::default_for_item(self.genv(), def_id.resolved_id())?)?;
-
-        if let Some(predicates) = generics.predicates {
+        let predicates = if let Some(fhir_predicates) = generics.predicates {
             let mut clauses = vec![];
-            for pred in predicates {
+            for pred in fhir_predicates {
                 let span = pred.bounded_ty.span;
                 let bounded_ty = self.conv_ty(env, &pred.bounded_ty)?;
                 for clause in self.conv_generic_bounds(env, span, bounded_ty, pred.bounds)? {
                     clauses.push(clause);
                 }
             }
-        }
+            self.match_clauses(def_id, &clauses)?
+        } else {
+            self.genv()
+                .lower_predicates_of(def_id)?
+                .refine(&Refiner::default_for_item(self.genv(), def_id.resolved_id())?)?
+        };
         Ok(rty::EarlyBinder(predicates))
+    }
+
+    fn match_clauses(
+        &self,
+        def_id: MaybeExternId,
+        refined_clauses: &[rty::Clause],
+    ) -> QueryResult<rty::GenericPredicates> {
+        let tcx = self.genv().tcx();
+        let predicates = tcx.predicates_of(def_id);
+        let unrefined_clauses = predicates.predicates;
+
+        // For each *refined clause* at index `j` find a corrresponding *unrefined clause* at index
+        // `i` and save a mapping `i -> j`.
+        let mut map = UnordMap::default();
+        for (j, clause) in refined_clauses.iter().enumerate() {
+            let clause = clause.to_rustc(tcx);
+            let Some((i, _)) = unrefined_clauses.iter().find_position(|it| it.0 == clause) else {
+                self.emit_fail_to_match_predicates(def_id)?;
+            };
+            if map.insert(i, j).is_some() {
+                self.emit_fail_to_match_predicates(def_id)?;
+            }
+        }
+
+        // For each unrefined clause, create a default refined clause or use corresponding refined
+        // clause if one was found.
+        let refiner = Refiner::default_for_item(self.genv(), def_id.resolved_id())?;
+        let mut clauses = vec![];
+        for (i, (clause, span)) in unrefined_clauses.iter().enumerate() {
+            let clause = if let Some(j) = map.get(&i) {
+                refined_clauses[*j].clone()
+            } else {
+                clause
+                    .lower(tcx)
+                    .map_err(|reason| {
+                        let err = UnsupportedErr::new(reason).with_span(*span);
+                        QueryErr::unsupported(def_id.resolved_id(), err)
+                    })?
+                    .refine(&refiner)?
+            };
+            clauses.push(clause)
+        }
+
+        Ok(rty::GenericPredicates {
+            parent: predicates.parent,
+            predicates: List::from_vec(clauses),
+        })
+    }
+
+    fn emit_fail_to_match_predicates(&self, def_id: MaybeExternId) -> Result<!, ErrorGuaranteed> {
+        let span = self.tcx().def_span(def_id.resolved_id());
+        Err(self.emit(errors::FailToMatchPredicates { span }))
     }
 
     pub(crate) fn conv_opaque_ty(
@@ -2603,5 +2658,12 @@ mod errors {
         pub span: Span,
         pub def_descr: &'static str,
         pub name: String,
+    }
+
+    #[derive(Diagnostic)]
+    #[diag(fhir_analysis_fail_to_match_predicates, code = E0999)]
+    pub(super) struct FailToMatchPredicates {
+        #[primary_span]
+        pub span: Span,
     }
 }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -98,7 +98,7 @@ impl From<bool> for Trusted {
 pub struct Generics<'fhir> {
     pub params: &'fhir [GenericParam<'fhir>],
     pub refinement_params: &'fhir [RefineParam<'fhir>],
-    pub predicates: &'fhir [WhereBoundPredicate<'fhir>],
+    pub predicates: Option<&'fhir [WhereBoundPredicate<'fhir>]>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1173,10 +1173,6 @@ impl<'fhir> Generics<'fhir> {
             .iter()
             .find(|p| p.def_id.local_id() == def_id)
             .unwrap()
-    }
-
-    pub fn trivial() -> Self {
-        Generics { params: &[], refinement_params: &[], predicates: &[] }
     }
 }
 

--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -80,24 +80,6 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
         Ok(fhir::Generics { params, refinement_params: &[], predicates: None })
     }
 
-    fn lift_where_predicate(
-        &mut self,
-        pred: &hir::WherePredicate,
-    ) -> Result<fhir::WhereBoundPredicate<'genv>> {
-        if let hir::WherePredicate::BoundPredicate(bound) = pred {
-            if !bound.bound_generic_params.is_empty() {
-                return self.emit_unsupported("higher-rank trait bounds are not supported");
-            }
-            let bounded_ty = self.lift_ty(bound.bounded_ty)?;
-            let bounds =
-                try_alloc_slice!(self.genv, &bound.bounds, |bound| self.lift_generic_bound(bound))?;
-
-            Ok(fhir::WhereBoundPredicate { bounded_ty, bounds, span: bound.span })
-        } else {
-            self.emit_unsupported(&format!("unsupported where predicate: `{pred:?}`"))
-        }
-    }
-
     fn lift_generic_bound(
         &mut self,
         bound: &hir::GenericBound,

--- a/crates/flux-middle/src/fhir/lift.rs
+++ b/crates/flux-middle/src/fhir/lift.rs
@@ -76,11 +76,8 @@ impl<'a, 'genv, 'tcx> LiftCtxt<'a, 'genv, 'tcx> {
     fn lift_generics_inner(&mut self, generics: &hir::Generics) -> Result<fhir::Generics<'genv>> {
         let params =
             try_alloc_slice!(self.genv, &generics.params, |param| self.lift_generic_param(param))?;
-        let predicates = try_alloc_slice!(self.genv, &generics.predicates, |pred| {
-            self.lift_where_predicate(pred)
-        })?;
 
-        Ok(fhir::Generics { params, refinement_params: &[], predicates })
+        Ok(fhir::Generics { params, refinement_params: &[], predicates: None })
     }
 
     fn lift_where_predicate(

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -297,7 +297,9 @@ pub fn walk_impl_assoc_reft<'v, V: Visitor<'v>>(vis: &mut V, assoc_reft: &ImplAs
 
 pub fn walk_generics<'v, V: Visitor<'v>>(vis: &mut V, generics: &Generics<'v>) {
     walk_list!(vis, visit_refine_param, generics.refinement_params);
-    walk_list!(vis, visit_where_predicate, generics.predicates);
+    if let Some(predicates) = generics.predicates {
+        walk_list!(vis, visit_where_predicate, predicates);
+    }
 }
 
 pub fn walk_where_predicate<'v, V: Visitor<'v>>(vis: &mut V, predicate: &WhereBoundPredicate<'v>) {

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -365,6 +365,7 @@ pub type Clauses = List<Clause>;
 pub enum ClauseKind {
     Trait(TraitPredicate),
     Projection(ProjectionPredicate),
+    RegionOutlives(RegionOutlivesPredicate),
     TypeOutlives(TypeOutlivesPredicate),
     ConstArgHasType(Const, Ty),
 }
@@ -379,6 +380,9 @@ impl<'tcx> ToRustc<'tcx> for ClauseKind {
             }
             ClauseKind::Projection(projection_predicate) => {
                 rustc_middle::ty::ClauseKind::Projection(projection_predicate.to_rustc(tcx))
+            }
+            ClauseKind::RegionOutlives(outlives_predicate) => {
+                rustc_middle::ty::ClauseKind::RegionOutlives(outlives_predicate.to_rustc(tcx))
             }
             ClauseKind::TypeOutlives(outlives_predicate) => {
                 rustc_middle::ty::ClauseKind::TypeOutlives(outlives_predicate.to_rustc(tcx))
@@ -397,6 +401,7 @@ impl<'tcx> ToRustc<'tcx> for ClauseKind {
 pub struct OutlivesPredicate<T>(pub T, pub Region);
 
 pub type TypeOutlivesPredicate = OutlivesPredicate<Ty>;
+pub type RegionOutlivesPredicate = OutlivesPredicate<Region>;
 
 impl<'tcx, V: ToRustc<'tcx>> ToRustc<'tcx> for OutlivesPredicate<V> {
     type T = rustc_middle::ty::OutlivesPredicate<'tcx, V::T>;

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -12,6 +12,9 @@ impl Pretty for ClauseKind {
         match self {
             ClauseKind::Trait(pred) => w!(cx, f, "Trait ({:?})", ^pred),
             ClauseKind::Projection(pred) => w!(cx, f, "Projection ({:?})", ^pred),
+            ClauseKind::RegionOutlives(pred) => {
+                w!(cx, f, "Outlives ({:?}, {:?})", &pred.0, &pred.1)
+            }
             ClauseKind::TypeOutlives(pred) => w!(cx, f, "Outlives ({:?}, {:?})", &pred.0, &pred.1),
             ClauseKind::ConstArgHasType(c, ty) => w!(cx, f, "ConstArgHasType ({:?}, {:?})", c, ty),
         }

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -376,6 +376,10 @@ impl Refine for ty::ClauseKind {
                 };
                 rty::ClauseKind::Projection(pred)
             }
+            ty::ClauseKind::RegionOutlives(pred) => {
+                let pred = rty::OutlivesPredicate(pred.0, pred.1);
+                rty::ClauseKind::RegionOutlives(pred)
+            }
             ty::ClauseKind::TypeOutlives(pred) => {
                 let pred = rty::OutlivesPredicate(pred.0.refine(refiner)?, pred.1);
                 rty::ClauseKind::TypeOutlives(pred)

--- a/crates/flux-rustc-bridge/src/lowering.rs
+++ b/crates/flux-rustc-bridge/src/lowering.rs
@@ -77,7 +77,7 @@ impl UnsupportedErr {
         UnsupportedErr { descr: reason.descr, span: None }
     }
 
-    fn with_span(mut self, span: Span) -> Self {
+    pub fn with_span(mut self, span: Span) -> Self {
         self.span = Some(span);
         self
     }

--- a/crates/flux-rustc-bridge/src/lowering.rs
+++ b/crates/flux-rustc-bridge/src/lowering.rs
@@ -34,7 +34,10 @@ use super::{
 use crate::{
     const_eval::{scalar_to_bits, scalar_to_int, scalar_to_uint},
     mir::CallKind,
-    ty::{AliasTy, ExistentialTraitRef, GenericArgs, ProjectionPredicate, Region},
+    ty::{
+        AliasTy, ExistentialTraitRef, GenericArgs, ProjectionPredicate, Region,
+        RegionOutlivesPredicate,
+    },
 };
 
 pub trait Lower<'tcx> {
@@ -1091,6 +1094,9 @@ impl<'tcx> Lower<'tcx> for rustc_ty::ClauseKind<'tcx> {
                 let term = term.lower(tcx)?;
                 ClauseKind::Projection(ProjectionPredicate { projection_ty, term })
             }
+            rustc_ty::ClauseKind::RegionOutlives(outlives) => {
+                ClauseKind::RegionOutlives(outlives.lower(tcx)?)
+            }
             rustc_ty::ClauseKind::TypeOutlives(outlives) => {
                 ClauseKind::TypeOutlives(outlives.lower(tcx)?)
             }
@@ -1123,6 +1129,14 @@ impl<'tcx> Lower<'tcx> for rustc_ty::TraitRef<'tcx> {
 
 impl<'tcx> Lower<'tcx> for rustc_ty::TypeOutlivesPredicate<'tcx> {
     type R = Result<TypeOutlivesPredicate, UnsupportedReason>;
+
+    fn lower(self, tcx: TyCtxt<'tcx>) -> Self::R {
+        Ok(OutlivesPredicate(self.0.lower(tcx)?, self.1.lower(tcx)?))
+    }
+}
+
+impl<'tcx> Lower<'tcx> for rustc_ty::RegionOutlivesPredicate<'tcx> {
+    type R = Result<RegionOutlivesPredicate, UnsupportedReason>;
 
     fn lower(self, tcx: TyCtxt<'tcx>) -> Self::R {
         Ok(OutlivesPredicate(self.0.lower(tcx)?, self.1.lower(tcx)?))

--- a/crates/flux-rustc-bridge/src/ty/mod.rs
+++ b/crates/flux-rustc-bridge/src/ty/mod.rs
@@ -92,6 +92,7 @@ pub struct Clause {
 pub enum ClauseKind {
     Trait(TraitPredicate),
     Projection(ProjectionPredicate),
+    RegionOutlives(RegionOutlivesPredicate),
     TypeOutlives(TypeOutlivesPredicate),
     ConstArgHasType(Const, Ty),
 }
@@ -100,6 +101,7 @@ pub enum ClauseKind {
 pub struct OutlivesPredicate<T>(pub T, pub Region);
 
 pub type TypeOutlivesPredicate = OutlivesPredicate<Ty>;
+pub type RegionOutlivesPredicate = OutlivesPredicate<Region>;
 
 #[derive(PartialEq, Eq, Hash, Debug)]
 pub struct TraitPredicate {

--- a/crates/flux-syntax/src/grammar.lalrpop
+++ b/crates/flux-syntax/src/grammar.lalrpop
@@ -14,7 +14,7 @@ pub Generics: surface::Generics = {
     <lo:@L> <params:Comma<GenericParam>> <hi:@R> => {
         surface::Generics {
             params,
-            predicates: vec![],
+            predicates: None,
             span: cx.map_span(lo, hi),
         }
     }
@@ -25,7 +25,7 @@ GenericsWithAngleBrackets: surface::Generics = {
     <lo:@L> <hi:@R> => {
         surface::Generics {
             params: vec![],
-            predicates: vec![],
+            predicates: None,
             span: cx.map_span(lo, hi),
         }
     }
@@ -250,7 +250,7 @@ pub FnSig: surface::FnSig = {
         } else {
             surface::FnRetTy::Default(cx.map_span(ret_lo, ret_hi))
         };
-        generics.predicates = predicates.unwrap_or_default();
+        generics.predicates = predicates;
         let output = surface::FnOutput {
             returns,
             ensures: ensures.unwrap_or_default(),

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -58,7 +58,7 @@ pub struct SpecFunc {
 #[derive(Debug)]
 pub struct Generics {
     pub params: Vec<GenericParam>,
-    pub predicates: Vec<WhereBoundPredicate>,
+    pub predicates: Option<Vec<WhereBoundPredicate>>,
     pub span: Span,
 }
 

--- a/crates/flux-syntax/src/surface/visit.rs
+++ b/crates/flux-syntax/src/surface/visit.rs
@@ -335,7 +335,9 @@ pub fn walk_fn_output<V: Visitor>(vis: &mut V, fn_output: &FnOutput) {
 
 pub fn walk_generics<V: Visitor>(vis: &mut V, generics: &Generics) {
     walk_list!(vis, visit_generic_param, &generics.params);
-    walk_list!(vis, visit_where_predicate, &generics.predicates);
+    if let Some(predicates) = &generics.predicates {
+        walk_list!(vis, visit_where_predicate, predicates);
+    }
 }
 
 pub fn walk_fn_input<V: Visitor>(vis: &mut V, arg: &FnInput) {


### PR DESCRIPTION
Lifting predicates from fhir and then converting them into `rty`  was causing problems with complicated features like higher-ranked trait bounds and associated type bounds. It was also error-prone and unsound because we weren't "elaborating" all the predicates.

This PR instead makes generic predicates optional in the surface syntax. If no predicates are provided, we generate default ones from `rustc_middle` (instead of `hir`). If refined predicates are provided, we try to match them to a corresponding predicate from `rustc_middle`. This guarantees we will always have all predicates in rty.