### PR TITLE
Parse arbitrary expressions in callee position

### DIFF
--- a/crates/flux-desugar/locales/en-US.ftl
+++ b/crates/flux-desugar/locales/en-US.ftl
@@ -38,7 +38,7 @@ desugar_multiple_spreads_in_constructor =
     .help = previous spread found here. consider removing it
 
 desugar_unsupported_position =
-   expression not allowed this position
+   expression not allowed in this position
 
 # Resolve errors
 

--- a/crates/flux-desugar/locales/en-US.ftl
+++ b/crates/flux-desugar/locales/en-US.ftl
@@ -37,8 +37,8 @@ desugar_multiple_spreads_in_constructor =
     multiple spreads found in constructor
     .help = previous spread found here. consider removing it
 
-desugar_unsupported_callee =
-   expression not allowed in function position
+desugar_unsupported_position =
+   expression not allowed this position
 
 # Resolve errors
 

--- a/crates/flux-desugar/locales/en-US.ftl
+++ b/crates/flux-desugar/locales/en-US.ftl
@@ -37,6 +37,9 @@ desugar_multiple_spreads_in_constructor =
     multiple spreads found in constructor
     .help = previous spread found here. consider removing it
 
+desugar_unsupported_callee =
+   expression not allowed in function position
+
 # Resolve errors
 
 desugar_duplicate_param =

--- a/crates/flux-desugar/locales/en-US.ftl
+++ b/crates/flux-desugar/locales/en-US.ftl
@@ -16,10 +16,6 @@ desugar_invalid_dot_var =
 desugar_invalid_constructor_path =
     invalid use of path in constructor
 
-desugar_invalid_func_as_var =
-    invalid use of function
-    .label = function not supported in this position
-
 desugar_invalid_func =
     invalid name in function position
     .label = expected a function or parameter

--- a/crates/flux-desugar/locales/en-US.ftl
+++ b/crates/flux-desugar/locales/en-US.ftl
@@ -16,10 +16,6 @@ desugar_invalid_dot_var =
 desugar_invalid_constructor_path =
     invalid use of path in constructor
 
-desugar_invalid_func =
-    invalid name in function position
-    .label = expected a function or parameter
-
 desugar_invalid_loc =
     expected an `&strg` parameter
 

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1402,8 +1402,8 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                 }
             }
             surface::ExprKind::Call(callee, args) => self.desugar_call(callee, args),
-            surface::ExprKind::AssocReft(assoc_reft) => {
-                todo!("error")
+            surface::ExprKind::AssocReft(_) => {
+                fhir::ExprKind::Err(self.emit(errors::UnsupportedPosition::new(expr.span)))
             }
             surface::ExprKind::IfThenElse(box [p, e1, e2]) => {
                 let p = self.desugar_expr(p);
@@ -1450,7 +1450,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     Err(err) => fhir::ExprKind::Err(err),
                 }
             }
-            _ => fhir::ExprKind::Err(self.emit(errors::UnsupportedCallee::new(callee.span))),
+            _ => fhir::ExprKind::Err(self.emit(errors::UnsupportedPosition::new(callee.span))),
         }
     }
 

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1450,10 +1450,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     Err(err) => fhir::ExprKind::Err(err),
                 }
             }
-            _ => {
-                let a = 0;
-                todo!("error")
-            }
+            _ => fhir::ExprKind::Err(self.emit(errors::UnsupportedCallee::new(callee.span))),
         }
     }
 

--- a/crates/flux-desugar/src/errors.rs
+++ b/crates/flux-desugar/src/errors.rs
@@ -32,14 +32,6 @@ pub(super) struct InvalidDotVar {
 }
 
 #[derive(Diagnostic)]
