### PR TITLE
Add support for most theory functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,20 +59,18 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn",
 ]
@@ -340,7 +338,7 @@ dependencies = [
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "self_cell",
  "smallvec",
  "unic-langid",
@@ -379,7 +377,7 @@ version = "0.1.0"
 dependencies = [
  "dashmap",
  "hashbrown 0.14.5",
- "rustc-hash 2.1.1",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -407,7 +405,7 @@ dependencies = [
  "config",
  "flux-config",
  "home",
- "itertools",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -420,7 +418,7 @@ version = "0.1.0"
 dependencies = [
  "flux-config",
  "flux-macros",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]
@@ -452,8 +450,8 @@ dependencies = [
  "flux-macros",
  "flux-middle",
  "flux-syntax",
- "itertools",
- "rustc-hash 2.1.1",
+ "itertools 0.14.0",
+ "rustc-hash",
  "tracing",
 ]
 
@@ -473,7 +471,7 @@ dependencies = [
  "flux-refineck",
  "flux-rustc-bridge",
  "flux-syntax",
- "itertools",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "tracing",
@@ -500,8 +498,8 @@ dependencies = [
  "flux-macros",
  "flux-middle",
  "flux-rustc-bridge",
- "itertools",
- "rustc-hash 2.1.1",
+ "itertools 0.14.0",
+ "rustc-hash",
  "tracing",
 ]
 
@@ -515,10 +513,10 @@ dependencies = [
  "flux-macros",
  "flux-middle",
  "flux-rustc-bridge",
- "itertools",
+ "itertools 0.14.0",
  "liquid-fixpoint",
  "pad-adapter",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]
@@ -530,7 +528,7 @@ dependencies = [
  "annotate-snippets",
  "fluent-bundle",
  "fluent-syntax",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -547,8 +545,8 @@ dependencies = [
  "flux-errors",
  "flux-macros",
  "flux-middle",
- "itertools",
- "rustc-hash 2.1.1",
+ "itertools 0.14.0",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -566,9 +564,9 @@ dependencies = [
  "flux-rustc-bridge",
  "flux-syntax",
  "hashbrown 0.14.5",
- "itertools",
+ "itertools 0.14.0",
  "liquid-fixpoint",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
  "toposort-scc",
@@ -586,9 +584,9 @@ dependencies = [
  "flux-macros",
  "flux-middle",
  "flux-rustc-bridge",
- "itertools",
+ "itertools 0.14.0",
  "liquid-fixpoint",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tracing",
@@ -609,7 +607,7 @@ dependencies = [
  "flux-common",
  "flux-errors",
  "flux-macros",
- "itertools",
+ "itertools 0.14.0",
 ]
 
 [[package]]
@@ -848,6 +846,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -868,12 +875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,7 +887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -911,7 +912,7 @@ name = "liquid-fixpoint"
 version = "0.1.0"
 dependencies = [
  "derive-where",
- "itertools",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "z3",
@@ -980,6 +981,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,12 +1104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1114,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -1143,12 +1208,6 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -1376,7 +1435,7 @@ name = "tests"
 version = "0.1.0"
 dependencies = [
  "compiletest_rs",
- "itertools",
+ "itertools 0.14.0",
 ]
 
 [[package]]
@@ -1600,7 +1659,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.1",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -2062,21 +2121,23 @@ dependencies = [
 
 [[package]]
 name = "z3"
-version = "0.12.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7ff5718c079e7b813378d67a5bed32ccc2086f151d6185074a7e24f4a565e8"
+checksum = "2e6abe40eee88a065f2bde2f663e0e6aa95552d9124edc96ab291376db19f9a2"
 dependencies = [
  "log",
+ "num",
  "z3-sys",
 ]
 
 [[package]]
 name = "z3-sys"
-version = "0.8.1"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cf70fdbc0de3f42b404f49b0d4686a82562254ea29ff0a155eef2f5430f4b0"
+checksum = "6cd1b38ffd95fae0fcc40026fb1a822074e2a923ad4e011e90df878cbed721e0"
 dependencies = [
  "bindgen",
+ "pkg-config",
 ]
 
 [[package]]

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -157,6 +157,14 @@ pub mod fixpoint {
     #[derive(Hash, Clone, Debug)]
     pub struct SymStr(pub Symbol);
 
+    #[cfg(feature = "rust-fixpoint")]
+    impl FixpointFmt for SymStr {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    #[cfg(not(feature = "rust-fixpoint"))]
     impl FixpointFmt for SymStr {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "\"{}\"", self.0)
@@ -1175,7 +1183,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                 fixpoint::Expr::Let(vars[0].into(), Box::new([init, body]))
             }
             rty::ExprKind::GlobalFunc(SpecFuncKind::Thy(itf)) => {
-                fixpoint::Expr::Var(fixpoint::Var::Itf(*itf))
+                fixpoint::Expr::ThyFunc(*itf)
             }
             rty::ExprKind::GlobalFunc(SpecFuncKind::Uif(def_id)) => {
                 fixpoint::Expr::Var(self.define_const_for_uif(*def_id, scx))
@@ -1256,7 +1264,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
             fixpoint::BinRel::Le => fixpoint::ThyFunc::BvUle,
             _ => span_bug!(self.def_span(), "not a bitvector relation!"),
         };
-        fixpoint::Expr::Var(fixpoint::Var::Itf(itf))
+        fixpoint::Expr::ThyFunc(itf)
     }
 
     fn bv_op_to_fixpoint(&self, op: &rty::BinOp) -> fixpoint::Expr {
@@ -1273,7 +1281,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
             rty::BinOp::BitShr => fixpoint::ThyFunc::BvLshr,
             _ => span_bug!(self.def_span(), "not a bitvector operation!"),
         };
-        fixpoint::Expr::Var(fixpoint::Var::Itf(itf))
+        fixpoint::Expr::ThyFunc(itf)
     }
 
     fn bin_op_to_fixpoint(

--- a/lib/liquid-fixpoint/Cargo.toml
+++ b/lib/liquid-fixpoint/Cargo.toml
@@ -10,7 +10,7 @@ derive-where = "1.2.7"
 itertools = "0.14.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-z3 = { version = "0.12.1", optional = true }
+z3 = { version = "0.18.1", optional = true }
 
 [features]
 default = []

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 
 use derive_where::derive_where;
 
-use crate::Types;
+use crate::{ThyFunc, Types};
 
 #[derive_where(Hash, Clone, Debug)]
 pub struct Bind<T: Types> {
@@ -184,6 +184,7 @@ pub enum Expr<T: Types> {
     Iff(Box<[Self; 2]>),
     Atom(BinRel, Box<[Self; 2]>),
     Let(T::Var, Box<[Self; 2]>),
+    ThyFunc(ThyFunc),
 }
 
 impl<T: Types> From<Constant<T>> for Expr<T> {

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -53,11 +53,7 @@ impl<T: Types> ConstraintWithEnv<T> {
         assignments
     }
 
-    fn solve_for_kvars(
-        &self,
-        solver: &Solver,
-        env: &mut Env<T>,
-    ) -> Assignments<'_, T> {
+    fn solve_for_kvars(&self, solver: &Solver, env: &mut Env<T>) -> Assignments<'_, T> {
         let mut assignments = self.compute_initial_assignments();
         let (kvars_to_fragments, _) = self.constraint.kvar_mappings();
         let topo_order_fragments = self.constraint.topo_order_fragments();
@@ -123,10 +119,7 @@ impl<T: Types> ConstraintWithEnv<T> {
         let solver = Solver::new();
         let mut vars: Env<T> = Env::new();
         self.constants.iter().for_each(|const_decl| {
-            vars.insert(
-                const_decl.name.clone(),
-                new_binding(&const_decl.name, &const_decl.sort),
-            );
+            vars.insert(const_decl.name.clone(), new_binding(&const_decl.name, &const_decl.sort));
         });
         let kvar_assignment = self.solve_for_kvars(&solver, &mut vars);
         self.constraint = self.constraint.sub_all_kvars(&kvar_assignment);

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -7,7 +7,7 @@ use {
     },
     itertools::Itertools,
     std::collections::{HashMap, VecDeque},
-    z3::{Config, Context, Solver},
+    z3::Solver,
 };
 
 use crate::{
@@ -53,11 +53,10 @@ impl<T: Types> ConstraintWithEnv<T> {
         assignments
     }
 
-    fn solve_for_kvars<'ctx>(
+    fn solve_for_kvars(
         &self,
-        ctx: &'ctx Context,
-        solver: &Solver<'ctx>,
-        env: &mut Env<'ctx, T>,
+        solver: &Solver,
+        env: &mut Env<T>,
     ) -> Assignments<'_, T> {
         let mut assignments = self.compute_initial_assignments();
         let (kvars_to_fragments, _) = self.constraint.kvar_mappings();
@@ -73,7 +72,7 @@ impl<T: Types> ConstraintWithEnv<T> {
                 let initial_length = assignment.len();
                 assignment.retain(|assignment| {
                     let vc = subbed.sub_head(assignment);
-                    is_constraint_satisfiable(ctx, &vc, solver, env).is_safe()
+                    is_constraint_satisfiable(&vc, solver, env).is_safe()
                 });
                 if initial_length > assignment.len() {
                     work_list.extend(
@@ -121,19 +120,17 @@ impl<T: Types> ConstraintWithEnv<T> {
     }
 
     pub fn solve_by_predicate_abstraction(&mut self) -> FixpointResult<T::Tag> {
-        let cfg = Config::new();
-        let ctx = Context::new(&cfg);
-        let solver = Solver::new(&ctx);
-        let mut vars: Env<'_, T> = Env::new();
+        let solver = Solver::new();
+        let mut vars: Env<T> = Env::new();
         self.constants.iter().for_each(|const_decl| {
             vars.insert(
                 const_decl.name.clone(),
-                new_binding(&ctx, &const_decl.name, &const_decl.sort),
+                new_binding(&const_decl.name, &const_decl.sort),
             );
         });
-        let kvar_assignment = self.solve_for_kvars(&ctx, &solver, &mut vars);
+        let kvar_assignment = self.solve_for_kvars(&solver, &mut vars);
         self.constraint = self.constraint.sub_all_kvars(&kvar_assignment);
-        is_constraint_satisfiable(&ctx, &self.constraint, &solver, &mut vars)
+        is_constraint_satisfiable(&self.constraint, &solver, &mut vars)
     }
 }
 

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -319,6 +319,7 @@ impl<T: Types> fmt::Display for Expr<T> {
                 let [e1, e2] = &**exprs;
                 write!(f, "(let (({} {e1})) {e2})", name.display())
             }
+            Expr::ThyFunc(thy_func) => write!(f, "{}", thy_func),
         }
     }
 }


### PR DESCRIPTION
- Bump z3 bindings version up (is there a reason not to?) because it does away with the context stuff that made the code weird in #1284 and it makes strlen easier to implement
- Add support for most theory functions

15 more tests passing with these changes