### PR TITLE
Add syntax for weak kvars

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1451,6 +1451,13 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                 let body = self.genv().alloc(self.desugar_expr(body));
                 fhir::ExprKind::Block(decls, body)
             }
+            surface::ExprKind::WeakKvar(num, args) => {
+                fhir::ExprKind::WeakKvar(
+                    *num,
+                    self.genv()
+                        .alloc_slice_fill_iter(args.iter().map(|arg| self.desugar_epath(arg))),
+                )
+            }
         };
 
         fhir::Expr { kind, span: expr.span, fhir_id: self.next_fhir_id() }

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -604,8 +604,19 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
                 qualifiers: self.genv.alloc_slice(qual_names),
                 reveals: self.genv.alloc_slice(reveal_names),
                 decl: self.genv.alloc(decl),
+                weak_kvars: self.desugar_weak_kvars(&fn_spec.weak_kvars),
             },
         ))
+    }
+
+    fn desugar_weak_kvars(&mut self, wks: &[surface::WeakKvar]) -> &'genv [fhir::WeakKvar<'genv>] {
+        self.genv.alloc_slice_fill_iter(wks.iter().map(|wk| {
+            fhir::WeakKvar {
+                num: wk.num,
+                params: self.desugar_refine_params(&wk.params),
+                solutions: self.desugar_exprs(&wk.solutions),
+            }
+        }))
     }
 
     fn desugar_fn_sig_refine_params(

--- a/crates/flux-desugar/src/desugar/lift.rs
+++ b/crates/flux-desugar/src/desugar/lift.rs
@@ -446,6 +446,7 @@ impl<'genv> RustItemCtxt<'_, 'genv, '_> {
             qualifiers: &[],
             reveals: &[],
             decl: self.genv.alloc(decl),
+            weak_kvars: &[],
         }
     }
 

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -330,8 +330,14 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
         if let Some(fn_sig) = &fn_spec.fn_sig {
             ItemResolver::run(self, owner_id, |item_resolver| {
                 item_resolver.visit_fn_sig(fn_sig);
+                for wk in &fn_spec.weak_kvars {
+                    item_resolver.visit_weak_kvar(wk);
+                }
             })?;
             RefinementResolver::resolve_fn_sig(self, fn_sig)?;
+            for wk in &fn_spec.weak_kvars {
+                RefinementResolver::resolve_weak_kvar(self, wk)?;
+            }
         }
         Ok(())
     }

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -334,10 +334,7 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
                     item_resolver.visit_weak_kvar(wk);
                 }
             })?;
-            RefinementResolver::resolve_fn_sig(self, fn_sig)?;
-            for wk in &fn_spec.weak_kvars {
-                RefinementResolver::resolve_weak_kvar(self, wk)?;
-            }
+            RefinementResolver::resolve_fn_sig(self, fn_sig, &fn_spec.weak_kvars)?;
         }
         Ok(())
     }

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -429,16 +429,15 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
     pub(crate) fn resolve_fn_sig(
         resolver: &'a mut CrateResolver<'genv, 'tcx>,
         fn_sig: &surface::FnSig,
+        weak_kvars: &[surface::WeakKvar],
     ) -> Result {
         IllegalBinderVisitor::new(resolver).run(|vis| vis.visit_fn_sig(fn_sig))?;
-        Self::for_rust_item(resolver).run(|vis| vis.visit_fn_sig(fn_sig))
-    }
-
-    pub(crate) fn resolve_weak_kvar(
-        resolver: &'a mut CrateResolver<'genv, 'tcx>,
-        wk: &surface::WeakKvar,
-    ) -> Result {
-        Self::for_flux_item(resolver, &[]).run(|vis| vis.visit_weak_kvar(wk))
+        Self::for_rust_item(resolver).run(|vis| {
+            vis.visit_fn_sig(fn_sig);
+            for wk in weak_kvars {
+                vis.visit_weak_kvar(wk);
+            }
+        })
     }
 
     pub(crate) fn resolve_struct_def(

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -199,6 +199,12 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
         });
     }
 
