### PR TITLE
Support explicit const parameters in argument position

### DIFF
--- a/crates/flux-desugar/locales/en-US.ftl
+++ b/crates/flux-desugar/locales/en-US.ftl
@@ -37,7 +37,7 @@ desugar_multiple_spreads_in_constructor =
 desugar_unsupported_position =
    expression not allowed in this position
 
-desugar_final_assoc_without_body = 
+desugar_final_assoc_without_body =
     final associated refinements must have a body
 
 # Resolve errors
@@ -76,6 +76,9 @@ desugar_unknown_qualifier =
 desugar_unknown_reveal_definition =
     unknown function definition
 
+desugar_unsupported_const_generic_arg =
+    `{$res_descr}` not supported in this position
+    .label =  help: try using `_` instead
 
 # Lifting Errors
 

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1163,8 +1163,12 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
         path: &surface::Path,
         res: fhir::Res,
     ) -> fhir::GenericArg<'genv> {
-        let Res::Def(DefKind::ConstParam, def_id) = res else { todo!() };
-        let kind = fhir::ConstArgKind::Param(def_id);
+        let kind = if let Res::Def(DefKind::ConstParam, def_id) = res {
+            fhir::ConstArgKind::Param(def_id)
+        } else {
+            self.emit(errors::UnsupportedConstGenericArg::new(path.span, res.descr()));
+            fhir::ConstArgKind::Infer
+        };
         fhir::GenericArg::Const(fhir::ConstArg { kind, span: path.span })
     }
 

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -28,7 +28,7 @@ use itertools::{Either, Itertools};
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_errors::{Diagnostic, ErrorGuaranteed};
 use rustc_hash::FxHashSet;
-use rustc_hir::{self as hir, OwnerId};
+use rustc_hir::{self as hir, OwnerId, def::Namespace};
 use rustc_span::{
     DUMMY_SP, Span,
     def_id::{DefId, LocalDefId},
@@ -1131,10 +1131,19 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
         }
         for arg in args {
             match &arg.kind {
-                surface::GenericArgKind::Type(ty) if matches!(ty.kind, surface::TyKind::Hole) => {
-                    fhir_args.push(fhir::GenericArg::Infer);
-                }
                 surface::GenericArgKind::Type(ty) => {
+                    if matches!(ty.kind, surface::TyKind::Hole) {
+                        fhir_args.push(fhir::GenericArg::Infer);
+                        continue;
+                    }
+                    if let Some(path) = ty.is_potential_const_arg()
+                        && let Some(res) =
+                            self.resolver_output().path_res_map[&path.node_id].full_res()
+                        && res.matches_ns(Namespace::ValueNS)
+                    {
+                        fhir_args.push(self.desugar_const_path_to_const_arg(path, res));
+                        continue;
+                    }
                     let ty = self.desugar_ty(ty);
                     fhir_args.push(fhir::GenericArg::Type(self.genv().alloc(ty)));
                 }
@@ -1147,6 +1156,16 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
             }
         }
         (self.genv().alloc_slice(&fhir_args), self.genv().alloc_slice(&constraints))
+    }
+
+    fn desugar_const_path_to_const_arg(
+        &mut self,
+        path: &surface::Path,
+        res: fhir::Res,
+    ) -> fhir::GenericArg<'genv> {
+        let Res::Def(DefKind::ConstParam, def_id) = res else { todo!() };
+        let kind = fhir::ConstArgKind::Param(def_id);
+        fhir::GenericArg::Const(fhir::ConstArg { kind, span: path.span })
     }
 
     /// This is the mega desugaring function [`surface::Ty`] -> [`fhir::Ty`].

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1136,6 +1136,8 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                         fhir_args.push(fhir::GenericArg::Infer);
                         continue;
                     }
+                    // If the path was resolved in the value namespace then we must create a const
+                    // generic argument
                     if let Some(path) = ty.is_potential_const_arg()
                         && let Some(res) =
                             self.resolver_output().path_res_map[&path.node_id].full_res()

--- a/crates/flux-desugar/src/errors.rs
+++ b/crates/flux-desugar/src/errors.rs
@@ -126,3 +126,18 @@ impl FinalAssocReftWithoutBody {
         Self { span }
     }
 }
