### PR TITLE
Create custom datatypes from environment and handle them in expressions

### DIFF
--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -131,7 +131,7 @@ pub mod fixpoint {
         }
     }
 
-    #[derive(Clone, Hash, Debug)]
+    #[derive(Clone, Hash, Debug, PartialEq, Eq)]
     pub enum DataSort {
         Tuple(usize),
         Adt(AdtId),

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -43,20 +43,20 @@ impl<T: Types> Constraint<T> {
     }
 }
 
-#[derive_where(Hash)]
+#[derive_where(Hash, Clone)]
 pub struct DataDecl<T: Types> {
     pub name: T::Sort,
     pub vars: usize,
     pub ctors: Vec<DataCtor<T>>,
 }
 
-#[derive_where(Hash)]
+#[derive_where(Hash, Clone)]
 pub struct DataCtor<T: Types> {
     pub name: T::Var,
     pub fields: Vec<DataField<T>>,
 }
 
-#[derive_where(Hash)]
+#[derive_where(Hash, Clone)]
 pub struct DataField<T: Types> {
     pub name: T::Var,
     pub sort: Sort<T>,

--- a/lib/liquid-fixpoint/src/constraint_solving.rs
+++ b/lib/liquid-fixpoint/src/constraint_solving.rs
@@ -62,7 +62,7 @@ impl<T: Types> Constraint<T> {
 
     pub fn topo_order_fragments(&self) -> Vec<Self> {
         let (mut kvar_to_fragments, kvar_to_dependencies) = self.kvar_mappings();
-        let topologically_ordered_kvids = topological_sort_sccs::<T>(&kvar_to_dependencies);
+        let topologically_ordered_kvids = topological_sort_sccs(&kvar_to_dependencies);
         topologically_ordered_kvids
             .into_iter()
             .rev()

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -50,10 +50,7 @@ impl<T: Types> ConstraintWithEnv<T> {
         constants: Vec<ConstDecl<T>>,
         constraint: Constraint<T>,
     ) -> Self {
-        use crate::Identifier;
-
         let datatype_decls = Self::topo_sort_data_declarations(datatype_decls);
-        println!("{}", datatype_decls.iter().map(|decl| decl.name.display().to_string()).format(", "));
         Self { datatype_decls, kvar_decls, qualifiers, constants, constraint }
     }
 

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -2,8 +2,9 @@ use derive_where::derive_where;
 #[cfg(feature = "rust-fixpoint")]
 use {
     crate::{
-        FixpointResult,
+        FixpointResult, Sort, SortCtor,
         cstr2smt2::{Env, is_constraint_satisfiable, new_binding, new_datatype},
+        graph,
     },
     itertools::Itertools,
     std::collections::{HashMap, VecDeque},
@@ -17,18 +18,45 @@ use crate::{
 
 #[derive_where(Hash)]
 pub struct ConstraintWithEnv<T: Types> {
-    pub datatype_decls: Vec<DataDecl<T>>,
-    pub kvar_decls: Vec<KVarDecl<T>>,
-    pub qualifiers: Vec<Qualifier<T>>,
-    pub constants: Vec<ConstDecl<T>>,
-    pub constraint: Constraint<T>,
+    datatype_decls: Vec<DataDecl<T>>,
+    kvar_decls: Vec<KVarDecl<T>>,
+    qualifiers: Vec<Qualifier<T>>,
+    constants: Vec<ConstDecl<T>>,
+    constraint: Constraint<T>,
 }
 
 #[cfg(feature = "rust-fixpoint")]
 use crate::Assignments;
 
+#[cfg(not(feature = "rust-fixpoint"))]
+impl<T: Types> ConstraintWithEnv<T> {
+    pub fn new(
+        datatype_decls: Vec<DataDecl<T>>,
+        kvar_decls: Vec<KVarDecl<T>>,
+        qualifiers: Vec<Qualifier<T>>,
+        constants: Vec<ConstDecl<T>>,
+        constraint: Constraint<T>,
+    ) -> Self {
+        Self { datatype_decls, kvar_decls, qualifiers, constants, constraint }
+    }
+}
+
 #[cfg(feature = "rust-fixpoint")]
 impl<T: Types> ConstraintWithEnv<T> {
+    pub fn new(
+        datatype_decls: Vec<DataDecl<T>>,
+        kvar_decls: Vec<KVarDecl<T>>,
+        qualifiers: Vec<Qualifier<T>>,
+        constants: Vec<ConstDecl<T>>,
+        constraint: Constraint<T>,
+    ) -> Self {
+        use crate::Identifier;
+
+        let datatype_decls = Self::topo_sort_data_declarations(datatype_decls);
+        println!("{}", datatype_decls.iter().map(|decl| decl.name.display().to_string()).format(", "));
+        Self { datatype_decls, kvar_decls, qualifiers, constants, constraint }
+    }
+
     pub fn compute_initial_assignments(&self) -> Assignments<'_, T> {
         let mut assignments = HashMap::new();
 
@@ -132,6 +160,35 @@ impl<T: Types> ConstraintWithEnv<T> {
         let kvar_assignment = self.solve_for_kvars(&solver, &mut vars);
         self.constraint = self.constraint.sub_all_kvars(&kvar_assignment);
         is_constraint_satisfiable(&self.constraint, &solver, &mut vars)
+    }
+
+    fn topo_sort_data_declarations(datatype_decls: Vec<DataDecl<T>>) -> Vec<DataDecl<T>> {
+        let mut datatype_dependencies: HashMap<T::Sort, Vec<T::Sort>> = HashMap::new();
+        for datatype_decl in &datatype_decls {
+            datatype_dependencies.insert(datatype_decl.name.clone(), vec![]);
+        }
+        let mut data_decls_by_name = HashMap::new();
+        for datatype_decl in datatype_decls {
+            for data_constructor in &datatype_decl.ctors {
+                for accessor in &data_constructor.fields {
+                    if let Sort::App(ctor, _) = &accessor.sort
+                        && let SortCtor::Data(data_ctor) = &ctor
+                    {
+                        datatype_dependencies
+                            .get_mut(&datatype_decl.name)
+                            .unwrap()
+                            .push(data_ctor.clone());
+                    }
+                }
+            }
+            data_decls_by_name.insert(datatype_decl.name.clone(), datatype_decl);
+        }
+        graph::topological_sort_sccs(&datatype_dependencies)
+            .into_iter()
+            .flatten()
+            .rev()
+            .map(|datatype_decl_name| data_decls_by_name.remove(&datatype_decl_name).unwrap())
+            .collect_vec()
     }
 }
 

--- a/lib/liquid-fixpoint/src/cstr2smt2.rs
+++ b/lib/liquid-fixpoint/src/cstr2smt2.rs
@@ -8,7 +8,7 @@ use z3::{
 };
 
 use crate::{
-    Error, FixpointFmt, FixpointResult, Identifier, Stats, ThyFunc, Types,
+    DataDecl, Error, FixpointFmt, FixpointResult, Identifier, SortCtor, Stats, ThyFunc, Types,
     constraint::{BinOp, BinRel, Constant, Constraint, Expr, Pred, Sort},
 };
 
@@ -26,11 +26,12 @@ impl From<ast::Dynamic> for Binding {
 
 pub(crate) struct Env<T: Types> {
     bindings: HashMap<T::Var, Vec<Binding>>,
+    data_types: HashMap<T::Sort, z3::Sort>,
 }
 
 impl<T: Types> Env<T> {
     pub(crate) fn new() -> Self {
-        Self { bindings: HashMap::new() }
+        Self { bindings: HashMap::new(), data_types: HashMap::new() }
     }
 
     pub(crate) fn insert<B: Into<Binding>>(&mut self, name: T::Var, value: B) {
@@ -38,6 +39,10 @@ impl<T: Types> Env<T> {
             .entry(name)
             .or_default()
             .push(Into::<Binding>::into(value));
+    }
+
+    pub(crate) fn insert_data_decl(&mut self, name: T::Sort, datatype: z3::Sort) {
+        self.data_types.insert(name, datatype);
     }
 
     fn pop(&mut self, name: &T::Var) {
@@ -66,6 +71,10 @@ impl<T: Types> Env<T> {
 
     fn lookup(&self, name: &T::Var) -> Option<&Binding> {
         self.bindings.get(name).and_then(|stack| stack.last())
+    }
+
+    fn datatype_lookup(&self, name: &T::Sort) -> Option<&z3::Sort> {
+        self.data_types.get(name)
     }
 }
 
@@ -464,23 +473,66 @@ fn pred_to_z3<T: Types>(pred: &Pred<T>, env: &mut Env<T>) -> ast::Bool {
     }
 }
 
-pub(crate) fn new_binding<T: Types>(name: &T::Var, sort: &Sort<T>) -> Binding {
+pub(crate) fn new_datatype<T: Types>(
+    name: &T::Sort,
+    data_decl: &DataDecl<T>,
+    env: &mut Env<T>,
+) -> z3::Sort {
+    let mut builder = z3::DatatypeBuilder::new(name.display().to_string());
+    if data_decl.vars != 0 {
+        panic!("Unexpected polymorphic datatype constructor encountered {}", name.display())
+    }
+    for data_ctor in &data_decl.ctors {
+        let mut fields = Vec::new();
+        let data_field_names = data_ctor
+            .fields
+            .iter()
+            .map(|field| field.name.display().to_string())
+            .collect_vec();
+        for (name, field) in data_field_names.iter().zip(&data_ctor.fields) {
+            fields.push((name.as_str(), z3::DatatypeAccessor::sort(z3_sort(&field.sort, env))));
+        }
+        builder = builder.variant(data_ctor.name.display().to_string().as_str(), fields)
+    }
+    let z3::DatatypeSort { sort, variants } = builder.finish();
+    for (data_ctor, z3::DatatypeVariant { constructor, accessors, tester: _ }) in
+        data_decl.ctors.iter().zip(variants)
+    {
+        env.insert(
+            data_ctor.name.clone(),
+            Binding::Function(constructor, ast::Int::new_const(name.display().to_string()).into()),
+        );
+        for (field, accessor) in data_ctor.fields.iter().zip(accessors) {
+            env.insert(
+                field.name.clone(),
+                Binding::Function(
+                    accessor,
+                    ast::Int::new_const(field.name.display().to_string()).into(),
+                ),
+            );
+        }
+    }
+    sort
+}
+
+pub(crate) fn new_binding<T: Types>(name: &T::Var, sort: &Sort<T>, env: &Env<T>) -> Binding {
     match &sort {
         Sort::Int => Binding::Variable(ast::Int::new_const(name.display().to_string()).into()),
         Sort::Real => Binding::Variable(ast::Real::new_const(name.display().to_string()).into()),
         Sort::Bool => Binding::Variable(ast::Bool::new_const(name.display().to_string()).into()),
         Sort::Str => Binding::Variable(ast::String::new_const(name.display().to_string()).into()),
         Sort::Func(sorts) => {
-            let mut domain = vec![z3_sort(&sorts[0])];
+            let mut domain = vec![z3_sort(&sorts[0], env)];
             let mut current = sorts.as_ref();
             let mut range = &sorts[1];
             while let Sort::Func(sorts) = &current[1] {
-                domain.push(z3_sort(&(*sorts)[0]));
+                domain.push(z3_sort(&(*sorts)[0], env));
                 range = &sorts[1];
                 current = sorts.as_ref();
             }
             let domain_refs = domain.iter().collect_vec();
-            let fun_decl = FuncDecl::new(name.display().to_string(), &domain_refs, &z3_sort(range));
+            let fun_decl =
+                FuncDecl::new(name.display().to_string(), &domain_refs, &z3_sort(range, env));
             Binding::Function(fun_decl, ast::Int::new_const(name.display().to_string()).into())
         }
         Sort::BitVec(bv_size) => {
@@ -491,11 +543,40 @@ pub(crate) fn new_binding<T: Types>(name: &T::Var, sort: &Sort<T>) -> Binding {
                 _ => panic!("incorrect bitvector size specification"),
             }
         }
+        Sort::App(sort_ctor, args) => {
+            match sort_ctor {
+                SortCtor::Set => {
+                    Binding::Variable(
+                        ast::Set::new_const(name.display().to_string(), &z3_sort(&args[0], env))
+                            .into(),
+                    )
+                }
+                SortCtor::Map => {
+                    Binding::Variable(
+                        ast::Array::new_const(
+                            name.display().to_string(),
+                            &z3_sort(&args[0], env),
+                            &z3_sort(&args[1], env),
+                        )
+                        .into(),
+                    )
+                }
+                SortCtor::Data(data_ctor) => {
+                    Binding::Variable(
+                        ast::Datatype::new_const(
+                            name.display().to_string(),
+                            &env.datatype_lookup(data_ctor).unwrap(),
+                        )
+                        .into(),
+                    )
+                }
+            }
+        }
         &s => panic!("unhandled kind encountered: {:#?}", s),
     }
 }
 
-fn z3_sort<T: Types>(s: &Sort<T>) -> z3::Sort {
+fn z3_sort<T: Types>(s: &Sort<T>, env: &Env<T>) -> z3::Sort {
     match &s {
         Sort::Int => z3::Sort::int(),
         Sort::Real => z3::Sort::real(),
@@ -505,6 +586,13 @@ fn z3_sort<T: Types>(s: &Sort<T>) -> z3::Sort {
             match **bv_size {
                 Sort::BvSize(size) => z3::Sort::bitvector(size),
                 _ => panic!("incorrect bitvector size specification"),
+            }
+        }
+        Sort::App(sort_ctor, args) => {
+            match sort_ctor {
+                SortCtor::Set => z3::Sort::set(&z3_sort(&args[0], env)),
+                SortCtor::Map => z3::Sort::array(&z3_sort(&args[0], env), &z3_sort(&args[1], env)),
+                SortCtor::Data(sort) => env.datatype_lookup(&sort).unwrap().clone(),
             }
         }
         _ => panic!("unhandled sort encountered {:#?}", s),
@@ -540,7 +628,7 @@ pub(crate) fn is_constraint_satisfiable<T: Types>(
         }
 
         Constraint::ForAll(bind, inner) => {
-            env.insert(bind.name.clone(), new_binding(&bind.name, &bind.sort));
+            env.insert(bind.name.clone(), new_binding(&bind.name, &bind.sort, &env));
             solver.assert(&pred_to_z3(&bind.pred, env));
             let inner_soln = is_constraint_satisfiable(&**inner, solver, env);
             env.pop(&bind.name);

--- a/lib/liquid-fixpoint/src/graph.rs
+++ b/lib/liquid-fixpoint/src/graph.rs
@@ -1,12 +1,13 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    hash::Hash,
+};
 
-use crate::Types;
-
-fn dfs_finish_order<'a, T: Types>(
-    node: &'a T::KVar,
-    graph: &'a HashMap<T::KVar, Vec<T::KVar>>,
-    visited: &mut HashSet<T::KVar>,
-    order: &mut Vec<T::KVar>,
+fn dfs_finish_order<'a, T: Hash + Eq + Clone>(
+    node: &'a T,
+    graph: &'a HashMap<T, Vec<T>>,
+    visited: &mut HashSet<T>,
+    order: &mut Vec<T>,
 ) {
     if visited.contains(node) {
         return;
@@ -23,9 +24,7 @@ fn dfs_finish_order<'a, T: Types>(
     order.push(node.clone());
 }
 
-fn reverse_graph<T: Types>(
-    graph: &HashMap<T::KVar, Vec<T::KVar>>,
-) -> HashMap<T::KVar, Vec<T::KVar>> {
+fn reverse_graph<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -> HashMap<T, Vec<T>> {
     let mut reversed = HashMap::new();
 
     for (node, neighbors) in graph {
@@ -44,11 +43,11 @@ fn reverse_graph<T: Types>(
     reversed
 }
 
-fn dfs_collect_scc<'a, T: Types>(
-    node: &'a T::KVar,
-    graph: &'a HashMap<T::KVar, Vec<T::KVar>>,
-    visited: &mut HashSet<T::KVar>,
-    scc: &mut Vec<T::KVar>,
+fn dfs_collect_scc<'a, T: Hash + Eq + Clone>(
+    node: &'a T,
+    graph: &'a HashMap<T, Vec<T>>,
+    visited: &mut HashSet<T>,
+    scc: &mut Vec<T>,
 ) {
     if visited.contains(node) {
         return;
@@ -64,7 +63,7 @@ fn dfs_collect_scc<'a, T: Types>(
     }
 }
 
-fn find_sccs<T: Types>(graph: &HashMap<T::KVar, Vec<T::KVar>>) -> Vec<Vec<T::KVar>> {
+fn find_sccs<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -> Vec<Vec<T>> {
     let mut visited = HashSet::new();
     let mut order = Vec::new();
 
@@ -91,9 +90,7 @@ fn find_sccs<T: Types>(graph: &HashMap<T::KVar, Vec<T::KVar>>) -> Vec<Vec<T::KVa
     sccs
 }
 
-pub fn topological_sort_sccs<T: Types>(
-    graph: &HashMap<T::KVar, Vec<T::KVar>>,
-) -> Vec<Vec<T::KVar>> {
+pub fn topological_sort_sccs<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -> Vec<Vec<T>> {
     let sccs = find_sccs::<T>(graph);
 
     // Map each node to its SCC index

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -292,14 +292,15 @@ impl<T: Types> Task<T> {
 
     #[cfg(feature = "rust-fixpoint")]
     pub fn run(&self) -> io::Result<FixpointResult<T::Tag>> {
-        Ok(ConstraintWithEnv {
-            datatype_decls: self.data_decls.clone(),
-            kvar_decls: self.kvars.clone(),
-            qualifiers: self.qualifiers.clone(),
-            constants: self.constants.clone(),
-            constraint: self.constraint.clone(),
-        }
-        .is_satisfiable())
+        let mut cstr_with_env = ConstraintWithEnv::new(
+            self.data_decls.clone(),
+            self.kvars.clone(),
+            self.qualifiers.clone(),
+            self.constants.clone(),
+            self.constraint.clone(),
+        );
+        let is_satisfiable = cstr_with_env.is_satisfiable();
+        Ok(is_satisfiable)
     }
 
     #[cfg(not(feature = "rust-fixpoint"))]

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -54,7 +54,7 @@ pub type Assignments<'a, T> = HashMap<<T as Types>::KVar, Vec<(&'a Qualifier<T>,
 use crate::constraint_with_env::ConstraintWithEnv;
 
 pub trait Types {
-    type Sort: Identifier + Hash + Clone + Debug;
+    type Sort: Identifier + Hash + Clone + Debug + Eq;
     type KVar: Identifier + Hash + Clone + Debug + Eq;
     type Var: Identifier + Hash + Clone + Debug + Eq;
     type Decimal: FixpointFmt + Hash + Clone + Debug;
@@ -293,6 +293,7 @@ impl<T: Types> Task<T> {
     #[cfg(feature = "rust-fixpoint")]
     pub fn run(&self) -> io::Result<FixpointResult<T::Tag>> {
         Ok(ConstraintWithEnv {
+            datatype_decls: self.data_decls.clone(),
             kvar_decls: self.kvars.clone(),
             qualifiers: self.qualifiers.clone(),
             constants: self.constants.clone(),

--- a/lib/liquid-fixpoint/src/parser.rs
+++ b/lib/liquid-fixpoint/src/parser.rs
@@ -633,7 +633,13 @@ pub fn parse_constraint_with_kvars(
         } else if let Ok(qualifier) = sexp_to_qualifier(&sexp) {
             qualifiers.push(qualifier);
         } else if let Ok(constraint) = sexp_to_constraint(&sexp) {
-            return Ok(ConstraintWithEnv { kvar_decls, qualifiers, constants: vec![], constraint });
+            return Ok(ConstraintWithEnv {
+                datatype_decls: vec![],
+                kvar_decls,
+                qualifiers,
+                constants: vec![],
+                constraint,
+            });
         }
     }
     Err(ParseError::MalformedSexpError("No constraint found"))

--- a/lib/liquid-fixpoint/src/parser.rs
+++ b/lib/liquid-fixpoint/src/parser.rs
@@ -633,13 +633,7 @@ pub fn parse_constraint_with_kvars(
         } else if let Ok(qualifier) = sexp_to_qualifier(&sexp) {
             qualifiers.push(qualifier);
         } else if let Ok(constraint) = sexp_to_constraint(&sexp) {
-            return Ok(ConstraintWithEnv {
-                datatype_decls: vec![],
-                kvar_decls,
-                qualifiers,
-                constants: vec![],
-                constraint,
-            });
+            return Ok(ConstraintWithEnv::new(vec![], kvar_decls, qualifiers, vec![], constraint));
         }
     }
     Err(ParseError::MalformedSexpError("No constraint found"))


### PR DESCRIPTION
Handle custom datatypes
- keep a hash table of their sorts by name so that we can look them up
- add their constructors and field accessors to the hash table of function declarations

I tested on top of the changes from #1293 and lots more tests pass :)  One of the tests (`pos/enums/pred00.rs`) is very slow which tipped me off to the fact that I'm doing the elimination of acyclic kvars wrong. Fixing that is unrelated to this PR though.