+    fn visit_weak_kvar(&mut self, wk: &surface::WeakKvar) {
+        self.with_scope(ScopeKind::Misc, |this| {
+            surface::visit::walk_weak_kvar(this, wk);
+        });
+    }
+
     fn visit_fn_output(&mut self, output: &surface::FnOutput) {
         self.with_scope(ScopeKind::FnOutput, |this| {
             this.on_fn_output(output);
@@ -426,6 +432,13 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
     ) -> Result {
         IllegalBinderVisitor::new(resolver).run(|vis| vis.visit_fn_sig(fn_sig))?;
         Self::for_rust_item(resolver).run(|vis| vis.visit_fn_sig(fn_sig))
+    }
+
+    pub(crate) fn resolve_weak_kvar(
+        resolver: &'a mut CrateResolver<'genv, 'tcx>,
+        wk: &surface::WeakKvar,
+    ) -> Result {
+        Self::for_flux_item(resolver, &[]).run(|vis| vis.visit_weak_kvar(wk))
     }
 
     pub(crate) fn resolve_struct_def(

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -539,13 +539,17 @@ fn fn_sig(genv: GlobalEnv, def_id: LocalDefId) -> QueryResult<rty::EarlyBinder<r
     };
 
     let wfckresults = genv.check_wf(def_id.local_id())?;
-    let fn_sig = AfterSortck::new(genv, &wfckresults)
+    let (fn_sig, weak_kvars) = AfterSortck::new(genv, &wfckresults)
         .into_conv_ctxt()
         .conv_fn_sig(def_id, fhir_fn_sig)?;
-    let fn_sig = struct_compat::fn_sig(genv, fhir_fn_sig.decl, &fn_sig, def_id)?;
-    let fn_sig = fn_sig
-        .hoist_input_binders()
-        .add_weak_kvars(def_id.local_id().into());
+    genv.feed_weak_kvars(def_id.resolved_id(), weak_kvars);
+
+    let mut fn_sig = struct_compat::fn_sig(genv, fhir_fn_sig.decl, &fn_sig, def_id)?;
+    if fn_sig.vars().is_empty() {
+        fn_sig = fn_sig
+            .hoist_input_binders()
+            .add_weak_kvars(def_id.local_id().into());
+    }
 
     if config::dump_rty() {
         let generics = genv.generics_of(def_id)?;

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -347,9 +347,20 @@ impl<'genv> fhir::visit::Visitor<'genv> for Wf<'_, 'genv, '_> {
             .collect_err(&mut self.errors);
     }
 
-    fn visit_fn_decl(&mut self, decl: &fhir::FnDecl<'genv>) {
-        fhir::visit::walk_fn_decl(self, decl);
-        self.check_output_locs(decl);
+    fn visit_fn_sig(&mut self, sig: &fhir::FnSig<'genv>) {
+        for wk in sig.weak_kvars {
+            self.infcx.declare_weak_kvar(wk);
+        }
+        fhir::visit::walk_fn_sig(self, sig);
+        self.check_output_locs(sig.decl);
+    }
+
+    fn visit_weak_kvar(&mut self, wk: &fhir::WeakKvar<'genv>) {
+        for solution in wk.solutions {
+            self.infcx
+                .check_expr(solution, &rty::Sort::Bool)
+                .collect_err(&mut self.errors);
+        }
     }
 
     fn visit_requires(&mut self, requires: &fhir::Requires<'genv>) {

--- a/crates/flux-fhir-analysis/src/wf/param_usage.rs
+++ b/crates/flux-fhir-analysis/src/wf/param_usage.rs
@@ -141,6 +141,15 @@ impl<'a, 'genv, 'tcx> ParamUsesChecker<'a, 'genv, 'tcx> {
                 }
                 self.check_func_params_uses(body, false);
             }
+            fhir::ExprKind::WeakKvar(_, args) => {
+                for arg in args {
+                    if let fhir::ExprRes::Param(_, id) = arg.res
+                        && let sort @ rty::Sort::Func(_) = self.infcx.param_sort(id)
+                    {
+                        self.errors.emit(InvalidParamPos::new(arg.span, &sort));
+                    }
+                }
+            }
             fhir::ExprKind::Err(_) => {
                 // an error has already been reported so we can just skip
             }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -498,6 +498,7 @@ pub struct FnSig<'fhir> {
     pub weak_kvars: &'fhir [WeakKvar<'fhir>],
 }
 
+#[derive(Debug)]
 pub struct WeakKvar<'fhir> {
     pub num: u32,
     pub params: &'fhir [RefineParam<'fhir>],
@@ -996,6 +997,7 @@ pub enum ExprKind<'fhir> {
     Record(&'fhir [Expr<'fhir>]),
     Constructor(Option<PathExpr<'fhir>>, &'fhir [FieldExpr<'fhir>], Option<&'fhir Spread<'fhir>>),
     Block(&'fhir [LetDecl<'fhir>], &'fhir Expr<'fhir>),
+    WeakKvar(u32, &'fhir [PathExpr<'fhir>]),
     Err(ErrorGuaranteed),
 }
 
@@ -1527,6 +1529,7 @@ impl fmt::Debug for Expr<'_> {
                 }
                 write!(f, "{body:?}")
             }
+            ExprKind::WeakKvar(num, args) => write!(f, "$wk{num}({:?})", args.iter().format(", ")),
         }
     }
 }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -495,6 +495,13 @@ pub struct FnSig<'fhir> {
     //// List of reveals for this function
     pub reveals: &'fhir [FluxDefId],
     pub decl: &'fhir FnDecl<'fhir>,
