### PR TITLE
Plugs the rust fixpoint implementation into flux (behind the rust-fixpoint feature)

### DIFF
--- a/crates/flux-infer/Cargo.toml
+++ b/crates/flux-infer/Cargo.toml
@@ -26,3 +26,6 @@ workspace = true
 
 [package.metadata.rust-analyzer]
 rustc_private = true
+
+[features]
+rust-fixpoint = ["liquid-fixpoint/rust-fixpoint"]

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -442,6 +442,9 @@ where
         let mut constants = self.ecx.const_map.into_values().collect_vec();
         constants.extend(define_constants);
 
+        // The rust fixpoint implementation does not yet support polymorphic functions.
+        // For now we avoid including these by default so that cases where they are not needed can work.
+        // Should be removed when support is added.
         #[cfg(not(feature = "rust-fixpoint"))]
         for rel in fixpoint::BinRel::INEQUALITIES {
             // ∀a. a -> a -> bool

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -442,6 +442,7 @@ where
         let mut constants = self.ecx.const_map.into_values().collect_vec();
         constants.extend(define_constants);
 
+        #[cfg(not(feature = "rust-fixpoint"))]
         for rel in fixpoint::BinRel::INEQUALITIES {
             // ∀a. a -> a -> bool
             let sort = fixpoint::Sort::mk_func(

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -247,6 +247,21 @@ impl<T: Types> Pred<T> {
             Pred::Expr(_) => true,
         }
     }
+
+    pub fn simplify(&mut self) {
+        match self {
+            Pred::And(conjuncts) => {
+                if conjuncts.len() == 0 {
+                    *self = Pred::TRUE;
+                } else if conjuncts.len() == 1 {
+                    *self = conjuncts[0].clone();
+                } else {
+                    conjuncts.iter_mut().for_each(|pred| pred.simplify());
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 #[derive(Hash, Debug, Copy, Clone, PartialEq, Eq)]

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -248,6 +248,7 @@ impl<T: Types> Pred<T> {
         }
     }
 
+    #[cfg(feature = "rust-fixpoint")]
     pub(crate) fn simplify(&mut self) {
         match self {
             Pred::And(conjuncts) => {

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -248,7 +248,7 @@ impl<T: Types> Pred<T> {
         }
     }
 
-    pub fn simplify(&mut self) {
+    pub(crate) fn simplify(&mut self) {
         match self {
             Pred::And(conjuncts) => {
                 if conjuncts.len() == 0 {

--- a/lib/liquid-fixpoint/src/constraint_solving.rs
+++ b/lib/liquid-fixpoint/src/constraint_solving.rs
@@ -139,7 +139,7 @@ impl<T: Types> Constraint<T> {
         }
     }
 
-    pub fn simplify(&mut self) {
+    pub(crate) fn simplify(&mut self) {
         match self {
             Constraint::ForAll(bind, inner) => {
                 bind.pred.simplify();
@@ -163,7 +163,7 @@ impl<T: Types> Constraint<T> {
         }
     }
 
-    pub fn scope(&self, var: &T::KVar) -> Self {
+    fn scope(&self, var: &T::KVar) -> Self {
         self.scope_help(var)
             .unwrap_or(Constraint::Pred(Pred::Expr(Expr::Constant(Constant::Boolean(true))), None))
     }
@@ -194,7 +194,7 @@ impl<T: Types> Constraint<T> {
         }
     }
 
-    pub fn sol1(&self, var: &T::KVar) -> Vec<Solution<T>> {
+    fn sol1(&self, var: &T::KVar) -> Vec<Solution<T>> {
         match self {
             Constraint::ForAll(bind, inner) => {
                 inner
@@ -221,11 +221,11 @@ impl<T: Types> Constraint<T> {
         }
     }
 
-    pub fn elim(&self, vars: &Vec<T::KVar>) -> Self {
+    pub(crate) fn elim(&self, vars: &Vec<T::KVar>) -> Self {
         vars.iter().fold(self.clone(), |acc, var| acc.elim1(var))
     }
 
-    pub fn elim1(&self, var: &T::KVar) -> Self {
+    fn elim1(&self, var: &T::KVar) -> Self {
         let solution = self.scope(var).sol1(var);
         self.do_elim(var, &solution)
     }
@@ -304,7 +304,7 @@ impl<T: Types> Pred<T> {
         }
     }
 
-    pub fn kvars(&self) -> Vec<T::KVar> {
+    fn kvars(&self) -> Vec<T::KVar> {
         match self {
             Pred::KVar(kvid, _args) => vec![kvid.clone()],
             Pred::Expr(_expr) => vec![],
@@ -319,7 +319,7 @@ impl<T: Types> Pred<T> {
         }
     }
 
-    pub fn sub_kvars(
+    pub(crate) fn sub_kvars(
         &self,
         assignment: &HashMap<T::KVar, Vec<(&Qualifier<T>, Vec<usize>)>>,
     ) -> Self {
@@ -373,7 +373,7 @@ impl<T: Types> Pred<T> {
         }
     }
 
-    pub fn sub_head(&self, assignment: &(&Qualifier<T>, Vec<usize>)) -> Self {
+    pub(crate) fn sub_head(&self, assignment: &(&Qualifier<T>, Vec<usize>)) -> Self {
         match self {
             Pred::Expr(expr) => Pred::Expr(expr.clone()),
             Pred::KVar(_kvid, args) => {
@@ -391,7 +391,10 @@ impl<T: Types> Pred<T> {
         }
     }
 
-    pub fn partition_pred(&self, var: &T::KVar) -> (Vec<(T::KVar, Vec<T::Var>)>, Vec<Pred<T>>) {
+    pub(crate) fn partition_pred(
+        &self,
+        var: &T::KVar,
+    ) -> (Vec<(T::KVar, Vec<T::Var>)>, Vec<Pred<T>>) {
         let mut kvar_instances = vec![];
         let mut other_preds = vec![];
         self.partition_pred_help(var, &mut kvar_instances, &mut other_preds);
@@ -418,28 +421,10 @@ impl<T: Types> Pred<T> {
             }
         }
     }
-
-    pub fn rename(&mut self, from: &T::Var, to: &T::Var) {
-        match self {
-            Pred::Expr(expr) => {
-                expr.substitute_in_place(from, to);
-            }
-            Pred::KVar(_kvid, args) => {
-                args.iter_mut().for_each(|arg| {
-                    if from.eq(arg) {
-                        *arg = to.clone();
-                    }
-                });
-            }
-            Pred::And(conjuncts) => {
-                conjuncts.iter_mut().for_each(|pred| pred.rename(from, to));
-            }
-        }
-    }
 }
 
 impl<T: Types> Expr<T> {
-    pub fn substitute_in_place(&mut self, v_from: &T::Var, v_to: &T::Var) {
+    fn substitute_in_place(&mut self, v_from: &T::Var, v_to: &T::Var) {
         match self {
             Expr::Var(v) => {
                 if v == v_from {
@@ -469,7 +454,7 @@ impl<T: Types> Expr<T> {
         }
     }
 
-    pub fn substitute(&self, v_from: &T::Var, v_to: &T::Var) -> Self {
+    pub(crate) fn substitute(&self, v_from: &T::Var, v_to: &T::Var) -> Self {
         let mut new_expr = self.clone();
         new_expr.substitute_in_place(v_from, v_to);
         new_expr

--- a/lib/liquid-fixpoint/src/cstr2smt2.rs
+++ b/lib/liquid-fixpoint/src/cstr2smt2.rs
@@ -1,326 +1,417 @@
-use crate::{Types, constraint::Constraint};
+use core::panic;
+use std::{collections::HashMap, vec};
 
-#[cfg(feature = "rust-fixpoint")]
-mod rust_fixpoint {
-    use core::panic;
-    use std::collections::HashMap;
+use z3::{
+    Config, Context, FuncDecl, SatResult, Solver, SortKind,
+    ast::{self, Ast},
+};
 
-    use z3::{
-        Config, Context, SatResult, Solver, SortKind,
-        ast::{self, Ast},
-    };
+use crate::{
+    ConstDecl, Error, FixpointFmt, FixpointResult, Identifier, Stats, Types,
+    constraint::{BinOp, BinRel, Constant, Constraint, Expr, Pred, Sort},
+};
 
-    use crate::{
-        FixpointFmt, Identifier, Types,
-        constraint::{BinOp, BinRel, Bind, Constant, Constraint, Expr, Pred, Sort},
-    };
-    struct Env<'ctx, T: Types> {
-        bindings: HashMap<T::Var, Vec<ast::Dynamic<'ctx>>>,
-    }
+#[derive(Debug)]
+enum Binding<'ctx> {
+    Variable(ast::Dynamic<'ctx>),
+    Function(FuncDecl<'ctx>),
+}
 
-    impl<'ctx, T: Types> Env<'ctx, T> {
-        fn new() -> Self {
-            Self { bindings: HashMap::new() }
-        }
-
-        fn insert(&mut self, name: T::Var, value: ast::Dynamic<'ctx>) {
-            self.bindings.entry(name).or_default().push(value);
-        }
-
-        fn pop(&mut self, name: &T::Var) {
-            if let Some(stack) = self.bindings.get_mut(name) {
-                stack.pop();
-                if stack.is_empty() {
-                    self.bindings.remove(name);
-                }
-            }
-        }
-
-        fn lookup(&self, name: &T::Var) -> Option<ast::Dynamic<'ctx>> {
-            self.bindings
-                .get(name)
-                .and_then(|stack| stack.last().cloned())
-        }
-    }
-
-    fn const_to_z3<'ctx, T: Types>(ctx: &'ctx Context, cnst: &Constant<T>) -> ast::Dynamic<'ctx> {
-        match cnst {
-            Constant::Numeral(num) => ast::Int::from_i64(ctx, (*num).try_into().unwrap()).into(),
-            Constant::Boolean(b) => ast::Bool::from_bool(ctx, *b).into(),
-            Constant::String(strconst) => {
-                ast::String::from_str(ctx, &strconst.display().to_string())
-                    .unwrap()
-                    .into()
-            }
-            _ => panic!("handling for this kind of const isn't implemented yet"),
-        }
-    }
-
-    fn atom_to_z3<'ctx, T: Types>(
-        ctx: &'ctx Context,
-        bin_rel: &BinRel,
-        operands: &Box<[Expr<T>; 2]>,
-        env: &mut Env<'ctx, T>,
-    ) -> ast::Dynamic<'ctx> {
-        let loperand = expr_to_z3(ctx, &operands[0], env);
-        let roperand = expr_to_z3(ctx, &operands[1], env);
-        if loperand.sort_kind() != roperand.sort_kind() {
-            panic!("Operands must have the same sort");
-        }
-        if !matches!(bin_rel, BinRel::Eq | BinRel::Ne)
-            && !matches!(loperand.sort_kind(), SortKind::Int | SortKind::Real)
-        {
-            panic!("Comparison operators require numeric operands");
-        }
-        match (bin_rel, loperand.sort_kind(), roperand.sort_kind()) {
-            (BinRel::Ne, _, _) => loperand._eq(&roperand).not().into(),
-            (BinRel::Eq, _, _) => loperand._eq(&roperand).into(),
-            (BinRel::Gt, SortKind::Int, SortKind::Int) => {
-                let iloperand = loperand.as_int().expect("already checked");
-                let iroperand = roperand.as_int().expect("already checked");
-                iloperand.gt(&iroperand).into()
-            }
-            (BinRel::Gt, SortKind::Real, SortKind::Real) => {
-                let rloperand = loperand.as_real().expect("already checked");
-                let rroperand = roperand.as_real().expect("already checked");
-                rloperand.gt(&rroperand).into()
-            }
-            (BinRel::Ge, SortKind::Int, SortKind::Int) => {
-                let iloperand = loperand.as_int().expect("already checked");
-                let iroperand = roperand.as_int().expect("already checked");
-                iloperand.ge(&iroperand).into()
-            }
-            (BinRel::Ge, SortKind::Real, SortKind::Real) => {
-                let rloperand = loperand.as_real().expect("already checked");
-                let rroperand = roperand.as_real().expect("already checked");
-                rloperand.ge(&rroperand).into()
-            }
-            (BinRel::Lt, SortKind::Int, SortKind::Int) => {
-                let iloperand = loperand.as_int().expect("already checked");
-                let iroperand = roperand.as_int().expect("already checked");
-                iloperand.lt(&iroperand).into()
-            }
-            (BinRel::Lt, SortKind::Real, SortKind::Real) => {
-                let rloperand = loperand.as_real().expect("already checked");
-                let rroperand = roperand.as_real().expect("already checked");
-                rloperand.lt(&rroperand).into()
-            }
-            (BinRel::Le, SortKind::Int, SortKind::Int) => {
-                let iloperand = loperand.as_int().expect("already checked");
-                let iroperand = roperand.as_int().expect("already checked");
-                iloperand.le(&iroperand).into()
-            }
-            (BinRel::Le, SortKind::Real, SortKind::Real) => {
-                let rloperand = loperand.as_real().expect("already checked");
-                let rroperand = roperand.as_real().expect("already checked");
-                rloperand.le(&rroperand).into()
-            }
-            _ => panic!("Unsupported relation or operand types"),
-        }
-    }
-
-    fn binop_to_z3<'ctx, T: Types>(
-        ctx: &'ctx Context,
-        bin_op: &BinOp,
-        operands: &Box<[Expr<T>; 2]>,
-        env: &mut Env<'ctx, T>,
-    ) -> ast::Dynamic<'ctx> {
-        let lhs = expr_to_z3(ctx, &operands[0], env);
-        let rhs = expr_to_z3(ctx, &operands[1], env);
-
-        if lhs.sort_kind() != rhs.sort_kind() {
-            panic!("binary operands must have the same sort");
-        }
-
-        match lhs.sort_kind() {
-            // ------------------------------------------------------------------
-            // ✦  Integers  ✦
-            // ------------------------------------------------------------------
-            SortKind::Int => {
-                let l: ast::Int<'ctx> = lhs.as_int().unwrap();
-                let r: ast::Int<'ctx> = rhs.as_int().unwrap();
-
-                let res = match bin_op {
-                    BinOp::Add => ast::Int::add(ctx, &[&l, &r]),
-                    BinOp::Sub => ast::Int::sub(ctx, &[&l, &r]),
-                    BinOp::Mul => ast::Int::mul(ctx, &[&l, &r]),
-                    BinOp::Div => l.div(&r),
-                    BinOp::Mod => l.modulo(&r),
-                };
-                res.into()
-            }
-            SortKind::Real => {
-                let l: ast::Real<'ctx> = lhs.as_real().unwrap();
-                let r: ast::Real<'ctx> = rhs.as_real().unwrap();
-
-                let res = match bin_op {
-                    BinOp::Add => ast::Real::add(ctx, &[&l, &r]),
-                    BinOp::Sub => ast::Real::sub(ctx, &[&l, &r]),
-                    BinOp::Mul => ast::Real::mul(ctx, &[&l, &r]),
-                    BinOp::Div => l.div(&r),
-                    BinOp::Mod => panic!("modulo is not defined on Real numbers"),
-                };
-                res.into()
-            }
-
-            _ => panic!("arithmetic operators only support Int and Real"),
-        }
-    }
-
-    fn expr_to_z3<'ctx, T: Types>(
-        ctx: &'ctx Context,
-        expr: &Expr<T>,
-        env: &mut Env<'ctx, T>,
-    ) -> ast::Dynamic<'ctx> {
-        match expr {
-            Expr::Var(var) => env.lookup(var).expect("error if not present"),
-            Expr::Constant(cnst) => const_to_z3(ctx, cnst),
-            Expr::Atom(bin_rel, operands) => atom_to_z3(ctx, bin_rel, operands, env),
-            Expr::BinaryOp(bin_op, operands) => binop_to_z3(ctx, bin_op, operands, env),
-            Expr::And(conjuncts) => {
-                let booleans = conjuncts
-                    .iter()
-                    .map(|conjunct| expr_to_z3(ctx, conjunct, env).as_bool())
-                    .collect::<Option<Vec<_>>>()
-                    .unwrap();
-                let boolean_refs: Vec<&ast::Bool> = booleans.iter().collect();
-                let bool_ref_slice: &[&ast::Bool] = boolean_refs.as_slice();
-                ast::Bool::and(ctx, bool_ref_slice).into()
-            }
-            Expr::Or(options) => {
-                let booleans = options
-                    .iter()
-                    .map(|option| expr_to_z3(ctx, option, env).as_bool())
-                    .collect::<Option<Vec<_>>>()
-                    .unwrap();
-                let boolean_refs: Vec<&ast::Bool> = booleans.iter().collect();
-                let bool_ref_slice: &[&ast::Bool] = boolean_refs.as_slice();
-                ast::Bool::or(ctx, bool_ref_slice).into()
-            }
-            Expr::Not(inner) => {
-                expr_to_z3(ctx, &*inner, env)
-                    .as_bool()
-                    .unwrap()
-                    .not()
-                    .into()
-            }
-            Expr::Neg(number) => {
-                let zero = ast::Int::from_i64(ctx, 0);
-                let z3_num = expr_to_z3(ctx, &number, env);
-                match z3_num.sort_kind() {
-                    SortKind::Int => ast::Int::sub(ctx, &[&zero, &z3_num.as_int().unwrap()]).into(),
-                    SortKind::Real => {
-                        ast::Real::sub(ctx, &[&zero.to_real(), &z3_num.as_real().unwrap()]).into()
-                    }
-                    _ => panic!("Negation requires numeric operand"),
-                }
-            }
-            Expr::Iff(operands) => {
-                let lhs = expr_to_z3(ctx, &operands[0], env);
-                let rhs = expr_to_z3(ctx, &operands[1], env);
-                lhs.as_bool().unwrap().iff(&rhs.as_bool().unwrap()).into()
-            }
-            Expr::Imp(operands) => {
-                let lhs = expr_to_z3(ctx, &operands[0], env);
-                let rhs = expr_to_z3(ctx, &operands[1], env);
-                lhs.as_bool()
-                    .unwrap()
-                    .implies(&rhs.as_bool().unwrap())
-                    .into()
-            }
-            Expr::Let(variable, exprs) => {
-                let binding = expr_to_z3(ctx, &exprs[0], env);
-                env.insert(variable.clone(), binding);
-                let res = expr_to_z3(ctx, &exprs[1], env);
-                env.pop(&variable);
-                res
-            }
-            _ => {
-                panic!("handling for this kind of expression is not implemented yet")
-            }
-        }
-    }
-
-    fn pred_to_z3<'ctx, T: Types>(
-        ctx: &'ctx Context,
-        pred: &Pred<T>,
-        env: &mut Env<'ctx, T>,
-    ) -> ast::Bool<'ctx> {
-        match pred {
-            Pred::Expr(expr) => expr_to_z3(ctx, expr, env).as_bool().expect(" asldfj "),
-            Pred::And(conjuncts) => {
-                let bools: Vec<_> = conjuncts
-                    .iter()
-                    .map(|conjunct| pred_to_z3(ctx, conjunct, env))
-                    .collect::<Vec<_>>();
-                let bool_refs: Vec<&ast::Bool> = bools.iter().collect();
-                ast::Bool::and(ctx, bool_refs.as_slice()).into()
-            }
-            Pred::KVar(_kvar, _vars) => panic!("Kvars not supported yet"),
-        }
-    }
-
-    fn new_const<'ctx, T: Types>(ctx: &'ctx Context, bind: &Bind<T>) -> ast::Dynamic<'ctx> {
-        match &bind.sort {
-            Sort::Int => ast::Int::new_const(ctx, bind.name.display().to_string().as_str()).into(),
-            Sort::Real => {
-                ast::Real::new_const(ctx, bind.name.display().to_string().as_str()).into()
-            }
-            Sort::Bool => {
-                ast::Bool::new_const(ctx, bind.name.display().to_string().as_str()).into()
-            }
-            Sort::Str => {
-                ast::String::new_const(ctx, bind.name.display().to_string().as_str()).into()
-            }
-            _ => panic!("unhandled kind encountered"),
-        }
-    }
-
-    fn is_constraint_satisfiable_inner<'ctx, T: Types>(
-        ctx: &'ctx Context,
-        cstr: &Constraint<T>,
-        solver: &Solver,
-        env: &mut Env<'ctx, T>,
-    ) -> bool {
-        solver.push();
-        let res = match cstr {
-            Constraint::Pred(pred, _tag) => {
-                solver.assert(&pred_to_z3(ctx, pred, env).not());
-                matches!(solver.check(), SatResult::Unsat)
-            }
-            Constraint::Conj(conjuncts) => {
-                conjuncts
-                    .iter()
-                    .all(|conjunct| is_constraint_satisfiable_inner(ctx, conjunct, solver, env))
-            }
-
-            Constraint::ForAll(bind, inner) => {
-                env.insert(bind.name.clone(), new_const(ctx, bind));
-                solver.assert(&pred_to_z3(ctx, &bind.pred, env));
-                let inner_soln = is_constraint_satisfiable_inner(ctx, &**inner, solver, env);
-                env.pop(&bind.name);
-                inner_soln
-            }
-        };
-        solver.pop(1);
-        res
-    }
-
-    pub fn is_constraint_satisfiable<T: Types>(cstr: &Constraint<T>) -> bool {
-        let cfg = Config::new();
-        let ctx = Context::new(&cfg);
-        let solver = Solver::new(&ctx);
-        let mut vars = Env::new();
-        is_constraint_satisfiable_inner(&ctx, &cstr, &solver, &mut vars)
+impl<'ctx> From<ast::Dynamic<'ctx>> for Binding<'ctx> {
+    fn from(value: ast::Dynamic<'ctx>) -> Self {
+        Binding::Variable(value)
     }
 }
 
-#[cfg(feature = "rust-fixpoint")]
-pub fn is_constraint_satisfiable<T: Types>(cstr: &Constraint<T>) -> bool {
-    rust_fixpoint::is_constraint_satisfiable(cstr)
+impl<'ctx> From<FuncDecl<'ctx>> for Binding<'ctx> {
+    fn from(value: FuncDecl<'ctx>) -> Self {
+        Binding::Function(value)
+    }
 }
 
-#[cfg(not(feature = "rust-fixpoint"))]
-pub fn is_constraint_satisfiable<T: Types>(_cstr: &Constraint<T>) -> bool {
-    true
+pub struct Env<'ctx, T: Types> {
+    bindings: HashMap<T::Var, Vec<Binding<'ctx>>>,
+}
+
+impl<'ctx, T: Types> Env<'ctx, T> {
+    fn new() -> Self {
+        Self { bindings: HashMap::new() }
+    }
+
+    fn insert<B: Into<Binding<'ctx>>>(&mut self, name: T::Var, value: B) {
+        self.bindings
+            .entry(name)
+            .or_default()
+            .push(Into::<Binding<'ctx>>::into(value));
+    }
+
+    fn pop(&mut self, name: &T::Var) {
+        if let Some(stack) = self.bindings.get_mut(name) {
+            stack.pop();
+            if stack.is_empty() {
+                self.bindings.remove(name);
+            }
+        }
+    }
+
+    fn var_lookup(&self, name: &T::Var) -> Option<&ast::Dynamic<'ctx>> {
+        match &self.lookup(name) {
+            Some(Binding::Variable(var)) => Some(var),
+            _ => None,
+        }
+    }
+
+    fn fun_lookup(&self, name: &T::Var) -> Option<&FuncDecl<'ctx>> {
+        match &self.lookup(name) {
+            Some(Binding::Function(fun)) => Some(fun),
+            _ => None,
+        }
+    }
+
+    fn lookup(&self, name: &T::Var) -> Option<&Binding<'ctx>> {
+        self.bindings.get(name).and_then(|stack| stack.last())
+    }
+}
+
+fn const_to_z3<'ctx, T: Types>(ctx: &'ctx Context, cnst: &Constant<T>) -> ast::Dynamic<'ctx> {
+    match cnst {
+        Constant::Numeral(num) => ast::Int::from_i64(ctx, (*num).try_into().unwrap()).into(),
+        Constant::Boolean(b) => ast::Bool::from_bool(ctx, *b).into(),
+        Constant::String(strconst) => {
+            ast::String::from_str(ctx, &strconst.display().to_string())
+                .unwrap()
+                .into()
+        }
+        _ => panic!("handling for this kind of const isn't implemented yet"),
+    }
+}
+
+fn atom_to_z3<'ctx, T: Types>(
+    ctx: &'ctx Context,
+    bin_rel: &BinRel,
+    operands: &Box<[Expr<T>; 2]>,
+    env: &mut Env<'ctx, T>,
+) -> ast::Dynamic<'ctx> {
+    let loperand = expr_to_z3(ctx, &operands[0], env);
+    let roperand = expr_to_z3(ctx, &operands[1], env);
+    if loperand.sort_kind() != roperand.sort_kind() {
+        panic!("Operands must have the same sort");
+    }
+    if !matches!(bin_rel, BinRel::Eq | BinRel::Ne)
+        && !matches!(loperand.sort_kind(), SortKind::Int | SortKind::Real)
+    {
+        panic!("Comparison operators require numeric operands");
+    }
+    match (bin_rel, loperand.sort_kind(), roperand.sort_kind()) {
+        (BinRel::Ne, _, _) => loperand._eq(&roperand).not().into(),
+        (BinRel::Eq, _, _) => loperand._eq(&roperand).into(),
+        (BinRel::Gt, SortKind::Int, SortKind::Int) => {
+            let iloperand = loperand.as_int().expect("already checked");
+            let iroperand = roperand.as_int().expect("already checked");
+            iloperand.gt(&iroperand).into()
+        }
+        (BinRel::Gt, SortKind::Real, SortKind::Real) => {
+            let rloperand = loperand.as_real().expect("already checked");
+            let rroperand = roperand.as_real().expect("already checked");
+            rloperand.gt(&rroperand).into()
+        }
+        (BinRel::Ge, SortKind::Int, SortKind::Int) => {
+            let iloperand = loperand.as_int().expect("already checked");
+            let iroperand = roperand.as_int().expect("already checked");
+            iloperand.ge(&iroperand).into()
+        }
+        (BinRel::Ge, SortKind::Real, SortKind::Real) => {
+            let rloperand = loperand.as_real().expect("already checked");
+            let rroperand = roperand.as_real().expect("already checked");
+            rloperand.ge(&rroperand).into()
+        }
+        (BinRel::Lt, SortKind::Int, SortKind::Int) => {
+            let iloperand = loperand.as_int().expect("already checked");
+            let iroperand = roperand.as_int().expect("already checked");
+            iloperand.lt(&iroperand).into()
+        }
+        (BinRel::Lt, SortKind::Real, SortKind::Real) => {
+            let rloperand = loperand.as_real().expect("already checked");
+            let rroperand = roperand.as_real().expect("already checked");
+            rloperand.lt(&rroperand).into()
+        }
+        (BinRel::Le, SortKind::Int, SortKind::Int) => {
+            let iloperand = loperand.as_int().expect("already checked");
+            let iroperand = roperand.as_int().expect("already checked");
+            iloperand.le(&iroperand).into()
+        }
+        (BinRel::Le, SortKind::Real, SortKind::Real) => {
+            let rloperand = loperand.as_real().expect("already checked");
+            let rroperand = roperand.as_real().expect("already checked");
+            rloperand.le(&rroperand).into()
+        }
+        _ => panic!("Unsupported relation or operand types"),
+    }
+}
+
+fn binop_to_z3<'ctx, T: Types>(
+    ctx: &'ctx Context,
+    bin_op: &BinOp,
+    operands: &Box<[Expr<T>; 2]>,
+    env: &mut Env<'ctx, T>,
+) -> ast::Dynamic<'ctx> {
+    let lhs = expr_to_z3(ctx, &operands[0], env);
+    let rhs = expr_to_z3(ctx, &operands[1], env);
+
+    if lhs.sort_kind() != rhs.sort_kind() {
+        panic!("binary operands must have the same sort");
+    }
+
+    match lhs.sort_kind() {
+        // ------------------------------------------------------------------
+        // ✦  Integers  ✦
+        // ------------------------------------------------------------------
+        SortKind::Int => {
+            let l: ast::Int<'ctx> = lhs.as_int().unwrap();
+            let r: ast::Int<'ctx> = rhs.as_int().unwrap();
+
+            let res = match bin_op {
+                BinOp::Add => ast::Int::add(ctx, &[&l, &r]),
+                BinOp::Sub => ast::Int::sub(ctx, &[&l, &r]),
+                BinOp::Mul => ast::Int::mul(ctx, &[&l, &r]),
+                BinOp::Div => l.div(&r),
+                BinOp::Mod => l.modulo(&r),
+            };
+            res.into()
+        }
+        SortKind::Real => {
+            let l: ast::Real<'ctx> = lhs.as_real().unwrap();
+            let r: ast::Real<'ctx> = rhs.as_real().unwrap();
+
+            let res = match bin_op {
+                BinOp::Add => ast::Real::add(ctx, &[&l, &r]),
+                BinOp::Sub => ast::Real::sub(ctx, &[&l, &r]),
+                BinOp::Mul => ast::Real::mul(ctx, &[&l, &r]),
+                BinOp::Div => l.div(&r),
+                BinOp::Mod => panic!("modulo is not defined on Real numbers"),
+            };
+            res.into()
+        }
+
+        _ => panic!("arithmetic operators only support Int and Real"),
+    }
+}
+
+fn expr_to_z3<'ctx, T: Types>(
+    ctx: &'ctx Context,
+    expr: &Expr<T>,
+    env: &mut Env<'ctx, T>,
+) -> ast::Dynamic<'ctx> {
+    match expr {
+        Expr::Var(var) => {
+            env.var_lookup(var)
+                .map(|var| var.clone())
+                .expect("error if not present")
+        }
+        Expr::Constant(cnst) => const_to_z3(ctx, cnst),
+        Expr::Atom(bin_rel, operands) => atom_to_z3(ctx, bin_rel, operands, env),
+        Expr::BinaryOp(bin_op, operands) => binop_to_z3(ctx, bin_op, operands, env),
+        Expr::And(conjuncts) => {
+            let booleans = conjuncts
+                .iter()
+                .map(|conjunct| expr_to_z3(ctx, conjunct, env).as_bool())
+                .collect::<Option<Vec<_>>>()
+                .unwrap();
+            let boolean_refs: Vec<&ast::Bool> = booleans.iter().collect();
+            let bool_ref_slice: &[&ast::Bool] = boolean_refs.as_slice();
+            ast::Bool::and(ctx, bool_ref_slice).into()
+        }
+        Expr::Or(options) => {
+            let booleans = options
+                .iter()
+                .map(|option| expr_to_z3(ctx, option, env).as_bool())
+                .collect::<Option<Vec<_>>>()
+                .unwrap();
+            let boolean_refs: Vec<&ast::Bool> = booleans.iter().collect();
+            let bool_ref_slice: &[&ast::Bool] = boolean_refs.as_slice();
+            ast::Bool::or(ctx, bool_ref_slice).into()
+        }
+        Expr::Not(inner) => {
+            expr_to_z3(ctx, &*inner, env)
+                .as_bool()
+                .unwrap()
+                .not()
+                .into()
+        }
+        Expr::Neg(number) => {
+            let zero = ast::Int::from_i64(ctx, 0);
+            let z3_num = expr_to_z3(ctx, &number, env);
+            match z3_num.sort_kind() {
+                SortKind::Int => ast::Int::sub(ctx, &[&zero, &z3_num.as_int().unwrap()]).into(),
+                SortKind::Real => {
+                    ast::Real::sub(ctx, &[&zero.to_real(), &z3_num.as_real().unwrap()]).into()
+                }
+                _ => panic!("Negation requires numeric operand"),
+            }
+        }
+        Expr::Iff(operands) => {
+            let lhs = expr_to_z3(ctx, &operands[0], env);
+            let rhs = expr_to_z3(ctx, &operands[1], env);
+            lhs.as_bool().unwrap().iff(&rhs.as_bool().unwrap()).into()
+        }
+        Expr::Imp(operands) => {
+            let lhs = expr_to_z3(ctx, &operands[0], env);
+            let rhs = expr_to_z3(ctx, &operands[1], env);
+            lhs.as_bool()
+                .unwrap()
+                .implies(&rhs.as_bool().unwrap())
+                .into()
+        }
+        Expr::Let(variable, exprs) => {
+            let binding = expr_to_z3(ctx, &exprs[0], env);
+            env.insert(variable.clone(), binding);
+            let res = expr_to_z3(ctx, &exprs[1], env);
+            env.pop(&variable);
+            res
+        }
+        Expr::App(fun, args) => {
+            match &**fun {
+                Expr::Var(var) => {
+                    let arg_asts: Vec<Box<dyn Ast<'ctx>>> = args
+                        .iter()
+                        .map(|arg| dynamic_as_ast(expr_to_z3(ctx, arg, env)))
+                        .collect();
+                    let arg_refs: Vec<&_> = arg_asts.iter().map(|a| a.as_ref()).collect();
+                    let fun_decl = env.fun_lookup(var).expect("error if function not present");
+                    fun_decl.apply(&arg_refs)
+                }
+                _ => panic!("encountered function application but no function"),
+            }
+        }
+        _ => {
+            panic!("handling for this kind of expression is not implemented yet")
+        }
+    }
+}
+
+fn dynamic_as_ast<'ctx>(val: ast::Dynamic<'ctx>) -> Box<dyn Ast<'ctx> + 'ctx> {
+    if let Some(int_val) = val.as_int() {
+        Box::new(int_val) as Box<dyn Ast<'ctx>>
+    } else if let Some(real_val) = val.as_real() {
+        Box::new(real_val) as Box<dyn Ast<'ctx>>
+    } else if let Some(bool_val) = val.as_bool() {
+        Box::new(bool_val) as Box<dyn Ast<'ctx>>
+    } else if let Some(str_val) = val.as_string() {
+        Box::new(str_val) as Box<dyn Ast<'ctx>>
+    } else {
+        panic!("unhandled sort encountered")
+    }
+}
+
+fn pred_to_z3<'ctx, T: Types>(
+    ctx: &'ctx Context,
+    pred: &Pred<T>,
+    env: &mut Env<'ctx, T>,
+) -> ast::Bool<'ctx> {
+    match pred {
+        Pred::Expr(expr) => expr_to_z3(ctx, expr, env).as_bool().expect(" asldfj "),
+        Pred::And(conjuncts) => {
+            let bools: Vec<_> = conjuncts
+                .iter()
+                .map(|conjunct| pred_to_z3(ctx, conjunct, env))
+                .collect::<Vec<_>>();
+            let bool_refs: Vec<&ast::Bool> = bools.iter().collect();
+            ast::Bool::and(ctx, bool_refs.as_slice()).into()
+        }
+        Pred::KVar(_kvar, _vars) => panic!("Kvars not supported yet"),
+    }
+}
+
+fn new_binding<'ctx, T: Types>(ctx: &'ctx Context, name: &T::Var, sort: &Sort<T>) -> Binding<'ctx> {
+    match &sort {
+        Sort::Int => {
+            Binding::Variable(ast::Int::new_const(ctx, name.display().to_string().as_str()).into())
+        }
+        Sort::Real => {
+            Binding::Variable(ast::Real::new_const(ctx, name.display().to_string().as_str()).into())
+        }
+        Sort::Bool => {
+            Binding::Variable(ast::Bool::new_const(ctx, name.display().to_string().as_str()).into())
+        }
+        Sort::Str => {
+            Binding::Variable(
+                ast::String::new_const(ctx, name.display().to_string().as_str()).into(),
+            )
+        }
+        Sort::Func(sorts) => {
+            let fun_decl = FuncDecl::new(
+                ctx,
+                name.display().to_string().as_str(),
+                &[&z3_sort(ctx, &(*sorts)[0])],
+                &z3_sort(ctx, &(*sorts)[1]),
+            );
+            Binding::Function(fun_decl)
+        }
+        &s => panic!("unhandled kind encountered: {:#?}", s),
+    }
+}
+
+fn z3_sort<'ctx, T: Types>(ctx: &'ctx Context, s: &Sort<T>) -> z3::Sort<'ctx> {
+    match &s {
+        Sort::Int => z3::Sort::int(ctx),
+        Sort::Real => z3::Sort::real(ctx),
+        Sort::Bool => z3::Sort::bool(ctx),
+        Sort::Str => z3::Sort::string(ctx),
+        _ => panic!("unhandled sort encountered"),
+    }
+}
+
+fn is_constraint_satisfiable_inner<'ctx, T: Types>(
+    ctx: &'ctx Context,
+    cstr: &Constraint<T>,
+    solver: &Solver,
+    env: &mut Env<'ctx, T>,
+) -> FixpointResult<T::Tag> {
+    solver.push();
+    let res = match cstr {
+        Constraint::Pred(pred, tag) => {
+            solver.assert(&pred_to_z3(ctx, pred, env).not());
+            if solver.check() == SatResult::Unsat {
+                FixpointResult::Safe(Stats { num_cstr: 1, num_iter: 0, num_chck: 0, num_vald: 0 })
+            } else {
+                FixpointResult::Unsafe(
+                    Stats { num_cstr: 1, num_iter: 0, num_chck: 0, num_vald: 0 },
+                    match tag {
+                        Some(tag) => vec![Error { id: 0, tag: tag.clone() }],
+                        None => vec![],
+                    },
+                )
+            }
+        }
+        Constraint::Conj(conjuncts) => {
+            conjuncts.iter().fold(
+                FixpointResult::Safe(Stats { num_cstr: 0, num_iter: 0, num_chck: 0, num_vald: 0 }),
+                |acc, cstr| is_constraint_satisfiable_inner(ctx, cstr, solver, env).merge(acc),
+            )
+        }
+
+        Constraint::ForAll(bind, inner) => {
+            env.insert(bind.name.clone(), new_binding(ctx, &bind.name, &bind.sort));
+            solver.assert(&pred_to_z3(ctx, &bind.pred, env));
+            let inner_soln = is_constraint_satisfiable_inner(ctx, &**inner, solver, env);
+            env.pop(&bind.name);
+            inner_soln
+        }
+    };
+    solver.pop(1);
+    res
+}
+
+pub fn is_constraint_satisfiable<T: Types>(
+    cstr: &Constraint<T>,
+    consts: &Vec<ConstDecl<T>>,
+) -> FixpointResult<T::Tag> {
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let solver = Solver::new(&ctx);
+    let mut vars = Env::new();
+    consts.iter().for_each(|const_decl| {
+        vars.insert(const_decl.name.clone(), new_binding(&ctx, &const_decl.name, &const_decl.sort))
+    });
+    is_constraint_satisfiable_inner(&ctx, &cstr, &solver, &mut vars)
 }