+
+#[derive(Diagnostic)]
+#[diag(desugar_unsupported_const_generic_arg, code = E0999)]
+pub(super) struct UnsupportedConstGenericArg {
+    #[primary_span]
+    #[label]
+    span: Span,
+    res_descr: &'static str,
+}
+
+impl UnsupportedConstGenericArg {
+    pub(super) fn new(span: Span, res_descr: &'static str) -> Self {
+        Self { span, res_descr }
+    }
+}

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -838,6 +838,10 @@ impl surface::visit::Visitor for ItemResolver<'_, '_, '_> {
         if let surface::GenericArgKind::Type(ty) = &arg.kind
             && let Some(path) = ty.is_potential_const_arg()
         {
+            // We parse const arguments as path types as we cannot distinguish them during
+            // parsing. We try to resolve that ambiguity by attempting resolution in both the
+            // type and value namespaces. If we resolved the path in the value namespace, we
+            // transform it into a generic const argument.
             let check_ns = |ns| {
                 self.resolver
                     .resolve_ident_with_ribs(path.last().ident, ns)

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -619,7 +619,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                         rty::Expr::bvar(
                             INNERMOST,
                             BoundVar::from_usize(idx),
-                            rty::BoundReftKind::Annon,
+                            rty::BoundReftKind::Anon,
                         )
                     })
                     .collect(),
@@ -1765,7 +1765,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         let bty = bty.shift_in_escaping(1);
         let kind = match name {
             Some(name) => BoundReftKind::Named(name),
-            None => BoundReftKind::Annon,
+            None => BoundReftKind::Anon,
         };
         let var = rty::BoundVariableKind::Refine(sort, rty::InferMode::EVar, kind);
         let ctor = rty::Binder::bind_with_vars(
@@ -2528,7 +2528,7 @@ impl Layer {
                 Ok(List::singleton(rty::BoundVariableKind::Refine(
                     rty::Sort::App(ctor, args),
                     rty::InferMode::EVar,
-                    rty::BoundReftKind::Annon,
+                    rty::BoundReftKind::Anon,
                 )))
             }
         }
@@ -2565,7 +2565,7 @@ impl LookupResult<'_> {
                     }
                     LayerKind::Coalesce(def_id) => {
                         let var =
-                            rty::Expr::bvar(*debruijn, BoundVar::ZERO, rty::BoundReftKind::Annon)
+                            rty::Expr::bvar(*debruijn, BoundVar::ZERO, rty::BoundReftKind::Anon)
                                 .at(espan);
                         rty::Expr::field_proj(var, rty::FieldProj::Adt { def_id, field: *index })
                             .at(espan)

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1973,6 +1973,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         Err(self.emit(errors::AmbiguousAssocType { span, name: assoc_name }))?
     }
 
+    #[track_caller]
     fn report_expected_type(
         &self,
         span: Span,

--- a/crates/flux-middle/Cargo.toml
+++ b/crates/flux-middle/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "flux-middle"
-version = "0.1.0"
-
 edition.workspace = true
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -30,7 +30,7 @@ use rustc_hash::FxHashMap;
 pub use rustc_hir::PrimTy;
 use rustc_hir::{
     FnHeader, OwnerId, ParamName, Safety,
-    def::DefKind,
+    def::{DefKind, Namespace},
     def_id::{DefId, LocalDefId},
 };
 use rustc_index::newtype_index;
@@ -1116,6 +1116,22 @@ impl Res {
         } else {
             false
         }
+    }
+
+    /// Returns `None` if this is `Res::Err`
+    pub fn ns(&self) -> Option<Namespace> {
+        match self {
+            Res::Def(kind, ..) => kind.ns(),
+            Res::PrimTy(..) | Res::SelfTyAlias { .. } | Res::SelfTyParam { .. } => {
+                Some(Namespace::TypeNS)
+            }
+            Res::Err => None,
+        }
+    }
+
+    /// Always returns `true` if `self` is `Res::Err`
+    pub fn matches_ns(&self, ns: Namespace) -> bool {
+        self.ns().is_none_or(|actual_ns| actual_ns == ns)
     }
 }
 

--- a/crates/flux-middle/src/pretty.rs
+++ b/crates/flux-middle/src/pretty.rs
@@ -332,7 +332,7 @@ impl<'genv, 'tcx> PrettyCx<'genv, 'tcx> {
                         w!(self, f, ": {:?}", sort)?;
                     }
                 }