+    pub weak_kvars: &'fhir [WeakKvar<'fhir>],
+}
+
+pub struct WeakKvar<'fhir> {
+    pub num: u32,
+    pub params: &'fhir [RefineParam<'fhir>],
+    pub solutions: &'fhir [Expr<'fhir>],
 }
 
 #[derive(Clone, Copy)]

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -114,6 +114,10 @@ pub trait Visitor<'v>: Sized {
         walk_fn_sig(self, sig);
     }
 
+    fn visit_weak_kvar(&mut self, wk: &WeakKvar<'v>) {
+        walk_weak_kvar(self, wk);
+    }
+
     fn visit_fn_decl(&mut self, decl: &FnDecl<'v>) {
         walk_fn_decl(self, decl);
     }
@@ -361,9 +365,7 @@ pub fn walk_where_predicate<'v, V: Visitor<'v>>(vis: &mut V, predicate: &WhereBo
 
 pub fn walk_fn_sig<'v, V: Visitor<'v>>(vis: &mut V, sig: &FnSig<'v>) {
     vis.visit_fn_decl(sig.decl);
-    for wk in sig.weak_kvars {
-        walk_weak_kvar(vis, wk);
-    }
+    walk_list!(vis, visit_weak_kvar, sig.weak_kvars);
 }
 
 pub fn walk_weak_kvar<'v, V: Visitor<'v>>(vis: &mut V, wk: &WeakKvar<'v>) {
@@ -582,6 +584,9 @@ pub fn walk_expr<'v, V: Visitor<'v>>(vis: &mut V, expr: &Expr<'v>) {
                 vis.visit_refine_param(&decl.param);
             }
             vis.visit_expr(body);
+        }
+        ExprKind::WeakKvar(_, args) => {
+            walk_list!(vis, visit_path_expr, args);
         }
         ExprKind::Err(_) => {}
     }

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -7,7 +7,7 @@ use super::{
     StructDef, TraitAssocReft, TraitItem, TraitItemKind, Ty, TyAlias, TyKind, VariantDef,
     VariantRet, WhereBoundPredicate,
 };
-use crate::fhir::StructKind;
+use crate::fhir::{StructKind, WeakKvar};
 
 #[macro_export]
 macro_rules! walk_list {
@@ -361,6 +361,14 @@ pub fn walk_where_predicate<'v, V: Visitor<'v>>(vis: &mut V, predicate: &WhereBo
 
 pub fn walk_fn_sig<'v, V: Visitor<'v>>(vis: &mut V, sig: &FnSig<'v>) {
     vis.visit_fn_decl(sig.decl);
+    for wk in sig.weak_kvars {
+        walk_weak_kvar(vis, wk);
+    }
+}
+
+pub fn walk_weak_kvar<'v, V: Visitor<'v>>(vis: &mut V, wk: &WeakKvar<'v>) {
+    walk_list!(vis, visit_refine_param, wk.params);
+    walk_list!(vis, visit_expr, wk.solutions);
 }
 
 pub fn walk_fn_decl<'v, V: Visitor<'v>>(vis: &mut V, decl: &FnDecl<'v>) {

--- a/crates/flux-syntax/src/lexer.rs
+++ b/crates/flux-syntax/src/lexer.rs
@@ -75,6 +75,7 @@ pub enum Token {
     Hrn,
     Hdl,
     DotDot,
+    Dollar,
     Eof,
 }
 
@@ -147,6 +148,7 @@ impl Token {
             Token::Hrn => "rn",
             Token::Hdl => "hdl",
             Token::DotDot => "..",
+            Token::Dollar => "$",
             Token::Eof => "<eof>",
         }
     }
@@ -337,6 +339,7 @@ impl<'t> Cursor<'t> {
             TokenKind::Bang => Token::Bang,
             TokenKind::PathSep => Token::PathSep,
             TokenKind::DotDot => Token::DotDot,
+            TokenKind::Dollar => Token::Dollar,
             _ => Token::Invalid,
         };
         self.tokens.push_back((span.lo(), token, span.hi()));

--- a/crates/flux-syntax/src/lib.rs
+++ b/crates/flux-syntax/src/lib.rs
@@ -128,6 +128,14 @@ impl ParseSess {
         parser::parse_yes_or_no_with_reason(&mut self.cx(tokens, span))
     }
 
+    pub fn parse_weak_kvars(
+        &mut self,
+        tokens: &TokenStream,
+        span: Span,
+    ) -> ParseResult<Vec<surface::WeakKvar>> {
+        parser::parse_weak_kvars(&mut self.cx(tokens, span))
+    }
+
     pub fn next_node_id(&mut self) -> NodeId {
         let id = NodeId(self.next_node_id);
         self.next_node_id += 1;

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -246,6 +246,14 @@ pub struct FnSpec {
     pub fn_sig: Option<FnSig>,
     pub qual_names: Option<QualNames>,
     pub reveal_names: Option<RevealNames>,
+    pub weak_kvars: Vec<WeakKvar>,
+}
+
+#[derive(Debug)]
+pub struct WeakKvar {
+    pub num: u32,
+    pub params: RefineParams,
+    pub solutions: Vec<Expr>,
 }
 
 #[derive(Debug)]

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -545,6 +545,7 @@ pub enum ExprKind {
     Constructor(Option<ExprPath>, Vec<ConstructorArg>),
     BoundedQuant(QuantKind, RefineParam, Range<usize>, Box<Expr>),
     Block(Vec<LetDecl>, Box<Expr>),
+    WeakKvar(u32, Vec<ExprPath>),
 }
 
 #[derive(Debug)]

--- a/crates/flux-syntax/src/surface/visit.rs
+++ b/crates/flux-syntax/src/surface/visit.rs
@@ -550,6 +550,9 @@ pub fn walk_expr<V: Visitor>(vis: &mut V, expr: &Expr) {
             }
             vis.visit_expr(body);
         }
+        ExprKind::WeakKvar(_, args) => {
+            walk_list!(vis, visit_path_expr, args);
+        }
     }
 }
 