--- a/lib/liquid-fixpoint/src/cstr2smt2.rs
+++ b/lib/liquid-fixpoint/src/cstr2smt2.rs
@@ -92,58 +92,58 @@ fn atom_to_z3<'ctx, T: Types>(
     operands: &Box<[Expr<T>; 2]>,
     env: &mut Env<'ctx, T>,
 ) -> ast::Dynamic<'ctx> {
-    let loperand = expr_to_z3(ctx, &operands[0], env);
-    let roperand = expr_to_z3(ctx, &operands[1], env);
-    if loperand.sort_kind() != roperand.sort_kind() {
+    let lhs = expr_to_z3(ctx, &operands[0], env);
+    let rhs = expr_to_z3(ctx, &operands[1], env);
+    if lhs.sort_kind() != rhs.sort_kind() {
         panic!("Operands must have the same sort");
     }
     if !matches!(bin_rel, BinRel::Eq | BinRel::Ne)
-        && !matches!(loperand.sort_kind(), SortKind::Int | SortKind::Real)
+        && !matches!(lhs.sort_kind(), SortKind::Int | SortKind::Real)
     {
         panic!("Comparison operators require numeric operands");
     }
-    match (bin_rel, loperand.sort_kind(), roperand.sort_kind()) {
-        (BinRel::Ne, _, _) => loperand._eq(&roperand).not().into(),
-        (BinRel::Eq, _, _) => loperand._eq(&roperand).into(),
+    match (bin_rel, lhs.sort_kind(), rhs.sort_kind()) {
+        (BinRel::Ne, _, _) => lhs._eq(&rhs).not().into(),
+        (BinRel::Eq, _, _) => lhs._eq(&rhs).into(),
         (BinRel::Gt, SortKind::Int, SortKind::Int) => {
-            let iloperand = loperand.as_int().expect("already checked");
-            let iroperand = roperand.as_int().expect("already checked");
-            iloperand.gt(&iroperand).into()
+            let ilhs = lhs.as_int().expect("already checked");
+            let irhs = rhs.as_int().expect("already checked");
+            ilhs.gt(&irhs).into()
         }
         (BinRel::Gt, SortKind::Real, SortKind::Real) => {
-            let rloperand = loperand.as_real().expect("already checked");
-            let rroperand = roperand.as_real().expect("already checked");
-            rloperand.gt(&rroperand).into()
+            let rlhs = lhs.as_real().expect("already checked");
+            let rrhs = rhs.as_real().expect("already checked");
+            rlhs.gt(&rrhs).into()
         }
         (BinRel::Ge, SortKind::Int, SortKind::Int) => {
-            let iloperand = loperand.as_int().expect("already checked");
-            let iroperand = roperand.as_int().expect("already checked");
-            iloperand.ge(&iroperand).into()
+            let ilhs = lhs.as_int().expect("already checked");
+            let irhs = rhs.as_int().expect("already checked");
+            ilhs.ge(&irhs).into()
         }
         (BinRel::Ge, SortKind::Real, SortKind::Real) => {
-            let rloperand = loperand.as_real().expect("already checked");
-            let rroperand = roperand.as_real().expect("already checked");
-            rloperand.ge(&rroperand).into()
+            let rlhs = lhs.as_real().expect("already checked");
+            let rrhs = rhs.as_real().expect("already checked");
+            rlhs.ge(&rrhs).into()
         }
         (BinRel::Lt, SortKind::Int, SortKind::Int) => {
-            let iloperand = loperand.as_int().expect("already checked");
-            let iroperand = roperand.as_int().expect("already checked");
-            iloperand.lt(&iroperand).into()
+            let ilhs = lhs.as_int().expect("already checked");
+            let irhs = rhs.as_int().expect("already checked");
+            ilhs.lt(&irhs).into()
         }
         (BinRel::Lt, SortKind::Real, SortKind::Real) => {
-            let rloperand = loperand.as_real().expect("already checked");
-            let rroperand = roperand.as_real().expect("already checked");
-            rloperand.lt(&rroperand).into()
+            let rlhs = lhs.as_real().expect("already checked");
+            let rrhs = rhs.as_real().expect("already checked");
+            rlhs.lt(&rrhs).into()
         }
         (BinRel::Le, SortKind::Int, SortKind::Int) => {
-            let iloperand = loperand.as_int().expect("already checked");
-            let iroperand = roperand.as_int().expect("already checked");
-            iloperand.le(&iroperand).into()
+            let ilhs = lhs.as_int().expect("already checked");
+            let irhs = rhs.as_int().expect("already checked");
+            ilhs.le(&irhs).into()
         }
         (BinRel::Le, SortKind::Real, SortKind::Real) => {
-            let rloperand = loperand.as_real().expect("already checked");
-            let rroperand = roperand.as_real().expect("already checked");
-            rloperand.le(&rroperand).into()
+            let rlhs = lhs.as_real().expect("already checked");
+            let rrhs = rhs.as_real().expect("already checked");
+            rlhs.le(&rrhs).into()
         }
         _ => panic!("Unsupported relation or operand types"),
     }

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -11,12 +11,15 @@ extern crate rustc_serialize;
 extern crate rustc_span;
 
 mod constraint;
+#[cfg(feature = "rust-fixpoint")]
 mod constraint_fragments;
+#[cfg(feature = "rust-fixpoint")]
 mod constraint_solving;
 mod constraint_with_env;
 #[cfg(feature = "rust-fixpoint")]
 mod cstr2smt2;
 mod format;
+#[cfg(feature = "rust-fixpoint")]
 mod graph;
 mod parser;
 mod sexp;

--- a/lib/liquid-fixpoint/src/parser.rs
+++ b/lib/liquid-fixpoint/src/parser.rs
@@ -634,7 +634,7 @@ pub fn parse_constraint_with_kvars(
         } else if let Ok(qualifier) = sexp_to_qualifier(&sexp) {
             qualifiers.push(qualifier);
         } else if let Ok(constraint) = sexp_to_constraint(&sexp) {
-            return Ok(ConstraintWithEnv { kvar_decls, qualifiers, constraint });
+            return Ok(ConstraintWithEnv { kvar_decls, qualifiers, constants: vec![], constraint });
         }
     }
     Err(ParseError::MalformedSexpError("No constraint found"))

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,7 +19,7 @@ xflags::xflags! {
     cmd xtask {
         /// If true, run all cargo commands with `--offline`
         optional --offline
-        /// If true, run cargo build commands with --features liquid-fixpoint/rust-fixpiont
+        /// If true, run cargo build commands with --features rust-fixpiont
         optional --rust-fixpoint
 
         /// Run regression tests
@@ -231,7 +231,7 @@ fn doc(_args: Doc) -> anyhow::Result<()> {
 fn build_binary(bin: &str, profile: Profile, rust_fixpoint: bool) -> anyhow::Result<Utf8PathBuf> {
     let mut args = vec!["build", "--bin", bin, "--profile", profile.as_str()];
     if rust_fixpoint {
-        args.extend_from_slice(&["--features", "liquid-fixpoint/rust-fixpoint"]);
+        args.extend_from_slice(&["--features", "rust-fixpoint"]);
     }
     Command::new("cargo")
         .args(&args)
@@ -245,7 +245,7 @@ fn build_binary(bin: &str, profile: Profile, rust_fixpoint: bool) -> anyhow::Res
 struct SysrootConfig {
     /// Profile used to build `flux-driver` and libraries
     profile: Profile,
-    /// Whether liquid-fixpoint/rust-fixpoint should be enabled to build `flux-driver`
+    /// Whether rust-fixpoint should be enabled to build `flux-driver`
     rust_fixpoint: bool,
     /// Destination path for sysroot artifacts
     dst: PathBuf,


### PR DESCRIPTION
Makes the rust solver return `FixpointResult` instead of bool. The stats are definitely wrong but the Safe/Unsafe outcome should be correct.
- adds support for constants in the environment
- stops dropping the tags associated with constraints
- adds support for function sorts (partially)
- resolves an infinite loop bug by simplifying the constraint before handing it off to the solver

Lots of flux tests passing! Some failing :(. A few falling into infinite loops.