### PR TITLE
Make rust fixpoint faster by preserving solver and environment

### DIFF
--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -145,12 +145,12 @@ impl<T: Types> Pred<T> {
     pub(crate) fn simplify(&mut self) {
         if let Pred::And(conjuncts) = self {
             if conjuncts.is_empty() {
-                    *self = Pred::TRUE;
-                } else if conjuncts.len() == 1 {
-                    *self = conjuncts[0].clone();
-                } else {
-                    conjuncts.iter_mut().for_each(|pred| pred.simplify());
-                }
+                *self = Pred::TRUE;
+            } else if conjuncts.len() == 1 {
+                *self = conjuncts[0].clone();
+            } else {
+                conjuncts.iter_mut().for_each(|pred| pred.simplify());
+            }
         }
     }
 }

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -143,17 +143,14 @@ impl<T: Types> Pred<T> {
 
     #[cfg(feature = "rust-fixpoint")]
     pub(crate) fn simplify(&mut self) {
-        match self {
-            Pred::And(conjuncts) => {
-                if conjuncts.len() == 0 {
+        if let Pred::And(conjuncts) = self {
+            if conjuncts.is_empty() {
                     *self = Pred::TRUE;
                 } else if conjuncts.len() == 1 {
                     *self = conjuncts[0].clone();
                 } else {
                     conjuncts.iter_mut().for_each(|pred| pred.simplify());
                 }
-            }
-            _ => {}
         }
     }
 }

--- a/lib/liquid-fixpoint/src/constraint_solving.rs
+++ b/lib/liquid-fixpoint/src/constraint_solving.rs
@@ -140,7 +140,7 @@ impl<T: Types> Constraint<T> {
                 inner.simplify();
             }
             Constraint::Conj(conjuncts) => {
-                if conjuncts.len() == 0 {
+                if conjuncts.is_empty() {
                     *self = Constraint::Pred(Pred::TRUE, None);
                 } else if conjuncts.len() == 1 {
                     conjuncts[0].simplify();
@@ -321,8 +321,8 @@ impl<T: Types> Pred<T> {
             Pred::KVar(kvid, args) => {
                 let qualifiers = assignment
                     .get(kvid)
-                    .expect(format!("{:#?} should have an assignment", kvid).as_str());
-                if qualifiers.len() == 0 {
+                    .unwrap_or_else(|| panic!("{:#?} should have an assignment", kvid));
+                if qualifiers.is_empty() {
                     return Pred::Expr(Expr::Constant(Constant::Boolean(false)));
                 }
                 if qualifiers.len() == 1 {

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -28,9 +28,7 @@ use crate::Assignments;
 
 #[cfg(feature = "rust-fixpoint")]
 impl<T: Types> ConstraintWithEnv<T> {
-    pub fn compute_initial_assignments(
-        &self,
-    ) -> Assignments<'_, T> {
+    pub fn compute_initial_assignments(&self) -> Assignments<'_, T> {
         let mut assignments = HashMap::new();
 
         for decl in &self.kvar_decls {

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -3,7 +3,7 @@ use derive_where::derive_where;
 use {
     crate::{
         FixpointResult,
-        cstr2smt2::{Env, is_constraint_satisfiable_inner, new_binding},
+        cstr2smt2::{Env, is_constraint_satisfiable, new_binding},
     },
     itertools::Itertools,
     std::collections::{HashMap, VecDeque},
@@ -73,7 +73,7 @@ impl<T: Types> ConstraintWithEnv<T> {
                 let initial_length = assignment.len();
                 assignment.retain(|assignment| {
                     let vc = subbed.sub_head(assignment);
-                    is_constraint_satisfiable_inner(ctx, &vc, solver, env).is_safe()
+                    is_constraint_satisfiable(ctx, &vc, solver, env).is_safe()
                 });
                 if initial_length > assignment.len() {
                     work_list.extend(
@@ -133,7 +133,7 @@ impl<T: Types> ConstraintWithEnv<T> {
         });
         let kvar_assignment = self.solve_for_kvars(&ctx, &solver, &mut vars);
         self.constraint = self.constraint.sub_all_kvars(&kvar_assignment);
-        is_constraint_satisfiable_inner(&ctx, &self.constraint, &solver, &mut vars)
+        is_constraint_satisfiable(&ctx, &self.constraint, &solver, &mut vars)
     }
 }
 

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -1,9 +1,13 @@
 use derive_where::derive_where;
 #[cfg(feature = "rust-fixpoint")]
 use {
-    crate::{FixpointResult, cstr2smt2::is_constraint_satisfiable},
+    crate::{
+        FixpointResult,
+        cstr2smt2::{Env, is_constraint_satisfiable_inner, new_binding},
+    },
     itertools::Itertools,
     std::collections::{HashMap, VecDeque},
+    z3::{Config, Context, Solver},
 };
 
 use crate::{
@@ -21,16 +25,15 @@ pub struct ConstraintWithEnv<T: Types> {
 
 #[cfg(feature = "rust-fixpoint")]
 impl<T: Types> ConstraintWithEnv<T> {
-    pub fn compute_initial_assignments<'a>(
-        &'a self,
-        qualifiers: &'a Vec<Qualifier<T>>,
-    ) -> HashMap<T::KVar, Vec<(&'a Qualifier<T>, Vec<usize>)>> {
+    pub fn compute_initial_assignments(
+        &self,
+    ) -> HashMap<T::KVar, Vec<(&Qualifier<T>, Vec<usize>)>> {
         let mut assignments = HashMap::new();
 
         for decl in &self.kvar_decls {
             let kvar_arg_count = decl.sorts.len();
             assignments.insert(decl.kvid.clone(), vec![]);
-            for qualifier in qualifiers {
+            for qualifier in &self.qualifiers {
                 let qualifier_arg_count = qualifier.args.len();
                 for argument_combination in (0..kvar_arg_count).combinations(qualifier_arg_count) {
                     assignments.get_mut(&decl.kvid).unwrap().extend(
@@ -49,11 +52,13 @@ impl<T: Types> ConstraintWithEnv<T> {
         assignments
     }
 
-    pub fn solve_for_kvars<'a>(
-        &'a self,
-        qualifiers: &'a Vec<Qualifier<T>>,
-    ) -> HashMap<T::KVar, Vec<(&'a Qualifier<T>, Vec<usize>)>> {
-        let mut assignments = self.compute_initial_assignments(qualifiers);
+    fn solve_for_kvars<'ctx>(
+        &self,
+        ctx: &'ctx Context,
+        solver: &Solver<'ctx>,
+        env: &mut Env<'ctx, T>,
+    ) -> HashMap<T::KVar, Vec<(&Qualifier<T>, Vec<usize>)>> {
+        let mut assignments = self.compute_initial_assignments();
         let (kvars_to_fragments, _) = self.constraint.kvar_mappings();
         let topo_order_fragments = self.constraint.topo_order_fragments();
         let mut work_list = VecDeque::from_iter(topo_order_fragments.iter());
@@ -66,7 +71,7 @@ impl<T: Types> ConstraintWithEnv<T> {
                         let initial_length = assignment.len();
                         assignment.retain(|assignment| {
                             let vc = subbed.sub_head(assignment);
-                            is_constraint_satisfiable(&vc, &self.constants).is_safe()
+                            is_constraint_satisfiable_inner(ctx, &vc, solver, env).is_safe()
                         });
                         if initial_length > assignment.len() {
                             work_list.extend(
@@ -117,11 +122,19 @@ impl<T: Types> ConstraintWithEnv<T> {
     }
 
     pub fn solve_by_predicate_abstraction(&mut self) -> FixpointResult<T::Tag> {
-        let mut qualifiers: Vec<Qualifier<T>> = vec![];
-        qualifiers.extend(self.qualifiers.to_vec().into_iter());
-        let kvar_assignment = self.solve_for_kvars(&qualifiers);
+        let cfg = Config::new();
+        let ctx = Context::new(&cfg);
+        let solver = Solver::new(&ctx);
+        let mut vars: Env<'_, T> = Env::new();
+        self.constants.iter().for_each(|const_decl| {
+            vars.insert(
+                const_decl.name.clone(),
+                new_binding(&ctx, &const_decl.name, &const_decl.sort),
+            );
+        });
+        let kvar_assignment = self.solve_for_kvars(&ctx, &solver, &mut vars);
         self.constraint = self.constraint.sub_all_kvars(&kvar_assignment);
-        is_constraint_satisfiable(&self.constraint, &self.constants)
+        is_constraint_satisfiable_inner(&ctx, &self.constraint, &solver, &mut vars)
     }
 }
 

--- a/lib/liquid-fixpoint/src/cstr2smt2.rs
+++ b/lib/liquid-fixpoint/src/cstr2smt2.rs
@@ -203,9 +203,7 @@ fn expr_to_z3<'ctx, T: Types>(
     env: &mut Env<'ctx, T>,
 ) -> ast::Dynamic<'ctx> {
     match expr {
-        Expr::Var(var) => {
-            env.var_lookup(var).cloned().expect("error if not present")
-        }
+        Expr::Var(var) => env.var_lookup(var).cloned().expect("error if not present"),
         Expr::Constant(cnst) => const_to_z3(ctx, cnst),
         Expr::Atom(bin_rel, operands) => atom_to_z3(ctx, bin_rel, operands, env),
         Expr::BinaryOp(bin_op, operands) => binop_to_z3(ctx, bin_op, operands, env),
@@ -229,13 +227,7 @@ fn expr_to_z3<'ctx, T: Types>(
             let bool_ref_slice: &[&ast::Bool] = boolean_refs.as_slice();
             ast::Bool::or(ctx, bool_ref_slice).into()
         }
-        Expr::Not(inner) => {
-            expr_to_z3(ctx, inner, env)
-                .as_bool()
-                .unwrap()
-                .not()
-                .into()
-        }
+        Expr::Not(inner) => expr_to_z3(ctx, inner, env).as_bool().unwrap().not().into(),
         Expr::Neg(number) => {
             let zero = ast::Int::from_i64(ctx, 0);
             let z3_num = expr_to_z3(ctx, number, env);

--- a/lib/liquid-fixpoint/src/cstr2smt2.rs
+++ b/lib/liquid-fixpoint/src/cstr2smt2.rs
@@ -355,7 +355,7 @@ fn z3_sort<'ctx, T: Types>(ctx: &'ctx Context, s: &Sort<T>) -> z3::Sort<'ctx> {
     }
 }
 
-pub(crate) fn is_constraint_satisfiable_inner<'ctx, T: Types>(
+pub(crate) fn is_constraint_satisfiable<'ctx, T: Types>(
     ctx: &'ctx Context,
     cstr: &Constraint<T>,
     solver: &Solver,
@@ -380,14 +380,14 @@ pub(crate) fn is_constraint_satisfiable_inner<'ctx, T: Types>(
         Constraint::Conj(conjuncts) => {
             conjuncts.iter().fold(
                 FixpointResult::Safe(Stats { num_cstr: 0, num_iter: 0, num_chck: 0, num_vald: 0 }),
-                |acc, cstr| is_constraint_satisfiable_inner(ctx, cstr, solver, env).merge(acc),
+                |acc, cstr| is_constraint_satisfiable(ctx, cstr, solver, env).merge(acc),
             )
         }
 
         Constraint::ForAll(bind, inner) => {
             env.insert(bind.name.clone(), new_binding(ctx, &bind.name, &bind.sort));
             solver.assert(&pred_to_z3(ctx, &bind.pred, env));
-            let inner_soln = is_constraint_satisfiable_inner(ctx, &**inner, solver, env);
+            let inner_soln = is_constraint_satisfiable(ctx, &**inner, solver, env);
             env.pop(&bind.name);
             inner_soln
         }

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -293,9 +293,9 @@ impl<T: Types> Task<T> {
     #[cfg(feature = "rust-fixpoint")]
     pub fn run(&self) -> io::Result<FixpointResult<T::Tag>> {
         Ok(ConstraintWithEnv {
-            kvar_decls: self.kvars.to_vec(),
-            qualifiers: self.qualifiers.to_vec(),
-            constants: self.constants.to_vec(),
+            kvar_decls: self.kvars.clone(),
+            qualifiers: self.qualifiers.clone(),
+            constants: self.constants.clone(),
             constraint: self.constraint.clone(),
         }
         .is_satisfiable())


### PR DESCRIPTION
Use the same solver and constant bindings across constraints. On my machine this sped up `cargo x --rust-fixpoint test` by almost 2x.