--- a/crates/flux-syntax/src/surface/visit.rs
+++ b/crates/flux-syntax/src/surface/visit.rs
@@ -14,6 +14,7 @@ use super::{
     PathSegment, Qualifier, RefineArg, RefineParam, Sort, SortPath, SpecFunc, StructDef, Trait,
     TraitAssocReft, TraitRef, Ty, TyAlias, TyKind, VariantDef, VariantRet, WhereBoundPredicate,
 };
+use crate::surface::WeakKvar;
 
 #[macro_export]
 macro_rules! walk_list {
@@ -102,6 +103,10 @@ pub trait Visitor: Sized {
 
     fn visit_fn_sig(&mut self, fn_sig: &FnSig) {
         walk_fn_sig(self, fn_sig);
+    }
+
+    fn visit_weak_kvar(&mut self, wk: &WeakKvar) {
+        walk_weak_kvar(self, wk);
     }
 
     fn visit_fn_output(&mut self, fn_output: &FnOutput) {
@@ -337,6 +342,11 @@ pub fn walk_fn_sig<V: Visitor>(vis: &mut V, fn_sig: &FnSig) {
     }
     walk_list!(vis, visit_fn_input, &fn_sig.inputs);
     vis.visit_fn_output(&fn_sig.output);
+}
+
+pub fn walk_weak_kvar<V: Visitor>(vis: &mut V, wk: &WeakKvar) {
+    walk_list!(vis, visit_refine_param, &wk.params);
+    walk_list!(vis, visit_expr, &wk.solutions);
 }
 
 pub fn walk_fn_output<V: Visitor>(vis: &mut V, fn_output: &FnOutput) {

--- a/lib/flux-attrs/src/lib.rs
+++ b/lib/flux-attrs/src/lib.rs
@@ -109,6 +109,11 @@ pub fn reft(attrs: TokenStream, tokens: TokenStream) -> TokenStream {
     attr_impl::reft(attrs, tokens)
 }
 
+#[proc_macro_attribute]
+pub fn vars(attrs: TokenStream, tokens: TokenStream) -> TokenStream {
+    attr_impl::vars(attrs, tokens)
+}
+
 #[cfg(flux_sysroot)]
 mod attr_sysroot {
     use super::*;
@@ -153,6 +158,7 @@ mod attr_sysroot {
         ignore,
         should_fail,
         reft,
+        vars,
     );
 }
 
@@ -200,5 +206,6 @@ mod attr_dummy {
         ignore,
         should_fail,
         reft,
+        vars,
     );
 }


### PR DESCRIPTION
* Weak kvars are used like this

```rust
#[vars(
    $wk0(x, y) = [x > y, x > 0];
    $wk1(z) = [z > 0];
)]
#[spec(
    fn(x: i32, y: i32) -> i32[#z]
    requires $wk0(x, y)
    ensures $wk1(z)
)]
fn foo(x: i32, y: i32) -> i32 {
    x + y
}
```

* The syntax expects a weak kvar to be named `$wk{n}` where `n` is a number. Nothing is checking now that those numbers are distinct, and I don't know what happens if they are not.

* You can query the weak kvars for a function with `genv.weak_kvars_for`. That gives you a map indexed by the _number_ of the weak kvar, and each entry is a list of `rty::Binder<rty::Expr>`

* Bad things will happen if in the `spec` the arguments to a weak kvar do not correspond to a function parameter.
