### PR TITLE
Verify more vtock stuff in CI

### DIFF
--- a/.github/scripts/try-upgrade-toolchain.sh
+++ b/.github/scripts/try-upgrade-toolchain.sh
@@ -57,7 +57,7 @@ while true; do
   echo "::group::Vtock (nightly-$curr_toolchain)"
   cd ../tock
   cargo flux clean
-  cargo flux -p kernel
+  cargo flux -p cortexm -p rv32i
   cd ../flux
   echo "::endgroup::"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Check tock/kernel
         run: |
           cd tock
-          cargo flux -p kernel
+          cargo flux -p cortexm -p rv32i
 
   rustfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now that we've made progress in the multiarch verification, we should not only check `kernel`, but both `cortexm` and `rv32i` (which will pull and check `kernel` as a dependency)