### PR TITLE
Add error variants to fhir

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1,8 +1,14 @@
 use std::iter;
 
-use flux_common::{bug, dbg, index::IndexGen, iter::IterExt, span_bug};
+use flux_common::{
+    bug, dbg,
+    index::IndexGen,
+    iter::IterExt,
+    result::{ErrorCollector, ErrorEmitter},
+    span_bug,
+};
 use flux_config as config;
-use flux_errors::FluxSession;
+use flux_errors::Errors;
 use flux_middle::{
     MaybeExternId, ResolverOutput,
     fhir::{self, ExprRes, FhirId, FluxOwnerId, Res, lift::LiftCtxt},
@@ -35,14 +41,14 @@ pub(crate) fn desugar_qualifier<'genv>(
     resolver_output: &'genv ResolverOutput,
     qualifier: &surface::Qualifier,
 ) -> Result<fhir::Qualifier<'genv>> {
-    let mut cx = FluxItemCtxt::new(genv, resolver_output, qualifier.name.name);
-    let expr = cx.desugar_expr(&qualifier.expr);
-
-    Ok(fhir::Qualifier {
-        name: qualifier.name.name,
-        args: cx.desugar_refine_params(&qualifier.params),
-        global: qualifier.global,
-        expr: expr?,
+    FluxItemCtxt::with(genv, resolver_output, qualifier.name.name, |cx| {
+        let qualifier = fhir::Qualifier {
+            name: qualifier.name.name,
+            args: cx.desugar_refine_params(&qualifier.params),
+            global: qualifier.global,
+            expr: cx.desugar_expr(&qualifier.expr),
+        };
+        Ok(qualifier)
     })
 }
 
@@ -51,18 +57,15 @@ pub(crate) fn desugar_spec_func<'genv>(
     resolver_output: &'genv ResolverOutput,
     spec_func: &surface::SpecFunc,
 ) -> Result<fhir::SpecFunc<'genv>> {
-    let mut cx = FluxItemCtxt::new(genv, resolver_output, spec_func.name.name);
-    let body = spec_func
-        .body
-        .as_ref()
-        .map(|body| cx.desugar_expr(body))
-        .transpose()?;
-    let name = spec_func.name.name;
-    let params = spec_func.sort_vars.len();
-    let sort = cx.desugar_sort(&spec_func.output, None);
-    let args = cx.desugar_refine_params(&spec_func.params);
-
-    Ok(fhir::SpecFunc { name, params, args, sort, body })
+    FluxItemCtxt::with(genv, resolver_output, spec_func.name.name, |cx| {
+        let body = spec_func.body.as_ref().map(|body| cx.desugar_expr(body));
+        let name = spec_func.name.name;
+        let params = spec_func.sort_vars.len();
+        let sort = cx.desugar_sort(&spec_func.output, None);
+        let args = cx.desugar_refine_params(&spec_func.params);
+        let func = fhir::SpecFunc { name, params, args, sort, body };
+        Ok(func)
+    })
 }
 
 /// Collect all sorts resolved to a generic type in a list of refinement parameters. Return the set
@@ -107,30 +110,29 @@ pub(crate) struct RustItemCtxt<'a, 'genv, 'tcx> {
     fn_sig_scope: Option<NodeId>,
     resolver_output: &'genv ResolverOutput,
     opaque_tys: Option<&'a mut Vec<&'genv fhir::OpaqueTy<'genv>>>,
-}
-
-struct FluxItemCtxt<'genv, 'tcx> {
-    genv: GlobalEnv<'genv, 'tcx>,
-    resolver_output: &'genv ResolverOutput,
-    local_id_gen: IndexGen<fhir::ItemLocalId>,
-    owner: Symbol,
+    errors: Errors<'genv>,
 }
 
 impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
-    pub(crate) fn new(
+    pub(crate) fn with<T>(
         genv: GlobalEnv<'genv, 'tcx>,
         owner: MaybeExternId<OwnerId>,
         resolver_output: &'genv ResolverOutput,
         opaque_tys: Option<&'a mut Vec<&'genv fhir::OpaqueTy<'genv>>>,
-    ) -> Self {
-        RustItemCtxt {
+        f: impl FnOnce(&mut Self) -> Result<T>,
+    ) -> Result<T> {
+        let mut cx = RustItemCtxt {
             genv,
             owner,
             fn_sig_scope: None,
             local_id_gen: IndexGen::new(),
             resolver_output,
             opaque_tys,
-        }
+            errors: Errors::new(genv.sess()),
+        };
+        let r = f(&mut cx)?;
+        cx.into_result()?;
+        Ok(r)
     }
 
     fn as_lift_cx<'b>(&'b mut self) -> LiftCtxt<'b, 'genv, 'tcx> {
@@ -143,7 +145,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
         } else {
             self.as_lift_cx().lift_generics()?
         };
-        let assoc_refinements = self.desugar_trait_assoc_refts(&trait_.assoc_refinements)?;
+        let assoc_refinements = self.desugar_trait_assoc_refts(&trait_.assoc_refinements);
         let trait_ = fhir::Trait { assoc_refinements };
 
         if config::dump_fhir() {
@@ -156,17 +158,18 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
     fn desugar_trait_assoc_refts(
         &mut self,
         assoc_refts: &[surface::TraitAssocReft],
-    ) -> Result<&'genv [fhir::TraitAssocReft<'genv>]> {
-        try_alloc_slice!(self.genv, assoc_refts, |assoc_reft| {
-            let name = assoc_reft.name.name;
-            let params = self.desugar_refine_params(&assoc_reft.params);
-            let output = self.desugar_base_sort(&assoc_reft.output, None);
-            let body = match &assoc_reft.body {
-                Some(expr) => Some(self.desugar_expr(expr)?),
-                None => None,
-            };
-            Ok(fhir::TraitAssocReft { name, params, output, body, span: assoc_reft.span })
-        })
+    ) -> &'genv [fhir::TraitAssocReft<'genv>] {
+        self.genv()
+            .alloc_slice_fill_iter(assoc_refts.iter().map(|assoc_reft| {
+                let name = assoc_reft.name.name;
+                let params = self.desugar_refine_params(&assoc_reft.params);
+                let output = self.desugar_base_sort(&assoc_reft.output, None);
+                let body = match &assoc_reft.body {
+                    Some(expr) => Some(self.desugar_expr(expr)),
+                    None => None,
+                };
+                fhir::TraitAssocReft { name, params, output, body, span: assoc_reft.span }
+            }))
     }
 
     pub(crate) fn desugar_impl(&mut self, impl_: &surface::Impl) -> Result<fhir::Item<'genv>> {
