### PR TITLE
Strict underflow checking

### DIFF
--- a/crates/flux-config/src/lib.rs
+++ b/crates/flux-config/src/lib.rs
@@ -193,12 +193,17 @@ impl IncludePattern {
 #[derive(Clone, Copy, Debug, Deserialize, Default)]
 #[serde(try_from = "String")]
 pub enum OverflowMode {
-    /// No overflow checking
+    /// Strict-Underflow, No overflow checking
     #[default]
     None,
-    /// Lose all information unless values are known to be in valid range
+    /// Lazy underflow, Lazy overflow checking; lose all information
+    /// unless values are known to be in valid range
     Lazy,
-    /// Check values are always in valid range
+    /// Strict underflow, Lazy overflow checking; always check
+    /// unsignedness (non-negativity) but lazy for upper-bound
+    StrictUnder,
+    /// Strict underflow, Strict overflow checking; always check
+    /// values in valid range for type
     Strict,
 }
 
@@ -214,6 +219,7 @@ impl FromStr for OverflowMode {
             "none" => Ok(OverflowMode::None),
             "lazy" => Ok(OverflowMode::Lazy),
             "strict" => Ok(OverflowMode::Strict),
+            "strict-under" => Ok(OverflowMode::StrictUnder),
             _ => Err(Self::ERROR),
         }
     }
@@ -233,6 +239,7 @@ impl fmt::Display for OverflowMode {
             OverflowMode::None => write!(f, "none"),
             OverflowMode::Lazy => write!(f, "lazy"),
             OverflowMode::Strict => write!(f, "strict"),
+            OverflowMode::StrictUnder => write!(f, "strict-under"),
         }
     }
 }

--- a/crates/flux-refineck/src/primops.rs
+++ b/crates/flux-refineck/src/primops.rs
@@ -58,6 +58,7 @@ pub(crate) fn match_bin_op(
         OverflowMode::Strict => &OVERFLOW_STRICT_BIN_OPS,
         OverflowMode::Lazy => &OVERFLOW_LAZY_BIN_OPS,
         OverflowMode::None => &OVERFLOW_NONE_BIN_OPS,
+        OverflowMode::StrictUnder => &OVERFLOW_STRICT_UNDER_BIN_OPS,
     };
     table.match_inputs(&op, [(bty1.clone(), idx1.clone()), (bty2.clone(), idx2.clone())])
 }
@@ -72,6 +73,7 @@ pub(crate) fn match_un_op(
         OverflowMode::Strict => &OVERFLOW_STRICT_UN_OPS,
         OverflowMode::None => &OVERFLOW_NONE_UN_OPS,
         OverflowMode::Lazy => &OVERFLOW_LAZY_UN_OPS,
+        OverflowMode::StrictUnder => &OVERFLOW_STRICT_UNDER_UN_OPS,
     };
     table.match_inputs(&op, [(bty.clone(), idx.clone())])
 }
@@ -179,6 +181,36 @@ static OVERFLOW_LAZY_BIN_OPS: LazyLock<RuleTable<mir::BinOp, 2>> = LazyLock::new
     }
 });
 
