### PR TITLE
Glob prefix fix

### DIFF
--- a/crates/flux-bin/src/lib.rs
+++ b/crates/flux-bin/src/lib.rs
@@ -58,9 +58,12 @@ impl FluxMetadata {
         }
         if let Some(patterns) = self.include {
             for pat in patterns {
-                if let Some(glob_prefix) = glob_prefix {
+                if let Some(glob_prefix) = glob_prefix
+                    && !glob_prefix.as_str().is_empty()
+                {
                     // I haven't tested this on windows, but it should work because `globset`
                     // will normalize patterns to use `/` as separator
+                    // don't use the empty `glob_prefix` as that makes the pattern hang off root!
                     flags.push(format!("-Finclude={glob_prefix}/{pat}"));
                 } else {
                     flags.push(format!("-Finclude={pat}"));

--- a/crates/flux-config/src/lib.rs
+++ b/crates/flux-config/src/lib.rs
@@ -168,7 +168,6 @@ pub struct IncludePattern {
 
 impl IncludePattern {
     fn new(includes: Vec<String>) -> Result<Self, String> {
-        println!("TRACE: IncludePattern::new({includes:?})");
         let mut defs = Vec::new();
         let mut spans = Vec::new();
         let mut glob = GlobSetBuilder::new();
@@ -179,7 +178,6 @@ impl IncludePattern {
                 spans.push(Pos::from_str(suffix)?);
             } else {
                 let suffix = include.strip_prefix("glob:").unwrap_or(&include);
-                println!("TRACE: include pattern glob: {suffix}");
                 let glob_pattern = Glob::new(suffix.trim()).map_err(|_| "invalid glob pattern")?;
                 glob.add(glob_pattern);
             }

--- a/crates/flux-config/src/lib.rs
+++ b/crates/flux-config/src/lib.rs
@@ -156,7 +156,7 @@ impl fmt::Display for IncludePattern {
 /// This specifies which `DefId` should be checked. It can be specified via multiple patterns
 /// of the form `-Finclude=<pattern>` and the `DefId` is checked if it matches *any* of the patterns.
 /// Patterns are checked relative to the current working directory.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct IncludePattern {
     /// files matching the glob pattern, e.g. `glob:src/ascii/*.rs` to check all files in the `ascii` module
     pub glob: GlobSet,
@@ -168,6 +168,7 @@ pub struct IncludePattern {
 
 impl IncludePattern {
     fn new(includes: Vec<String>) -> Result<Self, String> {
+        println!("TRACE: IncludePattern::new({includes:?})");
         let mut defs = Vec::new();
         let mut spans = Vec::new();
         let mut glob = GlobSetBuilder::new();
@@ -178,6 +179,7 @@ impl IncludePattern {
                 spans.push(Pos::from_str(suffix)?);
             } else {
                 let suffix = include.strip_prefix("glob:").unwrap_or(&include);
+                println!("TRACE: include pattern glob: {suffix}");
                 let glob_pattern = Glob::new(suffix.trim()).map_err(|_| "invalid glob pattern")?;
                 glob.add(glob_pattern);
             }

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -218,6 +218,7 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
         }) {
             return true;
         }
+        println!("TRACE: is_included {def_id:?} -> false");
         false
     }
 

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -218,7 +218,6 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
         }) {
             return true;
         }
-        println!("TRACE: is_included {def_id:?} -> false");
         false
     }
 


### PR DESCRIPTION
Padding an *empty* `glob_prefix` as a prefix of the pattern made the glob patterns like `src/ch03_structs.rs` become `/src/ch03_structs.rs` which of course doesn't match the file, thwarting the `include`...

 