-#[diag(desugar_invalid_func_as_var, code = E0999)]
-pub(super) struct InvalidFuncAsVar {
-    #[primary_span]
-    #[label]
-    pub(super) span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(desugar_invalid_func, code = E0999)]
 pub(super) struct InvalidFunc {
     #[primary_span]

--- a/crates/flux-desugar/src/errors.rs
+++ b/crates/flux-desugar/src/errors.rs
@@ -109,13 +109,13 @@ impl MultipleSpreadsInConstructor {
 }
 
 #[derive(Diagnostic)]
-#[diag(desugar_unsupported_callee, code = E0999)]
-pub(super) struct UnsupportedCallee {
+#[diag(desugar_unsupported_position, code = E0999)]
+pub(super) struct UnsupportedPosition {
     #[primary_span]
     span: Span,
 }
 
-impl UnsupportedCallee {
+impl UnsupportedPosition {
     pub(super) fn new(span: Span) -> Self {
         Self { span }
     }

--- a/crates/flux-desugar/src/errors.rs
+++ b/crates/flux-desugar/src/errors.rs
@@ -107,3 +107,16 @@ impl MultipleSpreadsInConstructor {
         Self { span, prev_span }
     }
 }
+
+#[derive(Diagnostic)]
+#[diag(desugar_unsupported_callee, code = E0999)]
+pub(super) struct UnsupportedCallee {
+    #[primary_span]
+    span: Span,
+}
+
+impl UnsupportedCallee {
+    pub(super) fn new(span: Span) -> Self {
+        Self { span }
+    }
+}

--- a/crates/flux-desugar/src/errors.rs
+++ b/crates/flux-desugar/src/errors.rs
@@ -32,14 +32,6 @@ pub(super) struct InvalidDotVar {
 }
 
 #[derive(Diagnostic)]
-#[diag(desugar_invalid_func, code = E0999)]
-pub(super) struct InvalidFunc {
-    #[primary_span]
-    #[label]
-    pub(super) span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(desugar_invalid_loc, code = E0999)]
 pub(super) struct InvalidLoc {
     #[primary_span]

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -70,7 +70,6 @@ pub(crate) trait ScopedVisitor: Sized {
     fn on_fn_sig(&mut self, _fn_sig: &surface::FnSig) {}
     fn on_fn_output(&mut self, _output: &surface::FnOutput) {}
     fn on_loc(&mut self, _loc: Ident, _node_id: NodeId) {}
-    fn on_func(&mut self, _func: Ident, _node_id: NodeId) {}
     fn on_path(&mut self, _path: &surface::ExprPath) {}
     fn on_base_sort(&mut self, _sort: &surface::BaseSort) {}
 }
@@ -285,13 +284,6 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
                 surface::visit::walk_bty(self, bty);
             }
         }
-    }
-
-    fn visit_expr(&mut self, expr: &surface::Expr) {
-        if let surface::ExprKind::App(func, _) = &expr.kind {
-            self.on_func(*func, expr.node_id);
-        }
-        surface::visit::walk_expr(self, expr);
     }
 
     fn visit_path_expr(&mut self, path: &surface::ExprPath) {
@@ -787,10 +779,6 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
 
     fn on_refine_param(&mut self, param: &surface::RefineParam) {
         self.define_param(param.ident, fhir::ParamKind::Explicit(param.mode), param.node_id, None);
-    }
-
-    fn on_func(&mut self, func: Ident, node_id: NodeId) {
-        self.resolve_ident(func, node_id);
     }
 
     fn on_loc(&mut self, loc: Ident, node_id: NodeId) {

--- a/crates/flux-driver/src/collector/mod.rs
+++ b/crates/flux-driver/src/collector/mod.rs
@@ -911,9 +911,6 @@ mod errors {
                             }
                         }
                     }
-                    ParseErrorKind::UnsupportedCallee => {
-                        "expression not allowed in callee position".to_string()
-                    }
                     ParseErrorKind::UnsupportedProj => {
                         "expression not allowed in field projection".to_string()
                     }

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -284,6 +284,5 @@ fhir_analysis_fail_to_match_predicates =
     cannot determine corresponding unrefined predicate
     .note = you can only add a refined predicate if an corresponding unrefined one exists
 
-fhir_analysis_invalid_func_as_var =
-    invalid use of function
-    .label = function not supported in this position
+fhir_analysis_invalid_position =
+    expression not allowed in this position

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -283,3 +283,7 @@ fhir_analysis_expected_type =
 fhir_analysis_fail_to_match_predicates =
     cannot determine corresponding unrefined predicate
     .note = you can only add a refined predicate if an corresponding unrefined one exists
+
+fhir_analysis_invalid_func_as_var =
+    invalid use of function
+    .label = function not supported in this position

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2036,7 +2036,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                         rty::Expr::constant(rty::Constant::from(num)).at(espan)
                     }
                     ExprRes::GlobalFunc(..) => {
-                        span_bug!(var.span, "unexpected func in var position")
+                        Err(self.emit(errors::InvalidFuncAsVar { span: expr.span }))?
                     }
                     ExprRes::Ctor(..) => {
                         span_bug!(var.span, "unexpected constructor in var position")
@@ -2809,5 +2809,13 @@ mod errors {
     pub(super) struct FailToMatchPredicates {
         #[primary_span]
         pub span: Span,
+    }
+
+    #[derive(Diagnostic)]
+    #[diag(fhir_analysis_invalid_func_as_var, code = E0999)]
+    pub(super) struct InvalidFuncAsVar {
+        #[primary_span]
+        #[label]
+        pub(super) span: Span,
     }
 }

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2036,7 +2036,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                         rty::Expr::constant(rty::Constant::from(num)).at(espan)
                     }
                     ExprRes::GlobalFunc(..) => {
-                        Err(self.emit(errors::InvalidFuncAsVar { span: expr.span }))?
+                        Err(self.emit(errors::InvalidPosition { span: expr.span }))?
                     }
                     ExprRes::Ctor(..) => {
                         span_bug!(var.span, "unexpected constructor in var position")
@@ -2812,10 +2812,9 @@ mod errors {
     }
 
     #[derive(Diagnostic)]
-    #[diag(fhir_analysis_invalid_func_as_var, code = E0999)]
-    pub(super) struct InvalidFuncAsVar {
+    #[diag(fhir_analysis_invalid_position, code = E0999)]
+    pub(super) struct InvalidPosition {
         #[primary_span]
-        #[label]
         pub(super) span: Span,
     }
 }

--- a/crates/flux-syntax/src/lib.rs
+++ b/crates/flux-syntax/src/lib.rs
@@ -170,10 +170,6 @@ impl<'a> ParseCtxt<'a> {
         ParseError { kind, span: self.mk_span(lo, hi) }
     }
 
-    fn unsupported_callee(&self, span: Span) -> ParseError {
-        ParseError { kind: ParseErrorKind::UnsupportedCallee, span }
-    }
-
     fn unsupported_proj(&self, span: Span) -> ParseError {
         ParseError { kind: ParseErrorKind::UnsupportedProj, span }
     }
@@ -194,7 +190,6 @@ pub struct ParseError {
 pub enum ParseErrorKind {
     UnexpectedToken { expected: Vec<&'static str> },
     UnexpectedEof,
-    UnsupportedCallee,
     UnsupportedProj,
     CannotBeChained,
 }

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         Token::{self as Tok, Caret, CloseDelim, Comma, OpenDelim},
     },
     surface::{
-        AssocReft, Async, BaseSort, BaseTy, BaseTyKind, BinOp, BindKind, ConstArg, ConstArgKind,
+        Async, BaseSort, BaseTy, BaseTyKind, BinOp, BindKind, ConstArg, ConstArgKind,
         ConstructorArg, Ensures, Expr, ExprKind, ExprPath, ExprPathSegment, FieldExpr, FnInput,
         FnOutput, FnRetTy, FnSig, GenericArg, GenericArgKind, GenericBounds, GenericParam,
         GenericParamKind, Generics, Ident, ImplAssocReft, Indices, Item, LitKind, Mutability,
@@ -866,7 +866,7 @@ fn parse_atom(cx: &mut ParseCtxt, allow_struct: bool) -> ParseResult<Expr> {
         cx.expect(Tok::PathSep)?;
         let name = parse_ident(cx)?;
         let hi = cx.hi();
-        let kind = ExprKind::AssocReft(AssocReft { qself: Box::new(qself), path, name });
+        let kind = ExprKind::AssocReft(Box::new(qself), path, name);
         return Ok(Expr { kind, node_id: cx.next_node_id(), span: cx.mk_span(lo, hi) });
     } else if lookahead.peek([Tok::Exists, Tok::Forall]) {
         parse_bounded_quantifier(cx)

--- a/crates/flux-syntax/src/parser/utils.rs
+++ b/crates/flux-syntax/src/parser/utils.rs
@@ -60,7 +60,7 @@ pub(crate) fn punctuated_with_trailing<E: Peek, R>(
 /// Parses a list of zero or more items separated by a punctuation, with optional trailing
 /// punctuation. Parsing continues until the requested `end` token is reached. This does not
 /// consume the end token.
-pub(crate) fn punctuated<E: Peek, R>(
+pub(crate) fn punctuated_until<E: Peek, R>(
     cx: &mut ParseCtxt,
     sep: Token,
     end: E,
@@ -98,7 +98,7 @@ pub(crate) fn angle<R>(
     parse: impl FnMut(&mut ParseCtxt) -> ParseResult<R>,
 ) -> ParseResult<Vec<R>> {
     cx.expect(LAngle)?;
-    let items = punctuated(cx, sep, RAngle, parse)?;
+    let items = punctuated_until(cx, sep, RAngle, parse)?;
     cx.expect(RAngle)?;
     Ok(items)
 }
@@ -110,7 +110,7 @@ fn punctuated_delimited<R>(
     parse: impl FnMut(&mut ParseCtxt) -> ParseResult<R>,
 ) -> ParseResult<Vec<R>> {
     cx.expect(Token::OpenDelim(delim))?;
-    let r = punctuated(cx, sep, Token::CloseDelim(delim), parse)?;
+    let r = punctuated_until(cx, sep, Token::CloseDelim(delim), parse)?;
     cx.expect(Token::CloseDelim(delim))?;
     Ok(r)
 }

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -320,14 +320,6 @@ pub struct Ty {
     pub span: Span,
 }
 
-/// `<qself as path>::name`
-#[derive(Debug)]
-pub struct AssocReft {
-    pub qself: Box<Ty>,
-    pub path: Path,
-    pub name: Ident,
-}
-
 #[derive(Debug)]
 pub enum TyKind {
     /// ty
@@ -510,7 +502,8 @@ pub enum ExprKind {
     BinaryOp(BinOp, Box<[Expr; 2]>),
     UnaryOp(UnOp, Box<Expr>),
     Call(Box<Expr>, Vec<Expr>),
-    AssocReft(AssocReft),
+    /// `<qself as path>::name`
+    AssocReft(Box<Ty>, Path, Ident),
     IfThenElse(Box<[Expr; 3]>),
     Constructor(Option<ExprPath>, Vec<ConstructorArg>),
     BoundedQuant(QuantKind, RefineParam, Range<usize>, Box<Expr>),

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -322,7 +322,7 @@ pub struct Ty {
 
 /// `<qself as path>::name`
 #[derive(Debug)]
-pub struct AliasReft {
+pub struct AssocReft {
     pub qself: Box<Ty>,
     pub path: Path,
     pub name: Ident,
@@ -509,8 +509,8 @@ pub enum ExprKind {
     Literal(Lit),
     BinaryOp(BinOp, Box<[Expr; 2]>),
     UnaryOp(UnOp, Box<Expr>),
-    App(Ident, Vec<Expr>),
-    Alias(AliasReft, Vec<Expr>),
+    Call(Box<Expr>, Vec<Expr>),
+    AssocReft(AssocReft),
     IfThenElse(Box<[Expr; 3]>),
     Constructor(Option<ExprPath>, Vec<ConstructorArg>),
     BoundedQuant(QuantKind, RefineParam, Range<usize>, Box<Expr>),

--- a/crates/flux-syntax/src/surface/visit.rs
+++ b/crates/flux-syntax/src/surface/visit.rs
@@ -1,12 +1,11 @@
 use rustc_span::symbol::Ident;
 
 use super::{
-    AssocReft, Async, BaseSort, BaseTy, BaseTyKind, ConstArg, ConstantInfo, ConstructorArg,
-    Ensures, EnumDef, Expr, ExprKind, ExprPath, ExprPathSegment, FieldExpr, FnInput, FnOutput,
-    FnRetTy, FnSig, GenericArg, GenericArgKind, GenericParam, Generics, Impl, ImplAssocReft,
-    Indices, Lit, Path, PathSegment, Qualifier, RefineArg, RefineParam, Sort, SortPath, SpecFunc,
-    StructDef, Trait, TraitAssocReft, TraitRef, Ty, TyAlias, TyKind, VariantDef, VariantRet,
-    WhereBoundPredicate,
+    Async, BaseSort, BaseTy, BaseTyKind, ConstArg, ConstantInfo, ConstructorArg, Ensures, EnumDef,
+    Expr, ExprKind, ExprPath, ExprPathSegment, FieldExpr, FnInput, FnOutput, FnRetTy, FnSig,
+    GenericArg, GenericArgKind, GenericParam, Generics, Impl, ImplAssocReft, Indices, Lit, Path,
+    PathSegment, Qualifier, RefineArg, RefineParam, Sort, SortPath, SpecFunc, StructDef, Trait,
+    TraitAssocReft, TraitRef, Ty, TyAlias, TyKind, VariantDef, VariantRet, WhereBoundPredicate,
 };
 
 #[macro_export]
@@ -163,10 +162,6 @@ pub trait Visitor: Sized {
             ConstructorArg::FieldExpr(field_expr) => walk_field_expr(self, field_expr),
             ConstructorArg::Spread(spread) => self.visit_expr(&spread.expr),
         }
-    }
-
-    fn visit_assoc_reft(&mut self, assoc_reft: &AssocReft) {
-        walk_assoc_reft(self, assoc_reft);
     }
 
     fn visit_path_expr(&mut self, qpath: &ExprPath) {
@@ -481,12 +476,6 @@ pub fn walk_path_segment<V: Visitor>(vis: &mut V, segment: &PathSegment) {
     walk_list!(vis, visit_generic_arg, &segment.args);
 }
 
-pub fn walk_assoc_reft<V: Visitor>(vis: &mut V, alias: &AssocReft) {
-    vis.visit_ty(&alias.qself);
-    vis.visit_path(&alias.path);
-    vis.visit_ident(alias.name);
-}
-
 pub fn walk_field_expr<V: Visitor>(vis: &mut V, expr: &FieldExpr) {
     vis.visit_ident(expr.ident);
     vis.visit_expr(&expr.expr);
@@ -512,8 +501,10 @@ pub fn walk_expr<V: Visitor>(vis: &mut V, expr: &Expr) {
             vis.visit_expr(callee);
             walk_list!(vis, visit_expr, args);
         }
-        ExprKind::AssocReft(assoc_reft) => {
-            vis.visit_assoc_reft(assoc_reft);
+        ExprKind::AssocReft(qself, path, name) => {
+            vis.visit_ty(qself);
+            vis.visit_path(path);
+            vis.visit_ident(*name);
         }
         ExprKind::IfThenElse(box exprs) => {
             walk_list!(vis, visit_expr, exprs);

--- a/crates/flux-syntax/src/surface/visit.rs
+++ b/crates/flux-syntax/src/surface/visit.rs
@@ -1,7 +1,7 @@
 use rustc_span::symbol::Ident;
 
 use super::{
-    AliasReft, Async, BaseSort, BaseTy, BaseTyKind, ConstArg, ConstantInfo, ConstructorArg,
+    AssocReft, Async, BaseSort, BaseTy, BaseTyKind, ConstArg, ConstantInfo, ConstructorArg,
     Ensures, EnumDef, Expr, ExprKind, ExprPath, ExprPathSegment, FieldExpr, FnInput, FnOutput,
     FnRetTy, FnSig, GenericArg, GenericArgKind, GenericParam, Generics, Impl, ImplAssocReft,
     Indices, Lit, Path, PathSegment, Qualifier, RefineArg, RefineParam, Sort, SortPath, SpecFunc,
@@ -165,8 +165,8 @@ pub trait Visitor: Sized {
         }
     }
 
-    fn visit_alias_pred(&mut self, alias_pred: &AliasReft) {
-        walk_alias_pred(self, alias_pred);
+    fn visit_assoc_reft(&mut self, assoc_reft: &AssocReft) {
+        walk_assoc_reft(self, assoc_reft);
     }
 
     fn visit_path_expr(&mut self, qpath: &ExprPath) {
@@ -481,7 +481,7 @@ pub fn walk_path_segment<V: Visitor>(vis: &mut V, segment: &PathSegment) {
     walk_list!(vis, visit_generic_arg, &segment.args);
 }
 
-pub fn walk_alias_pred<V: Visitor>(vis: &mut V, alias: &AliasReft) {
+pub fn walk_assoc_reft<V: Visitor>(vis: &mut V, alias: &AssocReft) {
     vis.visit_ty(&alias.qself);
     vis.visit_path(&alias.path);
     vis.visit_ident(alias.name);
@@ -508,13 +508,12 @@ pub fn walk_expr<V: Visitor>(vis: &mut V, expr: &Expr) {
         ExprKind::UnaryOp(_bin_op, e) => {
             vis.visit_expr(e);
         }
-        ExprKind::App(fun, exprs) => {
-            vis.visit_ident(*fun);
-            walk_list!(vis, visit_expr, exprs);
-        }
-        ExprKind::Alias(alias_pred, args) => {
-            vis.visit_alias_pred(alias_pred);
+        ExprKind::Call(callee, args) => {
+            vis.visit_expr(callee);
             walk_list!(vis, visit_expr, args);
+        }
+        ExprKind::AssocReft(assoc_reft) => {
+            vis.visit_assoc_reft(assoc_reft);
         }
         ExprKind::IfThenElse(box exprs) => {
             walk_list!(vis, visit_expr, exprs);

--- a/tests/tests/neg/error_messages/conv/invalid_position.rs
+++ b/tests/tests/neg/error_messages/conv/invalid_position.rs
@@ -1,0 +1,14 @@
+use flux_rs::attrs::*;
+
+defs! {
+    fn add1(x: int) -> int {
+        x + 1
+    }
+}
+
+#[opaque]
+#[refined_by(p: int -> int)]
+struct S;
+
+#[sig(fn(S[add1]))] //~ ERROR expression not allowed in this position
+fn test(x: S) {}

--- a/tests/tests/neg/error_messages/desugar/invalid_position.rs
+++ b/tests/tests/neg/error_messages/desugar/invalid_position.rs
@@ -1,0 +1,11 @@
+use flux_rs::attrs::*;
+
+defs! {
+    fn test00() -> int {
+        1(0) //~ ERROR expression not allowed in this position
+    }
+
+    fn test01() -> int {
+        <Self as Trait>::assoc + 1 //~ ERROR expression not allowed in this position
+    }
+}

--- a/tests/tests/neg/error_messages/wf/badd_fun_app.rs
+++ b/tests/tests/neg/error_messages/wf/badd_fun_app.rs
@@ -1,0 +1,9 @@
+use flux_rs::attrs::*;
+
+const N: i32 = 0;
+
+defs! {
+    fn foo() -> int {
+        N(0) //~ ERROR expected function, found `int`
+    }
+}


### PR DESCRIPTION
This simplifies the parser and name resolution. Function calls are put into a more restricted syntax during desugaring.