### PR TITLE
Lazy overflow checking

### DIFF
--- a/crates/flux-bin/src/lib.rs
+++ b/crates/flux-bin/src/lib.rs
@@ -1,5 +1,5 @@
 use cargo_metadata::camino::Utf8Path;
-use flux_config::SmtSolver;
+use flux_config::{OverflowMode, SmtSolver};
 use serde::Deserialize;
 
 pub mod utils;
@@ -15,7 +15,7 @@ pub struct FluxMetadata {
     /// Enable qualifier scrapping in fixpoint
     pub scrape_quals: Option<bool>,
     /// Enable overflow checking
-    pub check_overflow: Option<bool>,
+    pub check_overflow: Option<OverflowMode>,
     /// Enable uninterpreted casts
     pub allow_uninterpreted_cast: Option<bool>,
     /// Enable flux-defs to be defined as SMT functions

--- a/crates/flux-driver/src/collector/mod.rs
+++ b/crates/flux-driver/src/collector/mod.rs
@@ -11,7 +11,7 @@ use flux_common::{
     result::{ErrorCollector, ResultExt},
     tracked_span_assert_eq,
 };
-use flux_config::{self as config, PartialInferOpts, SmtSolver};
+use flux_config::{self as config, OverflowMode, PartialInferOpts, SmtSolver};
 use flux_errors::{Errors, FluxSession};
 use flux_middle::{
     Specs,
@@ -845,7 +845,7 @@ impl AttrMap {
     fn try_into_infer_opts(&mut self) -> AttrMapErr<PartialInferOpts> {
         let mut infer_opts = PartialInferOpts::default();
         try_read_setting!(self, allow_uninterpreted_cast, bool, infer_opts);
-        try_read_setting!(self, check_overflow, bool, infer_opts);
+        try_read_setting!(self, check_overflow, OverflowMode, infer_opts);
         try_read_setting!(self, scrape_quals, bool, infer_opts);
         try_read_setting!(self, solver, SmtSolver, infer_opts);
 

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, fmt, iter};
 
 use flux_common::{bug, dbg, tracked_span_assert_eq, tracked_span_bug, tracked_span_dbg_assert_eq};
-use flux_config::{self as config, InferOpts};
+use flux_config::{self as config, InferOpts, OverflowMode};
 use flux_macros::{TypeFoldable, TypeVisitable};
 use flux_middle::{
     FixpointQueryKind,
@@ -242,7 +242,7 @@ pub struct InferCtxt<'infcx, 'genv, 'tcx> {
     pub genv: GlobalEnv<'genv, 'tcx>,
     pub region_infcx: &'infcx rustc_infer::infer::InferCtxt<'tcx>,
     pub def_id: DefId,
-    pub check_overflow: bool,
+    pub check_overflow: OverflowMode,
     cursor: Cursor<'infcx>,
     inner: &'infcx RefCell<InferCtxtInner>,
 }

--- a/crates/flux-refineck/src/primops.rs
+++ b/crates/flux-refineck/src/primops.rs
@@ -26,6 +26,7 @@
 use std::{fmt, hash::Hash, sync::LazyLock};
 
 use flux_common::tracked_span_bug;
+use flux_config::OverflowMode;
 use flux_infer::infer::ConstrReason;
 use flux_macros::primop_rules;
 use flux_middle::rty::{self, BaseTy, Expr, Sort};
@@ -51,9 +52,13 @@ pub(crate) fn match_bin_op(
     idx1: &Expr,
     bty2: &BaseTy,
     idx2: &Expr,
-    check_overflow: bool,
+    overflow_mode: OverflowMode,
 ) -> MatchedRule {
-    let table = if check_overflow { &OVERFLOW_BIN_OPS } else { &DEFAULT_BIN_OPS };
+    let table = match overflow_mode {
+        OverflowMode::Strict => &OVERFLOW_STRICT_BIN_OPS,
+        OverflowMode::Lazy => &OVERFLOW_LAZY_BIN_OPS,
+        OverflowMode::None => &OVERFLOW_NONE_BIN_OPS,
+    };
     table.match_inputs(&op, [(bty1.clone(), idx1.clone()), (bty2.clone(), idx2.clone())])
 }
 
@@ -61,9 +66,13 @@ pub(crate) fn match_un_op(
     op: mir::UnOp,
     bty: &BaseTy,
     idx: &Expr,
-    check_overflow: bool,
+    overflow_mode: OverflowMode,
 ) -> MatchedRule {
-    let table = if check_overflow { &OVERFLOW_UN_OPS } else { &DEFAULT_UN_OPS };
+    let table = match overflow_mode {
+        OverflowMode::Strict => &OVERFLOW_STRICT_UN_OPS,
+        OverflowMode::None => &OVERFLOW_NONE_UN_OPS,
+        OverflowMode::Lazy => &OVERFLOW_LAZY_UN_OPS,
+    };
     table.match_inputs(&op, [(bty.clone(), idx.clone())])
 }
 
@@ -80,14 +89,14 @@ impl<Op: Eq + Hash + fmt::Debug, const N: usize> RuleTable<Op, N> {
 
 type RuleMatcher<const N: usize> = fn(&[(BaseTy, Expr); N]) -> Option<MatchedRule>;
 
-static DEFAULT_BIN_OPS: LazyLock<RuleTable<mir::BinOp, 2>> = LazyLock::new(|| {
+static OVERFLOW_NONE_BIN_OPS: LazyLock<RuleTable<mir::BinOp, 2>> = LazyLock::new(|| {
     use mir::BinOp::*;
     RuleTable {
         rules: [
             // Arith
-            (Add, mk_add_rules(false)),
-            (Mul, mk_mul_rules(false)),
-            (Sub, mk_sub_rules(false)),
+            (Add, mk_add_rules(OverflowMode::None)),
+            (Mul, mk_mul_rules(OverflowMode::None)),
+            (Sub, mk_sub_rules(OverflowMode::None)),
             (Div, mk_div_rules()),
             (Rem, mk_rem_rules()),
             // Bitwise
@@ -110,14 +119,14 @@ static DEFAULT_BIN_OPS: LazyLock<RuleTable<mir::BinOp, 2>> = LazyLock::new(|| {
     }
 });
 
-static OVERFLOW_BIN_OPS: LazyLock<RuleTable<mir::BinOp, 2>> = LazyLock::new(|| {
+static OVERFLOW_STRICT_BIN_OPS: LazyLock<RuleTable<mir::BinOp, 2>> = LazyLock::new(|| {
     use mir::BinOp::*;
     RuleTable {
         rules: [
             // Arith
-            (Add, mk_add_rules(true)),
-            (Mul, mk_mul_rules(true)),
-            (Sub, mk_sub_rules(true)),
+            (Add, mk_add_rules(OverflowMode::Strict)),
+            (Mul, mk_mul_rules(OverflowMode::Strict)),
+            (Sub, mk_sub_rules(OverflowMode::Strict)),
             (Div, mk_div_rules()),
             (Rem, mk_rem_rules()),
             // Bitwise
@@ -140,110 +149,197 @@ static OVERFLOW_BIN_OPS: LazyLock<RuleTable<mir::BinOp, 2>> = LazyLock::new(|| {
     }
 });
 
-static DEFAULT_UN_OPS: LazyLock<RuleTable<mir::UnOp, 1>> = LazyLock::new(|| {
+static OVERFLOW_LAZY_BIN_OPS: LazyLock<RuleTable<mir::BinOp, 2>> = LazyLock::new(|| {
+    use mir::BinOp::*;
+    RuleTable {
+        rules: [
+            // Arith
+            (Add, mk_add_rules(OverflowMode::Lazy)),
+            (Mul, mk_mul_rules(OverflowMode::Lazy)),
+            (Sub, mk_sub_rules(OverflowMode::Lazy)),
+            (Div, mk_div_rules()),
+            (Rem, mk_rem_rules()),
+            // Bitwise
+            (BitAnd, mk_bit_and_rules()),
+            (BitOr, mk_bit_or_rules()),
+            (BitXor, mk_bit_xor_rules()),
+            // Cmp
+            (Eq, mk_eq_rules()),
+            (Ne, mk_ne_rules()),
+            (Le, mk_le_rules()),
+            (Ge, mk_ge_rules()),
+            (Lt, mk_lt_rules()),
+            (Gt, mk_gt_rules()),
+            // Shifts
+            (Shl, mk_shl_rules()),
+            (Shr, mk_shr_rules()),
+        ]
+        .into_iter()
+        .collect(),
+    }
+});
+
+static OVERFLOW_NONE_UN_OPS: LazyLock<RuleTable<mir::UnOp, 1>> = LazyLock::new(|| {
     use mir::UnOp::*;
     RuleTable {
-        rules: [(Neg, mk_neg_rules(false)), (Not, mk_not_rules())]
+        rules: [(Neg, mk_neg_rules(OverflowMode::None)), (Not, mk_not_rules())]
             .into_iter()
             .collect(),
     }
 });
 
-static OVERFLOW_UN_OPS: LazyLock<RuleTable<mir::UnOp, 1>> = LazyLock::new(|| {
+static OVERFLOW_LAZY_UN_OPS: LazyLock<RuleTable<mir::UnOp, 1>> = LazyLock::new(|| {
     use mir::UnOp::*;
     RuleTable {
-        rules: [(Neg, mk_neg_rules(true)), (Not, mk_not_rules())]
+        rules: [(Neg, mk_neg_rules(OverflowMode::Lazy)), (Not, mk_not_rules())]
             .into_iter()
             .collect(),
     }
 });
+
+static OVERFLOW_STRICT_UN_OPS: LazyLock<RuleTable<mir::UnOp, 1>> = LazyLock::new(|| {
+    use mir::UnOp::*;
+    RuleTable {
+        rules: [(Neg, mk_neg_rules(OverflowMode::Strict)), (Not, mk_not_rules())]
+            .into_iter()
+            .collect(),
+    }
+});
+
+fn valid_int(e: impl Into<Expr>, int_ty: rty::IntTy) -> rty::Expr {
+    let e1 = e.into();
+    let e2 = e1.clone();
+    E::and(E::ge(e1, E::int_min(int_ty)), E::le(e2, E::int_max(int_ty)))
+}
+
+fn valid_uint(e: impl Into<Expr>, uint_ty: rty::UintTy) -> rty::Expr {
+    let e1 = e.into();
+    let e2 = e1.clone();
+    E::and(E::ge(e1, 0), E::le(e2, E::uint_max(uint_ty)))
+}
 
 /// `a + b`
-fn mk_add_rules(check_overflow: bool) -> RuleMatcher<2> {
-    if check_overflow {
-        primop_rules! {
-            fn(a: T, b: T) -> T[a + b]
-            requires E::and(
-                         E::ge(a + b, E::int_min(int_ty)),
-                         E::le(a + b, E::int_max(int_ty)),
-                     ) => ConstrReason::Overflow
-            if let &BaseTy::Int(int_ty) = T
+fn mk_add_rules(overflow_mode: OverflowMode) -> RuleMatcher<2> {
+    match overflow_mode {
+        OverflowMode::Strict => {
+            primop_rules! {
+                fn(a: T, b: T) -> T[a + b]
+                requires valid_int(a + b, int_ty) => ConstrReason::Overflow
+                if let &BaseTy::Int(int_ty) = T
 
-            fn(a: T, b: T) -> T[a + b]
-            requires E::le(a + b, E::uint_max(uint_ty)) => ConstrReason::Overflow
-            if let &BaseTy::Uint(uint_ty) = T
+                fn(a: T, b: T) -> T[a + b]
+                requires valid_uint(a + b, uint_ty) => ConstrReason::Overflow
+                if let &BaseTy::Uint(uint_ty) = T
 
-            fn(a: T, b: T) -> T
+                fn(a: T, b: T) -> T
+            }
         }
-    } else {
-        primop_rules! {
-            fn(a: T, b: T) -> T[a + b]
-            if T.is_integral()
 
-            fn(a: T, b: T) -> T
+        OverflowMode::Lazy => {
+            primop_rules! {
+                fn(a: T, b: T) -> T{v: E::implies(valid_int(a + b, int_ty), E::eq(v, a+b)) }
+                if let &BaseTy::Int(int_ty) = T
+
+                fn(a: T, b: T) -> T{v: E::implies(valid_uint(a + b, uint_ty), E::eq(v, a+b)) }
+                if let &BaseTy::Uint(uint_ty) = T
+
+                fn(a: T, b: T) -> T
+            }
+        }
+
+        OverflowMode::None => {
+            primop_rules! {
+                fn(a: T, b: T) -> T[a + b]
+                if T.is_integral()
+
+                fn(a: T, b: T) -> T
+            }
         }
     }
 }
 
 /// `a * b`
-fn mk_mul_rules(check_overflow: bool) -> RuleMatcher<2> {
-    if check_overflow {
-        primop_rules! {
-            fn(a: T, b: T) -> T[a * b]
-            requires E::and(
-                         E::ge(a * b, E::int_min(int_ty)),
-                         E::le(a * b, E::int_max(int_ty)),
-                     ) => ConstrReason::Overflow
-            if let &BaseTy::Int(int_ty) = T
+fn mk_mul_rules(overflow_mode: OverflowMode) -> RuleMatcher<2> {
+    match overflow_mode {
+        OverflowMode::Strict => {
+            primop_rules! {
+                fn(a: T, b: T) -> T[a * b]
+                requires valid_int(a * b, int_ty) => ConstrReason::Overflow
+                if let &BaseTy::Int(int_ty) = T
 
-            fn(a: T, b: T) -> T[a * b]
-            requires E::le(a * b, E::uint_max(uint_ty)) => ConstrReason::Overflow
-            if let &BaseTy::Uint(uint_ty) = T
+                fn(a: T, b: T) -> T[a * b]
+                requires valid_uint(a * b, uint_ty) => ConstrReason::Overflow
+                if let &BaseTy::Uint(uint_ty) = T
 
-            fn(a: T, b: T) -> T
+                fn(a: T, b: T) -> T
+            }
         }
-    } else {
-        primop_rules!(
-            fn(a: T, b: T) -> T[a * b]
-            if T.is_integral()
 
-            fn(a: T, b: T) -> T
-            if T.is_float()
-        )
+        OverflowMode::Lazy => {
+            primop_rules! {
+                fn(a: T, b: T) -> T{v: E::implies(valid_int(a * b, int_ty), E::eq(v, a * b)) }
+                if let &BaseTy::Int(int_ty) = T
+
+                fn(a: T, b: T) -> T{v: E::implies(valid_uint(a * b, uint_ty), E::eq(v, a * b)) }
+                if let &BaseTy::Uint(uint_ty) = T
+
+                fn(a: T, b: T) -> T
+            }
+        }
+
+        OverflowMode::None => {
+            primop_rules!(
+                fn(a: T, b: T) -> T[a * b]
+                if T.is_integral()
+
+                fn(a: T, b: T) -> T
+                if T.is_float()
+            )
+        }
     }
 }
 
 /// `a - b`
-fn mk_sub_rules(check_overflow: bool) -> RuleMatcher<2> {
-    if check_overflow {
-        primop_rules! {
-            fn(a: T, b: T) -> T[a - b]
-            requires E::and(
-                         E::ge(a - b, E::int_min(int_ty)),
-                         E::le(a - b, E::int_max(int_ty)),
-                     ) => ConstrReason::Overflow
-            if let &BaseTy::Int(int_ty) = T
+fn mk_sub_rules(overflow_mode: OverflowMode) -> RuleMatcher<2> {
+    match overflow_mode {
+        OverflowMode::Strict => {
+            primop_rules! {
+                fn(a: T, b: T) -> T[a - b]
+                requires valid_int(a - b, int_ty) => ConstrReason::Overflow
+                if let &BaseTy::Int(int_ty) = T
 
-            fn(a: T, b: T) -> T[a - b]
-            requires E::and(
-                         E::ge(a - b, 0),
-                         E::le(a - b, E::uint_max(uint_ty)),
-                     ) => ConstrReason::Overflow
-            if let &BaseTy::Uint(uint_ty) = T
+                fn(a: T, b: T) -> T[a - b]
+                requires valid_uint(a - b, uint_ty) => ConstrReason::Overflow
+                if let &BaseTy::Uint(uint_ty) = T
 
-            fn(a: T, b: T) -> T
+                fn(a: T, b: T) -> T
+            }
         }
-    } else {
-        primop_rules! {
-            fn(a: T, b: T) -> T[a - b]
-            requires E::ge(a - b, 0) => ConstrReason::Overflow
-            if T.is_unsigned()
 
-            fn(a: T, b: T) -> T[a - b]
-            if T.is_signed()
+        OverflowMode::Lazy => {
+            primop_rules! {
+                fn(a: T, b: T) -> T{v: E::implies(valid_int(a - b, int_ty), E::eq(v, a - b)) }
+                if let &BaseTy::Int(int_ty) = T
 
-            fn(a: T, b: T) -> T
-            if T.is_float()
+                fn(a: T, b: T) -> T{v: E::implies(valid_uint(a - b, uint_ty), E::eq(v, a - b)) }
+                if let &BaseTy::Uint(uint_ty) = T
+
+                fn(a: T, b: T) -> T
+            }
+        }
+
+        OverflowMode::None => {
+            primop_rules! {
+                fn(a: T, b: T) -> T[a - b]
+                requires E::ge(a - b, 0) => ConstrReason::Overflow
+                if T.is_unsigned()
+
+                fn(a: T, b: T) -> T[a - b]
+                if T.is_signed()
+
+                fn(a: T, b: T) -> T
+                if T.is_float()
+            }
         }
     }
 }
@@ -391,23 +487,35 @@ fn mk_shr_rules() -> RuleMatcher<2> {
 }
 
 /// `-a`
-fn mk_neg_rules(check_overflow: bool) -> RuleMatcher<1> {
-    if check_overflow {
-        primop_rules! {
-            fn(a: T) -> T[a.neg()]
-            requires E::ne(a, E::int_min(int_ty)) => ConstrReason::Overflow
-            if let &BaseTy::Int(int_ty) = T
+fn mk_neg_rules(overflow_mode: OverflowMode) -> RuleMatcher<1> {
+    match overflow_mode {
+        OverflowMode::Strict => {
+            primop_rules! {
+                fn(a: T) -> T[a.neg()]
+                requires E::ne(a, E::int_min(int_ty)) => ConstrReason::Overflow
+                if let &BaseTy::Int(int_ty) = T
 
-            fn(a: T) -> T[a.neg()]
-            if T.is_float()
+                fn(a: T) -> T[a.neg()]
+                if T.is_float()
+            }
         }
-    } else {
-        primop_rules! {
-            fn(a: T) -> T[a.neg()]
-            if T.is_integral()
+        OverflowMode::Lazy => {
+            primop_rules! {
+                fn(a: T) -> T{v: E::implies(E::ne(a, E::int_min(int_ty)), E::eq(v, a.neg())) }
+                if let &BaseTy::Int(int_ty) = T
 
-            fn(a: T) -> T
-            if T.is_float()
+                fn(a: T) -> T[a.neg()]
+                if T.is_float()
+            }
+        }
+        OverflowMode::None => {
+            primop_rules! {
+                fn(a: T) -> T[a.neg()]
+                if T.is_integral()
+
+                fn(a: T) -> T
+                if T.is_float()
+            }
         }
     }
 }

--- a/tests/tests/neg/config/test-config00.rs
+++ b/tests/tests/neg/config/test-config00.rs
@@ -1,4 +1,4 @@
-#![flux::opts(check_overflow = "do it!")] //~ ERROR invalid attribute: incorrect type in value for setting `check_overflow`, expected bool
+#![flux::opts(check_overflow = "do it!")] //~ ERROR invalid attribute: incorrect type in value for setting `check_overflow`, expected OverflowMode
 
 #[flux::sig(fn(x: i32, y: i32) -> i32)]
 pub fn test(x: i32, y: i32) -> i32 {

--- a/tests/tests/neg/surface/binop_overflow.rs
+++ b/tests/tests/neg/surface/binop_overflow.rs
@@ -1,4 +1,4 @@
-#![flux::opts(check_overflow = true)]
+#![flux::opts(check_overflow = "strict")]
 
 // Arithmetic BinOps
 // These check for over/underflow

--- a/tests/tests/neg/surface/check_overflow00.rs
+++ b/tests/tests/neg/surface/check_overflow00.rs
@@ -1,4 +1,4 @@
-#[flux::opts(check_overflow = true)]
+#[flux::opts(check_overflow = "strict")]
 fn add(x: u32, y: u32) -> u32 {
     x + y //~ ERROR arithmetic operation may overflow
 }

--- a/tests/tests/neg/surface/check_overflow01.rs
+++ b/tests/tests/neg/surface/check_overflow01.rs
@@ -1,5 +1,5 @@
 // Error on both of these as they may overflow
-#![flux::opts(check_overflow = true)]
+#![flux::opts(check_overflow = "strict")]
 mod my_mod {
     fn add(x: u32, y: u32) -> u32 {
         x + y //~ ERROR arithmetic operation may overflow

--- a/tests/tests/neg/surface/check_overflow02.rs
+++ b/tests/tests/neg/surface/check_overflow02.rs
@@ -10,7 +10,7 @@ impl MyStruct {
     }
 
     // Error as this may overflow
-    #[flux::opts(check_overflow = true)]
+    #[flux::opts(check_overflow = "strict")]
     fn add2(&self) -> u32 {
         self.inner + 2 //~ERROR arithmetic operation may overflow
     }

--- a/tests/tests/neg/surface/check_overflow03.rs
+++ b/tests/tests/neg/surface/check_overflow03.rs
@@ -6,7 +6,7 @@ trait MyTrait {
     fn add(x: u32, y: u32) -> u32;
 }
 
-#[flux::opts(check_overflow = true)]
+#[flux::opts(check_overflow = "strict")]
 impl MyTrait for MyStruct {
     fn add(x: u32, y: u32) -> u32 {
         x + y //~ ERROR arithmetic operation may overflow

--- a/tests/tests/neg/surface/int_bounds_invariants.rs
+++ b/tests/tests/neg/surface/int_bounds_invariants.rs
@@ -1,6 +1,6 @@
 // Check that integer bound invariants are not assumed when overflow checking is disabled
 
-#![flux::opts(check_overflow = false)]
+#![flux::opts(check_overflow = "none")]
 
 #[flux::sig(fn(bool[true]))]
 fn assert(_: bool) {}

--- a/tests/tests/neg/surface/unop_overflow.rs
+++ b/tests/tests/neg/surface/unop_overflow.rs
@@ -1,4 +1,4 @@
-#![flux::opts(check_overflow = true)]
+#![flux::opts(check_overflow = "strict")]
 
 #[flux::sig(fn(a: i32) -> i32[-a])]
 pub fn neg_overflow_i32(a: i32) -> i32 {

--- a/tests/tests/pos/surface/assume_invariant00.rs
+++ b/tests/tests/pos/surface/assume_invariant00.rs
@@ -1,6 +1,6 @@
 //! Test we assume invariants when unfolding
 
-#![flux::opts(check_overflow = true)]
+#![flux::opts(check_overflow = "strict")]
 
 #[flux::sig(fn(bool[true]))]
 fn assert(_: bool) {}

--- a/tests/tests/pos/surface/binop_overflow.rs
+++ b/tests/tests/pos/surface/binop_overflow.rs
@@ -1,4 +1,4 @@
-#![flux::opts(check_overflow = true)]
+#![flux::opts(check_overflow = "strict")]
 
 // Arithmetic BinOps
 //

--- a/tests/tests/pos/surface/check_overflow00.rs
+++ b/tests/tests/pos/surface/check_overflow00.rs
@@ -1,7 +1,7 @@
 const MAX: u32 = std::u32::MAX;
 
 // Error on this as it may overflow
-#[flux::opts(check_overflow = true)]
+#[flux::opts(check_overflow = "strict")]
 #[flux::sig(fn (u32[@x], u32[@y], u32[@z]) -> u32[x + y + z] requires x + y + z <= MAX)]
 fn add_three(x: u32, y: u32, z: u32) -> u32 {
     x + y + z

--- a/tests/tests/pos/surface/check_overflow01.rs
+++ b/tests/tests/pos/surface/check_overflow01.rs
@@ -1,4 +1,4 @@
-#[flux::opts(check_overflow = true)]
+#[flux::opts(check_overflow = "strict")]
 mod my_mod {
     const MAX: u32 = std::u32::MAX;
 

--- a/tests/tests/pos/surface/check_overflow02.rs
+++ b/tests/tests/pos/surface/check_overflow02.rs
@@ -12,7 +12,7 @@ impl MyStruct {
     }
 
     // Error as this may overflow
-    #[flux::opts(check_overflow = true)]
+    #[flux::opts(check_overflow = "strict")]
     #[flux::sig(fn (&MyStruct[@inner]) -> u32[inner + 2] requires inner + 2 <= MAX)]
     fn add2(&self) -> u32 {
         self.inner + 2

--- a/tests/tests/pos/surface/check_overflow03.rs
+++ b/tests/tests/pos/surface/check_overflow03.rs
@@ -4,7 +4,7 @@ struct MyStruct {
     inner: u32,
 }
 
-#[flux::opts(check_overflow = true)]
+#[flux::opts(check_overflow = "strict")]
 trait MyTrait {
     #[flux::sig(fn(u32[@x], { u32[@y] | x + y <= MAX }) -> u32[x + y] )]
     fn add(x: u32, y: u32) -> u32;

--- a/tests/tests/pos/surface/check_overflow05.rs
+++ b/tests/tests/pos/surface/check_overflow05.rs
@@ -1,5 +1,5 @@
 // configure check for the entire thing
-#![cfg_attr(flux, flux::opts(check_overflow = true))]
+#![cfg_attr(flux, flux::opts(check_overflow = "strict"))]
 
 const MAX: u32 = std::u32::MAX;
 
@@ -8,7 +8,7 @@ fn add(x: u32, y: u32) -> u32 {
     x + y
 }
 
-#[flux::opts(check_overflow = false)]
+#[flux::opts(check_overflow = "none")]
 fn add_more(x: u32, y: u32, z: u32) -> u32 {
     x + y + z
 }

--- a/tests/tests/pos/surface/int_bounds_invariants.rs
+++ b/tests/tests/pos/surface/int_bounds_invariants.rs
@@ -1,6 +1,6 @@
 // Check that integer bound invariants are assumed when overflow checking is enabled
 
-#![flux::opts(check_overflow = true)]
+#![flux::opts(check_overflow = "strict")]
 
 #[flux::sig(fn(bool[true]))]
 fn assert(_: bool) {}

--- a/tests/tests/pos/surface/kmp_overflow.rs
+++ b/tests/tests/pos/surface/kmp_overflow.rs
@@ -1,6 +1,6 @@
 // Implementation of kmp with overflow checks enabled
 
-#![flux::opts(check_overflow = true)]
+#![flux::opts(check_overflow = "strict")]
 
 #[path = "../../lib/rvec.rs"]
 mod rvec;

--- a/tests/tests/pos/surface/unop_overflow.rs
+++ b/tests/tests/pos/surface/unop_overflow.rs
@@ -1,4 +1,4 @@
-#![flux::opts(check_overflow = true)]
+#![flux::opts(check_overflow = "strict")]
 
 #[flux::sig(fn(a: i32{a != i32::MIN}) -> i32[-a])]
 pub fn neg_overflow_i32(a: i32) -> i32 {


### PR DESCRIPTION
overflow checking now has three modes

- `strict`
- `lazy`
- `none` (aka "yolo"), which remains the default.

See https://ucsd-progsys.github.io/liquidhaskell/blogposts/2017-03-20-arithmetic-overflows.lhs/ 