### PR TITLE
Correctly encode multiple associated refinements from the same trait

### DIFF
--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -557,7 +557,7 @@ where
                     .into_iter()
                     .map(|e| self.head_to_fixpoint(e, mk_tag))
                     .try_collect()?;
-                Ok(fixpoint::Constraint::Conj(cstrs))
+                Ok(fixpoint::Constraint::conj(cstrs))
             }
             rty::ExprKind::BinaryOp(rty::BinOp::Imp, e1, e2) => {
                 let (bindings, assumption) = self.assumption_to_fixpoint(e1)?;
@@ -607,7 +607,7 @@ where
         let mut bindings = vec![];
         let mut preds = vec![];
         self.assumption_to_fixpoint_aux(pred, &mut bindings, &mut preds)?;
-        Ok((bindings, fixpoint::Pred::And(preds)))
+        Ok((bindings, fixpoint::Pred::and(preds)))
     }
 
     /// Auxiliary function to merge nested conjunctions in a single predicate
@@ -1358,7 +1358,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
         scx: &mut SortEncodingCtxt,
         mk_proj: impl Fn(u32) -> rty::FieldProj,
     ) -> QueryResult<fixpoint::Expr> {
-        Ok(fixpoint::Expr::And(
+        Ok(fixpoint::Expr::and(
             sorts
                 .iter()
                 .enumerate()

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -124,6 +124,10 @@ impl<T: Types> Constraint<T> {
             .fold(c, |c, bind| Constraint::ForAll(bind, Box::new(c)))
     }
 
+    pub fn conj(mut cstrs: Vec<Self>) -> Self {
+        if cstrs.len() == 1 { cstrs.remove(0) } else { Self::Conj(cstrs) }
+    }
+
     /// Returns true if the constraint has at least one concrete RHS ("head") predicates.
     /// If `!c.is_concrete` then `c` is trivially satisfiable and we can avoid calling fixpoint.
     pub fn is_concrete(&self) -> bool {
@@ -213,6 +217,10 @@ pub enum Pred<T: Types> {
 impl<T: Types> Pred<T> {
     pub const TRUE: Self = Pred::Expr(Expr::Constant(Constant::Boolean(true)));
 
+    pub fn and(mut preds: Vec<Self>) -> Self {
+        if preds.len() == 1 { preds.remove(0) } else { Self::And(preds) }
+    }
+
     pub fn is_trivially_true(&self) -> bool {
         match self {
             Pred::Expr(Expr::Constant(Constant::Boolean(true))) => true,
@@ -273,6 +281,10 @@ impl<T: Types> Expr<T> {
 
     pub fn eq(self, other: Self) -> Self {
         Expr::Atom(BinRel::Eq, Box::new([self, other]))
+    }
+
+    pub fn and(mut exprs: Vec<Self>) -> Self {
+        if exprs.len() == 1 { exprs.remove(0) } else { Self::And(exprs) }
     }
 }
 

--- a/tests/tests/pos/surface/issue-1025.rs
+++ b/tests/tests/pos/surface/issue-1025.rs
@@ -13,5 +13,5 @@ trait Trait {
 
 #[sig(fn(x: i32{ <T as Trait>::p1(x) }, y: bool { <T as Trait>::p2(y) }))]
 fn test00<T: Trait>(x: i32, y: bool) {
-    assert(x > 0);
+    assert(x + 1 >= 1 + x); // We need the constraint to contain at least one head
 }

--- a/tests/tests/pos/surface/issue-1025.rs
+++ b/tests/tests/pos/surface/issue-1025.rs
@@ -1,0 +1,17 @@
+// test that we correctly encode different associated refinements from the same trate as different
+// constants in smt
+
+use flux_rs::{assert, attrs::*};
+
+trait Trait {
+    #![reft(
+        fn p1(n: int) -> bool;
+        fn p2(b: bool) -> bool;
+    )]
+    //
+}
+
+#[sig(fn(x: i32{ <T as Trait>::p1(x) }, y: bool { <T as Trait>::p2(y) }))]
+fn test00<T: Trait>(x: i32, y: bool) {
+    assert(x > 0);
+}


### PR DESCRIPTION
Fixes #1025 