### PR TITLE
Encode/Decode `Span` properly

### DIFF
--- a/crates/flux-metadata/src/decoder.rs
+++ b/crates/flux-metadata/src/decoder.rs
@@ -7,24 +7,34 @@ use std::{
 
 use flux_common::bug;
 use flux_errors::FluxSession;
-use rustc_data_structures::sync::HashMapExt;
+use rustc_data_structures::{fx::FxHashMap, sync::HashMapExt};
 use rustc_hir::def_id::DefId;
 use rustc_middle::{
     implement_ty_decoder,
     ty::{self, TyCtxt, codec::TyDecoder},
 };
-use rustc_serialize::{Decodable, Decoder as _, opaque::MemDecoder};
+use rustc_serialize::{
+    Decodable, Decoder as _,
+    opaque::{IntEncodedWithFixedSize, MemDecoder},
+};
 use rustc_session::StableCrateId;
 use rustc_span::{
-    BytePos, ByteSymbol, Span, SpanDecoder, StableSourceFileId, Symbol, SyntaxContext,
+    BytePos, ByteSymbol, DUMMY_SP, Span, SpanDecoder, StableSourceFileId, Symbol, SyntaxContext,
     def_id::{CrateNum, DefIndex},
+    hygiene::{HygieneDecodeContext, SyntaxContextKey},
 };
 
-use crate::{CrateMetadata, METADATA_HEADER, SYMBOL_OFFSET, SYMBOL_PREDEFINED, SYMBOL_STR};
+use crate::{
+    AbsoluteBytePos, CrateMetadata, Footer, METADATA_HEADER, SYMBOL_OFFSET, SYMBOL_PREDEFINED,
+    SYMBOL_STR, TAG_FULL_SPAN, TAG_PARTIAL_SPAN,
+};
 
 struct DecodeContext<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     opaque: MemDecoder<'a>,
+    syntax_contexts: &'a FxHashMap<u32, AbsoluteBytePos>,
+    expn_data: FxHashMap<(StableCrateId, u32), AbsoluteBytePos>,
+    hygiene_context: &'a HygieneDecodeContext,
 }
 
 pub(super) fn decode_crate_metadata(
@@ -45,8 +55,23 @@ pub(super) fn decode_crate_metadata(
         bug!("incompatible metadata version");
     }
 
-    let mut decoder =
-        DecodeContext { tcx, opaque: MemDecoder::new(&buf, METADATA_HEADER.len()).unwrap() };
+    let footer = {
+        let mut decoder = MemDecoder::new(&buf, 0).unwrap();
+        let footer_pos = decoder
+            .with_position(decoder.len() - IntEncodedWithFixedSize::ENCODED_SIZE, |d| {
+                IntEncodedWithFixedSize::decode(d).0 as usize
+            });
+        decoder.with_position(footer_pos, |d| Footer::decode(d))
+    };
+
+    let mut decoder = DecodeContext {
+        tcx,
+        opaque: MemDecoder::new(&buf, METADATA_HEADER.len()).unwrap(),
+        syntax_contexts: &footer.syntax_contexts,
+        expn_data: footer.expn_data,
+        hygiene_context: &Default::default(),
+    };
+
     Some(CrateMetadata::decode(&mut decoder))
 }
 
@@ -70,27 +95,69 @@ impl SpanDecoder for DecodeContext<'_, '_> {
         DefId { krate: Decodable::decode(self), index: Decodable::decode(self) }
     }
 
