### PR TITLE
Elaborate function application sorts in `rty`

### DIFF
--- a/book/src/guide/specifications.md
+++ b/book/src/guide/specifications.md
@@ -957,3 +957,11 @@ or lemmas. See `tests/tests/pos/surface/primops00.rs` for an example.
 ```rust,noplayground
 {{#include ../../../tests/tests/pos/surface/primops00.rs}}
 ```
+
+## Casting Sorts to Int
+
+You can convert refinements of different sorts to `int` using the `to_int` internal function.
+
+```rust,noplayground
+{{#include ../../../tests/tests/pos/surface/to_int00.rs}}
+```

--- a/book/src/guide/specifications.md
+++ b/book/src/guide/specifications.md
@@ -958,9 +958,10 @@ or lemmas. See `tests/tests/pos/surface/primops00.rs` for an example.
 {{#include ../../../tests/tests/pos/surface/primops00.rs}}
 ```
 
-## Casting Sorts to Int
+## Casting Sorts
 
-You can convert refinements of different sorts to `int` using the `to_int` internal function.
+You can convert refinements of different sorts -- e.g. `int` to `char` or `int` to `bool` --
+using the `cast` internal function.
 
 ```rust,noplayground
 {{#include ../../../tests/tests/pos/surface/to_int00.rs}}

--- a/crates/flux-config/src/flags.rs
+++ b/crates/flux-config/src/flags.rs
@@ -37,6 +37,8 @@ pub struct Flags {
     pub solver: SmtSolver,
     /// Enables qualifier scrapping in fixpoint
     pub scrape_quals: bool,
+    /// Enables uninterpreted casts
+    pub allow_uninterpreted_cast: bool,
     /// Translates _monomorphic_ `defs` functions into SMT `define-fun` instead of inlining them
     /// away inside `flux`.
     pub smt_define_fun: bool,
@@ -84,6 +86,7 @@ impl Default for Flags {
             cache: None,
             check_overflow: false,
             scrape_quals: false,
+            allow_uninterpreted_cast: false,
             solver: SmtSolver::default(),
             smt_define_fun: false,
             verbose: false,
@@ -114,6 +117,7 @@ pub(crate) static FLAGS: LazyLock<Flags> = LazyLock::new(|| {
             "pointer-width" => parse_pointer_width(&mut flags.pointer_width, value),
             "check-overflow" => parse_bool(&mut flags.check_overflow, value),
             "scrape-quals" => parse_bool(&mut flags.scrape_quals, value),
+            "allow-uninterpreted-cast" => parse_bool(&mut flags.allow_uninterpreted_cast, value),
             "solver" => parse_solver(&mut flags.solver, value),
             "verbose" => parse_bool(&mut flags.verbose, value),
             "smt-define-fun" => parse_bool(&mut flags.smt_define_fun, value),

--- a/crates/flux-config/src/lib.rs
+++ b/crates/flux-config/src/lib.rs
@@ -69,6 +69,10 @@ fn check_overflow() -> bool {
     FLAGS.check_overflow
 }
 
+fn allow_uninterpreted_cast() -> bool {
+    FLAGS.allow_uninterpreted_cast
+}
+
 fn scrape_quals() -> bool {
     FLAGS.scrape_quals
 }
@@ -156,6 +160,8 @@ pub struct InferOpts {
     /// Whether qualifiers should be scraped from the constraint.
     pub scrape_quals: bool,
     pub solver: SmtSolver,
+    /// Whether to allow uninterpreted casts (e.g., from some random `S` to `int`).
+    pub allow_uninterpreted_cast: bool,
 }
 
 impl From<PartialInferOpts> for InferOpts {
@@ -164,6 +170,9 @@ impl From<PartialInferOpts> for InferOpts {
             check_overflow: opts.check_overflow.unwrap_or_else(check_overflow),
             scrape_quals: opts.scrape_quals.unwrap_or_else(scrape_quals),
             solver: opts.solver.unwrap_or_else(solver),
+            allow_uninterpreted_cast: opts
+                .allow_uninterpreted_cast
+                .unwrap_or_else(allow_uninterpreted_cast),
         }
     }
 }
@@ -173,11 +182,15 @@ pub struct PartialInferOpts {
     pub check_overflow: Option<bool>,
     pub scrape_quals: Option<bool>,
     pub solver: Option<SmtSolver>,
+    pub allow_uninterpreted_cast: Option<bool>,
 }
 
 impl PartialInferOpts {
     pub fn merge(&mut self, other: &Self) {
         self.check_overflow = self.check_overflow.or(other.check_overflow);
+        self.allow_uninterpreted_cast = self
+            .allow_uninterpreted_cast
+            .or(other.allow_uninterpreted_cast);
         self.scrape_quals = self.scrape_quals.or(other.scrape_quals);
         self.solver = self.solver.or(other.solver);
     }

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -135,7 +135,7 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
                 .map(|(_, itf)| (itf.name, fhir::SpecFuncKind::Thy(itf.itf))),
         );
         self.func_decls
-            .insert(Symbol::intern("char_to_int"), fhir::SpecFuncKind::CharToInt);
+            .insert(Symbol::intern("to_int"), fhir::SpecFuncKind::ToInt);
     }
 
     fn define_items(&mut self, item_ids: impl IntoIterator<Item = &'tcx ItemId>) {

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -135,7 +135,7 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
                 .map(|(_, itf)| (itf.name, fhir::SpecFuncKind::Thy(itf.itf))),
         );
         self.func_decls
-            .insert(Symbol::intern("to_int"), fhir::SpecFuncKind::ToInt);
+            .insert(Symbol::intern("cast"), fhir::SpecFuncKind::Cast);
     }
 
     fn define_items(&mut self, item_ids: impl IntoIterator<Item = &'tcx ItemId>) {

--- a/crates/flux-driver/src/collector/mod.rs
+++ b/crates/flux-driver/src/collector/mod.rs
@@ -532,8 +532,8 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
     }
 
     fn collect_infer_opts(&mut self, attrs: &mut FluxAttrs, def_id: LocalDefId) {
-        if let Some(check_overflow) = attrs.infer_opts() {
-            self.specs.infer_opts.insert(def_id, check_overflow);
+        if let Some(infer_opts) = attrs.infer_opts() {
+            self.specs.infer_opts.insert(def_id, infer_opts);
         }
     }
 }
@@ -827,6 +827,7 @@ impl AttrMap {
 
     fn try_into_infer_opts(&mut self) -> AttrMapErr<PartialInferOpts> {
         let mut infer_opts = PartialInferOpts::default();
+        try_read_setting!(self, allow_uninterpreted_cast, bool, infer_opts);
         try_read_setting!(self, check_overflow, bool, infer_opts);
         try_read_setting!(self, scrape_quals, bool, infer_opts);
         try_read_setting!(self, solver, SmtSolver, infer_opts);

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -99,6 +99,11 @@ fhir_analysis_cannot_infer_sort =
     .label = cannot infer sort
     .note = sort must be known at this point
 
+fhir_analysis_invalid_cast =
+    invalid cast from `{$from}` to `{$to}`
+    .label = invalid cast
+    .note = use `allow_uninterpreted_cast` to enable this cast
+
 # Structural Compatibility
 
 fhir_analysis_incompatible_refinement =

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2299,7 +2299,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
             fhir::SpecFuncKind::Thy(thy_func) => Ok(rty::SpecFuncKind::Thy(*thy_func)),
             fhir::SpecFuncKind::Uif(flux_id) => Ok(rty::SpecFuncKind::Uif(*flux_id)),
             fhir::SpecFuncKind::Def(flux_id) => Ok(rty::SpecFuncKind::Def(*flux_id)),
-            fhir::SpecFuncKind::ToInt => Err(rty::InternalFuncKind::ToInt),
+            fhir::SpecFuncKind::Cast => Err(rty::InternalFuncKind::Cast),
         }
     }
 

--- a/crates/flux-fhir-analysis/src/wf/errors.rs
+++ b/crates/flux-fhir-analysis/src/wf/errors.rs
@@ -275,3 +275,20 @@ impl CannotInferSort {
         Self { span }
     }
 }
+
+#[derive(Diagnostic)]
+#[diag(fhir_analysis_invalid_cast, code = E0999)]
+#[note]
+pub(super) struct InvalidCast {
+    #[primary_span]
+    #[label]
+    span: Span,
+    from: String,
+    to: String,
+}
+
+impl InvalidCast {
+    pub(super) fn new(span: Span, from: &rty::Sort, to: &rty::Sort) -> Self {
+        Self { span, from: format!("{from:?}"), to: format!("{to:?}") }
+    }
+}

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -578,4 +578,8 @@ impl WfckResultsProvider for InferCtxt<'_, '_> {
     fn node_sort(&self, _: FhirId) -> rty::Sort {
         rty::Sort::Err
     }
+
+    fn node_sort_args(&self, _: FhirId) -> rty::List<rty::SortArg> {
+        rty::List::empty()
+    }
 }

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -820,11 +820,10 @@ impl<'genv> InferCtxt<'genv, '_> {
             self.wfckresults.bin_op_sorts_mut().insert(fhir_id, sort);
         }
 
-        let allow_uninterpreted_cast = if let Some(def_id) = self.owner.def_id() {
-            self.genv.infer_opts(def_id).allow_uninterpreted_cast
-        } else {
-            false
-        };
+        let allow_uninterpreted_cast = self
+            .owner
+            .def_id()
+            .map_or(false, |def_id| self.genv.infer_opts(def_id).allow_uninterpreted_cast);
 
         // Make sure that function applications are fully resolved
         for (fhir_id, (sort_args, span)) in std::mem::take(&mut self.sort_args_of_app) {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -36,7 +36,7 @@ pub(super) struct InferCtxt<'genv, 'tcx> {
     sort_of_bty: FxHashMap<FhirId, rty::Sort>,
     sort_of_literal: FxHashMap<FhirId, (rty::Sort, Span)>,
     sort_of_bin_op: FxHashMap<FhirId, (rty::Sort, Span)>,
-    sorts_of_fn_app: FxHashMap<FhirId, (List<rty::SortArg>, Span)>,
+    sort_args_of_app: FxHashMap<FhirId, (List<rty::SortArg>, Span)>,
     path_args: UnordMap<FhirId, rty::GenericArgs>,
     sort_of_alias_reft: FxHashMap<FhirId, rty::FuncSort>,
 }
@@ -68,7 +68,7 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
             sort_of_bin_op: Default::default(),
             path_args: Default::default(),
             sort_of_alias_reft: Default::default(),
-            sorts_of_fn_app: Default::default(),
+            sort_args_of_app: Default::default(),
         }
     }
 
@@ -515,7 +515,7 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
                 }
             })
             .collect_vec();
