### PR TITLE
Add TypeRelative paths to refinements

### DIFF
--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -802,7 +802,12 @@ impl Segment for surface::PathSegment {
 }
 
 impl Segment for surface::ExprPathSegment {
-    fn record_segment_res(_resolver: &mut CrateResolver, _segment: &Self, _res: fhir::Res) {}
+    fn record_segment_res(resolver: &mut CrateResolver, segment: &Self, res: fhir::Res) {
+        resolver
+            .output
+            .expr_path_res_map
+            .insert(segment.node_id, fhir::PartialRes::new(res.map_param_id(|p| p)));
+    }
 
     fn ident(&self) -> Ident {
         self.ident

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -825,27 +825,6 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
     }
 }
 
-macro_rules! define_resolve_num_const {
-    ($($typ:ident),*) => {
-        fn resolve_num_const(typ: surface::Ident, name: surface::Ident) -> Option<Res<NodeId>> {
-            match typ.name.as_str() {
-                $(
-                    stringify!($typ) => {
-                        match name.name.as_str() {
-                            "MAX" => Some(Res::NumConst($typ::MAX.try_into().unwrap())),
-                            "MIN" => Some(Res::NumConst($typ::MIN.try_into().unwrap())),
-                            _ => None,
-                        }
-                    },
-                )*
-                _ => None
-            }
-        }
-    };
-}
-
-define_resolve_num_const!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
-
 struct IllegalBinderVisitor<'a, 'genv, 'tcx> {
     scopes: Vec<ScopeKind>,
     resolver: &'a CrateResolver<'genv, 'tcx>,

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -4,7 +4,7 @@ use flux_common::index::IndexGen;
 use flux_errors::Errors;
 use flux_middle::{
     ResolverOutput,
-    fhir::{self, Res},
+    fhir::{self, PartialRes, Res},
 };
 use flux_syntax::{
     surface::{self, Ident, NodeId, visit::Visitor as _},
@@ -397,7 +397,7 @@ pub(crate) struct RefinementResolver<'a, 'genv, 'tcx> {
     sort_params: FxIndexSet<Symbol>,
     param_defs: FxIndexMap<NodeId, ParamDef>,
     resolver: &'a mut CrateResolver<'genv, 'tcx>,
-    path_res_map: FxHashMap<NodeId, Res<NodeId>>,
+    path_res_map: FxHashMap<NodeId, PartialRes<NodeId>>,
     errors: Errors<'genv>,
 }
 
@@ -548,24 +548,17 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         if let [segment] = &path.segments[..]
             && let Some(res) = self.try_resolve_param(segment.ident)
         {
-            self.path_res_map.insert(path.node_id, res);
+            self.path_res_map.insert(path.node_id, PartialRes::new(res));
             return;
         }
         if let Some(res) = self.try_resolve_expr_with_ribs(&path.segments) {
             self.path_res_map.insert(path.node_id, res);
             return;
         }
-        // TODO(nilehmann) move this to resolve_with_ribs
-        if let [typ, name] = &path.segments[..]
-            && let Some(res) = resolve_num_const(typ.ident, name.ident)
-        {
-            self.path_res_map.insert(path.node_id, res);
-            return;
-        }
         if let [segment] = &path.segments[..]
             && let Some(res) = self.try_resolve_global_func(segment.ident)
         {
-            self.path_res_map.insert(path.node_id, res);
+            self.path_res_map.insert(path.node_id, PartialRes::new(res));
             return;
         }
 
@@ -574,7 +567,7 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
 
     fn resolve_ident(&mut self, ident: Ident, node_id: NodeId) {
         if let Some(res) = self.try_resolve_param(ident) {
-            self.path_res_map.insert(node_id, res);
+            self.path_res_map.insert(node_id, PartialRes::new(res));
             return;
         }
         if let Some(res) = self.try_resolve_expr_with_ribs(&[ident]) {
@@ -582,20 +575,22 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
             return;
         }
         if let Some(res) = self.try_resolve_global_func(ident) {
-            self.path_res_map.insert(node_id, res);
+            self.path_res_map.insert(node_id, PartialRes::new(res));
             return;
         }
         self.errors.emit(errors::UnresolvedVar::from_ident(ident));
     }
 