@@ -175,7 +178,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
         } else {
             self.as_lift_cx().lift_generics()?
         };
-        let assoc_refinements = self.desugar_impl_assoc_refts(&impl_.assoc_refinements)?;
+        let assoc_refinements = self.desugar_impl_assoc_refts(&impl_.assoc_refinements);
         let impl_ = fhir::Impl { assoc_refinements };
 
         if config::dump_fhir() {
@@ -188,14 +191,15 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
     fn desugar_impl_assoc_refts(
         &mut self,
         assoc_refts: &[surface::ImplAssocReft],
-    ) -> Result<&'genv [fhir::ImplAssocReft<'genv>]> {
-        try_alloc_slice!(self.genv, assoc_refts, |assoc_reft| {
-            let name = assoc_reft.name.name;
-            let body = self.desugar_expr(&assoc_reft.body)?;
-            let params = self.desugar_refine_params(&assoc_reft.params);
-            let output = self.desugar_base_sort(&assoc_reft.output, None);
-            Ok(fhir::ImplAssocReft { name, params, output, body, span: assoc_reft.span })
-        })
+    ) -> &'genv [fhir::ImplAssocReft<'genv>] {
+        self.genv()
+            .alloc_slice_fill_iter(assoc_refts.iter().map(|assoc_reft| {
+                let name = assoc_reft.name.name;
+                let body = self.desugar_expr(&assoc_reft.body);
+                let params = self.desugar_refine_params(&assoc_reft.params);
+                let output = self.desugar_base_sort(&assoc_reft.output, None);
+                fhir::ImplAssocReft { name, params, output, body, span: assoc_reft.span }
+            }))
     }
 
     pub(crate) fn desugar_generics(
@@ -213,7 +217,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
         )?;
 
         let predicates = if let Some(predicates) = &generics.predicates {
-            Some(self.desugar_generic_predicates(predicates)?)
+            Some(self.desugar_generic_predicates(predicates))
         } else {
             None
         };
@@ -234,37 +238,37 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
     fn desugar_generic_predicates(
         &mut self,
         predicates: &[surface::WhereBoundPredicate],
-    ) -> Result<&'genv [fhir::WhereBoundPredicate<'genv>]> {
-        try_alloc_slice!(self.genv, predicates, |pred| {
-            let bounded_ty = self.desugar_ty(&pred.bounded_ty);
-            let bounds = self.desugar_generic_bounds(&pred.bounds)?;
-            Ok(fhir::WhereBoundPredicate { span: pred.span, bounded_ty, bounds })
-        })
+    ) -> &'genv [fhir::WhereBoundPredicate<'genv>] {
+        self.genv
+            .alloc_slice_fill_iter(predicates.iter().map(|pred| {
+                let bounded_ty = self.desugar_ty(&pred.bounded_ty);
+                let bounds = self.desugar_generic_bounds(&pred.bounds);
+                fhir::WhereBoundPredicate { span: pred.span, bounded_ty, bounds }
+            }))
     }
 
     fn desugar_generic_bounds(
         &mut self,
         bounds: &[surface::TraitRef],
-    ) -> Result<fhir::GenericBounds<'genv>> {
-        try_alloc_slice!(self.genv, bounds, |bound| {
-            Ok(fhir::GenericBound::Trait(self.desugar_trait_ref(bound)?))
-        })
+    ) -> fhir::GenericBounds<'genv> {
+        self.genv().alloc_slice_fill_iter(
+            bounds
+                .iter()
+                .map(|bound| fhir::GenericBound::Trait(self.desugar_trait_ref(bound))),
+        )
     }
 
-    fn desugar_trait_ref(
-        &mut self,
-        trait_ref: &surface::TraitRef,
-    ) -> Result<fhir::PolyTraitRef<'genv>> {
-        let fhir::QPath::Resolved(None, path) = self.desugar_qpath(None, &trait_ref.path)? else {
+    fn desugar_trait_ref(&mut self, trait_ref: &surface::TraitRef) -> fhir::PolyTraitRef<'genv> {
+        let fhir::QPath::Resolved(None, path) = self.desugar_qpath(None, &trait_ref.path) else {
             span_bug!(trait_ref.path.span, "desugar_alias_reft: unexpected qpath")
         };
         let span = path.span;
-        Ok(fhir::PolyTraitRef {
+        fhir::PolyTraitRef {
             bound_generic_params: &[],
             modifiers: fhir::TraitBoundModifier::None,
             trait_ref: path,
             span,
-        })
+        }
     }
 
     fn desugar_refined_by(
@@ -296,9 +300,12 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
 
         let generics = self.desugar_opt_generics(struct_def.generics.as_ref())?;
 
-        let invariants = try_alloc_slice!(self.genv, &struct_def.invariants, |invariant| {
-            self.desugar_expr(invariant)
-        })?;
+        let invariants = self.genv().alloc_slice_fill_iter(
+            struct_def
+                .invariants
+                .iter()
+                .map(|invariant| self.desugar_expr(invariant)),
+        );
 
         let kind = if struct_def.opaque {
             fhir::StructKind::Opaque
@@ -366,9 +373,12 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
 
         let generics = self.desugar_opt_generics(enum_def.generics.as_ref())?;
 
-        let invariants = try_alloc_slice!(self.genv, &enum_def.invariants, |invariant| {
-            self.desugar_expr(invariant)
-        })?;
+        let invariants = self.genv().alloc_slice_fill_iter(
+            enum_def
+                .invariants
+                .iter()
+                .map(|invariant| self.desugar_expr(invariant)),
+        );
 
         let params = self.desugar_refine_params(enum_def.refined_by.as_deref().unwrap_or(&[]));
         let enum_def =
@@ -389,7 +399,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
     ) -> Result<fhir::VariantDef<'genv>> {
         if let Some(variant_def) = variant_def {
             if reflected {
-                return Err(self.emit_err(errors::InvalidReflectedVariant::new(hir_variant.span)));
+                return Err(self.emit(errors::InvalidReflectedVariant::new(hir_variant.span)));
             }
             let fields = try_alloc_slice!(self.genv, &variant_def.fields, |ty| {
                 Ok(fhir::FieldDef { ty: self.desugar_ty(ty), lifted: false })
@@ -494,19 +504,19 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
     pub(crate) fn desugar_const_spec(
         &mut self,
         const_info: &surface::ConstantInfo,
-    ) -> Result<Option<fhir::Expr<'genv>>> {
+    ) -> Option<fhir::Expr<'genv>> {
         let expr = match &const_info.expr {
-            Some(expr) => Some(self.desugar_expr(expr)?),
+            Some(expr) => Some(self.desugar_expr(expr)),
             None => None,
         };
-        Ok(expr)
+        expr
     }
 
     pub(crate) fn desugar_const(
         &mut self,
         const_info: &surface::ConstantInfo,
     ) -> Result<fhir::Item<'genv>> {
-        let expr = self.desugar_const_spec(const_info)?;
+        let expr = self.desugar_const_spec(const_info);
         let owner_id = self.owner;
         let generics = self.as_lift_cx().lift_generics()?;
         let kind = fhir::ItemKind::Const(expr);
@@ -539,13 +549,14 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
 
             for surface_requires in &fn_sig.requires {
                 let params = self.desugar_refine_params(&surface_requires.params);
-                let pred = self.desugar_expr(&surface_requires.pred)?;
+                let pred = self.desugar_expr(&surface_requires.pred);
                 requires.push(fhir::Requires { params, pred });
             }
 
             // Bail out if there's an error in the arguments to avoid confusing error messages
-            let inputs =
-                try_alloc_slice!(self.genv, &fn_sig.inputs, |arg| self.desugar_fn_input(arg))?;
+            let inputs = self
+                .genv()
+                .alloc_slice_fill_iter(fn_sig.inputs.iter().map(|arg| self.desugar_fn_input(arg)));
 
             let output = self.desugar_fn_output(fn_sig.asyncness, &fn_sig.output)?;
 
@@ -620,18 +631,18 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
                 Ok(fhir::Ensures::Type(path, ty))
             }
             surface::Ensures::Pred(e) => {
-                let pred = self.desugar_expr(e)?;
+                let pred = self.desugar_expr(e);
                 Ok(fhir::Ensures::Pred(pred))
             }
         }
     }
 
