### PR TITLE
Use relational equality in `flux-core`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,10 @@ jobs:
       - name: Patch flux-rs dependency if in pull request
         if: github.event_name == 'pull_request'
         run: |
-          mkdir -p tock/.cargo
-          echo '[patch."https://github.com/flux-rs/flux.git"]' >> tock/.cargo/config.toml
-          echo 'flux-rs = { path = "../lib/flux-rs" }' >> tock/.cargo/config.toml
-          echo 'flux-core = { path = "../lib/flux-core" }' >> tock/.cargo/config.toml
-          echo 'flux-alloc = { path = "../lib/flux-alloc" }' >> tock/.cargo/config.toml
+          echo '[patch."https://github.com/flux-rs/flux.git"]' >> tock/Cargo.toml
+          echo 'flux-rs = { path = "../lib/flux-rs" }' >> tock/Cargo.toml
+          echo 'flux-core = { path = "../lib/flux-core" }' >> tock/Cargo.toml
+          echo 'flux-alloc = { path = "../lib/flux-alloc" }' >> tock/Cargo.toml
 
       - name: Check tock/kernel
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,9 @@ jobs:
       - name: Patch flux-rs dependency if in pull request
         if: github.event_name == 'pull_request'
         run: |
-          echo '[patch."https://github.com/flux-rs/flux.git"]' >> tock/Cargo.toml
-          echo 'flux-rs = { path = "../lib/flux-rs" }' >> tock/Cargo.toml
+          mkdir -p tock/.cargo
+          echo '[patch."https://github.com/flux-rs/flux.git"]' >> tock/.cargo/config.toml
+          echo 'flux-rs = { path = "../lib/flux-rs" }' >> tock/.cargo/config.toml
 
       - name: Check tock/kernel
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
           mkdir -p tock/.cargo
           echo '[patch."https://github.com/flux-rs/flux.git"]' >> tock/.cargo/config.toml
           echo 'flux-rs = { path = "../lib/flux-rs" }' >> tock/.cargo/config.toml
+          echo 'flux-core = { path = "../lib/flux-core" }' >> tock/.cargo/config.toml
+          echo 'flux-alloc = { path = "../lib/flux-alloc" }' >> tock/.cargo/config.toml
 
       - name: Check tock/kernel
         run: |

--- a/lib/flux-alloc/src/string.rs
+++ b/lib/flux-alloc/src/string.rs
@@ -6,11 +6,11 @@ struct String;
 
 #[extern_spec]
 #[assoc(
-    fn eq(x: String, y: String) -> bool { x.val == y.val }
-    fn ne(x: String, y: String) -> bool { x.val != y.val }
+    fn is_eq(x: String, y: String, res: bool) -> bool { res <=> (x.val == y.val) }
+    fn is_ne(x: String, y: String, res: bool) -> bool { res <=> (x.val != y.val) }
 )]
 impl PartialEq for String {
-    #[spec(fn(&String[@s], &String[@t]) -> bool[<String as PartialEq>::eq(s, t)])]
+    #[spec(fn(&String[@s], &String[@t]) -> bool[s == t])]
     fn eq(&self, other: &String) -> bool;
 }
 

--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -2,21 +2,16 @@ use core::marker::PointeeSized;
 
 use flux_attrs::*;
 
-defs! {
-    fn uif_eq<A, B>(a: A, b: B) -> bool;
-    fn uif_ne<A, B>(a: A, b: B) -> bool;
-}
-
 #[extern_spec]
 #[assoc(
-    fn eq(x: Self, y: Rhs) -> bool { uif_eq(x, y) }
-    fn ne(x: Self, y: Rhs) -> bool { uif_ne(x, y) }
+    fn is_eq(x: Self, y: Rhs, res: bool) -> bool { true }
+    fn is_ne(x: Self, y: Rhs, res: bool) -> bool { true }
 )]
 trait PartialEq<Rhs: PointeeSized = Self>: PointeeSized {
-    #[spec(fn(&Self[@s], &Rhs[@t]) -> bool[Self::eq(s, t)] )]
+    #[spec(fn(&Self[@s], &Rhs[@t]) -> bool{v: Self::is_eq(s, t, v)})]
     fn eq(&self, other: &Rhs) -> bool;
 
-    #[spec(fn(&Self[@s], &Rhs[@t]) -> bool[Self::ne(s, t)] )]
+    #[spec(fn(&Self[@s], &Rhs[@t]) -> bool{v: Self::is_ne(s, t, v)})]
     fn ne(&self, other: &Rhs) -> bool;
 }
 
@@ -24,16 +19,16 @@ trait PartialEq<Rhs: PointeeSized = Self>: PointeeSized {
 macro_rules! eq {
     ($type_name:ident) => {
         #[specs {
-                            impl PartialEq for $type_name {
-                                #[reft] fn eq(self: $type_name, other: $type_name) -> bool {
-                                        self == other
-                                }
-                                #[reft] fn ne(self: $type_name, other: $type_name) -> bool {
-                                        self != other
-                                }
-                                fn eq(&$type_name[@v1], other: &$type_name[@v2]) -> bool[v1 == v2];
-                            }
-                        }]
+                    impl PartialEq for $type_name {
+                        #[reft] fn is_eq(self: $type_name, other: $type_name, res: bool) -> bool {
+                            res <=> (self == other)
+                        }
+                        #[reft] fn is_ne(self: $type_name, other: $type_name, res: bool) -> bool {
+                            res <=> (self != other)
+                        }
+                        fn eq(&$type_name[@v1], other: &$type_name[@v2]) -> bool[v1 == v2];
+                    }
+                }]
         const _: () = ();
     };
 }

--- a/tests/tests/pos/surface/bv_ord.rs
+++ b/tests/tests/pos/surface/bv_ord.rs
@@ -37,15 +37,12 @@ impl Sub for BV32 {
 }
 
 #[trusted]
-#[assoc(
-    fn eq(x: BV32, y: BV32) -> bool { x == y }
-)]
 impl PartialEq for BV32 {
-    #[sig(fn(&BV32[@val1], &BV32[@val2]) -> bool[<BV32 as PartialEq>::eq(val1, val2)])]
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
+flux_core::eq!(BV32);
 
 impl PartialOrd for BV32 {
     #[flux::trusted]


### PR DESCRIPTION
As the default (unrefined), derived `PartialEq` trivially holds, and you can add proper equality using `flux_core::eq!` if you want.