### PR TITLE
Fix support for 'int' suffix

### DIFF
--- a/crates/flux-bin/src/lib.rs
+++ b/crates/flux-bin/src/lib.rs
@@ -16,6 +16,8 @@ pub struct FluxMetadata {
     pub scrape_quals: Option<bool>,
     /// Enable overflow checking
     pub check_overflow: Option<bool>,
+    /// Enable uninterpreted casts
+    pub allow_uninterpreted_cast: Option<bool>,
     /// Enable flux-defs to be defined as SMT functions
     pub smt_define_fun: Option<bool>,
     /// Set trusted to trusted
@@ -50,6 +52,9 @@ impl FluxMetadata {
         }
         if let Some(v) = self.default_ignore {
             flags.push(format!("-Fignore={v}"));
+        }
+        if let Some(v) = self.allow_uninterpreted_cast {
+            flags.push(format!("-Fallow-uninterpreted-cast={v}"));
         }
         if let Some(patterns) = self.include {
             for pat in patterns {

--- a/crates/flux-config/src/lib.rs
+++ b/crates/flux-config/src/lib.rs
@@ -69,7 +69,7 @@ fn check_overflow() -> bool {
     FLAGS.check_overflow
 }
 
-fn allow_uninterpreted_cast() -> bool {
+pub fn allow_uninterpreted_cast() -> bool {
     FLAGS.allow_uninterpreted_cast
 }
 

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1593,15 +1593,15 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     Ok(n) => n,
                     Err(err) => return fhir::ExprKind::Err(err),
                 };
-                let suffix = lit.suffix.unwrap_or(sym::int);
-                if suffix == sym::int {
-                    fhir::Lit::Int(n)
-                } else if suffix == sym::real {
-                    fhir::Lit::Real(n)
-                } else {
-                    return fhir::ExprKind::Err(
-                        self.emit(errors::InvalidNumericSuffix::new(span, suffix)),
-                    );
+                match lit.suffix {
+                    Some(sym::int) => fhir::Lit::Int(n, Some(fhir::NumLitKind::Int)),
+                    Some(sym::real) => fhir::Lit::Int(n, Some(fhir::NumLitKind::Real)),
+                    None => fhir::Lit::Int(n, None),
+                    Some(suffix) => {
+                        return fhir::ExprKind::Err(
+                            self.emit(errors::InvalidNumericSuffix::new(span, suffix)),
+                        );
+                    }
                 }
             }
             surface::LitKind::Bool => fhir::Lit::Bool(lit.symbol == kw::True),

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2061,21 +2061,26 @@ fn prim_ty_to_bty(prim_ty: rustc_hir::PrimTy) -> rty::BaseTy {
 impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
     fn conv_lit(&self, lit: fhir::Lit, fhir_id: FhirId, span: Span) -> QueryResult<rty::Constant> {
         match lit {
-            fhir::Lit::Int(n) => {
-                let sort = self.results().node_sort(fhir_id);
-                if let rty::Sort::BitVec(bvsize) = sort {
-                    if let rty::BvSize::Fixed(size) = bvsize
-                        && (n == 0 || n.ilog2() < size)
-                    {
-                        Ok(rty::Constant::BitVec(n, size))
-                    } else {
-                        Err(self.emit(errors::InvalidBitVectorConstant::new(span, sort)))?
+            fhir::Lit::Int(n, kind) => {
+                match kind {
+                    Some(fhir::NumLitKind::Int) => Ok(rty::Constant::Int(n.into())),
+                    Some(fhir::NumLitKind::Real) => Ok(rty::Constant::Real(rty::Real(n))),
+                    None => {
+                        let sort = self.results().node_sort(fhir_id);
+                        if let rty::Sort::BitVec(bvsize) = sort {
+                            if let rty::BvSize::Fixed(size) = bvsize
+                                && (n == 0 || n.ilog2() < size)
+                            {
+                                Ok(rty::Constant::BitVec(n, size))
+                            } else {
+                                Err(self.emit(errors::InvalidBitVectorConstant::new(span, sort)))?
+                            }
+                        } else {
+                            Ok(rty::Constant::from(n))
+                        }
                     }
-                } else {
-                    Ok(rty::Constant::from(n))
                 }
             }
-            fhir::Lit::Real(r) => Ok(rty::Constant::Real(rty::Real(r))),
             fhir::Lit::Bool(b) => Ok(rty::Constant::from(b)),
             fhir::Lit::Str(s) => Ok(rty::Constant::from(s)),
             fhir::Lit::Char(c) => Ok(rty::Constant::from(c)),

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2063,7 +2063,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         match lit {
             fhir::Lit::Int(n, kind) => {
                 match kind {
-                    Some(fhir::NumLitKind::Int) => Ok(rty::Constant::Int(n.into())),
+                    Some(fhir::NumLitKind::Int) => Ok(rty::Constant::from(n)),
                     Some(fhir::NumLitKind::Real) => Ok(rty::Constant::Real(rty::Real(n))),
                     None => {
                         let sort = self.results().node_sort(fhir_id);

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -1016,9 +1016,14 @@ impl Expr<'_> {
 }
 
 #[derive(Clone, Copy)]
+pub enum NumLitKind {
+    Int,
+    Real,
+}
+
+#[derive(Clone, Copy)]
 pub enum Lit {
-    Int(u128),
-    Real(u128),
+    Int(u128, Option<NumLitKind>),
     Bool(bool),
     Str(Symbol),
     Char(char),
@@ -1192,7 +1197,7 @@ pub enum SpecFuncKind {
     Uif(FluxDefId),
     /// User-defined functions with a body definition
     Def(FluxDefId),
-    /// Char-Int Conversions
+    /// Casts between sorts: id for char, int; if-then-else for bool-int; uninterpreted otherwise.
     Cast,
 }
 
@@ -1548,8 +1553,8 @@ impl fmt::Debug for PathExpr<'_> {
 impl fmt::Debug for Lit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Lit::Int(i) => write!(f, "{i}"),
-            Lit::Real(r) => write!(f, "{r}real"),
+            Lit::Int(i, Some(NumLitKind::Real)) => write!(f, "{i}real"),
+            Lit::Int(i, _) => write!(f, "{i}"),
             Lit::Bool(b) => write!(f, "{b}"),
             Lit::Str(s) => write!(f, "\"{s:?}\""),
             Lit::Char(c) => write!(f, "\'{c}\'"),

--- a/tests/tests/neg/surface/to_int00.rs
+++ b/tests/tests/neg/surface/to_int00.rs
@@ -1,17 +1,12 @@
 #![flux::defs {
-    // wrapper to monomorphize cast
-    fn cast_to_int(x:char) -> int {
-        cast(x)
-    }
-
     fn is_ascii_digit(c:char) -> bool {
-        let i = cast_to_int(c);
-        48 <= i && i <= 57
+        let i = cast(c);
+        48int <= i && i <= 57
     }
 
     fn is_ascii(c:char) -> bool {
-        let i = cast_to_int(c);
-        0 <= i && i <= 127
+        let i = cast(c);
+        0int <= i && i <= 127
     }
 }]
 

--- a/tests/tests/pos/surface/to_int00.rs
+++ b/tests/tests/pos/surface/to_int00.rs
@@ -1,17 +1,13 @@
 #![flux::defs {
 
-    fn cast_to_int(c:char) -> int {
-        cast(c)
-    }
-
     fn is_ascii_digit(c:char) -> bool {
-        let i = cast_to_int(c);
-        48 <= i && i <= 57
+        let i = cast(c);
+        48int <= i && i <= 57
     }
 
     fn is_ascii(c:char) -> bool {
-        let i = cast_to_int(c);
-        0 <= i && i <= 127
+        let i = cast(c);
+        0int <= i && i <= 127
     }
 }]
 

--- a/tests/tests/pos/surface/to_int02.rs
+++ b/tests/tests/pos/surface/to_int02.rs
@@ -1,6 +1,0 @@
-use flux_rs::attrs::*;
-
-#[spec(fn (x:u8{10 < x}) -> u32 ensures 10int <= cast(x))]
-pub fn test_cast_poly(x: u8) -> u32 {
-    x as u32
-}

--- a/tests/tests/pos/surface/to_int02.rs
+++ b/tests/tests/pos/surface/to_int02.rs
@@ -1,0 +1,6 @@
+use flux_rs::attrs::*;
+
+#[spec(fn (x:u8{10 < x}) -> u32 ensures 10int <= cast(x))]
+pub fn test_cast_poly(x: u8) -> u32 {
+    x as u32
+}


### PR DESCRIPTION
1. fix stuff about flags (for `allow_uninterpreted_cast`)
2. preserve `int` or `real` suffix after parsing literals