-    fn desugar_fn_input(&mut self, input: &surface::FnInput) -> Result<fhir::Ty<'genv>> {
+    fn desugar_fn_input(&mut self, input: &surface::FnInput) -> fhir::Ty<'genv> {
         match input {
             surface::FnInput::Constr(bind, path, pred, node_id) => {
-                let bty = self.desugar_path_to_bty(None, path)?;
+                let bty = self.desugar_path_to_bty(None, path);
 
-                let pred = self.desugar_expr(pred)?;
+                let pred = self.desugar_expr(pred);
 
                 let ty = if let Some(idx) = self.implicit_param_into_refine_arg(*bind, *node_id) {
                     fhir::Ty { kind: fhir::TyKind::Indexed(bty, idx), span: path.span }
@@ -641,7 +652,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
 
                 let span = path.span.to(pred.span);
                 let kind = fhir::TyKind::Constr(pred, self.genv.alloc(ty));
-                Ok(fhir::Ty { kind, span })
+                fhir::Ty { kind, span }
             }
             surface::FnInput::StrgRef(loc, ty, node_id) => {
                 let span = loc.span;
@@ -658,7 +669,7 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
                     self.genv.alloc(path),
                     self.genv.alloc(ty),
                 );
-                Ok(fhir::Ty { kind, span })
+                fhir::Ty { kind, span }
             }
             surface::FnInput::Ty(bind, ty, node_id) => {
                 if let Some(bind) = bind
@@ -671,9 +682,9 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
                         } else {
                             fhir::TyKind::BaseTy(bty)
                         };
-                    Ok(fhir::Ty { kind, span: ty.span })
+                    fhir::Ty { kind, span: ty.span }
                 } else {
-                    Ok(self.desugar_ty(ty))
+                    self.desugar_ty(ty)
                 }
             }
         }
@@ -765,10 +776,9 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
         &mut self,
         def_id: LocalDefId,
         bounds: &[surface::TraitRef],
-    ) -> Result<fhir::OpaqueTy<'genv>> {
-        let bounds = self.desugar_generic_bounds(bounds)?;
-        let opaque_ty = fhir::OpaqueTy { def_id: MaybeExternId::Local(def_id), bounds };
-        Ok(opaque_ty)
+    ) -> fhir::OpaqueTy<'genv> {
+        let bounds = self.desugar_generic_bounds(bounds);
+        fhir::OpaqueTy { def_id: MaybeExternId::Local(def_id), bounds }
     }
 
     fn desugar_variant_ret(
@@ -776,9 +786,9 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
         ret: &surface::VariantRet,
     ) -> Result<fhir::VariantRet<'genv>> {
         let Some(enum_id) = self.check_variant_ret_path(&ret.path) else {
-            return Err(self.emit_err(errors::InvalidVariantRet::new(&ret.path)));
+            return Err(self.emit(errors::InvalidVariantRet::new(&ret.path)));
         };
-        let idx = self.desugar_indices(&ret.indices)?;
+        let idx = self.desugar_indices(&ret.indices);
         Ok(fhir::VariantRet { enum_id, idx })
     }
 
@@ -827,24 +837,73 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
             .push(opaque_ty);
         opaque_ty
     }
+}
 
-    #[track_caller]
-    fn emit_err<'b>(&'b self, err: impl Diagnostic<'b>) -> ErrorGuaranteed {
-        self.sess().emit_err(err)
+impl ErrorEmitter for RustItemCtxt<'_, '_, '_> {
+    fn emit<'a>(&'a self, err: impl Diagnostic<'a>) -> ErrorGuaranteed {
+        self.errors.emit(err)
     }