+static OVERFLOW_STRICT_UNDER_BIN_OPS: LazyLock<RuleTable<mir::BinOp, 2>> = LazyLock::new(|| {
+    use mir::BinOp::*;
+    RuleTable {
+        rules: [
+            // Arith
+            (Add, mk_add_rules(OverflowMode::StrictUnder)),
+            (Mul, mk_mul_rules(OverflowMode::StrictUnder)),
+            (Sub, mk_sub_rules(OverflowMode::StrictUnder)),
+            (Div, mk_div_rules()),
+            (Rem, mk_rem_rules()),
+            // Bitwise
+            (BitAnd, mk_bit_and_rules()),
+            (BitOr, mk_bit_or_rules()),
+            (BitXor, mk_bit_xor_rules()),
+            // Cmp
+            (Eq, mk_eq_rules()),
+            (Ne, mk_ne_rules()),
+            (Le, mk_le_rules()),
+            (Ge, mk_ge_rules()),
+            (Lt, mk_lt_rules()),
+            (Gt, mk_gt_rules()),
+            // Shifts
+            (Shl, mk_shl_rules()),
+            (Shr, mk_shr_rules()),
+        ]
+        .into_iter()
+        .collect(),
+    }
+});
+
 static OVERFLOW_NONE_UN_OPS: LazyLock<RuleTable<mir::UnOp, 1>> = LazyLock::new(|| {
     use mir::UnOp::*;
     RuleTable {
@@ -192,6 +224,15 @@ static OVERFLOW_LAZY_UN_OPS: LazyLock<RuleTable<mir::UnOp, 1>> = LazyLock::new(|
     use mir::UnOp::*;
     RuleTable {
         rules: [(Neg, mk_neg_rules(OverflowMode::Lazy)), (Not, mk_not_rules())]
+            .into_iter()
+            .collect(),
+    }
+});
+
+static OVERFLOW_STRICT_UNDER_UN_OPS: LazyLock<RuleTable<mir::UnOp, 1>> = LazyLock::new(|| {
+    use mir::UnOp::*;
+    RuleTable {
+        rules: [(Neg, mk_neg_rules(OverflowMode::StrictUnder)), (Not, mk_not_rules())]
             .into_iter()
             .collect(),
     }
@@ -218,6 +259,10 @@ fn valid_uint(e: impl Into<Expr>, uint_ty: rty::UintTy) -> rty::Expr {
     E::and(E::ge(e1, 0), E::le(e2, E::uint_max(uint_ty)))
 }
 
+fn nonnegative(e: impl Into<Expr>) -> rty::Expr {
+    E::ge(e.into(), 0)
+}
+
 /// `a + b`
 fn mk_add_rules(overflow_mode: OverflowMode) -> RuleMatcher<2> {
     match overflow_mode {
@@ -229,6 +274,20 @@ fn mk_add_rules(overflow_mode: OverflowMode) -> RuleMatcher<2> {
 
                 fn(a: T, b: T) -> T[a + b]
                 requires valid_uint(a + b, uint_ty) => ConstrReason::Overflow
+                if let &BaseTy::Uint(uint_ty) = T
+
+                fn(a: T, b: T) -> T
+            }
+        }
+
+        // like Lazy, but we also check for underflow on unsigned addition
+        OverflowMode::StrictUnder => {
+            primop_rules! {
+                fn(a: T, b: T) -> T{v: E::implies(valid_int(a + b, int_ty), E::eq(v, a+b)) }
+                if let &BaseTy::Int(int_ty) = T
+
+                fn(a: T, b: T) -> T{v: E::implies(valid_uint(a + b, uint_ty), E::eq(v, a+b)) }
+                requires nonnegative(a + b) => ConstrReason::Overflow
                 if let &BaseTy::Uint(uint_ty) = T
 
                 fn(a: T, b: T) -> T
@@ -275,6 +334,20 @@ fn mk_mul_rules(overflow_mode: OverflowMode) -> RuleMatcher<2> {
             }
         }
 
+        // like Lazy, but we also check for underflow on unsigned addition
+        OverflowMode::StrictUnder => {
+            primop_rules! {
+                fn(a: T, b: T) -> T{v: E::implies(valid_int(a * b, int_ty), E::eq(v, a * b)) }
+                if let &BaseTy::Int(int_ty) = T
+
+                fn(a: T, b: T) -> T{v: E::implies(valid_uint(a * b, uint_ty), E::eq(v, a * b)) }
+                requires nonnegative(a * b) => ConstrReason::Overflow
+                if let &BaseTy::Uint(uint_ty) = T
+
+                fn(a: T, b: T) -> T
+            }
+        }
+
         OverflowMode::Lazy => {
             primop_rules! {
                 fn(a: T, b: T) -> T{v: E::implies(valid_int(a * b, int_ty), E::eq(v, a * b)) }
@@ -310,6 +383,20 @@ fn mk_sub_rules(overflow_mode: OverflowMode) -> RuleMatcher<2> {
 
                 fn(a: T, b: T) -> T[a - b]
                 requires valid_uint(a - b, uint_ty) => ConstrReason::Overflow
+                if let &BaseTy::Uint(uint_ty) = T
+
+                fn(a: T, b: T) -> T
+            }
+        }
+
+        // like Lazy, but we also check for underflow on unsigned subtraction
+        OverflowMode::StrictUnder => {
+            primop_rules! {
+                fn(a: T, b: T) -> T{v: E::implies(valid_int(a - b, int_ty), E::eq(v, a - b)) }
+                if let &BaseTy::Int(int_ty) = T
+
+                fn(a: T, b: T) -> T{v: E::implies(valid_uint(a - b, uint_ty), E::eq(v, a - b)) }
+                requires nonnegative(a - b) => ConstrReason::Overflow
                 if let &BaseTy::Uint(uint_ty) = T
 
                 fn(a: T, b: T) -> T
@@ -499,7 +586,7 @@ fn mk_neg_rules(overflow_mode: OverflowMode) -> RuleMatcher<1> {
                 if T.is_float()
             }
         }
-        OverflowMode::Lazy => {
+        OverflowMode::Lazy | OverflowMode::StrictUnder => {
             primop_rules! {
                 fn(a: T) -> T{v: E::implies(E::ne(a, E::int_min(int_ty)), E::eq(v, a.neg())) }
                 if let &BaseTy::Int(int_ty) = T

--- a/crates/flux-refineck/src/primops.rs
+++ b/crates/flux-refineck/src/primops.rs
@@ -287,7 +287,7 @@ fn mk_add_rules(overflow_mode: OverflowMode) -> RuleMatcher<2> {
                 if let &BaseTy::Int(int_ty) = T
 
                 fn(a: T, b: T) -> T{v: E::implies(valid_uint(a + b, uint_ty), E::eq(v, a+b)) }
-                requires nonnegative(a + b) => ConstrReason::Overflow
+                requires nonnegative(a + b) => ConstrReason::Overflow   // check for underflow
                 if let &BaseTy::Uint(uint_ty) = T
 
                 fn(a: T, b: T) -> T
@@ -334,14 +334,14 @@ fn mk_mul_rules(overflow_mode: OverflowMode) -> RuleMatcher<2> {
             }
         }
 
-        // like Lazy, but we also check for underflow on unsigned addition
+        // like Lazy, but we also check for underflow on unsigned multiplication
         OverflowMode::StrictUnder => {
             primop_rules! {
                 fn(a: T, b: T) -> T{v: E::implies(valid_int(a * b, int_ty), E::eq(v, a * b)) }
                 if let &BaseTy::Int(int_ty) = T
 
                 fn(a: T, b: T) -> T{v: E::implies(valid_uint(a * b, uint_ty), E::eq(v, a * b)) }
-                requires nonnegative(a * b) => ConstrReason::Overflow
+                requires nonnegative(a * b) => ConstrReason::Overflow // check for underflow
                 if let &BaseTy::Uint(uint_ty) = T
 
                 fn(a: T, b: T) -> T
@@ -396,7 +396,7 @@ fn mk_sub_rules(overflow_mode: OverflowMode) -> RuleMatcher<2> {
                 if let &BaseTy::Int(int_ty) = T
 
                 fn(a: T, b: T) -> T{v: E::implies(valid_uint(a - b, uint_ty), E::eq(v, a - b)) }
-                requires nonnegative(a - b) => ConstrReason::Overflow
+                requires nonnegative(a - b) => ConstrReason::Overflow // check for underflow
                 if let &BaseTy::Uint(uint_ty) = T
 
                 fn(a: T, b: T) -> T


### PR DESCRIPTION
Add a `"strict-under"` mode which is like `"lazy"` but where we strictly check that unsigned operators preserve non-negativity.