-    fn try_resolve_expr_with_ribs<S: Segment>(&mut self, segments: &[S]) -> Option<Res<NodeId>> {
+    fn try_resolve_expr_with_ribs<S: Segment>(
+        &mut self,
+        segments: &[S],
+    ) -> Option<PartialRes<NodeId>> {
         if let Some(partial_res) = self.resolver.resolve_path_with_ribs(segments, ValueNS) {
-            return partial_res.full_res().map(|r| r.map_param_id(|p| p));
+            return Some(partial_res.map_param_id(|p| p));
         }
 
         self.resolver
-            .resolve_path_with_ribs(segments, TypeNS)?
-            .full_res()
+            .resolve_path_with_ribs(segments, TypeNS)
             .map(|r| r.map_param_id(|p| p))
     }
 

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -157,14 +157,13 @@ fhir_analysis_definition_cycle =
 
 # Conv errors
 
-fhir_analysis_assoc_type_not_found =
-    associated type not found
-    .label = cannot resolve this associated type
-    .note = Flux cannot resolved associated types if they are defined in a super trait
+fhir_analysis_assoc_item_not_found =
+    associated {$tag} not found
+    .label = cannot resolve this associated {$tag}
+    .note = Flux cannot resolved associated {$tag}s if they are defined in a super trait
 
-fhir_analysis_ambiguous_assoc_type =
-    ambiguous associated type `{$name}`
-    .label = help: use fully-qualified syntax
+fhir_analysis_ambiguous_assoc_item =
+    ambiguous associated {$tag} `{$name}`
 
 fhir_analysis_invalid_base_instance =
     values of this type cannot be used as base sorted instances

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1794,10 +1794,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 rty::BaseTy::Foreign(def_id)
             }
             fhir::Res::Def(kind, def_id) => self.report_expected_type(path.span, kind, def_id)?,
-            fhir::Res::Param(..)
-            | fhir::Res::NumConst(_)
-            | fhir::Res::GlobalFunc(..)
-            | fhir::Res::Err => {
+            fhir::Res::Param(..) | fhir::Res::GlobalFunc(..) | fhir::Res::Err => {
                 span_bug!(path.span, "unexpected resolution in conv_ty_ctor: {:?}", path.res)
             }
         };
@@ -2269,9 +2266,6 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 // FIXME(nilehmann) generalize this to other sorts
                 let sort = rty::Sort::Int;
                 (rty::Expr::const_generic(def_id_to_param_const(genv, def_id)).at(espan), sort)