+}
+
+impl ErrorCollector<ErrorGuaranteed> for RustItemCtxt<'_, '_, '_> {
+    type Result = std::result::Result<(), ErrorGuaranteed>;
+
+    fn collect(&mut self, err: ErrorGuaranteed) {
+        self.errors.collect(err);
+    }
+
+    fn into_result(self) -> Self::Result {
+        self.errors.into_result()
+    }
+}
+
+struct FluxItemCtxt<'genv, 'tcx> {
+    genv: GlobalEnv<'genv, 'tcx>,
+    resolver_output: &'genv ResolverOutput,
+    local_id_gen: IndexGen<fhir::ItemLocalId>,
+    owner: Symbol,
+    errors: Errors<'genv>,
 }
 
 impl<'genv, 'tcx> FluxItemCtxt<'genv, 'tcx> {
-    fn new(
+    fn with<T>(
         genv: GlobalEnv<'genv, 'tcx>,
         resolver_output: &'genv ResolverOutput,
         owner: Symbol,
-    ) -> Self {
-        Self { genv, resolver_output, local_id_gen: Default::default(), owner }
+        f: impl FnOnce(&mut Self) -> Result<T>,
+    ) -> Result<T> {
+        let mut cx = Self {
+            genv,
+            resolver_output,
+            local_id_gen: Default::default(),
+            owner,
+            errors: Errors::new(genv.sess()),
+        };
+        let r = f(&mut cx)?;
+        cx.into_result()?;
+        Ok(r)
     }
 }
 
-trait DesugarCtxt<'genv, 'tcx: 'genv> {
+impl ErrorEmitter for FluxItemCtxt<'_, '_> {
+    fn emit<'a>(&'a self, err: impl Diagnostic<'a>) -> ErrorGuaranteed {
+        self.errors.emit(err)
+    }
+}
+
+impl ErrorCollector<ErrorGuaranteed> for FluxItemCtxt<'_, '_> {
+    type Result = std::result::Result<(), ErrorGuaranteed>;
+
+    fn collect(&mut self, err: ErrorGuaranteed) {
+        self.errors.collect(err);
+    }
+
+    fn into_result(self) -> Self::Result {
+        self.errors.into_result()
+    }
+}
+
+trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaranteed> {
     fn genv(&self) -> GlobalEnv<'genv, 'tcx>;
     fn resolver_output(&self) -> &'genv ResolverOutput;
     fn next_fhir_id(&self) -> FhirId;
@@ -852,17 +911,13 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
         &mut self,
         node_id: NodeId,
         bounds: &[surface::TraitRef],
-    ) -> Result<fhir::TyKind<'genv>>;
-
-    fn sess(&self) -> &'genv FluxSession {
-        self.genv().sess()
-    }
+    ) -> fhir::TyKind<'genv>;
 
     fn resolve_implicit_param(&self, node_id: NodeId) -> Option<(fhir::ParamId, fhir::ParamKind)> {
         self.resolver_output().param_res_map.get(&node_id).copied()
     }
 
-    fn desugar_var(&self, path: &surface::ExprPath) -> Result<fhir::ExprKind<'genv>> {
+    fn desugar_var(&self, path: &surface::ExprPath) -> fhir::ExprKind<'genv> {
         let res = *self
             .resolver_output()
             .expr_path_res_map
@@ -871,7 +926,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
 
         if let ExprRes::GlobalFunc(..) = res {
             let span = path.span;
-            return Err(self.emit_err(errors::InvalidFuncAsVar { span }));
+            return fhir::ExprKind::Err(self.emit(errors::InvalidFuncAsVar { span }));
         }
 
         let path = fhir::PathExpr {
@@ -882,7 +937,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
             fhir_id: self.next_fhir_id(),
             span: path.span,
         };
-        Ok(fhir::ExprKind::Var(path, None))
+        fhir::ExprKind::Var(path, None)
     }
 
     #[track_caller]
@@ -892,7 +947,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
             Ok(res)
         } else {
             let span = ident.span;
-            Err(self.emit_err(errors::InvalidLoc { span }))
+            Err(self.emit(errors::InvalidLoc { span }))
         }
     }
 
@@ -904,7 +959,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
             Ok(fhir::PathExpr { segments, res, fhir_id: self.next_fhir_id(), span: func.span })
         } else {
             let span = func.span;
-            Err(self.emit_err(errors::InvalidFunc { span }))
+            Err(self.emit(errors::InvalidFunc { span }))
         }
     }
 
@@ -1076,7 +1131,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
             }
             surface::TyKind::Indexed { bty, indices } => {
                 let bty = self.desugar_bty(bty);
-                let idx = self.desugar_indices(indices)?;
+                let idx = self.desugar_indices(indices);
                 fhir::TyKind::Indexed(bty, idx)
             }
             surface::TyKind::Exists { bind, bty, pred } => {
@@ -1084,7 +1139,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                 let bty_span = bty.span;
 
                 let bty = self.desugar_bty(bty);
-                let pred = self.desugar_expr(pred)?;
+                let pred = self.desugar_expr(pred);
 
                 let (id, kind) = self.resolve_param(node_id);
                 let param = fhir::RefineParam {
@@ -1116,7 +1171,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
             surface::TyKind::GeneralExists { params, ty, pred } => {
                 let mut ty = self.desugar_ty(ty);
                 if let Some(pred) = pred {
-                    let pred = self.desugar_expr(pred)?;
+                    let pred = self.desugar_expr(pred);
                     ty = fhir::Ty { kind: fhir::TyKind::Constr(pred, self.genv().alloc(ty)), span };
                 }
                 let params = self.desugar_refine_params(params);
@@ -1124,7 +1179,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                 fhir::TyKind::Exists(params, self.genv().alloc(ty))
             }
             surface::TyKind::Constr(pred, ty) => {
-                let pred = self.desugar_expr(pred)?;
+                let pred = self.desugar_expr(pred);
                 let ty = self.desugar_ty(ty);
                 fhir::TyKind::Constr(pred, self.genv().alloc(ty))
             }
@@ -1145,7 +1200,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                 fhir::TyKind::Array(self.genv().alloc(ty), len)
             }
             surface::TyKind::ImplTrait(node_id, bounds) => {
-                self.desugar_impl_trait(*node_id, bounds)?
+                self.desugar_impl_trait(*node_id, bounds)
             }
             surface::TyKind::Hole => fhir::TyKind::Infer,
         };