-                BoundVariableKind::Refine(sort, mode, BoundReftKind::Annon) => {
+                BoundVariableKind::Refine(sort, mode, BoundReftKind::Anon) => {
                     if print_infer_mode {
                         w!(self, f, "{}", ^mode.prefix_str())?;
                     }
@@ -357,7 +357,7 @@ impl<'genv, 'tcx> PrettyCx<'genv, 'tcx> {
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
         match breft.kind {
-            BoundReftKind::Annon => {
+            BoundReftKind::Anon => {
                 if let Some(name) = self.bvar_env.lookup(debruijn, breft.var) {
                     w!(self, f, "{name:?}")
                 } else {
@@ -523,7 +523,7 @@ impl BoundVarEnv {
     ) {
         let mut name_map = UnordMap::default();
         for (idx, var) in vars.iter().enumerate() {
-            if let BoundVariableKind::Refine(_, _, BoundReftKind::Annon) = var {
+            if let BoundVariableKind::Refine(_, _, BoundReftKind::Anon) = var {
                 name_map.insert(BoundVar::from_usize(idx), self.name_gen.fresh());
             }
         }

--- a/crates/flux-middle/src/rty/binder.rs
+++ b/crates/flux-middle/src/rty/binder.rs
@@ -277,7 +277,7 @@ impl BoundVariableKind {
 
 impl From<Sort> for BoundVariableKind {
     fn from(sort: Sort) -> Self {
-        Self::Refine(sort, InferMode::EVar, BoundReftKind::Annon)
+        Self::Refine(sort, InferMode::EVar, BoundReftKind::Anon)
     }
 }
 
@@ -285,7 +285,7 @@ pub type BoundVariableKinds = List<BoundVariableKind>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
 pub enum BoundReftKind {
-    Annon,
+    Anon,
     Named(Symbol),
 }
 

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -186,7 +186,7 @@ impl Expr {
     }
 
     pub fn nu() -> Expr {
-        Expr::bvar(INNERMOST, BoundVar::ZERO, BoundReftKind::Annon)
+        Expr::bvar(INNERMOST, BoundVar::ZERO, BoundReftKind::Anon)
     }
 
     pub fn is_nu(&self) -> bool {
@@ -560,7 +560,7 @@ impl Expr {
 
     pub fn eta_expand_abs(&self, inputs: &BoundVariableKinds, output: Sort) -> Lambda {
         let args = (0..inputs.len())
-            .map(|idx| Expr::bvar(INNERMOST, BoundVar::from_usize(idx), BoundReftKind::Annon))
+            .map(|idx| Expr::bvar(INNERMOST, BoundVar::from_usize(idx), BoundReftKind::Anon))
             .collect();
         let body = Expr::app(self, List::empty(), args);
         Lambda::bind_with_vars(body, inputs.clone(), output)

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -662,7 +662,7 @@ impl BasicBlockEnvShape {
                     Expr::bvar(
                         INNERMOST,
                         BoundVar::from_usize(bound_sorts.len() - 1),
-                        BoundReftKind::Annon,
+                        BoundReftKind::Anon,
                     )
                 }
             }

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -503,6 +503,18 @@ impl Ty {
         vis.visit_ty(self);
         vis.is_refined
     }
+
+    pub fn is_potential_const_arg(&self) -> Option<&Path> {
+        if let TyKind::Base(bty) = &self.kind
+            && let BaseTyKind::Path(None, path) = &bty.kind
+            && let [segment] = &path.segments[..]
+            && segment.args.len() == 0
+        {
+            Some(path)
+        } else {
+            None
+        }
+    }
 }
 #[derive(Debug)]
 pub struct BaseTy {

--- a/tests/tests/neg/error_messages/desugar/constant_const_generic.rs
+++ b/tests/tests/neg/error_messages/desugar/constant_const_generic.rs
@@ -1,0 +1,8 @@
+use flux_rs::attrs::*;
+
+const C: usize = 0;
+
+struct S<const N: usize> {}
+
+#[spec(fn(S<C>))] //~ ERROR `constant` not supported in this position
+fn foo(x: S<C>) {}

--- a/tests/tests/pos/const_generics/const_param_arg.rs
+++ b/tests/tests/pos/const_generics/const_param_arg.rs
@@ -1,0 +1,25 @@
+// Test support for const generic parameters used in argument position inside refinements. These
+// are parsed as types and disambiguated during name resolution.
+
+use flux_rs::attrs::*;
+
+struct S1<const N: usize> {}
+
+#[refined_by()]
+struct S2<const M: usize> {
+    #[field(S1<M>)]
+    f: S1<M>,
+}
+
+trait Trait1<const N: usize> {
+    #[spec(fn(S1<N>))]
+    fn method(x: S1<N>);
+}
+
+#[assoc(fn f(self: Self::Assoc) -> bool)]
+trait Trait2<const N: usize> {
+    type Assoc;
+
+    #[spec(fn(x: Self::Assoc{ <Self as Trait2<N>>::f(x) }))]
+    fn fun(x: Self::Assoc);
+}


### PR DESCRIPTION
Normally, you can use `_` to let Flux infer a const argument; however, this doesn't work in the following
```rust
trait Trait<const N: usize> { 
  fn foo(x: Self::Assoc{ <Self as Trait2<_>>::f(x) })
}
```
This is because we don't have anything to match the hole inside the refinement against. 

After this PR, we can mention const parameter explicitly so the following works now:

```rust
trait Trait<const N: usize> { 
  fn foo(x: Self::Assoc{ <Self as Trait2<N>>::f(x) })
}
```

Note that this only adds support for const parameters. Supporting other constants (e.g., a global constant) is more complicated because they are represented as anonymous bodies in rustc.