### PR TITLE
Hoist function definitions

### DIFF
--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -512,6 +512,7 @@ fn fn_sig(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<r
         .into_conv_ctxt()
         .conv_fn_sig(def_id, fhir_fn_sig)?;
     let fn_sig = struct_compat::fn_sig(genv, fhir_fn_sig.decl, &fn_sig, def_id)?;
+    let fn_sig = fn_sig.hoist_input_binders();
 
     if config::dump_rty() {
         let generics = genv.generics_of(def_id)?;

--- a/crates/flux-infer/src/refine_tree.rs
+++ b/crates/flux-infer/src/refine_tree.rs
@@ -87,7 +87,7 @@ pub struct Cursor<'a> {
     ptr: NodePtr,
 }
 
-impl<'a> Cursor<'a> {
+impl Cursor<'_> {
     /// Moves the cursor to the specified [marker]. If `clear_children` is `true`, all children of
     /// the node are removed after moving the cursor, invalidating any markers pointing to a node
     /// within those children.

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -734,7 +734,8 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                     let fn_sig = genv
                         .lower_fn_sig(def_id)?
                         .skip_binder()
-                        .refine(&Refiner::default_for_item(genv, def_id)?)?;
+                        .refine(&Refiner::default_for_item(genv, def_id)?)?
+                        .hoist_input_binders();
                     Ok(rty::EarlyBinder(fn_sig))
                 },
             )

--- a/crates/flux-middle/src/rty/canonicalize.rs
+++ b/crates/flux-middle/src/rty/canonicalize.rs
@@ -37,7 +37,9 @@ use rustc_ast::Mutability;
 use rustc_type_ir::{BoundVar, INNERMOST};
 
 use super::{
-    fold::{TypeFoldable, TypeFolder, TypeSuperFoldable}, BaseTy, Binder, BoundVariableKind, Expr, FnSig, GenericArg, GenericArgsExt, PolyFnSig, SubsetTy, Ty, TyCtor, TyKind, TyOrBase
+    BaseTy, Binder, BoundVariableKind, Expr, FnSig, GenericArg, GenericArgsExt, PolyFnSig,
+    SubsetTy, Ty, TyCtor, TyKind, TyOrBase,
+    fold::{TypeFoldable, TypeFolder, TypeSuperFoldable},
 };
 
 /// The [`Hoister`] struct is responsible for hoisting existentials and predicates out of a type.

--- a/crates/flux-middle/src/rty/canonicalize.rs
+++ b/crates/flux-middle/src/rty/canonicalize.rs
@@ -229,7 +229,7 @@ impl PolyFnSig {
     pub fn hoist_input_binders(&self) -> Self {
         let original_vars = self.vars().to_vec();
         let fn_sig = self.skip_binder_ref();
-        let mut delegate = LocalHoister { vars: original_vars, preds: vec![] };
+        let mut delegate = LocalHoister { vars: original_vars, preds: fn_sig.requires().to_vec() };
         let mut hoister = Hoister::with_delegate(&mut delegate).transparent();
 
         let inputs = fn_sig

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -223,22 +223,22 @@ pub trait TypeVisitable: Sized {
         collector.0
     }
 
-    fn evars(&self) -> FxIndexSet<EVid> {
-        struct CollectEVars(FxIndexSet<EVid>);
+    // fn evars(&self) -> FxIndexSet<EVid> {
+    //     struct CollectEVars(FxIndexSet<EVid>);
 
-        impl TypeVisitor for CollectEVars {
-            fn visit_expr(&mut self, e: &Expr) -> ControlFlow<Self::BreakTy> {
-                if let ExprKind::Var(Var::EVar(evid)) = e.kind() {
-                    self.0.insert(*evid);
-                }
-                e.super_visit_with(self)
-            }
-        }
+    //     impl TypeVisitor for CollectEVars {
+    //         fn visit_expr(&mut self, e: &Expr) -> ControlFlow<Self::BreakTy> {
+    //             if let ExprKind::Var(Var::EVar(evid)) = e.kind() {
+    //                 self.0.insert(*evid);
+    //             }
+    //             e.super_visit_with(self)
+    //         }
+    //     }
 
-        let mut collector = CollectEVars(FxIndexSet::default());
-        self.visit_with(&mut collector);
-        collector.0
-    }
+    //     let mut collector = CollectEVars(FxIndexSet::default());
+    //     self.visit_with(&mut collector);
+    //     collector.0
+    // }
 }
 
 pub trait TypeSuperVisitable: TypeVisitable {

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -221,23 +221,6 @@ pub trait TypeVisitable: Sized {
         self.visit_with(&mut collector);
         collector.0
     }
-
-    // fn evars(&self) -> FxIndexSet<EVid> {
-    //     struct CollectEVars(FxIndexSet<EVid>);
-
-    //     impl TypeVisitor for CollectEVars {
-    //         fn visit_expr(&mut self, e: &Expr) -> ControlFlow<Self::BreakTy> {
-    //             if let ExprKind::Var(Var::EVar(evid)) = e.kind() {
-    //                 self.0.insert(*evid);
-    //             }
-    //             e.super_visit_with(self)
-    //         }
-    //     }
-
-    //     let mut collector = CollectEVars(FxIndexSet::default());
-    //     self.visit_with(&mut collector);
-    //     collector.0
-    // }
 }
 
 pub trait TypeSuperVisitable: TypeVisitable {

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -6,7 +6,6 @@ use std::ops::ControlFlow;
 use flux_arc_interner::{Internable, List};
 use flux_common::bug;
 use itertools::Itertools;
-use rustc_data_structures::fx::FxIndexSet;
 use rustc_hash::FxHashSet;
 use rustc_type_ir::{DebruijnIndex, INNERMOST};
 

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -89,6 +89,15 @@ struct Inherited<'ck, M> {
     closures: &'ck mut UnordMap<DefId, PolyFnSig>,
 }
 
+#[derive(Debug)]
+struct ResolvedCall {
+    output: Ty,
+    /// The refine arguments given to the call
+    _early_args: Vec<Expr>,
+    /// The refine arguments given to the call
+    _late_args: Vec<Expr>,
+}
+
 impl<'ck, M: Mode> Inherited<'ck, M> {
     fn new(
         mode: &'ck mut M,
@@ -685,7 +694,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                             &generic_args,
                             &actuals,
                         )?
-                        .0
+                        .output
                     }
                     mir::CallKind::FnPtr { operand, .. } => {
                         let ty = self
@@ -702,7 +711,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                                 &[],
                                 &actuals,
                             )?
-                            .0
+                            .output
                         } else {
                             bug!("TODO: fnptr call {ty:?}")
                         }