@@ -1163,7 +1218,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
     fn desugar_bty(&mut self, bty: &surface::BaseTy) -> fhir::BaseTy<'genv> {
         match &bty.kind {
             surface::BaseTyKind::Path(qself, path) => {
-                let qpath = self.desugar_qpath(qself.as_deref(), path)?;
+                let qpath = self.desugar_qpath(qself.as_deref(), path);
                 fhir::BaseTy::from_qpath(qpath, self.next_fhir_id())
             }
             surface::BaseTyKind::Slice(ty) => {
@@ -1178,16 +1233,16 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
         &mut self,
         qself: Option<&surface::Ty>,
         path: &surface::Path,
-    ) -> Result<fhir::BaseTy<'genv>> {
-        let qpath = self.desugar_qpath(qself, path)?;
-        Ok(fhir::BaseTy::from_qpath(qpath, self.next_fhir_id()))
+    ) -> fhir::BaseTy<'genv> {
+        let qpath = self.desugar_qpath(qself, path);
+        fhir::BaseTy::from_qpath(qpath, self.next_fhir_id())
     }
 
     fn desugar_qpath(
         &mut self,
         qself: Option<&surface::Ty>,
         path: &surface::Path,
-    ) -> Result<fhir::QPath<'genv>> {
+    ) -> fhir::QPath<'genv> {
         let qself = if let Some(ty) = qself {
             let ty = self.desugar_ty(ty);
             Some(self.genv().alloc(ty))
@@ -1207,16 +1262,16 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                     .iter()
                     .map(|segment| self.desugar_path_segment(segment)),
             ),
-            refine: try_alloc_slice!(self.genv(), &path.refine, |arg| {
-                self.desugar_refine_arg(arg)
-            })?,
+            refine: self
+                .genv()
+                .alloc_slice_fill_iter(path.refine.iter().map(|arg| self.desugar_refine_arg(arg))),
             span: path.span,
         };
 
         // Simple case, either no projections, or only fully-qualified.
         // E.g., `std::mem::size_of` or `<I as Iterator>::Item`.
         if unresolved_segments == 0 {
-            return Ok(fhir::QPath::Resolved(qself, fhir_path));
+            return fhir::QPath::Resolved(qself, fhir_path);
         }
 
         // Create the innermost type that we're projecting from.
@@ -1237,7 +1292,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
             let qpath = fhir::QPath::TypeRelative(ty, self.genv().alloc(hir_segment));
 
             if i == path.segments.len() - 1 {
-                return Ok(qpath);
+                return qpath;
             }
 
             ty = self.genv().alloc(self.ty_path(qpath));
@@ -1272,37 +1327,36 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
         fhir::Lifetime::Hole(self.next_fhir_id())
     }
 
-    fn desugar_indices(&mut self, idxs: &surface::Indices) -> Result<fhir::Expr<'genv>> {
+    fn desugar_indices(&mut self, idxs: &surface::Indices) -> fhir::Expr<'genv> {
         if let [arg] = &idxs.indices[..] {
             self.desugar_refine_arg(arg)
         } else {
-            let flds = try_alloc_slice!(self.genv(), &idxs.indices, |arg| {
-                self.desugar_refine_arg(arg)
-            })?;
-            Ok(fhir::Expr {
+            let flds = self
+                .genv()
+                .alloc_slice_fill_iter(idxs.indices.iter().map(|arg| self.desugar_refine_arg(arg)));
+            fhir::Expr {
                 kind: fhir::ExprKind::Record(flds),
                 fhir_id: self.next_fhir_id(),
                 span: idxs.span,
-            })
+            }
         }
     }
 
-    fn desugar_refine_arg(&mut self, arg: &surface::RefineArg) -> Result<fhir::Expr<'genv>> {
+    fn desugar_refine_arg(&mut self, arg: &surface::RefineArg) -> fhir::Expr<'genv> {
         match arg {
             surface::RefineArg::Bind(ident, .., node_id) => {
-                Ok(self
-                    .implicit_param_into_refine_arg(*ident, *node_id)
-                    .unwrap())
+                self.implicit_param_into_refine_arg(*ident, *node_id)
+                    .unwrap()
             }
             surface::RefineArg::Expr(expr) => self.desugar_expr(expr),
             surface::RefineArg::Abs(params, body, span, _) => {
-                let body = self.genv().alloc(self.desugar_expr(body)?);
+                let body = self.genv().alloc(self.desugar_expr(body));
                 let params = self.desugar_refine_params(params);
-                Ok(fhir::Expr {
+                fhir::Expr {
                     kind: fhir::ExprKind::Abs(params, body),
                     fhir_id: self.next_fhir_id(),
                     span: *span,
-                })
+                }
             }
         }
     }
@@ -1331,7 +1385,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
         alias_reft: &surface::AliasReft,
     ) -> Result<fhir::AliasReft<'genv>> {
         let self_ty = self.desugar_ty(&alias_reft.qself);
-        let fhir::QPath::Resolved(None, path) = self.desugar_qpath(None, &alias_reft.path)? else {
+        let fhir::QPath::Resolved(None, path) = self.desugar_qpath(None, &alias_reft.path) else {
             span_bug!(alias_reft.path.span, "desugar_alias_reft: unexpected qpath")
         };
         if let Res::Def(DefKind::Trait, _) = path.res {
@@ -1342,24 +1396,22 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
             })
         } else {
             // FIXME(nilehmann) we ought to report this error somewhere else
-            Err(self.emit_err(errors::InvalidAliasReft::new(&alias_reft.path)))
+            Err(self.emit(errors::InvalidAliasReft::new(&alias_reft.path)))
         }
     }
 
