### PR TITLE
Hyperlink the "detached" specs to original source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ name = "flux-common"
 version = "0.1.0"
 dependencies = [
  "flux-config",
+ "flux-macros",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/crates/flux-common/Cargo.toml
+++ b/crates/flux-common/Cargo.toml
@@ -11,6 +11,7 @@ flux-config.workspace = true
 rustc-hash.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+flux-macros.workspace = true
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/crates/flux-common/src/dbg.rs
+++ b/crates/flux-common/src/dbg.rs
@@ -156,7 +156,6 @@ pub use crate::_shape_goto_exit as shape_goto_exit;
 #[macro_export]
 macro_rules! _detached_link {
     ($tcx:expr, $src_span:expr, $dst_span:expr) => {{
-       // println!("TRACE: bing-bong detached link src = {:?}, dst = {:?}", $src_span, $dst_span);
        let src_json = SpanTrace::new($tcx, $src_span);
        let dst_json = SpanTrace::new($tcx, $dst_span);
        tracing::info!(event = "detached_link", src_span = ?src_json, dst_span = ?dst_json)

--- a/crates/flux-common/src/dbg.rs
+++ b/crates/flux-common/src/dbg.rs
@@ -3,10 +3,44 @@ use std::{
     fmt, fs,
     io::{self, Write},
 };
-
+use rustc_span::Span;
+use serde::Serialize;
 use flux_config as config;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
+use flux_macros::DebugAsJson;
+
+#[derive(Serialize, DebugAsJson)]
+pub struct SpanTrace {
+    file: Option<String>,
+    start_line: usize,
+    start_col: usize,
+    end_line: usize,
+    end_col: usize,
+}
+
+impl SpanTrace {
+    fn span_file(tcx: TyCtxt, span: Span) -> Option<String> {
+        let sm = tcx.sess.source_map();
+        let current_dir = &tcx.sess.opts.working_dir;
+        let current_dir = current_dir.local_path()?;
+        if let rustc_span::FileName::Real(file_name) = sm.span_to_filename(span) {
+            let file_path = file_name.local_path()?;
+            let full_path = current_dir.join(file_path);
+            Some(full_path.display().to_string())
+        } else {
+            None
+        }
+    }
+    pub fn new(tcx: TyCtxt, span: Span) -> Self {
+        let sm = tcx.sess.source_map();
+        let (_, start_line, start_col, end_line, end_col) = sm.span_to_location_info(span);
+        let file = SpanTrace::span_file(tcx, span);
+        SpanTrace { file, start_line, start_col, end_line, end_col }
+    }
+}
+
+
 
 pub fn writer_for_item(
     tcx: TyCtxt,
@@ -76,7 +110,7 @@ macro_rules! _statement{
             let local_decls = &ck.body.local_decls;
             let rcx_json = RefineCtxtTrace::new(genv, rcx);
             let env_json = TypeEnvTrace::new(genv, local_names, local_decls, $env);
-            let span_json = SpanTrace::new(genv, $span);
+            let span_json = SpanTrace::new(genv.tcx(), $span);
             tracing::info!(event = concat!("statement_", $pos), stmt = ?$stmt, stmt_span = ?$span, rcx = ?rcx, env = ?$env, rcx_json = ?rcx_json, env_json = ?env_json, stmt_span_json = ?span_json)
         }
     }};
@@ -118,6 +152,17 @@ macro_rules! _shape_goto_exit {
     }};
 }
 pub use crate::_shape_goto_exit as shape_goto_exit;
+
+#[macro_export]
+macro_rules! _detached_link {
+    ($tcx:expr, $src_span:expr, $dst_span:expr) => {{
+       // println!("TRACE: bing-bong detached link src = {:?}, dst = {:?}", $src_span, $dst_span);
+       let src_json = SpanTrace::new($tcx, $src_span);
+       let dst_json = SpanTrace::new($tcx, $dst_span);
+       tracing::info!(event = "detached_link", src_span = ?src_json, dst_span = ?dst_json)
+    }};
+}
+pub use crate::_detached_link as detached_link;
 
 fn dump_base_name(tcx: TyCtxt, def_id: DefId, ext: impl AsRef<str>) -> String {
     let crate_name = tcx.crate_name(def_id.krate);

--- a/crates/flux-common/src/dbg.rs
+++ b/crates/flux-common/src/dbg.rs
@@ -3,12 +3,13 @@ use std::{
     fmt, fs,
     io::{self, Write},
 };
-use rustc_span::Span;
-use serde::Serialize;
+
 use flux_config as config;
+use flux_macros::DebugAsJson;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
-use flux_macros::DebugAsJson;
+use rustc_span::Span;
+use serde::Serialize;
 
 #[derive(Serialize, DebugAsJson)]
 pub struct SpanTrace {
@@ -39,8 +40,6 @@ impl SpanTrace {
         SpanTrace { file, start_line, start_col, end_line, end_col }
     }
 }
-
-
 
 pub fn writer_for_item(
     tcx: TyCtxt,

--- a/crates/flux-driver/src/bin/logger.rs
+++ b/crates/flux-driver/src/bin/logger.rs
@@ -15,7 +15,11 @@ pub fn install() -> io::Result<()> {
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_writer(writer)
             .json()
-            .with_filter(Targets::new().with_target("flux_refineck::checker", Level::DEBUG));
+            .with_filter(
+                Targets::new()
+                    .with_target("flux_refineck::checker", Level::DEBUG)
+                    .with_target("flux_driver::collector", Level::DEBUG)
+            );
         let dispatch = Dispatch::new(Registry::default().with(fmt_layer));
         dispatch.clone().init();
     }

--- a/crates/flux-driver/src/bin/logger.rs
+++ b/crates/flux-driver/src/bin/logger.rs
@@ -18,7 +18,7 @@ pub fn install() -> io::Result<()> {
             .with_filter(
                 Targets::new()
                     .with_target("flux_refineck::checker", Level::DEBUG)
-                    .with_target("flux_driver::collector", Level::DEBUG)
+                    .with_target("flux_driver::collector", Level::DEBUG),
             );
         let dispatch = Dispatch::new(Registry::default().with(fmt_layer));
         dispatch.clone().init();

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -79,7 +79,6 @@ impl FluxCallbacks {
 fn check_crate(genv: GlobalEnv) -> Result<(), ErrorGuaranteed> {
     tracing::info_span!("check_crate").in_scope(move || {
         tracing::info!("Callbacks::check_wf");
-        println!("TRACE: callbacks::check_crate");
         // Query qualifiers and spec funcs to report wf errors
         let _ = genv.qualifiers().emit(&genv)?;
         let _ = genv.normalized_defns(LOCAL_CRATE);

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -79,7 +79,7 @@ impl FluxCallbacks {
 fn check_crate(genv: GlobalEnv) -> Result<(), ErrorGuaranteed> {
     tracing::info_span!("check_crate").in_scope(move || {
         tracing::info!("Callbacks::check_wf");
-
+        println!("TRACE: callbacks::check_crate");
         // Query qualifiers and spec funcs to report wf errors
         let _ = genv.qualifiers().emit(&genv)?;
         let _ = genv.normalized_defns(LOCAL_CRATE);

--- a/crates/flux-driver/src/collector/detached_specs.rs
+++ b/crates/flux-driver/src/collector/detached_specs.rs
@@ -375,6 +375,7 @@ impl<'a, 'sess, 'tcx> DetachedSpecsCollector<'a, 'sess, 'tcx> {
                     .emit(errors::UnresolvedSpecification::new(&path, "identifier")));
             };
             if let Some(def_id) = self.unwrap_def_id(&def_id)? {
+                dbg::detached_link!(self.inner.tcx, path.span, self.inner.tcx.def_span(def_id));
                 let owner_id = self.inner.tcx.local_def_id_to_hir_id(def_id).owner;
                 self.collect_fn_spec(owner_id, fn_spec)?;
             }

--- a/crates/flux-driver/src/collector/detached_specs.rs
+++ b/crates/flux-driver/src/collector/detached_specs.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, hash_map::Entry};
 
+use flux_common::dbg::{self, SpanTrace};
 use flux_middle::fhir::Trusted;
 use flux_syntax::surface::{self, ExprPath, FnSpec, Item, NodeId, Span};
 use itertools::Itertools;
@@ -192,7 +193,9 @@ impl<'a, 'sess, 'tcx> DetachedSpecsCollector<'a, 'sess, 'tcx> {
     fn attach(&mut self, item: surface::Item) -> Result {
         let def_id = self.lookup(&item)?;
         let owner_id = self.inner.tcx.local_def_id_to_hir_id(def_id).owner;
-        let span = item.path.span;
+        let span = item.span();
+        let dst_span = self.inner.tcx.def_span(def_id);
+        dbg::detached_link!(self.inner.tcx, span, dst_span);
         match item.kind {
             surface::ItemKind::FnSig(fn_spec) => self.collect_fn_spec(owner_id, fn_spec)?,
             surface::ItemKind::Struct(struct_def) => {

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1,7 +1,7 @@
 use std::{collections::hash_map::Entry, iter, vec};
 
 use flux_common::{
-    bug, dbg, index::IndexVec, iter::IterExt, span_bug, tracked_span_bug,
+    bug, dbg, dbg::SpanTrace, index::IndexVec, iter::IterExt, span_bug, tracked_span_bug,
     tracked_span_dbg_assert_eq,
 };
 use flux_config::{self as config, InferOpts};
@@ -56,9 +56,7 @@ use crate::{
     primops,
     queue::WorkQueue,
     rty::Char,
-    type_env::{
-        BasicBlockEnv, BasicBlockEnvShape, PtrToRefBound, SpanTrace, TypeEnv, TypeEnvTrace,
-    },
+    type_env::{BasicBlockEnv, BasicBlockEnvShape, PtrToRefBound, TypeEnv, TypeEnvTrace},
 };
 
 type Result<T = ()> = std::result::Result<T, CheckerError>;

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -2,7 +2,11 @@ mod place_ty;
 
 use std::{iter, ops::ControlFlow};
 
-use flux_common::{bug, dbg::debug_assert_eq3, tracked_span_bug, tracked_span_dbg_assert_eq};
+use flux_common::{
+    bug,
+    dbg::{SpanTrace, debug_assert_eq3},
+    tracked_span_bug, tracked_span_dbg_assert_eq,
+};
 use flux_infer::{
     fixpoint_encoding::KVarEncoding,
     infer::{ConstrReason, InferCtxt, InferCtxtAt, InferCtxtRoot, InferResult},

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -916,7 +916,7 @@ fn loc_span(
     if let Loc::Local(local) = loc {
         return local_decls
             .get(*local)
-            .map(|local_decl| SpanTrace::new(genv, local_decl.source_info.span));
+            .map(|local_decl| SpanTrace::new(genv.tcx(), local_decl.source_info.span));
     }
     None
 }
@@ -969,8 +969,7 @@ impl SpanTrace {
             None
         }
     }
-    pub fn new(genv: GlobalEnv, span: Span) -> Self {
-        let tcx = genv.tcx();
+    pub fn new(tcx: TyCtxt, span: Span) -> Self {
         let sm = tcx.sess.source_map();
         let (_, start_line, start_col, end_line, end_col) = sm.span_to_location_info(span);
         let file = SpanTrace::span_file(tcx, span);

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -946,33 +946,3 @@ impl TypeEnvTrace {
         TypeEnvTrace(bindings)
     }
 }
-
-#[derive(Serialize, DebugAsJson)]
-pub struct SpanTrace {
-    file: Option<String>,
-    start_line: usize,
-    start_col: usize,
-    end_line: usize,
-    end_col: usize,
-}
-
-impl SpanTrace {
-    fn span_file(tcx: TyCtxt, span: Span) -> Option<String> {
-        let sm = tcx.sess.source_map();
-        let current_dir = &tcx.sess.opts.working_dir;
-        let current_dir = current_dir.local_path()?;
-        if let rustc_span::FileName::Real(file_name) = sm.span_to_filename(span) {
-            let file_path = file_name.local_path()?;
-            let full_path = current_dir.join(file_path);
-            Some(full_path.display().to_string())
-        } else {
-            None
-        }
-    }
-    pub fn new(tcx: TyCtxt, span: Span) -> Self {
-        let sm = tcx.sess.source_map();
-        let (_, start_line, start_col, end_line, end_col) = sm.span_to_location_info(span);
-        let file = SpanTrace::span_file(tcx, span);
-        SpanTrace { file, start_line, start_col, end_line, end_col }
-    }
-}

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -251,7 +251,10 @@ fn parse_detached_trait(cx: &mut ParseCtxt) -> ParseResult<Item> {
 /// ⟨impl-spec⟩ ::= impl Ident (for Ident)? { ⟨#[assoc] impl_assoc_reft⟩* ⟨fn-spec⟩* }
 /// ```
 fn parse_detached_impl(cx: &mut ParseCtxt) -> ParseResult<Item> {
+    let lo = cx.lo();
     cx.expect(kw::Impl)?;
+    let hi = cx.hi();
+    let span = cx.mk_span(lo, hi);
     let outer_path = parse_expr_path(cx)?;
     let _generics = parse_opt_generics(cx)?;
     let inner_path = if cx.advance_if(kw::For) {
@@ -278,10 +281,10 @@ fn parse_detached_impl(cx: &mut ParseCtxt) -> ParseResult<Item> {
     if let Some(path) = inner_path {
         Ok(Item {
             path,
-            kind: ItemKind::TraitImpl(DetachedTraitImpl { trait_: outer_path, items, refts }),
+            kind: ItemKind::TraitImpl(DetachedTraitImpl { trait_: outer_path, items, refts, span }),
         })
     } else {
-        Ok(Item { path: outer_path, kind: ItemKind::InherentImpl(DetachedInherentImpl { items }) })
+        Ok(Item { path: outer_path, kind: ItemKind::InherentImpl(DetachedInherentImpl { items, span }) })
     }
 }
 

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -284,7 +284,10 @@ fn parse_detached_impl(cx: &mut ParseCtxt) -> ParseResult<Item> {
             kind: ItemKind::TraitImpl(DetachedTraitImpl { trait_: outer_path, items, refts, span }),
         })
     } else {
-        Ok(Item { path: outer_path, kind: ItemKind::InherentImpl(DetachedInherentImpl { items, span }) })
+        Ok(Item {
+            path: outer_path,
+            kind: ItemKind::InherentImpl(DetachedInherentImpl { items, span }),
+        })
     }
 }
 

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -119,6 +119,7 @@ pub struct DetachedTraitImpl {
     pub trait_: ExprPath,
     pub items: Vec<Item<FnSpec>>,
     pub refts: Vec<ImplAssocReft>,
+    pub span: Span,
 }
 
 #[derive(Debug)]
@@ -130,6 +131,7 @@ pub struct DetachedTrait {
 #[derive(Debug)]
 pub struct DetachedInherentImpl {
     pub items: Vec<Item<FnSpec>>,
+    pub span: Span,
 }
 
 impl DetachedInherentImpl {
@@ -142,6 +144,16 @@ impl DetachedInherentImpl {
 pub struct Item<K = ItemKind> {
     pub path: ExprPath,
     pub kind: K,
+}
+
+impl Item<ItemKind> {
+    pub fn span(&self) -> Span {
+        match &self.kind {
+            ItemKind::InherentImpl(impl_) => impl_.span,
+            ItemKind::TraitImpl(trait_impl) => trait_impl.span,
+            _ => self.path.span,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/tools/vscode/README.md
+++ b/tools/vscode/README.md
@@ -38,7 +38,3 @@ Flux View Panel: shows the types and environments known at each program point
 ![After Statement](static/flux_view_end.jpg)
 
 
-
-
-{"timestamp":"2025-07-31T03:43:54.718440Z","level":"INFO","fields":{"event":"detached_link","src_span":"{\"file\":\"/Users/rjhala/research/flux/tests/tests/pos/detached/detach_assoc00.rs\",\"start_line\":26,\"start_col\":11,\"end_line\":26,\"end_col\":18}","dst_span":"{\"file\":\"/Users/rjhala/research/flux/tests/tests/pos/detached/detach_assoc00.rs\",\"start_line\":5,\"start_col\":1,\"end_line\":5,\"end_col\":14}"},"target":"flux_driver::collector::detached_specs"}
-{"timestamp":"2025-07-31T03:43:54.718764Z","level":"INFO","fields":{"event":"detached_link","src_span":"{\"file\":\"/Users/rjhala/research/flux/tests/tests/pos/detached/detach_assoc00.rs\",\"start_line\":34,\"start_col\":5,\"end_line\":34,\"end_col\":9}","dst_span":"{\"file\":\"/Users/rjhala/research/flux/tests/tests/pos/detached/detach_assoc00.rs\",\"start_line\":11,\"start_col\":1,\"end_line\":11,\"end_col\":22}"},"target":"flux_driver::collector::detached_specs"}

--- a/tools/vscode/README.md
+++ b/tools/vscode/README.md
@@ -36,3 +36,9 @@ Flux View Panel: shows the types and environments known at each program point
 ![Before Statement](static/flux_view_start.jpg)
 
 ![After Statement](static/flux_view_end.jpg)
+
+
+
+
+{"timestamp":"2025-07-31T03:43:54.718440Z","level":"INFO","fields":{"event":"detached_link","src_span":"{\"file\":\"/Users/rjhala/research/flux/tests/tests/pos/detached/detach_assoc00.rs\",\"start_line\":26,\"start_col\":11,\"end_line\":26,\"end_col\":18}","dst_span":"{\"file\":\"/Users/rjhala/research/flux/tests/tests/pos/detached/detach_assoc00.rs\",\"start_line\":5,\"start_col\":1,\"end_line\":5,\"end_col\":14}"},"target":"flux_driver::collector::detached_specs"}
+{"timestamp":"2025-07-31T03:43:54.718764Z","level":"INFO","fields":{"event":"detached_link","src_span":"{\"file\":\"/Users/rjhala/research/flux/tests/tests/pos/detached/detach_assoc00.rs\",\"start_line\":34,\"start_col\":5,\"end_line\":34,\"end_col\":9}","dst_span":"{\"file\":\"/Users/rjhala/research/flux/tests/tests/pos/detached/detach_assoc00.rs\",\"start_line\":11,\"start_col\":1,\"end_line\":11,\"end_col\":22}"},"target":"flux_driver::collector::detached_specs"}

--- a/tools/vscode/src/extension.ts
+++ b/tools/vscode/src/extension.ts
@@ -97,6 +97,15 @@ export function activate(context: vscode.ExtensionContext) {
     }),
   );
 
+  // Register the detached link provider for Rust files
+  const detachedLinkProvider = new DetachedLinkProvider(infoProvider);
+  context.subscriptions.push(
+    vscode.languages.registerDocumentLinkProvider(
+      { scheme: 'file', language: 'rust' },
+      detachedLinkProvider
+    )
+  );
+
   // Reload the flux trace information for changedFiles
   const logFilePattern = new vscode.RelativePattern(workspacePath, checkerPath);
   const fileWatcher = vscode.workspace.createFileSystemWatcher(logFilePattern);
@@ -165,6 +174,17 @@ type LineMap = Map<number, LineInfo>;
 enum Position {
   Start,
   End,
+}
+
+class DetachedLinkProvider implements vscode.DocumentLinkProvider {
+  constructor(private readonly _infoProvider: InfoProvider) {}
+
+  provideDocumentLinks(
+    document: vscode.TextDocument,
+    token: vscode.CancellationToken
+  ): Promise<vscode.DocumentLink[]> {
+    return parseDetachedLinks(document.fileName);
+  }
 }
 
 class InfoProvider {
@@ -255,7 +275,8 @@ class InfoProvider {
 
   public async loadFluxInfo() {
     try {
-      const [detachedLinks, lineInfos] = await readFluxCheckerTrace();
+      const lineInfos = await parseLineInfos();
+
       lineInfos.forEach((lineInfo, fileName) => {
         this.updateInfo(fileName, lineInfo);
       });
@@ -880,25 +901,32 @@ async function readEventsStreaming(logPath: string): Promise<any[]> {
   return events;
 }
 
-async function readFluxCheckerTrace(): Promise<[ Array<DetachedLink>, Map<string, LineInfo[]> ] > {
+async function parseEventsWith<T>(def: T, parser: (events: any[]) => T): Promise<T> {
   try {
     // Get the workspace folder
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (!workspaceFolders) {
-      return [ new Array(), new Map() ];
+      return def;
     }
-
     // Read the file using VS Code's file system API
     const workspacePath = workspaceFolders[0].uri.fsPath;
     const logPath = path.join(workspacePath, checkerPath);
     const events = await readEventsStreaming(logPath);
-    const data = parseEvents(events);
-    const links = parseDetachedLinkEvents(events);
-    return [ links, data ];
+    // Parse the events using the provided parser function
+    const result = parser(events);
+    return result;
   } catch (error) {
     // vscode.window.showErrorMessage(`Failed to read line info: ${error}`);
-    return [ new Array(), new Map() ];
+    return def;
   }
+}
+
+async function parseLineInfos(): Promise<Map<string, LineInfo[]>> {
+  return parseEventsWith(new Map(), parseEvents);
+}
+
+function parseDetachedLinks(documentPath: string): Promise<vscode.DocumentLink[]> {
+  return parseEventsWith(new Array(), (events:any[]) => parseDocumentLinks(documentPath, events));
 }
 
 // TODO: add local-info to TypeEnvBind
@@ -934,23 +962,6 @@ type LineInfo = {
   env: string;
 };
 
-// function parseStatementSpan(span: string): StmtSpan | undefined {
-//     if (span) {
-//         const parts = span.split(':');
-//         if (parts.length === 5) {
-//             const end_col_str = parts[4].split(' ')[0];
-//             const end_col = parseInt(end_col_str, 10);
-//             return {
-//                 file: parts[0],
-//                 start_line: parseInt(parts[1], 10),
-//                 start_col: parseInt(parts[2], 10),
-//                 end_line: parseInt(parts[1], 10),
-//                 end_col: end_col,
-//             };
-//         }
-//     }
-//     return undefined;
-// }
 
 function parseStatementSpanJSON(span: string): StmtSpan | undefined {
   if (span) {
@@ -987,20 +998,47 @@ function parseEvent(event: any): [string, LineInfo] | undefined {
 
 type DetachedLink = {src_span: StmtSpan, dst_span: StmtSpan};
 
-function parseDetachedLinkEvents(events: any[]): Array<DetachedLink> {
+function parseDocumentLinks(documentPath: string, events: any[]): vscode.DocumentLink[] {
   return events
     .filter(event => event.fields && event.fields.event === "detached_link")
     .map(event => {
       try {
-        const src_span = JSON.parse(event.fields.src_span) as StmtSpan;
-        const dst_span = JSON.parse(event.fields.dst_span) as StmtSpan;
-        return { src_span, dst_span };
+        const srcSpan = JSON.parse(event.fields.src_span) as StmtSpan;
+        const dstSpan = JSON.parse(event.fields.dst_span) as StmtSpan;
+
+        // Create the source range (0-based indexing for VS Code)
+        const srcRange = new vscode.Range(
+          srcSpan.start_line - 1,
+          srcSpan.start_col - 1,
+          srcSpan.end_line - 1,
+          srcSpan.end_col - 1
+        );
+
+        if (!srcSpan.file || !dstSpan.file) {
+          console.log(`Invalid detached link: ${event.fields}`);
+          return null; // Skip invalid links
+        }
+        if (srcSpan.file !== documentPath) {
+          console.log(`skipping link: Source span file does not match document path: ${srcSpan.file} !== ${documentPath}`);
+          return null;
+        }
+        // Create the target URI with position fragment
+        // VS Code supports URI fragments like file:///path/to/file.rs#L10,5 to jump to specific line/column
+        const targetUri = vscode.Uri.file(dstSpan.file).with({
+          fragment: `L${dstSpan.start_line},${dstSpan.start_col}`
+        });
+
+        // Create the document link
+        const documentLink = new vscode.DocumentLink(srcRange, targetUri);
+        documentLink.tooltip = `Jump to detached specification (line ${dstSpan.start_line}:${dstSpan.start_col})`;
+        return documentLink;
+
       } catch (error) {
         console.log(`Failed to parse detached_link event: ${error}`);
         return null;
       }
     })
-    .filter(result => result !== null) as Array<{src_span: StmtSpan, dst_span: StmtSpan}>;
+    .filter(result => result !== null); // as Array<{src_span: StmtSpan, dst_span: StmtSpan}>;
 }
 
 function parseEvents(events: any[]): Map<string, LineInfo[]> {


### PR DESCRIPTION
[Occurs to me that it would be rather useful to do the same thing for `extern_specs` too...]

e.g.

https://github.com/user-attachments/assets/0b12a996-f62a-4a58-b8ce-d891da3d62b5