-            }
-            fhir::Res::NumConst(num) => {
-                (rty::Expr::constant(rty::Constant::from(num)).at(espan), rty::Sort::Int)
             }
             _ => {
                 Err(self.emit(errors::InvalidRes { span: path.span, res_descr: path.res.descr() }))?

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -21,7 +21,7 @@ use flux_common::{
 use flux_middle::{
     THEORY_FUNCS,
     def_id::MaybeExternId,
-    fhir::{self, FhirId, FluxOwnerId},
+    fhir::{self, FhirId, FluxOwnerId, QPathExpr},
     global_env::GlobalEnv,
     queries::{QueryErr, QueryResult},
     query_bug,
@@ -1541,6 +1541,38 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         Ok(alias_ty)
     }
 
+    fn conv_type_relative_path_const(
+        &mut self,
+        fhir_expr: &fhir::Expr,
+        qself: &rty::Ty,
+        assoc: Ident,
+    ) -> QueryResult<rty::Expr> {
+        let tcx = self.genv().tcx();
+
+        let mut candidates = vec![];
+        if let Some(simplified_type) = qself.simplify_type() {
+            candidates = tcx
+                .incoherent_impls(simplified_type)
+                .iter()
+                .filter_map(|impl_id| {
+                    tcx.associated_items(impl_id).find_by_ident_and_kind(
+                        tcx,
+                        assoc,
+                        AssocTag::Const,
+                        *impl_id,
+                    )
+                })
+                .collect_vec();
+        }
+        let (expr, sort) = match &candidates[..] {
+            [candidate] => self.conv_const(fhir_expr.span, candidate.def_id)?,
+            [] => todo!(),
+            candidates => todo!(),
+        };
+        self.0.insert_node_sort(fhir_expr.fhir_id, sort);
+        Ok(expr)
+    }
+
     /// Return the generics of the containing owner item
     fn refiner(&self) -> QueryResult<Refiner<'genv, 'tcx>> {
         match self.owner() {
@@ -2098,7 +2130,11 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         let fhir_id = expr.fhir_id;
         let espan = ESpan::new(expr.span);
         let expr = match expr.kind {
-            fhir::ExprKind::Var(path, _) => self.conv_path_expr(env, path)?,
+            fhir::ExprKind::Var(QPathExpr::Resolved(path, _)) => self.conv_path_expr(env, path)?,
+            fhir::ExprKind::Var(QPathExpr::TypeRelative(qself, assoc)) => {
+                let qself = self.conv_ty(env, qself)?;
+                self.conv_type_relative_path_const(expr, &qself, assoc)?
+            }
             fhir::ExprKind::Literal(lit) => {
                 rty::Expr::constant(self.conv_lit(lit, fhir_id, expr.span)?).at(espan)
             }
@@ -2214,15 +2250,8 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
             fhir::Res::Param(_, id) => (env.lookup(&path).to_expr(), self.results().param_sort(id)),
             fhir::Res::Def(DefKind::Const, def_id) => {
                 self.hyperlink(path.span, tcx.def_ident_span(def_id));
-                let Some(sort) = genv.sort_of_def_id(def_id).emit(&genv)? else {
-                    span_bug!(path.span, "unexpected const")
-                };
-                let info = genv.constant_info(def_id).emit(&genv)?;
-                // non-integral constant
-                if sort != rty::Sort::Int && matches!(info, rty::ConstantInfo::Uninterpreted) {
-                    Err(self.emit(errors::ConstantAnnotationNeeded::new(path.span)))?;
-                }
-                (rty::Expr::const_def_id(def_id).at(espan), sort)
+                let (expr, sort) = self.conv_const(path.span, def_id)?;
+                (expr.at(espan), sort)
             }
             fhir::Res::Def(DefKind::Ctor(..), ctor_id) => {
                 let Some(sort) = genv.sort_of_def_id(ctor_id).emit(&genv)? else {
@@ -2250,6 +2279,19 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         };
         self.0.insert_node_sort(path.fhir_id, sort);
         Ok(expr)
+    }
+
+    fn conv_const(&self, span: Span, def_id: DefId) -> QueryResult<(rty::Expr, rty::Sort)> {
+        let genv = self.genv();
+        let Some(sort) = genv.sort_of_def_id(def_id).emit(&genv)? else {
+            span_bug!(span, "unsupported const: `{def_id:?}`")
+        };
+        let info = genv.constant_info(def_id).emit(&genv)?;
+        // non-integral constant
+        if sort != rty::Sort::Int && matches!(info, rty::ConstantInfo::Uninterpreted) {
+            Err(self.emit(errors::ConstantAnnotationNeeded::new(span)))?;
+        }
+        Ok((rty::Expr::const_def_id(def_id), sort))
     }
 
     fn conv_constructor_exprs(

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2285,7 +2285,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         if sort != rty::Sort::Int && matches!(info, rty::ConstantInfo::Uninterpreted) {
             Err(self.emit(errors::ConstantAnnotationNeeded::new(span)))?;
         }
-        Ok((rty::Expr::const_def_id(def_id), sort))
+        Ok((rty::Expr::const_def_id(def_id).at(ESpan::new(span)), sort))
     }
 
     fn conv_constructor_exprs(

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -1136,7 +1136,11 @@ mod pretty {
 
     impl Pretty for Tag {
         fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            w!(cx, f, "{:?} at {:?}", ^self.reason, self.src_span)
+            w!(cx, f, "{:?} at {:?}", ^self.reason, self.src_span)?;
+            if let Some(dst_span) = self.dst_span {
+                w!(cx, f, " ({:?})", ^dst_span)?;
+            }
+            Ok(())
         }
     }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -727,8 +727,6 @@ pub enum Res<Id = !> {
     Param(ParamKind, Id),
     /// A refinement function defined with `defs!`
     GlobalFunc(SpecFuncKind),
-    /// A hack used to resolve `u32::MAX` ans similar.
-    NumConst(i128),
     Err,
 }
 
@@ -1110,7 +1108,6 @@ impl<Id> Res<Id> {
             Res::SelfTyAlias { .. } | Res::SelfTyParam { .. } => "self type",
             Res::Param(..) => "refinement parameter",
             Res::GlobalFunc(..) => "refinement function",
-            Res::NumConst(_) => "numeric constant",
             Res::Err => "unresolved item",
         }
     }
@@ -1130,7 +1127,7 @@ impl<Id> Res<Id> {
             Res::PrimTy(..) | Res::SelfTyAlias { .. } | Res::SelfTyParam { .. } => {
                 Some(Namespace::TypeNS)
             }
-            Res::Param(..) | Res::GlobalFunc(..) | Res::NumConst(..) => Some(Namespace::ValueNS),
+            Res::Param(..) | Res::GlobalFunc(..) => Some(Namespace::ValueNS),
             Res::Err => None,
         }
     }
@@ -1150,7 +1147,6 @@ impl<Id> Res<Id> {
             }
             Res::SelfTyParam { trait_ } => Res::SelfTyParam { trait_ },
             Res::GlobalFunc(spec_func_kind) => Res::GlobalFunc(spec_func_kind),
-            Res::NumConst(val) => Res::NumConst(val),
             Res::Err => Res::Err,
         }
     }

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -7,7 +7,7 @@ use super::{
     StructDef, TraitAssocReft, TraitItem, TraitItemKind, Ty, TyAlias, TyKind, VariantDef,
     VariantRet, WhereBoundPredicate,
 };
-use crate::fhir::{PrimOpProp, StructKind};
+use crate::fhir::{PrimOpProp, QPathExpr, StructKind};
 
 #[macro_export]
 macro_rules! walk_list {
@@ -538,7 +538,7 @@ pub fn walk_field_expr<'v, V: Visitor<'v>>(vis: &mut V, expr: &FieldExpr<'v>) {
 
 pub fn walk_expr<'v, V: Visitor<'v>>(vis: &mut V, expr: &Expr<'v>) {
     match expr.kind {
-        ExprKind::Var(path, _) => vis.visit_path_expr(&path),
+        ExprKind::Var(qpath) => walk_qpath_expr(vis, qpath),
         ExprKind::Dot(base, _fld) => {
             vis.visit_expr(base);
         }
@@ -592,5 +592,14 @@ pub fn walk_expr<'v, V: Visitor<'v>>(vis: &mut V, expr: &Expr<'v>) {
             vis.visit_expr(body);
         }
         ExprKind::Err(_) => {}
+    }
+}
+
+pub fn walk_qpath_expr<'v, V: Visitor<'v>>(vis: &mut V, qpath: QPathExpr<'v>) {
+    match qpath {
+        QPathExpr::Resolved(path, _param_kind) => {
+            vis.visit_path_expr(&path);
+        }
+        QPathExpr::TypeRelative(qself, _ident) => vis.visit_ty(qself),
     }
 }

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -419,7 +419,7 @@ pub struct ResolverOutput {
     /// [`surface::VariantDef`]. The [`NodeId`]s in the vectors are keys in [`Self::param_res_map`].
     pub implicit_params: UnordMap<NodeId, Vec<(Ident, NodeId)>>,
     pub sort_path_res_map: UnordMap<NodeId, fhir::SortRes>,
-    pub expr_path_res_map: UnordMap<NodeId, fhir::Res<fhir::ParamId>>,
+    pub expr_path_res_map: UnordMap<NodeId, fhir::PartialRes<fhir::ParamId>>,
     /// The resolved list of local qualifiers per function
     pub qualifier_res_map: UnordMap<OwnerId, Vec<def_id::FluxLocalDefId>>,
     /// The resolved list of local reveals per function

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -737,6 +737,7 @@ pub enum ExprKind {
     Var(Var),
     Local(Local),
     Constant(Constant),
+    /// A rust constant. This can be either `DefKind::Const` or `DefKind::AssocConst`
     ConstDefId(DefId),
     BinaryOp(BinOp, Expr, Expr),
     GlobalFunc(SpecFuncKind),

--- a/tests/tests/neg/error_messages/conv/not_found_assoc_const.rs
+++ b/tests/tests/neg/error_messages/conv/not_found_assoc_const.rs
@@ -1,0 +1,4 @@
+use flux_rs::attrs::*;
+
+#[spec(fn(x: i32 { x == i32::BAD }))] //~ ERROR associated constant not found
+fn test00(x: i32) {}


### PR DESCRIPTION
This replaces the numeric constant hack with proper type relative paths resolved during conv.