### PR TITLE
Some (blocked) progress on a spec for `.map()` and `.collect()`

### DIFF
--- a/book/src/dev/develop.md
+++ b/book/src/dev/develop.md
@@ -133,3 +133,11 @@ cargo x install --debug
 FLUX_DUMP_CHECKER_TRACE=1 FLUX_CHECK_DEF=mickey cargo flux
 python3  path/to/flux/tools/logreader.py
 ```
+
+## Debugging Extern Specs
+
+To see the expanded code of an `extern_spec` macro, you can do
+
+```
+cargo x expand path/to/file.rs
+```

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -520,6 +520,7 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
         let infcx = genv
             .tcx()
             .infer_ctxt()
+            .with_next_trait_solver(true)
             .build(TypingMode::non_body_analysis());
         if let Some(def_id) = owner.def_id()
             && let Ok(sort) = sort.normalize_sorts(def_id.into(), genv, &infcx)

--- a/crates/flux-infer/src/projections.rs
+++ b/crates/flux-infer/src/projections.rs
@@ -686,3 +686,7 @@ fn normalize_projection_ty_with_rustc<'tcx>(
             .expect_base(),
     ))
 }
+
+fn test_map_slice(slice: &[u8]) -> Vec<u8> {
+    slice.iter().map(|n| n + 2).collect()
+}

--- a/crates/flux-infer/src/projections.rs
+++ b/crates/flux-infer/src/projections.rs
@@ -686,7 +686,3 @@ fn normalize_projection_ty_with_rustc<'tcx>(
             .expect_base(),
     ))
 }
-
-fn test_map_slice(slice: &[u8]) -> Vec<u8> {
-    slice.iter().map(|n| n + 2).collect()
-}

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -325,6 +325,7 @@ pub(crate) fn trait_impl_subtyping<'genv, 'tcx>(
     let rustc_infcx = genv
         .tcx()
         .infer_ctxt()
+        .with_next_trait_solver(true)
         .build(TypingMode::non_body_analysis());
 
     let mut root_ctxt = genv

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1393,7 +1393,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             && let (deref_ty, alloc_ty) = args.box_args()
             && let TyKind::Indexed(BaseTy::Array(arr_ty, arr_len), _) = deref_ty.kind()
         {
-            let idx = Expr::from_const(self.genv.tcx(), arr_len);
+            let idx = Expr::from_const(self.genv.tcx(), &arr_len);
             Ok(Ty::mk_box(
                 self.genv,
                 Ty::indexed(BaseTy::Slice(arr_ty.clone()), idx),

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1393,7 +1393,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             && let (deref_ty, alloc_ty) = args.box_args()
             && let TyKind::Indexed(BaseTy::Array(arr_ty, arr_len), _) = deref_ty.kind()
         {
-            let idx = Expr::from_const(self.genv.tcx(), &arr_len);
+            let idx = Expr::from_const(self.genv.tcx(), arr_len);
             Ok(Ty::mk_box(
                 self.genv,
                 Ty::indexed(BaseTy::Slice(arr_ty.clone()), idx),

--- a/crates/flux-refineck/src/compare_impl_item.rs
+++ b/crates/flux-refineck/src/compare_impl_item.rs
@@ -39,6 +39,7 @@ pub fn check_impl_against_trait(genv: GlobalEnv, impl_id: MaybeExternId) -> Quer
     let rustc_infcx = genv
         .tcx()
         .infer_ctxt()
+        .with_next_trait_solver(true)
         .build(TypingMode::non_body_analysis());
     let mut root_ctxt = genv
         .infcx_root(&rustc_infcx, genv.infer_opts(impl_id.local_id()))

--- a/crates/flux-refineck/src/invariants.rs
+++ b/crates/flux-refineck/src/invariants.rs
@@ -52,6 +52,7 @@ fn check_invariant(
     let region_infercx = genv
         .tcx()
         .infer_ctxt()
+        .with_next_trait_solver(true)
         .build(TypingMode::non_body_analysis());
 
     let mut infcx_root = try_query(|| {

--- a/crates/flux-rustc-bridge/src/lowering.rs
+++ b/crates/flux-rustc-bridge/src/lowering.rs
@@ -109,7 +109,7 @@ pub fn resolve_trait_ref_impl_id<'tcx>(
     let param_env = tcx.param_env(def_id);
     let infcx = tcx
         .infer_ctxt()
-        // .with_next_trait_solver(true) TODO: breaks test `mismatched_generics.rs` ???
+        .with_next_trait_solver(true)
         .build(TypingMode::non_body_analysis());
     trait_ref_impl_id(tcx, &mut SelectionContext::new(&infcx), param_env, trait_ref)
 }

--- a/crates/flux-rustc-bridge/src/lowering.rs
+++ b/crates/flux-rustc-bridge/src/lowering.rs
@@ -107,7 +107,10 @@ pub fn resolve_trait_ref_impl_id<'tcx>(
     trait_ref: rustc_ty::TraitRef<'tcx>,
 ) -> Option<(DefId, rustc_middle::ty::GenericArgsRef<'tcx>)> {
     let param_env = tcx.param_env(def_id);
-    let infcx = tcx.infer_ctxt().build(TypingMode::non_body_analysis());
+    let infcx = tcx
+        .infer_ctxt()
+        // .with_next_trait_solver(true) TODO: breaks test `mismatched_generics.rs` ???
+        .build(TypingMode::non_body_analysis());
     trait_ref_impl_id(tcx, &mut SelectionContext::new(&infcx), param_env, trait_ref)
 }
 

--- a/crates/flux-rustc-bridge/src/mir.rs
+++ b/crates/flux-rustc-bridge/src/mir.rs
@@ -488,6 +488,7 @@ pub(crate) fn replicate_infer_ctxt<'tcx>(
 ) -> rustc_infer::infer::InferCtxt<'tcx> {
     let infcx = tcx
         .infer_ctxt()
+        .with_next_trait_solver(true)
         .build(TypingMode::analysis_in_body(tcx, def_id));
     for info in &body_with_facts.region_inference_context.var_infos {
         infcx.next_region_var(info.origin);

--- a/tests/tests/lib/iter.rs
+++ b/tests/tests/lib/iter.rs
@@ -10,7 +10,7 @@ struct Iter<'a, T>;
 struct Enumerate<I>;
 
 #[extern_spec(std::iter)]
-#[refined_by(len: int)]
+#[refined_by(inner: I)]
 struct Map<I, F>;
 
 #[extern_spec]
@@ -31,7 +31,7 @@ trait Iterator {
     where
         Self: Sized;
 
-    #[flux::sig(fn(Self[@s], f: F) -> Map<Self, F>[<Self as Iterator>::size(s)])]
+    #[flux::sig(fn(Self[@s], f: F) -> Map<Self, F>[s])]
     fn map<B, F>(self, f: F) -> Map<Self, F>
     where
         Self: Sized,
@@ -63,3 +63,10 @@ impl<I: Iterator> Iterator for Enumerate<I> {
     ensures self: Enumerate<I>{next_s: curr_s.idx + 1 == next_s.idx && <I as Iterator>::step(curr_s.inner, next_s.inner)})]
     fn next(&mut self) -> Option<(usize, <I as Iterator>::Item)>;
 }
+
+#[extern_spec(std::iter)]
+#[flux::generics(I as base)]
+#[flux::assoc(fn size(x: Map<I>) -> int { <I as Iterator>::size(x.inner) })]
+#[flux::assoc(fn done(x: Map<I>) -> bool { <I as Iterator>::done(x.inner)})]
+#[flux::assoc(fn step(x: Map<I>, y: Enumerate<I>) -> bool { <I as Iterator>::step(x.inner, y.inner)})]
+impl<B, I: Iterator, F> Iterator for Map<I, F> {} // where F: FnMut(I::Item) -> B {}

--- a/tests/tests/lib/iter.rs
+++ b/tests/tests/lib/iter.rs
@@ -44,11 +44,6 @@ trait Iterator {
         Self: Sized;
 }
 
-//    #[flux::sig(fn(Self[@s]) -> Map<Self, F>[<Self as Iterator>::size(s)])]
-//    fn collect<B: FromIterator<Self::Item>>(self) -> B
-//    where
-//        Self: Sized;
-
 #[extern_spec(std::slice)]
 #[flux::assoc(fn size(x: Iter) -> int { x.len - x.idx })]
 #[flux::assoc(fn done(x: Iter) -> bool { x.idx >= x.len })]

--- a/tests/tests/lib/iter.rs
+++ b/tests/tests/lib/iter.rs
@@ -11,6 +11,7 @@ struct Enumerate<I>;
 
 #[extern_spec(std::iter)]
 #[flux::generics(Self as base)]
+#[flux::assoc(fn size(self: Self) -> int { 0 - 1 })] // junk default!
 #[flux::assoc(fn done(self: Self) -> bool )]
 #[flux::assoc(fn step(self: Self, other: Self) -> bool )]
 trait Iterator {
@@ -24,6 +25,7 @@ trait Iterator {
 }
 
 #[extern_spec(std::slice)]
+#[flux::assoc(fn size(x: Iter) -> int { x.len - x.idx })]
 #[flux::assoc(fn done(x: Iter) -> bool { x.idx >= x.len })]
 #[flux::assoc(fn step(x: Iter, y: Iter) -> bool { x.idx + 1 == y.idx && x.len == y.len})]
 impl<'a, T> Iterator for Iter<'a, T> {
@@ -33,6 +35,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
 #[extern_spec(std::iter)]
 #[flux::generics(I as base)]
+#[flux::assoc(fn size(x: Enumerate<I>) -> int { <I as Iterator>::size(x.inner) })]
 #[flux::assoc(fn done(x: Enumerate<I>) -> bool { <I as Iterator>::done(x.inner)})]
 #[flux::assoc(fn step(x: Enumerate<I>, y: Enumerate<I>) -> bool { <I as Iterator>::step(x.inner, y.inner)})]
 impl<I: Iterator> Iterator for Enumerate<I> {

--- a/tests/tests/lib/iter.rs
+++ b/tests/tests/lib/iter.rs
@@ -68,5 +68,5 @@ impl<I: Iterator> Iterator for Enumerate<I> {
 #[flux::generics(I as base)]
 #[flux::assoc(fn size(x: Map<I>) -> int { <I as Iterator>::size(x.inner) })]
 #[flux::assoc(fn done(x: Map<I>) -> bool { <I as Iterator>::done(x.inner)})]
-#[flux::assoc(fn step(x: Map<I>, y: Enumerate<I>) -> bool { <I as Iterator>::step(x.inner, y.inner)})]
-impl<B, I: Iterator, F> Iterator for Map<I, F> {} // where F: FnMut(I::Item) -> B {}
+#[flux::assoc(fn step(x: Map<I>, y: Map<I>) -> bool { <I as Iterator>::step(x.inner, y.inner)})]
+impl<B, I: Iterator, F: FnMut(I::Item) -> B> Iterator for Map<I, F> {} // orig: where F: FnMut(I::Item) -> B {}

--- a/tests/tests/lib/iter.rs
+++ b/tests/tests/lib/iter.rs
@@ -18,8 +18,7 @@ struct Map<I, F>;
 trait FromIterator<A> {}
 
 #[extern_spec(std::iter)]
-#[flux::generics(Self as base)]
-#[flux::assoc(fn size(self: Self) -> int { 0 - 1 })] // TODO: junk default; should use option or UIF
+#[flux::assoc(fn size(self: Self) -> int)]
 #[flux::assoc(fn done(self: Self) -> bool )]
 #[flux::assoc(fn step(self: Self, other: Self) -> bool )]
 trait Iterator {
@@ -37,7 +36,6 @@ trait Iterator {
         Self: Sized,
         F: FnMut(Self::Item) -> B;
 
-    #[flux::generics(B as base)]
     #[flux::sig(fn (Self[@s]) -> B{v: <B as FromIterator<Self::Item>>::with_size(v, <Self as Iterator>::size(s))})]
     fn collect<B: FromIterator<Self::Item>>(self) -> B
     where
@@ -54,7 +52,6 @@ impl<'a, T> Iterator for Iter<'a, T> {
 }
 
 #[extern_spec(std::iter)]
-#[flux::generics(I as base)]
 #[flux::assoc(fn size(x: Enumerate<I>) -> int { <I as Iterator>::size(x.inner) })]
 #[flux::assoc(fn done(x: Enumerate<I>) -> bool { <I as Iterator>::done(x.inner)})]
 #[flux::assoc(fn step(x: Enumerate<I>, y: Enumerate<I>) -> bool { <I as Iterator>::step(x.inner, y.inner)})]
@@ -65,7 +62,6 @@ impl<I: Iterator> Iterator for Enumerate<I> {
 }
 
 #[extern_spec(std::iter)]
-#[flux::generics(I as base)]
 #[flux::assoc(fn size(x: Map<I>) -> int { <I as Iterator>::size(x.inner) })]
 #[flux::assoc(fn done(x: Map<I>) -> bool { <I as Iterator>::done(x.inner)})]
 #[flux::assoc(fn step(x: Map<I>, y: Map<I>) -> bool { <I as Iterator>::step(x.inner, y.inner)})]

--- a/tests/tests/lib/iterator.rs
+++ b/tests/tests/lib/iterator.rs
@@ -29,7 +29,6 @@ struct Zip<A, B>;
 struct Iter<'a, T>;
 
 #[flux_rs::extern_spec(std::iter)]
-#[flux_rs::generics(Self as base)]
 #[flux_rs::assoc(fn done(self: Self) -> bool  )]
 #[flux_rs::assoc(fn step(self: Self, other: Self) -> bool )]
 trait Iterator {
@@ -57,7 +56,6 @@ impl<'a, T> Iterator for Iter<'a, T> {
 }
 
 #[flux_rs::extern_spec(core::iter)]
-#[generics(I as base)]
 #[flux_rs::assoc(fn done(r: Enumerate<I>) -> bool { <I as Iterator>::done(r.inner) } )]
 #[flux_rs::assoc(fn step(self: Enumerate<I>, other: Enumerate<I>) -> bool { self.idx + 1 == other.idx } )]
 impl<I: Iterator> Iterator for Enumerate<I> {
@@ -66,7 +64,6 @@ impl<I: Iterator> Iterator for Enumerate<I> {
 }
 
 #[flux_rs::extern_spec(core::iter)]
-#[generics(I as base)]
 #[flux_rs::assoc(fn done(r: Skip<I>) -> bool { <I as Iterator>::done(r.inner) } )]
 #[flux_rs::assoc(fn step(self: Skip<I>, other: Skip<I>) -> bool { <I as Iterator>::step(self.inner, other.inner) } )]
 impl<I: Iterator> Iterator for Skip<I> {
@@ -84,7 +81,6 @@ impl<A: Iterator, B: Iterator> Iterator for Zip<A, B> {
 }
 
 #[flux_rs::extern_spec(std::iter)]
-#[generics(Self as base)]
 trait IntoIterator {
     #[flux_rs::sig(fn(self: Self) -> Self::IntoIter)]
     fn into_iter(self) -> Self::IntoIter
@@ -93,7 +89,6 @@ trait IntoIterator {
 }
 
 #[flux_rs::extern_spec(core::ops)]
-#[generics(I as base)]
 impl<I: Iterator> IntoIterator for I {
     #[flux_rs::sig(fn(self: I[@s]) -> I[s])]
     fn into_iter(self) -> I;

--- a/tests/tests/lib/vec.rs
+++ b/tests/tests/lib/vec.rs
@@ -23,14 +23,12 @@ where
 impl<T> SliceIndex<[T]> for usize {}
 
 #[extern_spec]
-#[flux::generics(I as base)]
 impl<T, I: SliceIndex<[T]>, A: Allocator> Index<I> for Vec<T, A> {
     #[flux::sig(fn(&Vec<T, A>[@len], {I[@idx] | <I as SliceIndex<[T]>>::in_bounds(idx, len)}) -> _)]
     fn index(z: &Vec<T, A>, index: I) -> &<I as SliceIndex<[T]>>::Output;
 }
 
 #[extern_spec]
-#[flux::generics(I as base)]
 impl<T, I: SliceIndex<[T]>, A: Allocator> IndexMut<I> for Vec<T, A> {
     #[flux::sig(fn(&mut Vec<T,A>[@len], {I[@idx] | <I as SliceIndex<[T]>>::in_bounds(idx, len)}) -> _)]
     fn index_mut(z: &mut Vec<T, A>, index: I) -> &mut <I as SliceIndex<[T]>>::Output;

--- a/tests/tests/lib/vec.rs
+++ b/tests/tests/lib/vec.rs
@@ -58,3 +58,7 @@ impl<'a, T, A: Allocator> IntoIterator for &'a Vec<T, A> {
     #[flux::sig(fn (&Vec<T, A>[@n]) -> <&Vec<T, A> as IntoIterator>::IntoIter[0,n])]
     fn into_iter(v: &'a Vec<T, A>) -> <&'a Vec<T, A> as IntoIterator>::IntoIter;
 }
+
+#[extern_spec]
+#[flux::assoc(fn with_size(self: Self, n:int) -> bool { self.len == n })]
+impl<T> FromIterator<T> for Vec<T> {}

--- a/tests/tests/neg/error_messages/extern_specs/mismatched_generics.rs
+++ b/tests/tests/neg/error_messages/extern_specs/mismatched_generics.rs
@@ -1,4 +1,6 @@
 //@aux-build:mismatched_generics_aux.rs
+#![feature(step_trait)]
+use std::iter::Step;
 
 extern crate mismatched_generics_aux;
 
@@ -10,4 +12,4 @@ struct S<T>; //~ERROR invalid extern spec for struct
 
 // The parameter should be called A
 #[extern_spec(std::ops)]
-impl<T> Iterator for Range<T> {} //~ERROR invalid extern spec for implementation
+impl<T: Step> Iterator for Range<T> {} //~ERROR invalid extern spec for implementation

--- a/tests/tests/neg/surface/iter_slice01.rs
+++ b/tests/tests/neg/surface/iter_slice01.rs
@@ -1,4 +1,3 @@
-//@ignore-test: ignored as its crashing in normalization :-(
 #![allow(unused)]
 #![feature(allocator_api)]
 

--- a/tests/tests/neg/surface/iter_slice01.rs
+++ b/tests/tests/neg/surface/iter_slice01.rs
@@ -1,0 +1,34 @@
+//@ignore-test: ignored as its crashing in normalization :-(
+#![allow(unused)]
+#![feature(allocator_api)]
+
+use std::{
+    alloc::{Allocator, Global},
+    ops::{Index, IndexMut},
+    slice::{Iter, SliceIndex},
+};
+
+use flux_rs::extern_spec;
+
+// needed for the iter-spec which indexes options
+#[path = "../../lib/option.rs"]
+mod option;
+
+#[path = "../../lib/slice.rs"]
+mod slice;
+
+#[path = "../../lib/vec.rs"]
+mod vec;
+
+#[path = "../../lib/iter.rs"]
+mod iter;
+
+// -------------------------------------------------------------------------------------
+
+#[flux::sig(fn(bool[true]))]
+pub fn assert(_b: bool) {}
+
+#[flux::sig(fn(slice: &[u8][@n]) -> Vec<u8>[n-1])]
+fn test_map_slice(slice: &[u8]) -> Vec<u8> {
+    slice.iter().map(|n| n + 2).collect() //~ ERROR refinement type
+}

--- a/tests/tests/pos/surface/iter_slice01.rs
+++ b/tests/tests/pos/surface/iter_slice01.rs
@@ -32,3 +32,8 @@ pub fn assert(_b: bool) {}
 fn test_map_slice(slice: &[u8]) -> Vec<u8> {
     slice.iter().map(|n| n + 2).collect()
 }
+
+// #[flux::sig(fn(slice: &[u8][@n]) -> Vec<u8>[n])]
+// fn test_iter_collect(slice: &[u8]) -> Vec<u8> {
+//     slice.into_iter().collect()
+// }

--- a/tests/tests/pos/surface/iter_slice01.rs
+++ b/tests/tests/pos/surface/iter_slice01.rs
@@ -1,0 +1,34 @@
+//@ignore-test: ignored as its crashing in normalization :-(
+#![allow(unused)]
+#![feature(allocator_api)]
+
+use std::{
+    alloc::{Allocator, Global},
+    ops::{Index, IndexMut},
+    slice::{Iter, SliceIndex},
+};
+
+use flux_rs::extern_spec;
+
+// needed for the iter-spec which indexes options
+#[path = "../../lib/option.rs"]
+mod option;
+
+#[path = "../../lib/slice.rs"]
+mod slice;
+
+#[path = "../../lib/vec.rs"]
+mod vec;
+
+#[path = "../../lib/iter.rs"]
+mod iter;
+
+// -------------------------------------------------------------------------------------
+
+#[flux::sig(fn(bool[true]))]
+pub fn assert(_b: bool) {}
+
+#[flux::sig(fn(slice: &[u8][@n]) -> Vec<u8>[n])]
+fn test_map_slice(slice: &[u8]) -> Vec<u8> {
+    slice.iter().map(|n| n + 2).collect()
+}

--- a/tests/tests/pos/surface/iter_slice01.rs
+++ b/tests/tests/pos/surface/iter_slice01.rs
@@ -32,8 +32,3 @@ pub fn assert(_b: bool) {}
 fn test_map_slice(slice: &[u8]) -> Vec<u8> {
     slice.iter().map(|n| n + 2).collect()
 }
-
-// #[flux::sig(fn(slice: &[u8][@n]) -> Vec<u8>[n])]
-// fn test_iter_collect(slice: &[u8]) -> Vec<u8> {
-//     slice.into_iter().collect()
-// }


### PR DESCRIPTION
Adds specs for `.map()` and `.collect()` on slices/vec. This required, in addition to writing the specs,

1. Switching to the "lazy" projection solver in rustc (See discussion here: https://flux-rs.zulipchat.com/#narrow/channel/486099-dev/topic/Specs.20for.20.60map.60.20and.20.60collect.60/with/514398186) 

2. Adding a missing call to `resolve_projection_predicates` 




--- 
I'm puzzled by this -- was feeling very pleased about the spec for `.collect()` but sadly this crashes the normalization code with this error :-( 

```rust
error: internal compiler error: crates/flux-infer/src/projections.rs:88:23: error selecting Obligation(predicate=TraitPredicate(<std::vec::Vec<u8> as std::iter::FromIterator<<std::iter::Map<std::slice::Iter<'_, u8>, {closure@tests/tests/pos/surface/iter_slice01.rs:33:22: 33:25}> as std::iter::Iterator>::Item>>, polarity:Positive), depth=0): Unimplemented
```

Any idea what is going on?