### PR TITLE
Parse `&mut` + `ensures` as `&strg`

### DIFF
--- a/crates/flux-driver/src/collector/mod.rs
+++ b/crates/flux-driver/src/collector/mod.rs
@@ -935,6 +935,9 @@ mod errors {
                         }
                     }
                     ParseErrorKind::CannotBeChained => "operator cannot be chained".to_string(),
+                    ParseErrorKind::InvalidBinding => {
+                        "identifier must be a mutable reference".to_string()
+                    }
                 });
             diag
         }

--- a/crates/flux-syntax/src/lib.rs
+++ b/crates/flux-syntax/src/lib.rs
@@ -195,4 +195,5 @@ pub enum ParseErrorKind {
     UnexpectedToken { expected: Vec<&'static str> },
     UnexpectedEof,
     CannotBeChained,
+    InvalidBinding,
 }

--- a/tests/tests/neg/error_messages/desugar/arg_syntax.rs
+++ b/tests/tests/neg/error_messages/desugar/arg_syntax.rs
@@ -12,10 +12,3 @@ fn mut_ref(x: &mut i32) -> i32 {
 fn shr_ref(x: &i32) -> i32 {
     *x
 }
-
-// ensures clause on non-strong reference
-#[flux::sig(fn(x: &mut i32[@n]) ensures x: i32[n+1])] //~ ERROR invalid use of refinement parameter
-pub fn test00(x: &mut i32) {
-    *x += 1;
-    return;
-}

--- a/tests/tests/neg/error_messages/mut_as_strg00.rs
+++ b/tests/tests/neg/error_messages/mut_as_strg00.rs
@@ -1,0 +1,8 @@
+#[flux::sig(fn(x: &i32[@n]) ensures x: i32[n+1])] //~ ERROR syntax error
+pub fn test00(x: &mut i32) {
+    *x += 1;
+    return;
+}
+
+#[flux::sig(fn(x: &i32[@n]) ensures x: i32[n+1])] //~ ERROR syntax error
+pub fn test01(x: &i32) {}

--- a/tests/tests/neg/surface/mut_as_strg00.rs
+++ b/tests/tests/neg/surface/mut_as_strg00.rs
@@ -1,0 +1,11 @@
+#[flux::sig(fn (x: &mut i32[@n]) ensures x: i32[n+1])]
+pub fn incr(x: &mut i32) {
+    *x += 1;
+}
+
+#[flux::sig(fn () -> i32[10])]
+pub fn client_safe() -> i32 {
+    let mut p = 10;
+    incr(&mut p);
+    p //~ ERROR refinement type
+}

--- a/tests/tests/pos/surface/mut_as_strg00.rs
+++ b/tests/tests/pos/surface/mut_as_strg00.rs
@@ -1,0 +1,14 @@
+#[flux::sig(fn (x: &mut i32[@n]) ensures x: i32[n+1])]
+pub fn incr(x: &mut i32) {
+    *x += 1;
+}
+
+#[flux::sig(fn (x: &mut i32{v: v> 999}) ensures x: i32)]
+pub fn bincr(_x: &mut i32) {}
+
+#[flux::sig(fn () -> i32[11])]
+pub fn client_safe() -> i32 {
+    let mut p = 10;
+    incr(&mut p);
+    p
+}


### PR DESCRIPTION
This implements Niko Matsakis' suggestion to let us just write the update clause with an `ensures` instead of necessarily having to spell out `&strg` e.g. the below works (and you get an error if the relevant location is _not_ a `&mut`.

```rust
#[flux::sig(fn (x: &mut i32[@n]) ensures x: i32[n+1])]
pub fn incr(x: &mut i32) {
    *x += 1;
}

#[flux::sig(fn () -> i32[11])]
pub fn client_safe() -> i32 {
    let mut p = 10;
    incr(&mut p);
    p
}
```