-    fn decode_syntax_context(&mut self) -> rustc_span::SyntaxContext {
-        bug!("cannot decode `SyntaxContext` with `DecodeContext`");
+    fn decode_syntax_context(&mut self) -> SyntaxContext {
+        // OLD: bug!("cannot decode `SyntaxContext` with `DecodeContext`");
+        let syntax_contexts = self.syntax_contexts;
+        rustc_span::hygiene::decode_syntax_context(self, &self.hygiene_context, |this, id| {
+            // This closure is invoked if we haven't already decoded the data for the `SyntaxContext` we are deserializing.
+            // We look up the position of the associated `SyntaxData` and decode it.
+            let pos = syntax_contexts.get(&id).unwrap();
+            this.with_position(pos.to_usize(), |decoder| SyntaxContextKey::decode(decoder))
+        })
     }
 
     fn decode_expn_id(&mut self) -> rustc_span::ExpnId {
-        bug!("cannot decode `ExpnId` with `DecodeContext`");
+        let stable_id = StableCrateId::decode(self);
+        let cnum = self.tcx.stable_crate_id_to_crate_num(stable_id);
+        let index = u32::decode(self);
+
+        let expn_id = rustc_span::hygiene::decode_expn_id(cnum, index, |_| {
+            let pos = self.expn_data.get(&(stable_id, index)).unwrap();
+            self.with_position(pos.to_usize(), |decoder| {
+                let data = rustc_span::ExpnData::decode(decoder);
+                let hash = rustc_span::ExpnHash::decode(decoder);
+                (data, hash)
+            })
+        });
+        expn_id
     }
 
     fn decode_span(&mut self) -> rustc_span::Span {
+        let ctxt = SyntaxContext::decode(self);
+        let tag: u8 = Decodable::decode(self);
+
+        if tag == TAG_PARTIAL_SPAN {
+            return DUMMY_SP.with_ctxt(ctxt);
+        }
+
+        debug_assert!(tag == TAG_FULL_SPAN);
+
+        // CREUSOT: let source_file_index = SourceFileIndex::decode(self);
         let sm = self.tcx.sess.source_map();
-        let pos = [(); 2].map(|_| {
-            let ssfi = StableSourceFileId::decode(self);
-            let rel_bp = BytePos::decode(self);
-            // See comment in 'encoder.rs'
-            //
-            // This should hopefully never fail,
-            // so maybe could be an `unwrap` instead?
-            sm.source_file_by_stable_id(ssfi)
-                .map_or(BytePos(0), |sf| sf.start_pos + rel_bp)
-        });
-        Span::new(pos[0], pos[1], SyntaxContext::root(), None)
+        let ssfi = StableSourceFileId::decode(self);
+        let lo = BytePos::decode(self);
+        let len = BytePos::decode(self);
+        let Some(file) = sm.source_file_by_stable_id(ssfi) else {
+            return DUMMY_SP.with_ctxt(ctxt);
+        };
+        // CREUSOT: let file = self.file_index_to_file(source_file_index);
+        let lo = file.start_pos + lo;
+        let hi = lo + len;
+
+        Span::new(lo, hi, ctxt, None)
+        // OLD CODE from prusti
+        // let sm = self.tcx.sess.source_map();
+        // let pos = [(); 2].map(|_| {
+        //     let ssfi = StableSourceFileId::decode(self);
+        //     let rel_bp = BytePos::decode(self);
+        //     // See comment in 'encoder.rs'
+        //     //
+        //     // This should hopefully never fail,
+        //     // so maybe could be an `unwrap` instead?
+        //     sm.source_file_by_stable_id(ssfi)
+        //         .map_or(BytePos(0), |sf| sf.start_pos + rel_bp)
+        // });
+        // Span::new(pos[0], pos[1], SyntaxContext::root(), None)
     }
 
     fn decode_symbol(&mut self) -> rustc_span::Symbol {

--- a/crates/flux-metadata/src/encoder.rs
+++ b/crates/flux-metadata/src/encoder.rs
@@ -241,19 +241,6 @@ impl SpanEncoder for EncodeContext<'_, '_> {
         source_file_index.encode(self);
         lo.encode(self);
         len.encode(self);
-
-        // OLD CODE from prusti
-        // let sm = self.tcx.sess.source_map();
-        // for bp in [span.lo(), span.hi()] {
-        //     let sf = sm.lookup_source_file(bp);
-        //     let ssfi = stable_source_file_id_for_export(self.tcx, &sf);
-        //     ssfi.encode(self);
-        //     // Not sure if this is the most stable way to encode a BytePos. If it fails
-        //     // try finding a function in `SourceMap` or `SourceFile` instead. E.g. the
-        //     // `bytepos_to_file_charpos` fn which returns `CharPos` (though there is
-        //     // currently no fn mapping back to `BytePos` for decode)
-        //     (bp - sf.start_pos).encode(self);
-        // }
     }
 
     fn encode_symbol(&mut self, sym: Symbol) {
@@ -325,19 +312,3 @@ impl Encoder for EncodeContext<'_, '_> {
         emit_raw_bytes(&[u8]);
     }
 }
-
-// fn stable_source_file_id_for_export(tcx: TyCtxt, sf: &SourceFile) -> StableSourceFileId {
-//     let working_directory = &tcx.sess.opts.working_dir;
-//     let crate_stable_id = tcx.stable_crate_id(sf.cnum);
-//     let mut filename = sf.name.clone();
-//     if let FileName::Real(original_file_name) = filename {
-//         let adapted_file_name = tcx
-//             .sess
-//             .source_map()
-//             .path_mapping()
-//             .to_embeddable_absolute_path(original_file_name.clone(), working_directory);
-
-//         filename = FileName::Real(adapted_file_name);
-//     }
-//     StableSourceFileId::from_filename_for_export(&filename, crate_stable_id)
-// }

--- a/crates/flux-metadata/src/lib.rs
+++ b/crates/flux-metadata/src/lib.rs
@@ -4,7 +4,6 @@
 extern crate rustc_ast;
 extern crate rustc_data_structures;
 extern crate rustc_errors;
-
 extern crate rustc_hir;
 extern crate rustc_macros;
 extern crate rustc_metadata;
@@ -15,6 +14,10 @@ extern crate rustc_span;
 
 mod decoder;
 mod encoder;
+
+// Tags used for encoding Spans:
+const TAG_FULL_SPAN: u8 = 0;
+const TAG_PARTIAL_SPAN: u8 = 1;
 
 use std::{hash::Hash, path::PathBuf, rc::Rc};
 
@@ -30,17 +33,20 @@ use flux_middle::{
     queries::QueryResult,
     rty,
 };
-use rustc_data_structures::unord::{ExtendUnord, UnordMap};
+use rustc_data_structures::{
+    fx::FxHashMap,
+    unord::{ExtendUnord, UnordMap},
+};
 use rustc_hir::{
     def::{CtorKind, DefKind},
     def_id::{LOCAL_CRATE, LocalDefId},
 };
-use rustc_macros::{TyDecodable, TyEncodable};
+use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::config::OutFileName;
 use rustc_span::{
     Span,
-    def_id::{CrateNum, DefId, DefIndex},
+    def_id::{CrateNum, DefId, DefIndex, StableCrateId},
 };
 
 pub use crate::encoder::encode_metadata;
@@ -54,6 +60,27 @@ const METADATA_HEADER: &[u8] = &[b'f', b'l', b'u', b'x', 0, 0, 0, METADATA_VERSI
 pub struct CStore {
     local_tables: UnordMap<CrateNum, Tables<DefIndex>>,
     extern_tables: Tables<DefId>,
+}
+
+// Taken from CREUSOT; used to store the info about syntax contexts
+#[derive(Default, Decodable, Encodable)]
+pub struct Footer {
+    // file_index_to_stable_id: FxHashMap<SourceFileIndex, EncodedSourceFileId>,
+    syntax_contexts: FxHashMap<u32, AbsoluteBytePos>,
+    expn_data: FxHashMap<(StableCrateId, u32), AbsoluteBytePos>,
+}
+
+#[derive(Encodable, Decodable, Clone, Copy)]
+pub struct AbsoluteBytePos(u64);
+
+impl AbsoluteBytePos {
+    fn new(pos: usize) -> AbsoluteBytePos {
+        AbsoluteBytePos(pos.try_into().unwrap())
+    }
+
+    fn to_usize(self) -> usize {
+        self.0 as usize
+    }
 }
 
 #[derive(Default, TyEncodable, TyDecodable)]

--- a/tests/tests/neg/surface/extern_spec_span.rs
+++ b/tests/tests/neg/surface/extern_spec_span.rs
@@ -1,0 +1,9 @@
+extern crate flux_core;
+
+fn test() {
+    flux_rs::assert(false); //~ ERROR refinement type error
+
+    let blah: Option<usize> = None;
+    blah.unwrap(); //~ ERROR refinement type error
+    // The "note" should mention `/flux-core/src/option.rs`  but looks like compiletest doesn't quite track that.
+}


### PR DESCRIPTION
fixes #1239 by using the same code as this `creusot` PR https://github.com/creusot-rs/creusot/commit/3ed91945a7d30ce8bc206ae6413d24a1379c2d0a 

Now the file 

```rust
extern crate flux_core;

fn test() {
    flux_rs::assert(false); //~ ERROR refinement type error

    let blah: Option<usize> = None;
    blah.unwrap(); //~ ERROR refinement type error
    // The "note" should mention `/flux-core/src/option.rs`  but looks like compiletest doesn't quite track that.
}
```

produces the error

```
error[E0999]: refinement type error
  --> tests/tests/neg/surface/extern_spec_span.rs:5:5
   |
 5 |     blah.unwrap(); //~ ERROR refinement type error
   |     ^^^^^^^^^^^^^ a precondition cannot be proved
   |
   = note: -Ztrack-diagnostics: created at crates/flux-refineck/src/lib.rs:141:10
note: this is the condition that cannot be proved
  --> /Users/rjhala/research/flux/lib/flux-core/src/option.rs:20:24
   |
20 |     #[sig(fn(Option<T>[true]) -> T)]
   |                        ^^^^

error: aborting due to 1 previous error
```
