### PR TITLE
Do enough generation for tock theorems

### DIFF
--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -1745,6 +1745,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
         scx: &mut SortEncodingCtxt,
     ) -> QueryResult<(Vec<fixpoint::FunDef>, Vec<fixpoint::ConstDecl>)> {
         let reveals: UnordSet<FluxDefId> = self.genv.reveals_for(def_id.local_id())?.collect();
+        let proven_externally = self.genv.proven_externally(def_id.local_id());
         let mut consts = vec![];
         let mut defs = vec![];
 
@@ -1757,7 +1758,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
             let comment = format!("flux def: {did:?}");
             let info = self.genv.normalized_info(did);
             let revealed = reveals.contains(&did);
-            if info.hide && !revealed {
+            if info.hide && !revealed && !proven_externally {
                 let sort = scx.func_sort_to_fixpoint(&self.genv.func_sort(did));
                 consts.push(fixpoint::ConstDecl { name, sort, comment: Some(comment) });
             } else {

--- a/crates/flux-infer/src/lean_encoding.rs
+++ b/crates/flux-infer/src/lean_encoding.rs
@@ -51,6 +51,7 @@ impl<'genv, 'tcx> LeanEncoder<'genv, 'tcx> {
             .tcx()
             .def_path(self.def_id.resolved_id())
             .to_filename_friendly_no_crate()
+            .replace("-", "_")
     }
 
     fn proof_name(&self) -> String {

--- a/crates/flux-infer/src/lean_encoding.rs
+++ b/crates/flux-infer/src/lean_encoding.rs
@@ -5,8 +5,11 @@ use std::{
     process::{Command, Stdio},
 };
 
-use flux_common::tracked_span_bug;
-use flux_middle::{def_id::MaybeExternId, global_env::GlobalEnv, queries::QueryResult};
+use flux_middle::{
+    def_id::MaybeExternId,
+    global_env::GlobalEnv,
+    queries::{QueryErr, QueryResult},
+};
 use itertools::Itertools;
 use liquid_fixpoint::Identifier;
 
@@ -154,8 +157,18 @@ impl<'genv, 'tcx> LeanEncoder<'genv, 'tcx> {
     }
 
     pub fn check_proof(&self, lean_path: &path::Path, project_name: &str) -> QueryResult<()> {
-        self.check_proof_help(lean_path, project_name)
-            .map_err(|_| tracked_span_bug!("checking proof for {} failed", self.theorem_name()))
+        self.check_proof_help(lean_path, project_name).map_err(|_| {
+            let msg = format!("checking proof for {} failed", self.theorem_name());
+            let span = self.genv.tcx().def_span(self.def_id.resolved_id());
+            QueryErr::Emitted(
+                self.genv
+                    .sess()
+                    .dcx()
+                    .handle()
+                    .struct_span_err(span, msg)
+                    .emit(),
+            )
+        })
     }
 
     fn snake_case_to_pascal_case(snake: &str) -> String {

--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use itertools::Itertools;
-use liquid_fixpoint::{FixpointFmt, Identifier};
+use liquid_fixpoint::{FixpointFmt, Identifier, ThyFunc};
 
 use crate::{
     fixpoint_encoding::fixpoint::{
@@ -17,6 +17,44 @@ struct LeanConstraint<'a>(&'a Constraint);
 struct LeanPred<'a>(&'a Pred);
 struct LeanExpr<'a>(&'a Expr);
 struct LeanVar<'a>(&'a Var);
+struct LeanThyFunc<'a>(&'a ThyFunc);
+
+impl<'a> fmt::Display for LeanThyFunc<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            ThyFunc::IntToBv8 => write!(f, "BitVec.ofInt 8"),
+            ThyFunc::IntToBv32 => write!(f, "BitVec.ofInt 32"),
+            ThyFunc::IntToBv64 => write!(f, "BitVec.ofInt 64"),
+            ThyFunc::Bv8ToInt | ThyFunc::Bv32ToInt | ThyFunc::Bv64ToInt => {
+                write!(f, "BitVec.toNat")
+            }
+            ThyFunc::BvAdd => write!(f, "BitVec.add"),
+            ThyFunc::BvSub => write!(f, "BitVec.sub"),
+            ThyFunc::BvMul => write!(f, "BitVec.mul"),
+            ThyFunc::BvNeg => write!(f, "BitVec.neg"),
+            ThyFunc::BvSdiv => write!(f, "BitVec.sdiv"),
+            ThyFunc::BvSrem => write!(f, "BitVec.srem"),
+            ThyFunc::BvUdiv => write!(f, "BitVec.udiv"),
+            ThyFunc::BvAnd => write!(f, "BitVec.and"),
+            ThyFunc::BvOr => write!(f, "BitVec.or"),
+            ThyFunc::BvXor => write!(f, "BitVec.xor"),
+            ThyFunc::BvNot => write!(f, "BitVec.not"),
+            ThyFunc::BvSle => write!(f, "BitVec.sle"),
+            ThyFunc::BvSlt => write!(f, "BitVec.slt"),
+            ThyFunc::BvUle => write!(f, "BitVec.ule"),
+            ThyFunc::BvUlt => write!(f, "BitVec.ult"),
+            ThyFunc::BvAshr => write!(f, "BitVec.sshiftRight"),
+            ThyFunc::BvLshr => write!(f, "BitVec.ushiftRight"),
+            ThyFunc::BvShl => write!(f, "BitVec.shiftLeft"),
+            ThyFunc::BvSignExtend(size) => write!(f, "BitVec.signExtend {}", size),
+            ThyFunc::BvZeroExtend(size) => write!(f, "BitVec.zeroExtend {}", size),
+            ThyFunc::BvUrem | ThyFunc::BvSge | ThyFunc::BvSgt | ThyFunc::BvUge | ThyFunc::BvUgt => {
+                todo!("No builtin {}, define a local function {} and call it here", self.0, self.0)
+            }
+            func => panic!("Unsupported theory function {}", func),
+        }
+    }
+}
 
 impl<'a> fmt::Display for LeanVar<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -60,7 +98,7 @@ impl<'a> fmt::Display for LeanExpr<'a> {
                     Constant::Boolean(b) => write!(f, "{}", b),
                     Constant::String(s) => write!(f, "{}", s.display()),
                     Constant::Decimal(d) => write!(f, "{}", d.display()),