@@ -765,10 +774,6 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
     }
 
     #[expect(clippy::too_many_arguments)]
-    /// Returns (resolved output type, resolved refinement arguments)
-    ///
-    /// The refinement arguments includes both EarlyBound and late Bound
-    /// parameters.
     fn check_call(
         &mut self,
         infcx: &mut InferCtxt<'_, 'genv, 'tcx>,
@@ -778,7 +783,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         fn_sig: EarlyBinder<PolyFnSig>,
         generic_args: &[GenericArg],
         actuals: &[Ty],
-    ) -> Result<(Ty, Vec<Expr>)> {
+    ) -> Result<ResolvedCall> {
         let genv = self.genv;
         let tcx = genv.tcx();
 
@@ -791,7 +796,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         let generic_args = infcx.instantiate_generic_args(generic_args);
 
         // Generate fresh inference variables for refinement arguments
-        let refine_args = match callee_def_id {
+        let early_refine_args = match callee_def_id {
             Some(callee_def_id) => {
                 infcx
                     .instantiate_refine_args(callee_def_id, &generic_args)
@@ -805,7 +810,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 genv.predicates_of(callee_def_id)
                     .with_span(span)?
                     .predicates()
-                    .instantiate(tcx, &generic_args, &refine_args)
+                    .instantiate(tcx, &generic_args, &early_refine_args)
             }
             None => crate::rty::List::empty(),
         };
@@ -819,16 +824,17 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         self.check_closure_clauses(infcx, &fn_clauses, span)?;
 
         // Instantiate function signature and normalize it
+        let mut late_refine_args = vec![];
         let fn_sig = fn_sig
-            .instantiate(tcx, &generic_args, &refine_args)
-            .replace_bound_vars(|_| rty::ReErased, |sort, mode| infcx.fresh_infer_var(sort, mode))
+            .instantiate(tcx, &generic_args, &early_refine_args)
+            .replace_bound_vars(|_| rty::ReErased, |sort, mode| {
+                let var = infcx.fresh_infer_var(sort, mode);
+                late_refine_args.push(var.clone());
+                var
+            })
             .normalize_projections(infcx)
             .with_span(span)?;
-        let evars: FxIndexSet<EVid> = fn_sig
-            .inputs()
-            .iter()
-            .flat_map(|input| input.evars())
-            .collect();
+
 
         let mut at = infcx.at(span);
 
@@ -845,10 +851,6 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
 
         infcx.pop_evar_scope().with_span(span)?;
         env.fully_resolve_evars(infcx);
-        let solved_evars = evars
-            .iter()
-            .map(|evar| infcx.fully_resolve_evars(&rty::Expr::evar(*evar)))
-            .collect_vec();
 
         let output = infcx
             .fully_resolve_evars(&fn_sig.output)
@@ -857,7 +859,11 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         env.assume_ensures(infcx, &output.ensures);
         fold_local_ptrs(infcx, env, span).with_span(span)?;
 
-        Ok((output.ret, solved_evars))
+        Ok(ResolvedCall {
+            output: output.ret,
+            _early_args: early_refine_args.into_iter().map(|arg| infcx.fully_resolve_evars(arg)).collect(),
+            _late_args: late_refine_args.into_iter().map(|arg| infcx.fully_resolve_evars(&arg)).collect(),
+        })
     }
 
     fn check_coroutine_obligations(
@@ -1245,7 +1251,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                     instantiate_args_for_constructor(genv, self.def_id.to_def_id(), *def_id, args)
                         .with_span(stmt_span)?;
                 self.check_call(infcx, env, stmt_span, Some(*def_id), sig, &args, &actuals)
-                    .map(|(ret_ty, _args)| ret_ty)
+                    .map(|resolved_call| resolved_call.output)
             }
             Rvalue::Aggregate(AggregateKind::Array(arr_ty), operands) => {
                 let args = self


### PR DESCRIPTION
There are two pieces to this PR.

1. The addition of `hoist_input_binders` (stolen from #1093) and application on unannotated and annotated functions alike.
2. The addition of an `evars` collector that we use in `check_call` to get an ordered list of all refinement arguments passed to a function.

I suspect the proper solution to 2 is to ensure that the hoisted binders make their way into `RefinementGenerics.refinement_parameters`, but I'm not sure how. My solution seems suitable enough though.