### PR TITLE
Add bitwuzla as a valid solver

### DIFF
--- a/crates/flux-config/src/lib.rs
+++ b/crates/flux-config/src/lib.rs
@@ -192,6 +192,7 @@ pub enum SmtSolver {
     #[default]
     Z3,
     CVC5,
+    Bitwuzla
 }
 
 impl FromStr for SmtSolver {
@@ -202,6 +203,7 @@ impl FromStr for SmtSolver {
         match s.as_str() {
             "z3" => Ok(SmtSolver::Z3),
             "cvc5" => Ok(SmtSolver::CVC5),
+            "bitwuzla" => Ok(SmtSolver::Bitwuzla),
             _ => Err("backend must be one of `z3` or `cvc5`"),
         }
     }

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -198,6 +198,7 @@ impl<'genv, 'tcx> InferCtxtRoot<'genv, 'tcx> {
         let backend = match self.opts.solver {
             flux_config::SmtSolver::Z3 => liquid_fixpoint::SmtSolver::Z3,
             flux_config::SmtSolver::CVC5 => liquid_fixpoint::SmtSolver::CVC5,
+            flux_config::SmtSolver::Bitwuzla => liquid_fixpoint::SmtSolver::Bitwuzla,
         };
 
         fcx.check(cache, cstr, self.opts.scrape_quals, backend)

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -160,6 +160,7 @@ pub struct Task<T: Types> {
 pub enum SmtSolver {
     Z3,
     CVC5,
+    Bitwuzla
 }
 
 impl fmt::Display for SmtSolver {
@@ -167,6 +168,7 @@ impl fmt::Display for SmtSolver {
         match self {
             SmtSolver::Z3 => write!(f, "z3"),
             SmtSolver::CVC5 => write!(f, "cvc5"),
+            SmtSolver::Bitwuzla => write!(f, "bitwuzla"),
         }
     }
 }


### PR DESCRIPTION
I want to add this solver to liquid fixpoint. See here: https://github.com/ucsd-progsys/liquid-fixpoint/pull/740

It would be nice if we could propogate this back to a flux option!