### PR TITLE
Work around silly fixpoint parser bug

### DIFF
--- a/book/src/dev/use.md
+++ b/book/src/dev/use.md
@@ -70,6 +70,25 @@ Like `&mut T` but which allow _strong updates_ via `ensures` clauses
 
 ## Requires Clauses
 
+Used to specify preconditions in a single spot, if needed.
+
 ```rust
 {{#include ../../../tests/tests/pos/surface/test01_where.rs}}
+```
+
+## Requires with `forall`
+
+We allow a `forall` on the requires clauses, e.g.
+
+```rust
+{{#include ../../../tests/tests/pos/surface/forall01.rs}}
+```
+
+
+## Pragma: `ignore`
+
+Used to tell `flux` to *ignore* (checking) a bunch of definitions.
+
+```rust
+{{#include ../../../tests/tests/neg/surface/ignore02.rs}}
 ```

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -106,7 +106,7 @@ pub mod fixpoint {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
                 Var::Global(v, None) => write!(f, "c{}", v.as_u32()),
-                Var::Global(v, Some(sym)) => write!(f, "{}${}", sym, v.as_u32()),
+                Var::Global(v, Some(sym)) => write!(f, "f${}${}", sym, v.as_u32()),
                 Var::Local(v) => write!(f, "a{}", v.as_u32()),
                 Var::DataCtor(adt_id, variant_idx) => {
                     write!(f, "mkadt{}${}", adt_id.as_u32(), variant_idx.as_u32())

--- a/tests/tests/pos/surface/forall01.rs
+++ b/tests/tests/pos/surface/forall01.rs
@@ -1,5 +1,4 @@
 #[flux::sig(fn(bool[true]))]
-
 fn assert(_: bool) {}
 #[flux::sig(
     fn(x: i32)


### PR DESCRIPTION
Add a `f$` in front of function names to work around

https://github.com/ucsd-progsys/liquid-fixpoint/issues/750 