### PR TITLE
Parse flags in cargo-flux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,10 +40,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -154,6 +198,52 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compiletest_rs"
@@ -373,8 +463,10 @@ dependencies = [
 name = "flux-bin"
 version = "0.1.0"
 dependencies = [
+ "anstyle",
  "anyhow",
  "cargo_metadata",
+ "clap",
  "config",
  "flux-config",
  "home",
@@ -658,6 +750,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +798,12 @@ checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
 dependencies = [
  "unic-langid",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -919,6 +1023,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "pad-adapter"
@@ -1173,6 +1283,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1478,6 +1594,12 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,11 @@ liquid-fixpoint = { path = "./lib/liquid-fixpoint", version = "0.1.0", features 
     "nightly",
 ] }
 
+anstyle = "1.0.13"
 anyhow = "1.0.97"
 bumpalo = "3.17.0"
 cargo_metadata = "0.23.0"
+clap = { version = "4.5", features = ["derive"] }
 config = { version = "0.15.11", features = ["toml"], default-features = false }
 dashmap = { version = "5.5.3", features = ["raw-api"] }
 derive-where = "1.2.7"

--- a/crates/flux-bin/Cargo.toml
+++ b/crates/flux-bin/Cargo.toml
@@ -28,6 +28,8 @@ serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 toml.workspace = true
+clap.workspace = true
+anstyle.workspace = true
 
 [lints]
 workspace = true

--- a/crates/flux-bin/build.rs
+++ b/crates/flux-bin/build.rs
@@ -1,32 +1,30 @@
 use std::process::{Command, Output};
 
-fn parse_output(output: Output) -> Option<String> {
-    Some(String::from_utf8(output.stdout).ok()?.trim().to_string())
+fn parse_output(output: Option<Output>) -> Option<String> {
+    Some(String::from_utf8(output?.stdout).ok()?.trim().to_string())
 }
 
-fn git_sha() -> Option<String> {
+fn git_sha() -> String {
     parse_output(
         Command::new("git")
             .args(["describe", "--always", "--dirty=*"])
             .output()
-            .ok()?,
+            .ok(),
     )
+    .unwrap_or("unknown".to_string())
 }
 
-fn git_date() -> Option<String> {
+fn git_date() -> String {
     parse_output(
         Command::new("git")
             .args(["show", "-s", "--format=%cd", "--date=format:%Y-%m-%d", "HEAD"])
             .output()
-            .ok()?,
+            .ok(),
     )
+    .unwrap_or("unknown".to_string())
 }
 
 fn main() {
-    if let Some(hash) = git_sha() {
-        println!("cargo:rustc-env=GIT_SHA={}", hash);
-    }
-    if let Some(date) = git_date() {
-        println!("cargo:rustc-env=GIT_DATE={}", date);
-    }
+    println!("cargo:rustc-env=GIT_SHA={}", git_sha());
+    println!("cargo:rustc-env=GIT_DATE={}", git_date());
 }

--- a/crates/flux-bin/src/bin/flux.rs
+++ b/crates/flux-bin/src/bin/flux.rs
@@ -5,12 +5,13 @@ use std::{env, process::Command};
 use anyhow::Result;
 use flux_bin::utils::{
     LIB_PATH, flux_sysroot_dir, get_flux_driver_path, get_rust_lib_path, get_rust_sysroot,
-    get_rust_toolchain, prepend_path_to_env_var, print_version_and_exit,
+    get_rust_toolchain, get_version, prepend_path_to_env_var,
 };
 
 fn main() -> Result<()> {
     if env::args().any(|arg| arg == "--version" || arg == "-V") {
-        print_version_and_exit("flux");
+        println!("flux {}", get_version());
+        std::process::exit(0);
     }
 
     let flux_sysroot = flux_sysroot_dir();

--- a/crates/flux-bin/src/cargo_flux_opts.rs
+++ b/crates/flux-bin/src/cargo_flux_opts.rs
@@ -1,0 +1,175 @@
+use std::path::PathBuf;
+
+use cargo_metadata::MetadataCommand;
+
+use crate::{cargo_style, utils::get_version};
+
+#[derive(clap::Parser)]
+#[command(name = "cargo")]
+#[command(bin_name = "cargo")]
+#[command(styles = cargo_style::CLAP_STYLING)]
+pub enum Cli {
+    /// Flux's integration with Cargo
+    Flux {
+        #[command(flatten)]
+        check_opts: CheckOptions,
+
+        #[command(flatten)]
+        global_opts: GlobalOptions,
+
+        #[command(subcommand)]
+        command: Option<CargoFluxCommand>,
+    },
+}
+
+#[derive(Debug, clap::Args)]
+#[command(about = None, long_about = None, next_help_heading = "Package Selection")]
+pub struct Workspace {
+    #[arg(short, long, value_name = "SPEC", global = true)]
+    /// Package to process (see `cargo help pkgid`)
+    pub package: Vec<String>,
+    #[arg(long, global = true)]
+    /// Process all packages in the workspace
+    pub workspace: bool,
+    #[arg(long, value_name = "SPEC", global = true)]
+    /// Exclude packages from being processed
+    pub exclude: Vec<String>,
+}
+
+#[derive(Default, Clone, Debug, PartialEq, Eq, clap::Args)]
+#[command(about = None, long_about = None, next_help_heading = "Feature Selection")]
+pub struct Features {
+    #[arg(short = 'F', long, value_delimiter = ' ', global = true)]
+    /// Space-separated list of features to activate
+    pub features: Vec<String>,
+    #[arg(long, global = true)]
+    /// Activate all available features
+    pub all_features: bool,
+    #[arg(long, global = true)]
+    /// Do not activate the `default` feature
+    pub no_default_features: bool,
+}
+
+#[derive(Debug, clap::Args)]
+#[command(version = get_version())]
+pub struct GlobalOptions {
+    #[command(flatten)]
+    workspace: Workspace,
+    #[command(flatten)]
+    features: Features,
+    #[command(flatten)]
+    manifest: ManifestOptions,
+}
+
+#[derive(Debug, clap::Args)]
+#[command(next_help_heading = "Manifest Options")]
+pub struct ManifestOptions {
+    #[arg(long, name = "PATH", global = true)]
+    /// Path to Cargo.toml
+    manifest_path: Option<PathBuf>,
+    /// Run without accessing the network
+    #[arg(long, global = true)]
+    offline: bool,
+}
+
+#[derive(clap::Args)]
+pub struct CheckOptions {
+    /// Error format [possible values: human, short, json, json-diagnostic-short, json-diagnostic-rendered-ansi, json-render-diagnostics]
+    #[arg(long, value_name = "FMT")]
+    message_format: Option<String>,
+}
+
+#[derive(clap::Subcommand)]
+pub enum CargoFluxCommand {
+    /// Check a local package and all of its dependencies for errors using Flux. This is the
+    /// default command if no command is specified.
+    Check(CheckOptions),
+    /// Remove artifacts that cargo-flux has generated in the past
+    Clean,
+}
+
+impl GlobalOptions {
+    /// Returns a vector of arguments to forward to the cargo command
+    pub fn forward_args(&self) -> Vec<&str> {
+        let mut forward_args = vec![];
+        if !self.features.features.is_empty() {
+            forward_args.extend(
+                self.features
+                    .features
+                    .iter()
+                    .flat_map(|feature| ["--features", feature]),
+            );
+        }
+        if self.features.all_features {
+            forward_args.push("--all-features");
+        }
+        if self.features.no_default_features {
+            forward_args.push("--no-default-features");
+        }
+        if self.manifest.offline {
+            forward_args.push("--offline");
+        }
+        if !self.workspace.package.is_empty() {
+            forward_args.extend(
+                self.workspace
+                    .package
+                    .iter()
+                    .flat_map(|package| ["--package", package]),
+            );
+        }
+        if self.workspace.workspace {
+            forward_args.push("--workspace");
+        }
+        if !self.workspace.exclude.is_empty() {
+            forward_args.extend(
+                self.workspace
+                    .exclude
+                    .iter()
+                    .flat_map(|package| ["--exclude", package]),
+            );
+        }
+        forward_args
+    }
+
+    pub fn metadata(&self) -> MetadataCommand {
+        let mut meta = cargo_metadata::MetadataCommand::new();
+        if let Some(ref manifest_path) = self.manifest.manifest_path {
+            meta.manifest_path(manifest_path);
+        }
+        if self.features.all_features {
+            meta.features(cargo_metadata::CargoOpt::AllFeatures);
+        }
+        if self.features.no_default_features {
+            meta.features(cargo_metadata::CargoOpt::NoDefaultFeatures);
+        }
+        if !self.features.features.is_empty() {
+            meta.features(cargo_metadata::CargoOpt::SomeFeatures(self.features.features.to_vec()));
+        }
+        meta
+    }
+}
+
+impl CargoFluxCommand {
+    /// Returns a vector of arguments to forward to the cargo command
+    pub fn forward_args(&self) -> Vec<&str> {
+        let mut forward_args = vec![];
+        match self {
+            CargoFluxCommand::Check(check_args) => {
+                if let Some(message_format) = &check_args.message_format {
+                    forward_args.push("--message-format");
+                    forward_args.push(&message_format);
+                }
+            }
+            CargoFluxCommand::Clean => todo!(),
+        }
+        forward_args
+    }
+
+    /// Returns the cargo subcommand
+    pub fn cargo_subcommand(&self) -> &'static str {
+        match self {
+            CargoFluxCommand::Clean => "clean",
+            CargoFluxCommand::Check { .. } => "check",
+        }
+    }
+}

--- a/crates/flux-bin/src/cargo_style.rs
+++ b/crates/flux-bin/src/cargo_style.rs
@@ -1,0 +1,24 @@
+use anstyle::{AnsiColor, Effects, Style};
+
+pub const NOP: Style = Style::new();
+pub const HEADER: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
+pub const USAGE: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
+pub const LITERAL: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+pub const PLACEHOLDER: Style = AnsiColor::Cyan.on_default();
+pub const ERROR: Style = AnsiColor::Red.on_default().effects(Effects::BOLD);
+pub const WARN: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
+pub const NOTE: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+pub const GOOD: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
+pub const VALID: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+pub const INVALID: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
+
+/// For use with
+/// [`clap::Command::styles`](https://docs.rs/clap/latest/clap/struct.Command.html#method.styles)
+pub const CLAP_STYLING: clap::builder::styling::Styles = clap::builder::styling::Styles::styled()
+    .header(HEADER)
+    .usage(USAGE)
+    .literal(LITERAL)
+    .placeholder(PLACEHOLDER)
+    .error(ERROR)
+    .valid(VALID)
+    .invalid(INVALID);

--- a/crates/flux-bin/src/lib.rs
+++ b/crates/flux-bin/src/lib.rs
@@ -2,6 +2,8 @@ use cargo_metadata::camino::Utf8Path;
 use flux_config::{OverflowMode, SmtSolver};
 use serde::Deserialize;
 
+pub mod cargo_flux_opts;
+pub mod cargo_style;
 pub mod utils;
 
 #[derive(Deserialize, Debug, Default)]

--- a/crates/flux-bin/src/utils.rs
+++ b/crates/flux-bin/src/utils.rs
@@ -93,9 +93,6 @@ fn bytes_to_pathbuf(input: Vec<u8>) -> Result<PathBuf> {
     Ok(PathBuf::from(String::from_utf8(input)?.trim()))
 }
 
-pub fn print_version_and_exit(tool: &str) {
-    let hash = option_env!("GIT_SHA").unwrap_or("unknown");
-    let date = option_env!("GIT_DATE").unwrap_or("unknown");
-    println!("{tool} {hash} ({date})");
-    std::process::exit(0);
+pub fn get_version() -> &'static str {
+    concat!(env!("GIT_SHA"), " (", env!("GIT_DATE"), ")")
 }


### PR DESCRIPTION
This is so we can more selectively forward them to cargo.

Fixes the issue discussed in https://flux-rs.zulipchat.com/#narrow/channel/486098-general/topic/Flux.20as.20.22dev-dependency.22/with/542782348