-    fn desugar_expr(&mut self, expr: &surface::Expr) -> Result<fhir::Expr<'genv>> {
+    fn desugar_expr(&mut self, expr: &surface::Expr) -> fhir::Expr<'genv> {
         let node_id = expr.node_id;
         let kind = match &expr.kind {
-            surface::ExprKind::Path(path) => self.desugar_var(path)?,
-            surface::ExprKind::Literal(lit) => {
-                fhir::ExprKind::Literal(self.desugar_lit(expr.span, *lit)?)
-            }
+            surface::ExprKind::Path(path) => self.desugar_var(path),
+            surface::ExprKind::Literal(lit) => self.desugar_lit(expr.span, *lit),
             surface::ExprKind::BinaryOp(op, box [e1, e2]) => {
                 let e1 = self.desugar_expr(e1);
                 let e2 = self.desugar_expr(e2);
-                fhir::ExprKind::BinaryOp(*op, self.genv().alloc(e1?), self.genv().alloc(e2?))
+                fhir::ExprKind::BinaryOp(*op, self.genv().alloc(e1), self.genv().alloc(e2))
             }
             surface::ExprKind::UnaryOp(op, box e) => {
-                fhir::ExprKind::UnaryOp(*op, self.genv().alloc(self.desugar_expr(e)?))
+                fhir::ExprKind::UnaryOp(*op, self.genv().alloc(self.desugar_expr(e)))
             }
             surface::ExprKind::Dot(path, fld) => {
                 let res = self.resolver_output().expr_path_res_map[&path.node_id];
@@ -1375,87 +1427,100 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
                     };
                     fhir::ExprKind::Dot(path, *fld)
                 } else {
-                    return Err(self.emit_err(errors::InvalidDotVar { span: path.span }));
+                    fhir::ExprKind::Err(self.emit(errors::InvalidDotVar { span: path.span }))
                 }
             }
             surface::ExprKind::App(func, args) => {
-                let args = self.desugar_exprs(args)?;
-                let func = self.desugar_func(*func, node_id)?;
-                fhir::ExprKind::App(func, args)
+                let args = self.desugar_exprs(args);
+                match self.desugar_func(*func, node_id) {
+                    Ok(func) => fhir::ExprKind::App(func, args),
+                    Err(err) => fhir::ExprKind::Err(err),
+                }
             }
             surface::ExprKind::Alias(alias_reft, func_args) => {
-                let func_args = try_alloc_slice!(self.genv(), func_args, |e| self.desugar_expr(e))?;
-                let alias_reft = self.desugar_alias_reft(alias_reft)?;
-                fhir::ExprKind::Alias(alias_reft, func_args)
+                let func_args = self.desugar_exprs(func_args);
+                match self.desugar_alias_reft(alias_reft) {
+                    Ok(alias_reft) => fhir::ExprKind::Alias(alias_reft, func_args),
+                    Err(err) => fhir::ExprKind::Err(err),
+                }
             }
             surface::ExprKind::IfThenElse(box [p, e1, e2]) => {
                 let p = self.desugar_expr(p);
                 let e1 = self.desugar_expr(e1);
                 let e2 = self.desugar_expr(e2);
                 fhir::ExprKind::IfThenElse(
-                    self.genv().alloc(p?),
-                    self.genv().alloc(e1?),
-                    self.genv().alloc(e2?),
+                    self.genv().alloc(p),
+                    self.genv().alloc(e1),
+                    self.genv().alloc(e2),
                 )
             }
             surface::ExprKind::Constructor(path, args) => {
-                let path = path
-                    .as_ref()
-                    .map(|p| self.desugar_constructor_path(p))
-                    .transpose()?;
-                let (field_exprs, spreads): (Vec<_>, Vec<_>) = args.iter().partition_map(|arg| {
-                    match arg {
-                        ConstructorArg::FieldExpr(e) => Either::Left(e),
-                        ConstructorArg::Spread(s) => Either::Right(s),
-                    }
-                });
-
-                let field_exprs = try_alloc_slice!(self.genv(), field_exprs, |field_expr| {
-                    let e = self.desugar_expr(&field_expr.expr)?;
-                    Ok(fhir::FieldExpr {
-                        ident: field_expr.ident,
-                        expr: e,
-                        fhir_id: self.next_fhir_id(),
-                        span: e.span,
-                    })
-                })?;
-
-                let spread = match &spreads[..] {
-                    [] => None,
-                    [s] => {
-                        let spread = fhir::Spread {
-                            expr: self.desugar_expr(&s.expr)?,
-                            span: s.span,
-                            fhir_id: self.next_fhir_id(),
-                        };
-                        Some(self.genv().alloc(spread))
-                    }
-                    [s1, s2, ..] => {
-                        let err = errors::MultipleSpreadsInConstructor::new(s1.span, s2.span);
-                        return Err(self.emit_err(err));
-                    }
-                };
-                fhir::ExprKind::Constructor(path, field_exprs, spread)
+                self.desugar_constructor(path.as_ref(), args)
             }
         };
 
-        Ok(fhir::Expr { kind, span: expr.span, fhir_id: self.next_fhir_id() })
+        fhir::Expr { kind, span: expr.span, fhir_id: self.next_fhir_id() }
     }
 
-    fn desugar_constructor_path(&self, path: &surface::ExprPath) -> Result<fhir::PathExpr<'genv>> {
-        let res = self.resolver_output().expr_path_res_map[&path.node_id];
-        if let ExprRes::Ctor(..) = res {
+    fn desugar_constructor(
+        &mut self,
+        path: Option<&surface::ExprPath>,
+        args: &[surface::ConstructorArg],
+    ) -> fhir::ExprKind<'genv> {
+        let path = if let Some(path) = path {
+            let res = self.resolver_output().expr_path_res_map[&path.node_id];
+            if !matches!(res, ExprRes::Ctor(..)) {
+                return fhir::ExprKind::Err(
+                    self.emit(errors::InvalidConstructorPath { span: path.span }),
+                );
+            };
             let segments = self
                 .genv()
                 .alloc_slice_fill_iter(path.segments.iter().map(|s| s.ident));
-            Ok(fhir::PathExpr { segments, res, fhir_id: self.next_fhir_id(), span: path.span })
+            Some(fhir::PathExpr { segments, res, fhir_id: self.next_fhir_id(), span: path.span })
         } else {
-            Err(self.emit_err(errors::InvalidConstructorPath { span: path.span }))
+            None
+        };
+
+        let (field_exprs, spreads): (Vec<_>, Vec<_>) = args.iter().partition_map(|arg| {
+            match arg {
+                ConstructorArg::FieldExpr(e) => Either::Left(e),
+                ConstructorArg::Spread(s) => Either::Right(s),
+            }
+        });
+
+        let field_exprs = self
+            .genv()
+            .alloc_slice_fill_iter(field_exprs.iter().map(|field_expr| {
+                let e = self.desugar_expr(&field_expr.expr);
+                fhir::FieldExpr {
+                    ident: field_expr.ident,
+                    expr: e,
+                    fhir_id: self.next_fhir_id(),
+                    span: e.span,
+                }
+            }));
+
+        match &spreads[..] {
+            [] => fhir::ExprKind::Constructor(path, field_exprs, None),
+            [s] => {
+                let spread = fhir::Spread {
+                    expr: self.desugar_expr(&s.expr),
+                    span: s.span,
+                    fhir_id: self.next_fhir_id(),
+                };
+                fhir::ExprKind::Constructor(path, field_exprs, Some(self.genv().alloc(spread)))
+            }
+            [s1, s2, ..] => {
+                let err = errors::MultipleSpreadsInConstructor::new(s1.span, s2.span);
+                fhir::ExprKind::Err(self.emit(err))
+            }
         }
     }
 
