### PR TITLE
Implement type-relative associated refinements

### DIFF
--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -528,8 +528,15 @@ pub fn walk_func_sort<'v, V: Visitor<'v>>(vis: &mut V, func: &FuncSort<'v>) {
 }
 
 pub fn walk_alias_reft<'v, V: Visitor<'v>>(vis: &mut V, alias: &AliasReft<'v>) {
-    vis.visit_ty(alias.qself);
-    vis.visit_path(&alias.path);
+    match alias {
+        AliasReft::Qualified { qself, trait_, name: _ } => {
+            vis.visit_ty(qself);
+            vis.visit_path(trait_);
+        }
+        AliasReft::TypeRelative { qself, name: _ } => {
+            vis.visit_ty(qself);
+        }
+    }
 }
 
 pub fn walk_field_expr<'v, V: Visitor<'v>>(vis: &mut V, expr: &FieldExpr<'v>) {

--- a/tests/tests/neg/surface/assoc_reft07.rs
+++ b/tests/tests/neg/surface/assoc_reft07.rs
@@ -1,0 +1,25 @@
+// Test we correctly resolve type-relative associated refinements
+
+use flux_rs::attrs::*;
+
+#[assoc(fn pre(x: int) -> bool)]
+trait MyTrait {
+    #[spec(fn(x: i32{ Self::pre(x) }))]
+    fn f(x: i32);
+}
+
+#[assoc(fn pre(x: int) -> bool { x > 0 })]
+impl MyTrait for i32 {
+    #[spec(fn(x: i32{ Self::pre(x) }))]
+    fn f(x: i32) {}
+}
+
+#[spec(fn(x: i32{ T::pre(x) }))]
+fn test00<T: MyTrait>(x: i32) {
+    T::f(x);
+}
+
+fn test01() {
+    test00::<i32>(0); //~ ERROR refinement type error
+    <i32>::f(0); //~ ERROR refinement type error
+}

--- a/tests/tests/pos/surface/assoc_reft07.rs
+++ b/tests/tests/pos/surface/assoc_reft07.rs
@@ -1,0 +1,25 @@
+// Test we correctly resolve type-relative associated refinements
+
+use flux_rs::attrs::*;
+
+#[assoc(fn pre(x: int) -> bool)]
+trait MyTrait {
+    #[spec(fn(x: i32{ Self::pre(x) }))]
+    fn f(x: i32);
+}
+
+#[assoc(fn pre(x: int) -> bool { x >= 0 })]
+impl MyTrait for i32 {
+    #[spec(fn(x: i32{ Self::pre(x) }))]
+    fn f(x: i32) {}
+}
+
+#[spec(fn(x: i32{ T::pre(x) }))]
+fn test00<T: MyTrait>(x: i32) {
+    T::f(x);
+}
+
+fn test01() {
+    test00::<i32>(0);
+    <i32>::f(0);
+}


### PR DESCRIPTION
This allows us to write `Self::assoc_refinement` instead of `<Self as MyTrait>::assoc_refinement`