### PR TITLE
Fix Constraint::simplify and ConstraintWithEnv::solve_for_kvars to avoid infinite loops

### DIFF
--- a/lib/liquid-fixpoint/src/constraint_solving.rs
+++ b/lib/liquid-fixpoint/src/constraint_solving.rs
@@ -157,8 +157,23 @@ impl<T: Types> Constraint<T> {
                         .for_each(|conjunct| conjunct.simplify());
                 }
             }
-            Constraint::Pred(p, _) => {
-                p.simplify();
+            Constraint::Pred(p, tag) => {
+                match p {
+                    Pred::And(conjuncts) => {
+                        let mut cstr_conj = Constraint::Conj(
+                            conjuncts
+                                .iter()
+                                .cloned()
+                                .map(|pred| Constraint::Pred(pred, tag.clone()))
+                                .collect(),
+                        );
+                        cstr_conj.simplify();
+                        *self = cstr_conj;
+                    }
+                    _ => {
+                        p.simplify();
+                    }
+                }
             }
         }
     }

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -70,7 +70,7 @@ impl<T: Types> ConstraintWithEnv<T> {
                             let vc = subbed.sub_head(assignment);
                             is_constraint_satisfiable(&vc, &self.constants).is_safe()
                         });
-                        if initial_length > qualifiers.len() {
+                        if initial_length > assignment.len() {
                             work_list.extend(
                                 fragment
                                     .kvar_deps()


### PR DESCRIPTION
A minor improvement in `Constraint::simplify` and a bug fix in `ConstraintWithEnv::solve_for_kvars` mean that the rust implementation of fixpoint doesn't go into infinite loops for any tests.