-        self.sorts_of_fn_app
+        self.sort_args_of_app
             .insert(fhir_id, (List::from_vec(args.clone()), span));
         fsort.instantiate(&args)
     }
@@ -800,7 +800,7 @@ impl<'genv> InferCtxt<'genv, '_> {
         }
 
         // Make sure that function applications are fully resolved
-        for (fhir_id, (sort_args, span)) in std::mem::take(&mut self.sorts_of_fn_app) {
+        for (fhir_id, (sort_args, span)) in std::mem::take(&mut self.sort_args_of_app) {
             let mut res = vec![];
             for sort_arg in &sort_args {
                 let sort_arg = if let rty::SortArg::Sort(sort) = sort_arg {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -396,7 +396,9 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
             }
             ExprRes::ConstGeneric(_) => Ok(rty::Sort::Int), // TODO: generalize generic-const sorts
             ExprRes::NumConst(_) => Ok(rty::Sort::Int),
-            ExprRes::GlobalFunc(spec_func) => Ok(self.genv.sort_of_spec_func(&spec_func)),
+            ExprRes::GlobalFunc(spec_func) => {
+                Ok(rty::Sort::Func(self.genv.sort_of_spec_func(&spec_func)))
+            }
             ExprRes::Ctor(_) => {
                 span_bug!(path.span, "unexpected constructor in var position")
             }
@@ -803,7 +805,7 @@ impl<'genv> InferCtxt<'genv, '_> {
             for sort_arg in &sort_args {
                 let sort_arg = if let rty::SortArg::Sort(sort) = sort_arg {
                     let sort = self
-                        .fully_resolve(&sort)
+                        .fully_resolve(sort)
                         .map_err(|_| self.emit_err(errors::CannotInferSort::new(span)))?;
                     rty::SortArg::Sort(sort)
                 } else {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -5,8 +5,7 @@ use flux_common::{bug, iter::IterExt, result::ResultExt, span_bug, tracked_span_
 use flux_errors::{ErrorGuaranteed, Errors};
 use flux_infer::projections::NormalizeExt;
 use flux_middle::{
-    THEORY_FUNCS,
-    fhir::{self, ExprRes, FhirId, FluxOwnerId, SpecFuncKind, visit::Visitor as _},
+    fhir::{self, ExprRes, FhirId, FluxOwnerId, visit::Visitor as _},
     global_env::GlobalEnv,
     queries::QueryResult,
     rty::{
@@ -397,18 +396,7 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
             }
             ExprRes::ConstGeneric(_) => Ok(rty::Sort::Int), // TODO: generalize generic-const sorts
             ExprRes::NumConst(_) => Ok(rty::Sort::Int),
-            ExprRes::GlobalFunc(SpecFuncKind::Def(name) | SpecFuncKind::Uif(name)) => {
-                Ok(rty::Sort::Func(self.genv.func_sort(name)))
-            }
-            ExprRes::GlobalFunc(SpecFuncKind::Thy(itf)) => {
-                Ok(rty::Sort::Func(THEORY_FUNCS.get(&itf).unwrap().sort.clone()))
-            }
-            ExprRes::GlobalFunc(SpecFuncKind::ToInt) => {
-                Ok(rty::Sort::Func(rty::PolyFuncSort::new(
-                    List::empty(),
-                    rty::FuncSort::new(vec![rty::Sort::Char], rty::Sort::Int),
-                )))
-            }
+            ExprRes::GlobalFunc(spec_func) => Ok(self.genv.sort_of_spec_func(&spec_func)),
             ExprRes::Ctor(_) => {
                 span_bug!(path.span, "unexpected constructor in var position")
             }

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -1075,7 +1075,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
             }
             InternalFuncKind::Cast => {
                 let [rty::SortArg::Sort(from), rty::SortArg::Sort(to)] = &sort_args else {
-                    span_bug!(self.def_span, "unexpected cast")
+                    span_bug!(self.def_span(), "unexpected cast")
                 };
                 match from.cast_kind(to) {
                     rty::CastKind::Identity => self.expr_to_fixpoint(&args[0], scx),

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -1047,6 +1047,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
     fn internal_func_to_fixpoint(
         &mut self,
         internal_func: &InternalFuncKind,
+        sort_args: &[rty::SortArg],
         args: &[rty::Expr],
         scx: &mut SortEncodingCtxt,
     ) -> QueryResult<fixpoint::Expr> {
@@ -1064,7 +1065,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                 };
                 self.expr_to_fixpoint(&expr, scx)
             }
-            InternalFuncKind::CharToInt | InternalFuncKind::IntToChar => {
+            InternalFuncKind::ToInt | InternalFuncKind::ToChar => {
                 // We can erase the "call" because fixpoint uses `int` to represent `char`
                 // so the conversions are unnecessary.
                 self.expr_to_fixpoint(&args[0], scx)
@@ -1094,9 +1095,9 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                 let var = self.define_const_for_rust_const(*did, scx);
                 fixpoint::Expr::Var(var)
             }
-            rty::ExprKind::App(func, args) => {
+            rty::ExprKind::App(func, sort_args, args) => {
                 if let rty::ExprKind::InternalFunc(func) = func.kind() {
-                    self.internal_func_to_fixpoint(func, args, scx)?
+                    self.internal_func_to_fixpoint(func, sort_args, args, scx)?
                 } else {
                     let func = self.expr_to_fixpoint(func, scx)?;
                     let args = self.exprs_to_fixpoint(args, scx)?;

--- a/crates/flux-metadata/src/encoder.rs
+++ b/crates/flux-metadata/src/encoder.rs
@@ -141,7 +141,7 @@ impl SpanEncoder for EncodeContext<'_, '_> {
 
     fn encode_byte_symbol(&mut self, byte_sym: ByteSymbol) {
         self.encode_symbol_or_byte_symbol(byte_sym.as_u32(), |this| {
-            this.emit_byte_str(byte_sym.as_byte_str())
+            this.emit_byte_str(byte_sym.as_byte_str());
         });
     }
 }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -1193,7 +1193,7 @@ pub enum SpecFuncKind {
     /// User-defined functions with a body definition
     Def(FluxDefId),
     /// Char-Int Conversions
-    CharToInt,
+    ToInt,
 }
 
 impl SpecFuncKind {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -1193,7 +1193,7 @@ pub enum SpecFuncKind {
     /// User-defined functions with a body definition
     Def(FluxDefId),
     /// Char-Int Conversions
-    ToInt,
+    Cast,
 }
 
 impl SpecFuncKind {

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -320,6 +320,14 @@ impl Expr {
         Expr::ctor_struct(def_id, List::empty())
     }
 
+    pub fn cast(from: Sort, to: Sort, idx: Expr) -> Expr {
+        Expr::app(
+            InternalFuncKind::Cast,
+            List::from_arr([SortArg::Sort(from), SortArg::Sort(to)]),
+            List::from_arr([idx]),
+        )
+    }
+
     pub fn app(func: impl Into<Expr>, sort_args: List<SortArg>, args: List<Expr>) -> Expr {
         ExprKind::App(func.into(), sort_args, args).intern()
     }
@@ -705,9 +713,8 @@ pub enum InternalFuncKind {
     Val(BinOp),
     /// UIF representing the relationship of a primop
     Rel(BinOp),
-    // CHARS
-    ToInt,
-    ToChar,
+    // Conversions betweeen Sorts
+    Cast,
 }
 
 #[derive(Debug, Clone, TyEncodable, TyDecodable, PartialEq, Eq, Hash)]
@@ -1304,8 +1311,7 @@ pub(crate) mod pretty {
             match self {
                 InternalFuncKind::Val(op) => w!(cx, f, "[{:?}]", op),
                 InternalFuncKind::Rel(op) => w!(cx, f, "[{:?}]?", op),
-                InternalFuncKind::ToInt => w!(cx, f, "to_int"),
-                InternalFuncKind::ToChar => w!(cx, f, "to_char"),
+                InternalFuncKind::Cast => w!(cx, f, "cast"),
             }
         }
     }

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -887,8 +887,9 @@ impl TypeSuperVisitable for Expr {
             ExprKind::FieldProj(e, _) | ExprKind::PathProj(e, _) | ExprKind::UnaryOp(_, e) => {
                 e.visit_with(visitor)
             }
-            ExprKind::App(func, arg) => {
+            ExprKind::App(func, sorts, arg) => {
                 func.visit_with(visitor)?;
+                sorts.visit_with(visitor)?;
                 arg.visit_with(visitor)
             }
             ExprKind::IfThenElse(p, e1, e2) => {
@@ -944,8 +945,12 @@ impl TypeSuperFoldable for Expr {
             ExprKind::Tuple(flds) => Expr::tuple(flds.try_fold_with(folder)?),
             ExprKind::Ctor(ctor, flds) => Expr::ctor(*ctor, flds.try_fold_with(folder)?),
             ExprKind::PathProj(e, field) => Expr::path_proj(e.try_fold_with(folder)?, *field),
-            ExprKind::App(func, arg) => {
-                Expr::app(func.try_fold_with(folder)?, arg.try_fold_with(folder)?)
+            ExprKind::App(func, sorts, arg) => {
+                Expr::app(
+                    func.try_fold_with(folder)?,
+                    sorts.try_fold_with(folder)?,
+                    arg.try_fold_with(folder)?,
+                )
             }
             ExprKind::IfThenElse(p, e1, e2) => {
                 Expr::ite(

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -2736,6 +2736,7 @@ impl_slice_internable!(
     Ensures,
     InferMode,
     Sort,
+    SortArg,
     GenericParamDef,
     TraitRef,
     Binder<ExistentialPredicate>,
@@ -2791,6 +2792,7 @@ pub use crate::_Ref as Ref;
 pub struct WfckResults {
     pub owner: FluxOwnerId,
     bin_op_sorts: ItemLocalMap<Sort>,
+    fn_app_sorts: ItemLocalMap<List<SortArg>>,
     coercions: ItemLocalMap<Vec<Coercion>>,
     field_projs: ItemLocalMap<FieldProj>,
     node_sorts: ItemLocalMap<Sort>,
@@ -2825,11 +2827,20 @@ impl WfckResults {
             field_projs: ItemLocalMap::default(),
             node_sorts: ItemLocalMap::default(),
             record_ctors: ItemLocalMap::default(),
+            fn_app_sorts: ItemLocalMap::default(),
         }
     }
 
     pub fn bin_op_sorts_mut(&mut self) -> LocalTableInContextMut<'_, Sort> {
         LocalTableInContextMut { owner: self.owner, data: &mut self.bin_op_sorts }
+    }
+
+    pub fn fn_app_sorts_mut(&mut self) -> LocalTableInContextMut<'_, List<SortArg>> {
+        LocalTableInContextMut { owner: self.owner, data: &mut self.fn_app_sorts }
+    }
+
+    pub fn fn_app_sorts(&self) -> LocalTableInContext<'_, List<SortArg>> {
+        LocalTableInContext { owner: self.owner, data: &self.fn_app_sorts }
     }
 
     pub fn bin_op_sorts(&self) -> LocalTableInContext<'_, Sort> {

--- a/crates/flux-middle/src/sort_of.rs
+++ b/crates/flux-middle/src/sort_of.rs
@@ -4,13 +4,11 @@ use rustc_hir::def::DefKind;
 use rustc_span::def_id::DefId;
 
 use crate::{
-    THEORY_FUNCS,
-    fhir::SpecFuncKind,
     global_env::GlobalEnv,
     queries::{QueryErr, QueryResult},
     query_bug,
     rty::{
-        self, SortParamKind,
+        self,
         fold::{FallibleTypeFolder, TypeFoldable, TypeSuperFoldable as _},
     },
 };
@@ -41,22 +39,6 @@ impl GlobalEnv<'_, '_> {
     pub fn sort_of_def_id(self, def_id: DefId) -> QueryResult<Option<rty::Sort>> {
         let ty = self.tcx().type_of(def_id).no_bound_vars().unwrap();
         if ty.is_integral() { Ok(Some(rty::Sort::Int)) } else { self.sort_of_rust_ty(def_id, ty) }
-    }
-
-    pub fn sort_of_spec_func(self, spec_func: &SpecFuncKind) -> rty::PolyFuncSort {
-        match spec_func {
-            SpecFuncKind::Def(name) | SpecFuncKind::Uif(name) => self.func_sort(name),
-            SpecFuncKind::Thy(itf) => THEORY_FUNCS.get(itf).unwrap().sort.clone(),
-            SpecFuncKind::Cast => {
-                rty::PolyFuncSort::new(
-                    List::from_arr([SortParamKind::Sort, SortParamKind::Sort]),
-                    rty::FuncSort::new(
-                        vec![rty::Sort::Var(rty::ParamSort::from(0_usize))],
-                        rty::Sort::Var(rty::ParamSort::from(1_usize)),
-                    ),
-                )
-            }
-        }
     }
 
     pub fn sort_of_rust_ty(

--- a/crates/flux-middle/src/sort_of.rs
+++ b/crates/flux-middle/src/sort_of.rs
@@ -47,12 +47,12 @@ impl GlobalEnv<'_, '_> {
         match spec_func {
             SpecFuncKind::Def(name) | SpecFuncKind::Uif(name) => self.func_sort(name),
             SpecFuncKind::Thy(itf) => THEORY_FUNCS.get(itf).unwrap().sort.clone(),
-            SpecFuncKind::ToInt => {
+            SpecFuncKind::Cast => {
                 rty::PolyFuncSort::new(
-                    List::singleton(SortParamKind::Sort),
+                    List::from_arr([SortParamKind::Sort, SortParamKind::Sort]),
                     rty::FuncSort::new(
                         vec![rty::Sort::Var(rty::ParamSort::from(0_usize))],
-                        rty::Sort::Int,
+                        rty::Sort::Var(rty::ParamSort::from(1_usize)),
                     ),
                 )
             }

--- a/crates/flux-middle/src/sort_of.rs
+++ b/crates/flux-middle/src/sort_of.rs
@@ -43,20 +43,18 @@ impl GlobalEnv<'_, '_> {
         if ty.is_integral() { Ok(Some(rty::Sort::Int)) } else { self.sort_of_rust_ty(def_id, ty) }
     }
 
-    pub fn sort_of_spec_func(self, spec_func: &SpecFuncKind) -> rty::Sort {
+    pub fn sort_of_spec_func(self, spec_func: &SpecFuncKind) -> rty::PolyFuncSort {
         match spec_func {
-            SpecFuncKind::Def(name) | SpecFuncKind::Uif(name) => {
-                rty::Sort::Func(self.func_sort(name))
-            }
-            SpecFuncKind::Thy(itf) => rty::Sort::Func(THEORY_FUNCS.get(&itf).unwrap().sort.clone()),
+            SpecFuncKind::Def(name) | SpecFuncKind::Uif(name) => self.func_sort(name),
+            SpecFuncKind::Thy(itf) => THEORY_FUNCS.get(itf).unwrap().sort.clone(),
             SpecFuncKind::ToInt => {
-                rty::Sort::Func(rty::PolyFuncSort::new(
+                rty::PolyFuncSort::new(
                     List::singleton(SortParamKind::Sort),
                     rty::FuncSort::new(
-                        vec![rty::Sort::Var(rty::ParamSort::from(0 as usize))],
+                        vec![rty::Sort::Var(rty::ParamSort::from(0_usize))],
                         rty::Sort::Int,
                     ),
-                ))
+                )
             }
         }
     }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -2004,16 +2004,20 @@ fn bool_int_cast(b: &Expr, int_ty: IntTy) -> Ty {
 }
 
 fn uint_char_cast(idx: &Expr) -> Ty {
+    let sort_arg = rty::SortArg::Sort(rty::Sort::Int);
     let idx = Expr::app(
-        rty::Expr::internal_func(InternalFuncKind::IntToChar),
+        rty::Expr::internal_func(InternalFuncKind::ToChar),
+        rty::List::singleton(sort_arg),
         rty::List::singleton(idx.clone()),
     );
     Ty::indexed(BaseTy::Char, idx)
 }
 
 fn char_uint_cast(idx: &Expr, uint_ty: UintTy) -> Ty {
+    let sort_arg = rty::SortArg::Sort(rty::Sort::Char);
     let idx = Expr::app(
-        Expr::internal_func(InternalFuncKind::IntToChar),
+        Expr::internal_func(InternalFuncKind::ToInt),
+        rty::List::singleton(sort_arg),
         rty::List::singleton(idx.clone()),
     );
     Ty::indexed(BaseTy::Uint(uint_ty), idx)

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -18,8 +18,8 @@ use flux_middle::{
     query_bug,
     rty::{
         self, AdtDef, BaseTy, Binder, Bool, Clause, CoroutineObligPredicate, EarlyBinder, Expr,
-        FnOutput, FnTraitPredicate, GenericArg, GenericArgsExt as _, Int, IntTy, InternalFuncKind,
-        Mutability, Path, PolyFnSig, PtrKind, RefineArgs, RefineArgsExt,
+        FnOutput, FnTraitPredicate, GenericArg, GenericArgsExt as _, Int, IntTy, Mutability, Path,
+        PolyFnSig, PtrKind, RefineArgs, RefineArgsExt,
         Region::ReStatic,
         Ty, TyKind, Uint, UintTy, VariantIdx,
         fold::{TypeFoldable, TypeFolder, TypeSuperFoldable},
@@ -2004,22 +2004,12 @@ fn bool_int_cast(b: &Expr, int_ty: IntTy) -> Ty {
 }
 
 fn uint_char_cast(idx: &Expr) -> Ty {
-    let sort_arg = rty::SortArg::Sort(rty::Sort::Int);
-    let idx = Expr::app(
-        rty::Expr::internal_func(InternalFuncKind::ToChar),
-        rty::List::singleton(sort_arg),
-        rty::List::singleton(idx.clone()),
-    );
+    let idx = Expr::cast(rty::Sort::Int, rty::Sort::Char, idx.clone());
     Ty::indexed(BaseTy::Char, idx)
 }
 
 fn char_uint_cast(idx: &Expr, uint_ty: UintTy) -> Ty {
-    let sort_arg = rty::SortArg::Sort(rty::Sort::Char);
-    let idx = Expr::app(
-        Expr::internal_func(InternalFuncKind::ToInt),
-        rty::List::singleton(sort_arg),
-        rty::List::singleton(idx.clone()),
-    );
+    let idx = Expr::cast(rty::Sort::Char, rty::Sort::Int, idx.clone());
     Ty::indexed(BaseTy::Uint(uint_ty), idx)
 }
 

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -336,7 +336,7 @@ impl<T: Types> fmt::Display for Constant<T> {
             Constant::Boolean(b) => write!(f, "{b}"),
             Constant::String(s) => write!(f, "{}", s.display()),
             Constant::BitVec(i, sz) => {
-                if sz % 4 == 0 {
+                if sz.is_multiple_of(4) {
                     write!(f, "(lit \"#x{i:00$x}\" (BitVec Size{sz}))", (sz / 4) as usize)
                 } else {
                     write!(f, "(lit \"#b{i:00$x}\" (BitVec Size{sz}))", *sz as usize)

--- a/tests/tests/neg/error_messages/wf/invalid_cast.rs
+++ b/tests/tests/neg/error_messages/wf/invalid_cast.rs
@@ -2,5 +2,5 @@ pub struct S {}
 
 #[flux::sig(fn(x:S) -> i32[cast(x)])] //~ ERROR invalid cast
 pub fn foo(_x: S) -> i32 {
-    0 //~ ERROR refinement type
+    0
 }

--- a/tests/tests/neg/error_messages/wf/invalid_cast.rs
+++ b/tests/tests/neg/error_messages/wf/invalid_cast.rs
@@ -1,0 +1,6 @@
+pub struct S {}
+
+#[flux::sig(fn(x:S) -> i32[cast(x)])] //~ ERROR invalid cast
+pub fn foo(_x: S) -> i32 {
+    0 //~ ERROR refinement type
+}

--- a/tests/tests/neg/surface/char_int00.rs
+++ b/tests/tests/neg/surface/char_int00.rs
@@ -1,11 +1,11 @@
 #![flux::defs {
     fn is_ascii_digit(c:char) -> bool {
-        let i = char_to_int(c);
+        let i = to_int(c);
         48 <= i && i <= 57
     }
 
     fn is_ascii(c:char) -> bool {
-            let i = char_to_int(c);
+            let i = to_int(c);
             0 <= i && i <= 127
     }
 }]

--- a/tests/tests/neg/surface/to_int00.rs
+++ b/tests/tests/neg/surface/to_int00.rs
@@ -1,0 +1,29 @@
+#![flux::defs {
+    fn is_ascii_digit(c:char) -> bool {
+        let i = to_int(c);
+        48 <= i && i <= 57
+    }
+
+    fn is_ascii(c:char) -> bool {
+            let i = to_int(c);
+            0 <= i && i <= 127
+    }
+}]
+
+use flux_rs::{assert, attrs::*};
+
+// extern specs for is_ascii and is_ascii_digit
+#[extern_spec]
+impl char {
+    #[spec(fn (&Self[@c]) -> bool[is_ascii(c)])]
+    fn is_ascii(&self) -> bool;
+
+    #[spec(fn (&Self[@c]) -> bool[is_ascii_digit(c)])]
+    fn is_ascii_digit(&self) -> bool;
+}
+
+pub fn test_err(x: char) {
+    if x.is_ascii() {
+        assert(x.is_ascii_digit()) //~ ERROR refinement type
+    }
+}

--- a/tests/tests/neg/surface/to_int00.rs
+++ b/tests/tests/neg/surface/to_int00.rs
@@ -1,16 +1,17 @@
 #![flux::defs {
-    fn as_int(x:int) -> int {
-        x
+    // wrapper to monomorphize cast
+    fn cast_to_int(x:char) -> int {
+        cast(x)
     }
 
     fn is_ascii_digit(c:char) -> bool {
-        let i = cast(c);
-        as_int(48) <= i && i <= as_int(57)
+        let i = cast_to_int(c);
+        48 <= i && i <= 57
     }
 
     fn is_ascii(c:char) -> bool {
-        let i = cast(c);
-        as_int(0) <= i && i <= as_int(127)
+        let i = cast_to_int(c);
+        0 <= i && i <= 127
     }
 }]
 

--- a/tests/tests/neg/surface/to_int00.rs
+++ b/tests/tests/neg/surface/to_int00.rs
@@ -1,12 +1,16 @@
 #![flux::defs {
+    fn as_int(x:int) -> int {
+        x
+    }
+
     fn is_ascii_digit(c:char) -> bool {
-        let i = to_int(c);
-        48 <= i && i <= 57
+        let i = cast(c);
+        as_int(48) <= i && i <= as_int(57)
     }
 
     fn is_ascii(c:char) -> bool {
-            let i = to_int(c);
-            0 <= i && i <= 127
+        let i = cast(c);
+        as_int(0) <= i && i <= as_int(127)
     }
 }]
 

--- a/tests/tests/neg/surface/to_int01.rs
+++ b/tests/tests/neg/surface/to_int01.rs
@@ -1,0 +1,11 @@
+use flux_rs::attrs::*;
+
+#[spec(fn (x:bool) -> u32[to_int(x)])]
+pub fn test_bool_to_int(_x: bool) -> u32 {
+    0 //~ ERROR refinement type
+}
+
+#[spec(fn (x:bool) -> u32[to_int(x)])]
+pub fn test_bool_to_int_with_if(x: bool) -> u32 {
+    if x { 1 } else { 1 } //~ERROR refinement type
+}

--- a/tests/tests/neg/surface/to_int01.rs
+++ b/tests/tests/neg/surface/to_int01.rs
@@ -12,6 +12,7 @@ pub fn test_bool_to_int_with_if(x: bool) -> u32 {
 
 struct S {}
 
+#[flux::opts(allow_uninterpreted_cast = true)]
 #[flux::sig(fn(x:S) -> i32[cast(x)])]
 fn foo(x: S) -> i32 {
     0 //~ ERROR refinement type

--- a/tests/tests/neg/surface/to_int01.rs
+++ b/tests/tests/neg/surface/to_int01.rs
@@ -1,18 +1,18 @@
 use flux_rs::attrs::*;
 
-#[spec(fn (x:bool) -> u32[to_int(x)])]
+#[spec(fn (x:bool) -> u32[cast(x)])]
 pub fn test_bool_to_int(_x: bool) -> u32 {
     0 //~ ERROR refinement type
 }
 
-#[spec(fn (x:bool) -> u32[to_int(x)])]
+#[spec(fn (x:bool) -> u32[cast(x)])]
 pub fn test_bool_to_int_with_if(x: bool) -> u32 {
     if x { 1 } else { 1 } //~ERROR refinement type
 }
 
 struct S {}
 
-#[flux::sig(fn(x:S) -> i32[to_int(x)])]
+#[flux::sig(fn(x:S) -> i32[cast(x)])]
 fn foo(x: S) -> i32 {
     0 //~ ERROR refinement type
 }

--- a/tests/tests/neg/surface/to_int01.rs
+++ b/tests/tests/neg/surface/to_int01.rs
@@ -9,3 +9,10 @@ pub fn test_bool_to_int(_x: bool) -> u32 {
 pub fn test_bool_to_int_with_if(x: bool) -> u32 {
     if x { 1 } else { 1 } //~ERROR refinement type
 }
+
+struct S {}
+
+#[flux::sig(fn(x:S) -> i32[to_int(x)])]
+fn foo(x: S) -> i32 {
+    0 //~ ERROR refinement type
+}

--- a/tests/tests/pos/surface/to_int00.rs
+++ b/tests/tests/pos/surface/to_int00.rs
@@ -1,16 +1,17 @@
 #![flux::defs {
-    fn as_int(x:int) -> int {
-        x
+
+    fn cast_to_int(c:char) -> int {
+        cast(c)
     }
 
     fn is_ascii_digit(c:char) -> bool {
-        let i = cast(c);
-        as_int(48) <= i && i <= as_int(57)
+        let i = cast_to_int(c);
+        48 <= i && i <= 57
     }
 
     fn is_ascii(c:char) -> bool {
-        let i = cast(c);
-        as_int(0) <= i && i <= as_int(127)
+        let i = cast_to_int(c);
+        0 <= i && i <= 127
     }
 }]
 

--- a/tests/tests/pos/surface/to_int00.rs
+++ b/tests/tests/pos/surface/to_int00.rs
@@ -28,12 +28,6 @@ pub fn test_ok(x: char) {
     }
 }
 
-pub fn test_err(x: char) {
-    if x.is_ascii() {
-        assert(x.is_ascii_digit()) //~ ERROR refinement type
-    }
-}
-
 #[spec(fn (char{v: '0' <= v && v <= '9'}))]
 pub fn test_digit(x: char) {
     assert(x.is_ascii_digit())

--- a/tests/tests/pos/surface/to_int00.rs
+++ b/tests/tests/pos/surface/to_int00.rs
@@ -1,12 +1,16 @@
 #![flux::defs {
+    fn as_int(x:int) -> int {
+        x
+    }
+
     fn is_ascii_digit(c:char) -> bool {
-        let i = to_int(c);
-        48 <= i && i <= 57
+        let i = cast(c);
+        as_int(48) <= i && i <= as_int(57)
     }
 
     fn is_ascii(c:char) -> bool {
-            let i = to_int(c);
-            0 <= i && i <= 127
+        let i = cast(c);
+        as_int(0) <= i && i <= as_int(127)
     }
 }]
 

--- a/tests/tests/pos/surface/to_int01.rs
+++ b/tests/tests/pos/surface/to_int01.rs
@@ -5,12 +5,17 @@ pub fn test_int_to_int(x: u8) -> u32 {
     x as u32
 }
 
-// #[spec(fn (x:bool) -> u32[to_int(x)])]
-// pub fn test_bool_to_int(x: bool) -> u32 {
-//     x as u32
-// }
-
 #[spec(fn (x:char) -> u32[to_int(x)])]
 pub fn test_char_to_int(x: char) -> u32 {
     x as u32
+}
+
+#[spec(fn (x:bool) -> u32[to_int(x)])]
+pub fn test_bool_to_int(x: bool) -> u32 {
+    x as u32
+}
+
+#[spec(fn (x:bool) -> u32[to_int(x)])]
+pub fn test_bool_to_int_with_if(x: bool) -> u32 {
+    if x { 1 } else { 0 }
 }

--- a/tests/tests/pos/surface/to_int01.rs
+++ b/tests/tests/pos/surface/to_int01.rs
@@ -1,0 +1,16 @@
+use flux_rs::{assert, attrs::*};
+
+#[spec(fn (x:u8) -> u32[to_int(x)])]
+pub fn test_int_to_int(x: u8) -> u32 {
+    x as u32
+}
+
+#[spec(fn (x:bool) -> u32[to_int(x)])]
+pub fn test_bool_to_int(x: bool) -> u32 {
+    x as u32
+}
+
+#[spec(fn (x:char) -> u32[to_int(x)])]
+pub fn test_char_to_int(x: char) -> u32 {
+    x as u32
+}

--- a/tests/tests/pos/surface/to_int01.rs
+++ b/tests/tests/pos/surface/to_int01.rs
@@ -1,14 +1,14 @@
-use flux_rs::{assert, attrs::*};
+use flux_rs::attrs::*;
 
 #[spec(fn (x:u8) -> u32[to_int(x)])]
 pub fn test_int_to_int(x: u8) -> u32 {
     x as u32
 }
 
-#[spec(fn (x:bool) -> u32[to_int(x)])]
-pub fn test_bool_to_int(x: bool) -> u32 {
-    x as u32
-}
+// #[spec(fn (x:bool) -> u32[to_int(x)])]
+// pub fn test_bool_to_int(x: bool) -> u32 {
+//     x as u32
+// }
 
 #[spec(fn (x:char) -> u32[to_int(x)])]
 pub fn test_char_to_int(x: char) -> u32 {

--- a/tests/tests/pos/surface/to_int01.rs
+++ b/tests/tests/pos/surface/to_int01.rs
@@ -25,8 +25,16 @@ pub fn test_usize_to_float(x: u8) -> f32 {
     x as f32
 }
 
+#[trusted]
+#[flux::opts(allow_uninterpreted_cast = true)]
+#[spec(fn (x:usize) -> bool[cast(x)])]
+pub fn test_usize_to_bool(x: usize) -> bool {
+    x != 0
+}
+
 pub struct S {}
 
+#[flux::opts(allow_uninterpreted_cast = true)]
 #[spec(fn(x:S, n:usize[cast(x)]) -> usize[cast(x)])]
 pub fn foo(_x: S, n: usize) -> usize {
     n

--- a/tests/tests/pos/surface/to_int01.rs
+++ b/tests/tests/pos/surface/to_int01.rs
@@ -1,28 +1,33 @@
 use flux_rs::attrs::*;
 
-#[spec(fn (x:u8) -> u32[to_int(x)])]
+#[spec(fn (x:u8) -> u32[cast(x)])]
 pub fn test_int_to_int(x: u8) -> u32 {
     x as u32
 }
 
-#[spec(fn (x:char) -> u32[to_int(x)])]
+#[spec(fn (x:char) -> u32[cast(x)])]
 pub fn test_char_to_int(x: char) -> u32 {
     x as u32
 }
 
-#[spec(fn (x:bool) -> u32[to_int(x)])]
+#[spec(fn (x:bool) -> u32[cast(x)])]
 pub fn test_bool_to_int(x: bool) -> u32 {
     x as u32
 }
 
-#[spec(fn (x:bool) -> u32[to_int(x)])]
+#[spec(fn (x:bool) -> u32[cast(x)])]
 pub fn test_bool_to_int_with_if(x: bool) -> u32 {
     if x { 1 } else { 0 }
 }
 
+#[spec(fn (x:u8) -> f32[cast(x)])]
+pub fn test_usize_to_float(x: u8) -> f32 {
+    x as f32
+}
+
 pub struct S {}
 
-#[spec(fn(x:S, n:usize[to_int(x)]) -> usize[to_int(x)])]
+#[spec(fn(x:S, n:usize[cast(x)]) -> usize[cast(x)])]
 pub fn foo(_x: S, n: usize) -> usize {
     n
 }

--- a/tests/tests/pos/surface/to_int01.rs
+++ b/tests/tests/pos/surface/to_int01.rs
@@ -19,3 +19,10 @@ pub fn test_bool_to_int(x: bool) -> u32 {
 pub fn test_bool_to_int_with_if(x: bool) -> u32 {
     if x { 1 } else { 0 }
 }
+
+pub struct S {}
+
+#[spec(fn(x:S, n:usize[to_int(x)]) -> usize[to_int(x)])]
+pub fn foo(_x: S, n: usize) -> usize {
+    n
+}


### PR DESCRIPTION
1. Changes the `rty::Expr::App` to explicitly track the `List<SortArg>` that were inferred during the `sortck`
2. Generalizes `char_to_int` to "polymorphic" ~~`to_int`~~ `cast`
3. Uses the explicit `SortArg` during fixpoint-conversion for ~~`to_int`~~ `cast`.

Allows stuff like

```rust
use flux_rs::attrs::*;

#[spec(fn (x:u8) -> u32[cast(x)])]
pub fn test_int_to_int(x: u8) -> u32 {
    x as u32
}

#[spec(fn (x:char) -> u32[cast(x)])]
pub fn test_char_to_int(x: char) -> u32 {
    x as u32
}

#[spec(fn (x:bool) -> u32[cast(x)])]
pub fn test_bool_to_int(x: bool) -> u32 {
    x as u32
}

#[spec(fn (x:bool) -> u32[cast(x)])]
pub fn test_bool_to_int_with_if(x: bool) -> u32 {
    if x { 1 } else { 0 }
}

pub struct S {}

#[spec(fn(x:S, n:usize[to_int(x)]) -> usize[cast(x)])]
pub fn foo(_x: S, n: usize) -> usize {
    n
}
``` 