### PR TITLE
Check files cargo

### DIFF
--- a/crates/flux-bin/src/lib.rs
+++ b/crates/flux-bin/src/lib.rs
@@ -16,12 +16,14 @@ pub struct FluxMetadata {
     pub scrape_quals: Option<bool>,
     /// Enable overflow checking
     pub check_overflow: Option<bool>,
-    /// Enable overflow checking
+    /// Enable flux-defs to be defined as SMT functions
     pub smt_define_fun: Option<bool>,
-    /// Set trusted trusted
+    /// Set trusted to trusted
     pub default_trusted: Option<bool>,
-    /// Set trusted ignore
+    /// Set trusted to ignore
     pub default_ignore: Option<bool>,
+    /// Only check the files matching these paths
+    pub check_files: Option<Vec<String>>,
 }
 
 impl FluxMetadata {
@@ -47,6 +49,9 @@ impl FluxMetadata {
         }
         if let Some(v) = self.default_ignore {
             flags.push(format!("-Fignore={v}"));
+        }
+        if let Some(files) = self.check_files {
+            flags.push(format!("-Fcheck-files={}", files.join(",")));
         }
         flags
     }

--- a/crates/flux-config/src/flags.rs
+++ b/crates/flux-config/src/flags.rs
@@ -139,10 +139,16 @@ pub struct Paths {
 }
 
 impl Paths {
+    fn file_matches(p: &PathBuf, file: &str) -> bool {
+        let res = p.to_str().map_or(false, |p| p == file);
+        println!("TRACE: file_matches[{p:?}] {file}) ==> {res}");
+        res
+    }
+
     pub fn is_checked_file(&self, file: &str) -> bool {
         self.paths
             .as_ref()
-            .is_none_or(|p| p.iter().any(|p| p.to_str().unwrap() == file))
+            .is_none_or(|p| p.iter().any(|p| Self::file_matches(p, file)))
     }
 }
 

--- a/crates/flux-config/src/flags.rs
+++ b/crates/flux-config/src/flags.rs
@@ -140,9 +140,7 @@ pub struct Paths {
 
 impl Paths {
     fn file_matches(p: &PathBuf, file: &str) -> bool {
-        let res = p.to_str().map_or(false, |p| p == file);
-        println!("TRACE: file_matches[{p:?}] {file}) ==> {res}");
-        res
+        p.to_str().map_or(false, |p| p == file)
     }
 
     pub fn is_checked_file(&self, file: &str) -> bool {

--- a/crates/flux-config/src/flags.rs
+++ b/crates/flux-config/src/flags.rs
@@ -140,7 +140,7 @@ pub struct Paths {
 
 impl Paths {
     fn file_matches(p: &PathBuf, file: &str) -> bool {
-        p.to_str().map_or(false, |p| p == file)
+        p.to_str().map_or(false, |p| file.ends_with(p))
     }
 
     pub fn is_checked_file(&self, file: &str) -> bool {


### PR DESCRIPTION
Use cargo manifest to specify `checked_files` instead of the command line. So now, we can write stuff like

```toml
[package.metadata.flux]
enabled = true
check_files = [ "src/ascii/ascii_char.rs" ]
```

in the `Cargo.toml` and then `flux` will only check the file matching that suffix.