-    fn desugar_exprs(&mut self, exprs: &[surface::Expr]) -> Result<&'genv [fhir::Expr<'genv>]> {
-        try_alloc_slice!(self.genv(), exprs, |e| self.desugar_expr(e))
+    fn desugar_exprs(&mut self, exprs: &[surface::Expr]) -> &'genv [fhir::Expr<'genv>] {
+        self.genv()
+            .alloc_slice_fill_iter(exprs.iter().map(|e| self.desugar_expr(e)))
     }
 
     fn try_parse_int_lit(&self, span: Span, s: &str) -> Result<i128> {
@@ -1474,36 +1539,35 @@ trait DesugarCtxt<'genv, 'tcx: 'genv> {
         if let Ok(n) = parsed_int {
             Ok(n) // convert error types
         } else {
-            Err(self.emit_err(errors::IntTooLarge { span }))
+            Err(self.emit(errors::IntTooLarge { span }))
         }
     }
 
     /// Desugar surface literal
-    fn desugar_lit(&self, span: Span, lit: surface::Lit) -> Result<fhir::Lit> {
-        match lit.kind {
+    fn desugar_lit(&self, span: Span, lit: surface::Lit) -> fhir::ExprKind<'genv> {
+        let lit = match lit.kind {
             surface::LitKind::Integer => {
-                let n = self.try_parse_int_lit(span, lit.symbol.as_str())?;
+                let n = match self.try_parse_int_lit(span, lit.symbol.as_str()) {
+                    Ok(n) => n,
+                    Err(err) => return fhir::ExprKind::Err(err),
+                };
                 let suffix = lit.suffix.unwrap_or(SORTS.int);
                 if suffix == SORTS.int {
-                    Ok(fhir::Lit::Int(n))
+                    fhir::Lit::Int(n)
                 } else if suffix == SORTS.real {
-                    Ok(fhir::Lit::Real(n))
+                    fhir::Lit::Real(n)
                 } else {
-                    Err(self.emit_err(errors::InvalidNumericSuffix::new(span, suffix)))
+                    return fhir::ExprKind::Err(
+                        self.emit(errors::InvalidNumericSuffix::new(span, suffix)),
+                    );
                 }
             }
-            surface::LitKind::Bool => Ok(fhir::Lit::Bool(lit.symbol == kw::True)),
-            surface::LitKind::Str => Ok(fhir::Lit::Str(lit.symbol)),
-            surface::LitKind::Char => {
-                Ok(fhir::Lit::Char(lit.symbol.as_str().parse::<char>().unwrap()))
-            }
-            _ => Err(self.emit_err(errors::UnexpectedLiteral { span })),
-        }
-    }
-
-    #[track_caller]
-    fn emit_err(&self, err: impl Diagnostic<'genv>) -> ErrorGuaranteed {
-        self.sess().emit_err(err)
+            surface::LitKind::Bool => fhir::Lit::Bool(lit.symbol == kw::True),
+            surface::LitKind::Str => fhir::Lit::Str(lit.symbol),
+            surface::LitKind::Char => fhir::Lit::Char(lit.symbol.as_str().parse::<char>().unwrap()),
+            _ => return fhir::ExprKind::Err(self.emit(errors::UnexpectedLiteral { span })),
+        };
+        fhir::ExprKind::Literal(lit)
     }
 }
 
@@ -1527,15 +1591,15 @@ impl<'genv, 'tcx> DesugarCtxt<'genv, 'tcx> for RustItemCtxt<'_, 'genv, 'tcx> {
         &mut self,
         node_id: NodeId,
         bounds: &[surface::TraitRef],
-    ) -> Result<fhir::TyKind<'genv>> {
+    ) -> fhir::TyKind<'genv> {
         let def_id = self.resolver_output().impl_trait_res_map[&node_id];
 
         // FIXME(nilehmann) since we can only pass local ids for opaque types it means we can't
         // support extern specs with opaque types.
-        let opaque_ty = self.desugar_opaque_ty_for_impl_trait(def_id, bounds)?;
+        let opaque_ty = self.desugar_opaque_ty_for_impl_trait(def_id, bounds);
         let opaque_ty = self.insert_opaque_ty(opaque_ty);
 
-        Ok(fhir::TyKind::OpaqueDef(opaque_ty))
+        fhir::TyKind::OpaqueDef(opaque_ty)
     }
 }
 
@@ -1552,11 +1616,7 @@ impl<'genv, 'tcx> DesugarCtxt<'genv, 'tcx> for FluxItemCtxt<'genv, 'tcx> {
         self.resolver_output
     }
 
-    fn desugar_impl_trait(
-        &mut self,
-        _: NodeId,
-        _: &[surface::TraitRef],
-    ) -> Result<fhir::TyKind<'genv>> {
+    fn desugar_impl_trait(&mut self, _: NodeId, _: &[surface::TraitRef]) -> fhir::TyKind<'genv> {
         unimplemented!("`impl Trait` not supported in this item")
     }
 }

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -800,6 +800,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
             fhir::Sort::Loc => rty::Sort::Loc,
             fhir::Sort::Func(fsort) => rty::Sort::Func(self.conv_poly_func_sort(fsort)?),
             fhir::Sort::Infer => rty::Sort::Infer(rty::SortVar(self.next_sort_vid())),
+            fhir::Sort::Err(_) => rty::Sort::Err,
         };
         Ok(sort)
     }
@@ -1227,6 +1228,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 }
             }
             fhir::TyKind::Infer => Ok(rty::Ty::infer(self.next_type_vid())),
+            fhir::TyKind::Err(err) => Err(QueryErr::Emitted(*err)),
         }
     }
 
@@ -1391,6 +1393,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 let ty = rty::Ty::indexed(bty, rty::Expr::nu());
                 Ok(rty::TyOrCtor::Ctor(rty::Binder::bind_with_sort(ty, sort)))
             }
+            fhir::BaseTyKind::Err(err) => Err(QueryErr::Emitted(*err)),
         }
     }
 

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2068,6 +2068,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 let assns = self.conv_constructor_exprs(def_id, env, exprs, spread)?;
                 rty::Expr::ctor_struct(def_id, assns)
             }
