### PR TITLE
Cleanup encoding of functions

### DIFF
--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2030,8 +2030,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                     ExprRes::Param(..) => env.lookup(&var).to_expr(),
                     ExprRes::Const(def_id) => {
                         if P::HAS_ELABORATED_INFORMATION {
-                            let info = self.genv().constant_info(def_id)?;
-                            rty::Expr::const_def_id(def_id, info).at(espan)
+                            rty::Expr::const_def_id(def_id).at(espan)
                         } else {
                             let Some(sort) = self.genv().sort_of_def_id(def_id)? else {
                                 span_bug!(expr.span, "missing sort for const {def_id:?}");

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -105,9 +105,7 @@ fn try_normalized_defns(genv: GlobalEnv) -> Result<rty::NormalizedDefns, ErrorGu
         };
 
         if let Some(defn) = defn {
-            // inline all polymorphic definitions, as they cannot be `define-fun`ed in SMT
-            let inline = !genv.is_define_fun(func.def_id.to_def_id());
-            defns.push((func.def_id, defn, inline, func.hide));
+            defns.push((func.def_id, defn, func.hide));
         }
     }
     errors.into_result()?;

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -355,7 +355,7 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
             ExprRes::ConstGeneric(_) => Ok(rty::Sort::Int), // TODO: generalize generic-const sorts
             ExprRes::NumConst(_) => Ok(rty::Sort::Int),
             ExprRes::GlobalFunc(SpecFuncKind::Def(name) | SpecFuncKind::Uif(name)) => {
-                Ok(rty::Sort::Func(self.genv.func_sort(name).emit(&self.genv)?))
+                Ok(rty::Sort::Func(self.genv.func_sort(name)))
             }
             ExprRes::GlobalFunc(SpecFuncKind::Thy(itf)) => {
                 Ok(rty::Sort::Func(THEORY_FUNCS.get(&itf).unwrap().sort.clone()))

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -1299,7 +1299,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
     /// Where `<=` is the (interpreted) less than or equal relation between integers and `le` is
     /// an uninterpreted relation between ([the encoding] of) lambdas.
     ///
-    /// [the encoding]: Self::register_const_for_lambda
+    /// [the encoding]: Self::define_const_for_lambda
     fn bin_rel_to_fixpoint(
         &mut self,
         sort: &rty::Sort,
@@ -1554,7 +1554,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                 let sort = scx.func_sort_to_fixpoint(&self.genv.func_sort(did));
                 consts.push(fixpoint::ConstDecl { name, sort, comment: Some(comment) });
             } else {
-                let out = scx.sort_to_fixpoint(&self.genv.func_sort(did).expect_mono().output());
+                let out = scx.sort_to_fixpoint(self.genv.func_sort(did).expect_mono().output());
                 let (args, body) = self.body_to_fixpoint(&info.body, scx)?;
                 let fun_def = fixpoint::FunDef { name, args, body, out, comment: Some(comment) };
                 defs.push((info.rank, fun_def));

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -162,13 +162,13 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         Ok(reveals.iter().copied())
     }
 
-    pub fn func_sort(self, def_id: FluxDefId) -> QueryResult<rty::PolyFuncSort> {
+    pub fn func_sort(self, def_id: FluxDefId) -> rty::PolyFuncSort {
         self.inner.queries.func_sort(self, def_id)
     }
 
-    pub fn is_define_fun(self, def_id: FluxDefId) -> QueryResult<bool> {
-        let is_mono = self.func_sort(def_id)?.params().len() == 0;
-        Ok(is_mono && flux_config::smt_define_fun())
+    pub fn is_define_fun(self, def_id: FluxDefId) -> bool {
+        let is_mono = self.func_sort(def_id).params().len() == 0;
+        is_mono && flux_config::smt_define_fun()
     }
 
     pub fn variances_of(self, did: DefId) -> &'tcx [Variance] {

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -166,9 +166,9 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         self.inner.queries.func_sort(self, def_id)
     }
 
-    pub fn is_define_fun(self, def_id: FluxDefId) -> bool {
-        let is_mono = self.func_sort(def_id).params().len() == 0;
-        is_mono && flux_config::smt_define_fun()
+    pub fn should_inline_fun(self, def_id: FluxDefId) -> bool {
+        let is_poly = self.func_sort(def_id).params().len() > 0;
+        is_poly || !flux_config::smt_define_fun()
     }
 
     pub fn variances_of(self, did: DefId) -> &'tcx [Variance] {
@@ -596,7 +596,7 @@ impl<'genv, 'tcx> Map<'genv, 'tcx> {
         }
     }
 
-    pub fn fn_reveals_for(self, def_id: LocalDefId) -> QueryResult<&'genv [FluxDefId]> {
+    fn fn_reveals_for(self, def_id: LocalDefId) -> QueryResult<&'genv [FluxDefId]> {
         if let Some(fn_sig) = self.expect_owner_node(def_id)?.fn_sig() {
             Ok(fn_sig.reveals)
         } else {

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -22,8 +22,8 @@ use rustc_target::abi::FieldIdx;
 use rustc_type_ir::{BoundVar, DebruijnIndex, INNERMOST};
 
 use super::{
-    BaseTy, Binder, BoundReftKind, BoundVariableKinds, ConstantInfo, FuncSort, GenericArgs,
-    GenericArgsExt as _, IntTy, Sort, UintTy,
+    BaseTy, Binder, BoundReftKind, BoundVariableKinds, FuncSort, GenericArgs, GenericArgsExt as _,
+    IntTy, Sort, UintTy,
 };
 use crate::{
     big_int::BigInt,
@@ -231,8 +231,8 @@ impl Expr {
         ExprKind::Constant(c).intern()
     }
 
-    pub fn const_def_id(c: DefId, info: ConstantInfo) -> Expr {
-        ExprKind::ConstDefId(c, info).intern()
+    pub fn const_def_id(c: DefId) -> Expr {
+        ExprKind::ConstDefId(c).intern()
     }
 
     pub fn const_generic(param: ParamConst) -> Expr {
@@ -662,7 +662,7 @@ pub enum ExprKind {
     Var(Var),
     Local(Local),
     Constant(Constant),
-    ConstDefId(DefId, ConstantInfo),
+    ConstDefId(DefId),
     BinaryOp(BinOp, Expr, Expr),
     GlobalFunc(SpecFuncKind),
     UnaryOp(UnOp, Expr),
@@ -1229,7 +1229,7 @@ pub(crate) mod pretty {
             match e.kind() {
                 ExprKind::Var(var) => w!(cx, f, "{:?}", var),
                 ExprKind::Local(local) => w!(cx, f, "{:?}", ^local),
-                ExprKind::ConstDefId(did, _) => w!(cx, f, "{}", ^def_id_to_string(*did)),
+                ExprKind::ConstDefId(did) => w!(cx, f, "{}", ^def_id_to_string(*did)),
                 ExprKind::Constant(c) => w!(cx, f, "{:?}", c),
                 ExprKind::BinaryOp(op, e1, e2) => {
                     if should_parenthesize(op, e1) {

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -893,7 +893,7 @@ impl TypeSuperVisitable for Expr {
             | ExprKind::Hole(_)
             | ExprKind::Local(_)
             | ExprKind::GlobalFunc(..)
-            | ExprKind::ConstDefId(_, _) => ControlFlow::Continue(()),
+            | ExprKind::ConstDefId(_) => ControlFlow::Continue(()),
         }
     }
 }
@@ -911,7 +911,7 @@ impl TypeSuperFoldable for Expr {
             ExprKind::Var(var) => Expr::var(*var),
             ExprKind::Local(local) => Expr::local(*local),
             ExprKind::Constant(c) => Expr::constant(*c),
-            ExprKind::ConstDefId(did, info) => Expr::const_def_id(*did, info.clone()),
+            ExprKind::ConstDefId(did) => Expr::const_def_id(*did),
             ExprKind::BinaryOp(op, e1, e2) => {
                 Expr::binary_op(
                     op.try_fold_with(folder)?,

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1071,14 +1071,6 @@ impl PolyFuncSort {
     pub fn instantiate(&self, args: &[SortArg]) -> FuncSort {
         self.fsort.fold_with(&mut SortSubst::new(args))
     }
-
-    pub fn arity(&self) -> usize {
-        self.params
-            .iter()
-            .filter(|kind| matches!(kind, SortParamKind::Sort))
-            .collect_vec()
-            .len()
-    }
 }
 
 /// An argument for a generic parameter in a [`Sort`] which can be either a generic sort or a

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -1065,7 +1065,7 @@ fn parse_int<T: FromStr>(cx: &mut ParseCtxt) -> ParseResult<T> {
     Err(cx.unexpected_token(vec![std::any::type_name::<T>()]))
 }
 
-/// `text
+/// ```text
 /// ⟨sort⟩ :=  ⟨base_sort⟩
 ///         |  ( ⟨base_sort⟩,* ) -> ⟨base_sort⟩
 ///         |  ⟨base_sort⟩ -> ⟨base_sort⟩

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -116,7 +116,7 @@ macro_rules! declare_types {
             pub type Constraint = $crate::Constraint<FixpointTypes>;
             pub type KVarDecl = $crate::KVarDecl<FixpointTypes>;
             pub type ConstDecl = $crate::ConstDecl<FixpointTypes>;
-            pub type FunDecl = $crate::FunDef<FixpointTypes>;
+            pub type FunDef = $crate::FunDef<FixpointTypes>;
             pub type Task = $crate::Task<FixpointTypes>;
             pub type Qualifier = $crate::Qualifier<FixpointTypes>;
             pub type Sort = $crate::Sort<FixpointTypes>;


### PR DESCRIPTION
Various simplifications to how we encode functions when there are hidden or when `FLUX_SMT_DEFINE_FUN` is set