-                    _ => todo!(),
+                    Constant::BitVec(bv, size) => write!(f, "{}#{}", bv, size),
                 }
             }
             Expr::BinaryOp(bin_op, args) => {
@@ -98,7 +136,37 @@ impl<'a> fmt::Display for LeanExpr<'a> {
             Expr::Or(exprs) => {
                 write!(f, "({})", exprs.iter().map(LeanExpr).format(" || "))
             }
-            _ => todo!(),
+            Expr::Neg(inner) => {
+                write!(f, "(-{})", LeanExpr(inner.as_ref()))
+            }
+            Expr::IfThenElse(ite) => {
+                let [condition, if_true, if_false] = ite.as_ref();
+                write!(
+                    f,
+                    "(ite {} {} {})",
+                    LeanExpr(condition),
+                    LeanExpr(if_true),
+                    LeanExpr(if_false)
+                )
+            }
+            Expr::Not(inner) => {
+                write!(f, "(¬{})", LeanExpr(inner.as_ref()))
+            }
+            Expr::Imp(implication) => {
+                let [lhs, rhs] = implication.as_ref();
+                write!(f, "({} -> {})", LeanExpr(lhs), LeanExpr(rhs))
+            }
+            Expr::Iff(equiv) => {
+                let [lhs, rhs] = equiv.as_ref();
+                write!(f, "({} <-> {})", LeanExpr(lhs), LeanExpr(rhs))
+            }
+            Expr::Let(binder, exprs) => {
+                let [def, body] = exprs.as_ref();
+                write!(f, "(let {} := {}; {})", LeanVar(binder), LeanExpr(def), LeanExpr(body))
+            }
+            Expr::ThyFunc(thy_func) => {
+                write!(f, "{}", LeanThyFunc(thy_func))
+            }
         }
     }
 }

--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -143,7 +143,7 @@ impl<'a> fmt::Display for LeanExpr<'a> {
                 let [condition, if_true, if_false] = ite.as_ref();
                 write!(
                     f,
-                    "(ite {} {} {})",
+                    "(if {} then {} else {})",
                     LeanExpr(condition),
                     LeanExpr(if_true),
                     LeanExpr(if_false)


### PR DESCRIPTION
- Include refinement function definitions in fixpoint translation when a function is marked as `proven_externally`
- Stop panicking at the first externally proven function that doesn't typecheck so that one run can generate multiple theorems
- Support more expressions and (bitvec related) theory functions

This adds enough so that all `trusted` functions in [this part of tock](https://github.com/PLSysSec/tock/blob/master/arch/cortex-m/src/tcb/theorems.rs) can instead be marked with `proven_externally` and have theorems be generated for them. I can try to prove the theorems 🤷🏽

I made the choice to represent bitvectors in lean as `BitVec`s. Maybe that's not always optimal.