+            fhir::ExprKind::Err(err) => Err(QueryErr::Emitted(*err))?,
         };
         Ok(self.add_coercions(expr, fhir_id))
     }

--- a/crates/flux-fhir-analysis/src/wf/param_usage.rs
+++ b/crates/flux-fhir-analysis/src/wf/param_usage.rs
@@ -123,6 +123,9 @@ impl<'a, 'genv, 'tcx> ParamUsesChecker<'a, 'genv, 'tcx> {
                     self.check_func_params_uses(&expr.expr, false, false);
                 }
             }
+            fhir::ExprKind::Err(_) => {
+                // an error has already been reported so we can just skip
+            }
         }
     }
 

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -203,6 +203,9 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
                     return Err(self.emit_sort_mismatch(expr.span, &expected, &found));
                 }
             }
+            fhir::ExprKind::Err(_) => {
+                // an error has already been reported so we can just skip
+            }
         }
         Ok(())
     }

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -346,7 +346,7 @@ impl SortEncodingCtxt {
                         }],
                     }
                 }),
-        )
+        );
     }
 
     fn into_data_decls(self, genv: GlobalEnv) -> QueryResult<Vec<fixpoint::DataDecl>> {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -979,6 +979,7 @@ pub enum ExprKind<'fhir> {
     Abs(&'fhir [RefineParam<'fhir>], &'fhir Expr<'fhir>),
     Record(&'fhir [Expr<'fhir>]),
     Constructor(Option<PathExpr<'fhir>>, &'fhir [FieldExpr<'fhir>], Option<&'fhir Spread<'fhir>>),
+    Err(ErrorGuaranteed),
 }
 
 impl Expr<'_> {
@@ -1488,6 +1489,7 @@ impl fmt::Debug for Expr<'_> {
                     write!(f, "{{ {:?} }}", exprs.iter().format(", "))
                 }
             }
+            ExprKind::Err(_) => write!(f, "err"),
         }
     }
 }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -36,7 +36,7 @@ use rustc_index::newtype_index;
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
 pub use rustc_middle::mir::Mutability;
 use rustc_middle::{middle::resolve_bound_vars::ResolvedArg, ty::TyCtxt};
-use rustc_span::{Span, Symbol, symbol::Ident};
+use rustc_span::{ErrorGuaranteed, Span, Symbol, symbol::Ident};
 pub use rustc_target::abi::VariantIdx;
 use rustc_target::spec::abi;
 
@@ -544,6 +544,7 @@ pub enum TyKind<'fhir> {
     TraitObject(&'fhir [PolyTraitRef<'fhir>], Lifetime, TraitObjectSyntax),
     Never,
     Infer,
+    Err(ErrorGuaranteed),
 }
 
 pub struct BareFnTy<'fhir> {
@@ -639,6 +640,7 @@ impl<'fhir> BaseTy<'fhir> {
 pub enum BaseTyKind<'fhir> {
     Path(QPath<'fhir>),
     Slice(&'fhir Ty<'fhir>),
+    Err(ErrorGuaranteed),
 }
 
 #[derive(Clone, Copy)]
@@ -904,6 +906,7 @@ pub enum Sort<'fhir> {
     Func(PolyFuncSort<'fhir>),
     /// A sort that needs to be inferred.
     Infer,
+    Err(ErrorGuaranteed),
 }
 
 /// See [`flux_syntax::surface::SortPath`]
@@ -1328,6 +1331,7 @@ impl fmt::Debug for Ty<'_> {
             TyKind::TraitObject(poly_traits, _lft, _syntax) => {
                 write!(f, "dyn {poly_traits:?}")
             }
+            TyKind::Err(_) => write!(f, "err"),
         }
     }
 }
@@ -1378,6 +1382,7 @@ impl fmt::Debug for BaseTy<'_> {
         match &self.kind {
             BaseTyKind::Path(qpath) => write!(f, "{qpath:?}"),
             BaseTyKind::Slice(ty) => write!(f, "[{ty:?}]"),
+            BaseTyKind::Err(_) => write!(f, "err"),
         }
     }
 }
@@ -1513,6 +1518,7 @@ impl fmt::Debug for Sort<'_> {
             Sort::Loc => write!(f, "loc"),
             Sort::Func(fsort) => write!(f, "{fsort:?}"),
             Sort::Infer => write!(f, "_"),
+            Sort::Err(_) => write!(f, "err"),
         }
     }
 }

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -407,7 +407,7 @@ pub fn walk_ty<'v, V: Visitor<'v>>(vis: &mut V, ty: &Ty<'v>) {
             walk_list!(vis, visit_poly_trait_ref, poly_traits);
             vis.visit_lifetime(&lft);
         }
-        TyKind::Never | TyKind::Infer => {}
+        TyKind::Never | TyKind::Infer | TyKind::Err(_) => {}
     }
 }
 
@@ -415,6 +415,7 @@ pub fn walk_bty<'v, V: Visitor<'v>>(vis: &mut V, bty: &BaseTy<'v>) {
     match &bty.kind {
         BaseTyKind::Path(path) => vis.visit_qpath(path),
         BaseTyKind::Slice(ty) => vis.visit_ty(ty),
+        BaseTyKind::Err(_) => {}
     }
 }
 
@@ -458,7 +459,7 @@ pub fn walk_sort<'v, V: Visitor<'v>>(vis: &mut V, sort: &Sort<'v>) {
     match sort {
         Sort::Path(path) => vis.visit_sort_path(path),
         Sort::Func(func) => vis.visit_poly_func_sort(func),
-        Sort::Loc | Sort::BitVec(_) | Sort::Infer => {}
+        Sort::Loc | Sort::BitVec(_) | Sort::Infer | Sort::Err(_) => {}
     }
 }
 

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -525,5 +525,6 @@ pub fn walk_expr<'v, V: Visitor<'v>>(vis: &mut V, expr: &Expr<'v>) {
                 vis.visit_expr(&s.expr);
             }
         }
+        ExprKind::Err(_) => {}
     }
 }


### PR DESCRIPTION
This adds error variants to `BaseTyKind`, `TyKind` and `ExprKind` in `fhir`. This is similar to what rustc does and allows us to implement desugaring without returning a `Result`.