### PR TITLE
Detached hacks

### DIFF
--- a/crates/flux-driver/src/collector/detached_specs.rs
+++ b/crates/flux-driver/src/collector/detached_specs.rs
@@ -85,16 +85,10 @@ impl ScopeResolver {
         }
         for trait_impl_key in impl_resolver.items.keys() {
             if let LookupRes::DefId(trait_id) = trait_impl_key.trait_ {
-                // let name = tcx.item_name(trait_id);
                 let name = Symbol::intern(&tcx.def_path_str(trait_id));
-                // println!(
-                //     "TRACE: ScopeResolver: Found trait impl for trait_id={:?} name={}",
-                //     trait_id, name
-                // );
                 items.insert((name, DefKind::Trait), trait_impl_key.trait_);
             }
         }
-        // println!("TRACE: ScopeResolver: {:#?}", items);
         Self { items }
     }
 
@@ -213,10 +207,10 @@ impl<'a, 'sess, 'tcx> DetachedSpecsCollector<'a, 'sess, 'tcx> {
         {
             return Ok(impl_id);
         }
-        if let Some(LookupRes::DefId(def_id)) = self.id_resolver.get(&item.path.node_id) {
-            if let Some(local_def_id) = self.unwrap_def_id(def_id)? {
-                return Ok(local_def_id);
-            }
+        if let Some(LookupRes::DefId(def_id)) = self.id_resolver.get(&item.path.node_id)
+            && let Some(local_def_id) = self.unwrap_def_id(def_id)?
+        {
+            return Ok(local_def_id);
         }
         Err(self
             .inner

--- a/crates/flux-driver/src/collector/detached_specs.rs
+++ b/crates/flux-driver/src/collector/detached_specs.rs
@@ -8,7 +8,7 @@ use rustc_errors::ErrorGuaranteed;
 use rustc_hir::{
     OwnerId,
     def::{DefKind, Res},
-    def_id::{CRATE_DEF_ID, LocalDefId},
+    def_id::LocalDefId,
 };
 use rustc_middle::ty::{AssocItem, AssocKind, Ty, TyCtxt};
 use rustc_span::{Symbol, def_id::DefId};
@@ -129,12 +129,13 @@ impl<'a, 'sess, 'tcx> DetachedSpecsCollector<'a, 'sess, 'tcx> {
     pub(super) fn collect(
         inner: &'a mut SpecCollector<'sess, 'tcx>,
         attrs: &mut FluxAttrs,
+        module_id: LocalDefId,
     ) -> Result {
         if let Some(detached_specs) = attrs.detached_specs() {
             let trait_impl_resolver = TraitImplResolver::new(inner.tcx);
             let mut collector =
                 Self { inner, id_resolver: HashMap::default(), impl_resolver: trait_impl_resolver };
-            collector.run(detached_specs, CRATE_DEF_ID)?;
+            collector.run(detached_specs, module_id)?;
         };
         Ok(())
     }

--- a/crates/flux-driver/src/collector/detached_specs.rs
+++ b/crates/flux-driver/src/collector/detached_specs.rs
@@ -17,7 +17,6 @@ use crate::collector::{FluxAttrs, SpecCollector, errors};
 type Result<T = ()> = std::result::Result<T, ErrorGuaranteed>;
 
 #[derive(PartialEq, Eq, Debug, Hash, Clone, Copy)]
-// struct ImplKey(Symbol);
 enum LookupRes {
     DefId(DefId),
     Name(Symbol),
@@ -81,7 +80,6 @@ impl ScopeResolver {
         let mut items = HashMap::default();
         for child in tcx.module_children_local(def_id) {
             let ident = child.ident;
-            // println!("TRACE: scope-resolver::new : item = {:?} res = {:?}", ident.name, child.res);
 
             if let Res::Def(exp_kind, def_id) = child.res {
                 items.insert((ident.name, exp_kind), LookupRes::DefId(def_id));
@@ -126,15 +124,12 @@ impl TraitImplResolver {
                 }
             }
         }
-        // println!("TRACE: trait-impl-resolver = {:?}", items);
         Self { items }
     }
 
     fn resolve(&self, trait_: &ExprPath, self_ty: LookupRes) -> Option<LocalDefId> {
         let trait_ = path_to_symbol(trait_);
         let key = TraitImplKey { trait_, self_ty };
-        // println!("TRACE: trait-impl-resolver::resolve: items = {:?}", self.items);
-        // println!("TRACE: trait-impl-resolver::RESOLVE: key = {:?}", key);
         self.items.get(&key).copied()
     }
 }
@@ -161,7 +156,6 @@ impl<'a, 'sess, 'tcx> DetachedSpecsCollector<'a, 'sess, 'tcx> {
     }
 
     fn run(&mut self, detached_specs: surface::DetachedSpecs, def_id: LocalDefId) -> Result {
-        //println!("TRACE: detached-collector: run : {def_id:?}");
         self.resolve(&detached_specs, def_id)?;
         for item in detached_specs.items {
             self.attach(item)?;
@@ -171,11 +165,7 @@ impl<'a, 'sess, 'tcx> DetachedSpecsCollector<'a, 'sess, 'tcx> {
 
     fn resolve(&mut self, detached_specs: &surface::DetachedSpecs, def_id: LocalDefId) -> Result {
         let resolver = ScopeResolver::new(self.inner.tcx, def_id);
-        // println!("TRACE: detached-resolver = {resolver:?}");
         for item in &detached_specs.items {
-            // if matches!(item.kind, surface::ItemKind::TraitImpl(_)) {
-            //     continue;
-            // }
             let path = &item.path;
             let Some(def_id) = resolver.lookup(path, &item.kind) else {
                 return Err(self

--- a/crates/flux-driver/src/collector/mod.rs
+++ b/crates/flux-driver/src/collector/mod.rs
@@ -94,7 +94,7 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
         let mut attrs = self.parse_attrs_and_report_dups(CRATE_DEF_ID)?;
         self.collect_ignore_and_trusted(&mut attrs, CRATE_DEF_ID);
         self.collect_infer_opts(&mut attrs, CRATE_DEF_ID);
-        DetachedSpecsCollector::collect(self, &mut attrs)?;
+        DetachedSpecsCollector::collect(self, &mut attrs, CRATE_DEF_ID)?;
 
         self.specs
             .flux_items_by_parent
@@ -110,7 +110,13 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
         let mut attrs = self.parse_attrs_and_report_dups(owner_id.def_id)?;
         self.collect_ignore_and_trusted(&mut attrs, owner_id.def_id);
         self.collect_infer_opts(&mut attrs, owner_id.def_id);
-        DetachedSpecsCollector::collect(self, &mut attrs)?;
+
+        // Get the parent module's LocalDefId
+        let module_id = self
+            .tcx
+            .parent_module_from_def_id(owner_id.def_id)
+            .to_local_def_id();
+        DetachedSpecsCollector::collect(self, &mut attrs, module_id)?;
 
         match &item.kind {
             ItemKind::Fn { .. } => {

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -122,7 +122,7 @@ pub struct DetachedTraitImpl {
     pub span: Span,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct DetachedTrait {
     pub items: Vec<Item<FnSpec>>,
     pub refts: Vec<TraitAssocReft>,

--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -19,7 +19,7 @@ trait PartialEq<Rhs: PointeeSized = Self>: PointeeSized {
 macro_rules! eq {
     ($type_name:path) => {
         #[flux_rs::specs {
-                    impl PartialEq for $type_name {
+                    impl std::cmp::PartialEq for $type_name {
                         #[reft] fn is_eq(self: $type_name, other: $type_name, res: bool) -> bool {
                             res <=> (self == other)
                         }

--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -18,7 +18,7 @@ trait PartialEq<Rhs: PointeeSized = Self>: PointeeSized {
 #[macro_export]
 macro_rules! eq {
     ($type_name:path) => {
-        #[flux_rs::specs {
+        #[cfg_attr(flux, flux::specs {
                     impl std::cmp::PartialEq for $type_name {
                         #[reft] fn is_eq(self: $type_name, other: $type_name, res: bool) -> bool {
                             res <=> (self == other)

--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -18,7 +18,7 @@ trait PartialEq<Rhs: PointeeSized = Self>: PointeeSized {
 #[macro_export]
 macro_rules! eq {
     ($type_name:path) => {
-        #[specs {
+        #[flux_rs::specs {
                     impl PartialEq for $type_name {
                         #[reft] fn is_eq(self: $type_name, other: $type_name, res: bool) -> bool {
                             res <=> (self == other)

--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -17,7 +17,7 @@ trait PartialEq<Rhs: PointeeSized = Self>: PointeeSized {
 
 #[macro_export]
 macro_rules! eq {
-    ($type_name:ident) => {
+    ($type_name:path) => {
         #[specs {
                     impl PartialEq for $type_name {
                         #[reft] fn is_eq(self: $type_name, other: $type_name, res: bool) -> bool {

--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -28,7 +28,7 @@ macro_rules! eq {
                         }
                         fn eq(&$type_name[@v1], other: &$type_name[@v2]) -> bool[v1 == v2];
                     }
-                }]
+                })]
         const _: () = ();
     };
 }

--- a/tests/tests/neg/detached/detach_impl01.rs
+++ b/tests/tests/neg/detached/detach_impl01.rs
@@ -71,11 +71,11 @@ fn test_c() -> Usize {
       fn succ(n:Nat) -> Nat[n+1];
     }
 
-    impl From<Usize> for Nat {
+    impl std::convert::From<Usize> for Nat {
       fn from(n: Usize) -> Nat[n];
     }
 
-    impl From<Nat> for Usize {
+    impl std::convert::From<Nat> for Usize {
       fn from(n: Nat) -> Usize[n];
     }
 }]

--- a/tests/tests/neg/detached/detach_impl02.rs
+++ b/tests/tests/neg/detached/detach_impl02.rs
@@ -67,11 +67,11 @@ fn test_c() -> usize {
       fn succ(n:Nat) -> Nat[n+1];
     }
 
-    impl From<usize> for Nat {
+    impl std::convert::From<usize> for Nat {
       fn from(n: usize) -> Nat[n];
     }
 
-    impl From<Nat> for usize {
+    impl std::convert::From<Nat> for usize {
       fn from(n: Nat) -> usize[n];
     }
 }]

--- a/tests/tests/neg/error_messages/annot_check/invalid_detach_trait_impl00.rs
+++ b/tests/tests/neg/error_messages/annot_check/invalid_detach_trait_impl00.rs
@@ -2,7 +2,7 @@
 
 #[flux::specs {
 
-    impl Gromp for usize {  //~ ERROR unresolved item
+    impl Gromp for usize {  //~ ERROR unresolved
       fn gromp() -> usize[0];
     }
 

--- a/tests/tests/neg/error_messages/annot_check/invalid_detach_trait_impl01.rs
+++ b/tests/tests/neg/error_messages/annot_check/invalid_detach_trait_impl01.rs
@@ -2,7 +2,7 @@
 
 #[flux::specs {
 
-    impl From<u32> for busize { //~ ERROR unresolved item
+    impl From<u32> for busize { //~ ERROR unresolved name
       fn gromp() -> usize[0];
     }
 }]

--- a/tests/tests/pos/detached/detach_enum02.rs
+++ b/tests/tests/pos/detached/detach_enum02.rs
@@ -1,0 +1,25 @@
+pub mod wrapper {
+
+    pub enum Nat {
+        Zero,
+        Succ(Box<Nat>),
+    }
+
+    pub fn zero() -> Nat {
+        Nat::Zero
+    }
+
+    //
+    #[flux::specs {
+        #[refined_by(n: int)]
+        #[invariant(0 <= n)]
+        enum Nat {
+          Zero               -> Nat[0],
+          Succ(Box<Nat[@n]>) -> Nat[n+1],
+        }
+
+        fn zero() -> Nat[0];
+
+    }]
+    const _: () = ();
+}

--- a/tests/tests/pos/detached/detach_impl01.rs
+++ b/tests/tests/pos/detached/detach_impl01.rs
@@ -71,11 +71,11 @@ fn test_c() -> Usize {
       fn succ(n:Nat) -> Nat[n+1];
     }
 
-    impl From<Usize> for Nat {
+    impl std::convert::From<Usize> for Nat {
       fn from(n: Usize) -> Nat[n];
     }
 
-    impl From<Nat> for Usize {
+    impl std::convert::From<Nat> for Usize {
       fn from(n: Nat) -> Usize[n];
     }
 }]

--- a/tests/tests/pos/detached/detach_impl02.rs
+++ b/tests/tests/pos/detached/detach_impl02.rs
@@ -67,11 +67,11 @@ fn test_c() -> usize {
       fn succ(n:Nat) -> Nat[n+1];
     }
 
-    impl From<usize> for Nat {
+    impl std::convert::From<usize> for Nat {
       fn from(n: usize) -> Nat[n];
     }
 
-    impl From<Nat> for usize {
+    impl std::convert::From<Nat> for usize {
       fn from(n: Nat) -> usize[n];
     }
 }]

--- a/tests/tests/pos/detached/detach_impl03.rs
+++ b/tests/tests/pos/detached/detach_impl03.rs
@@ -1,0 +1,42 @@
+#![allow(unused)]
+
+extern crate flux_core;
+
+use flux_rs::{assert, attrs::*};
+
+pub mod wrapper {
+
+    #[flux_rs::reflect]
+    #[derive(PartialEq)]
+    pub enum Role {
+        User,
+        Admin,
+    }
+
+    #[flux_rs::specs {
+
+        impl PartialEq for Role {
+            #[reft] fn is_eq(self: Role, other: Role, res: bool) -> bool {
+                res <=> (self == other)
+            }
+            #[reft] fn is_ne(self: Role, other: Role, res: bool) -> bool {
+                res <=> (self != other)
+            }
+            fn eq(&Role[@r1], other: &Role[@r2]) -> bool[r1 == r2];
+        }
+
+    }]
+    const _: () = ();
+}
+
+fn test() {
+    use wrapper::Role;
+    let r1 = Role::User;
+    let r2 = Role::User;
+    let r3 = Role::Admin;
+    assert(r1 == r2); // checks
+    assert(r1 == r1); // checks
+    assert(r1 != r3); // checks
+}
+
+// --------------------------------------------------------------------------------------

--- a/tests/tests/pos/detached/detach_impl03.rs
+++ b/tests/tests/pos/detached/detach_impl03.rs
@@ -15,7 +15,7 @@ pub mod wrapper {
 
     #[flux_rs::specs {
 
-        impl PartialEq for Role {
+        impl std::cmp::PartialEq for Role {
             #[reft] fn is_eq(self: Role, other: Role, res: bool) -> bool {
                 res <=> (self == other)
             }

--- a/tests/tests/pos/detached/detach_impl04.rs
+++ b/tests/tests/pos/detached/detach_impl04.rs
@@ -1,0 +1,30 @@
+#![allow(unused)]
+
+extern crate flux_core;
+
+use flux_rs::{assert, attrs::*};
+
+pub mod wrapper {
+
+    use flux_rs::specs;
+
+    #[flux_rs::reflect]
+    #[derive(PartialEq)]
+    pub enum Role {
+        User,
+        Admin,
+    }
+    flux_core::eq!(Role);
+}
+
+fn test() {
+    use wrapper::Role;
+    let r1 = Role::User;
+    let r2 = Role::User;
+    let r3 = Role::Admin;
+    assert(r1 == r2); // checks
+    assert(r1 == r1); // checks
+    assert(r1 != r3); // checks
+}
+
+// --------------------------------------------------------------------------------------

--- a/tests/tests/pos/detached/detach_impl05.rs
+++ b/tests/tests/pos/detached/detach_impl05.rs
@@ -18,7 +18,7 @@ pub mod wrapper {
 
 #[flux_rs::specs {
     mod wrapper {
-        impl PartialEq for Role {
+        impl std::cmp::PartialEq for Role {
             #[reft] fn is_eq(self: Role, other: Role, res: bool) -> bool {
                 res <=> (self == other)
             }

--- a/tests/tests/pos/detached/detach_impl05.rs
+++ b/tests/tests/pos/detached/detach_impl05.rs
@@ -1,0 +1,44 @@
+#![allow(unused)]
+
+extern crate flux_core;
+
+use flux_rs::{assert, attrs::*};
+
+pub mod wrapper {
+
+    use flux_rs::specs;
+
+    #[flux_rs::reflect]
+    #[derive(PartialEq)]
+    pub enum Role {
+        User,
+        Admin,
+    }
+}
+
+#[flux_rs::specs {
+    mod wrapper {
+        impl PartialEq for Role {
+            #[reft] fn is_eq(self: Role, other: Role, res: bool) -> bool {
+                res <=> (self == other)
+            }
+            #[reft] fn is_ne(self: Role, other: Role, res: bool) -> bool {
+                res <=> (self != other)
+            }
+            fn eq(&Role[@r1], other: &Role[@r2]) -> bool[r1 == r2];
+        }
+    }
+}]
+const _: () = ();
+
+fn test() {
+    use wrapper::Role;
+    let r1 = Role::User;
+    let r2 = Role::User;
+    let r3 = Role::Admin;
+    assert(r1 == r2); // checks
+    assert(r1 == r1); // checks
+    assert(r1 != r3); // checks
+}
+
+// --------------------------------------------------------------------------------------

--- a/tests/tests/pos/detached/detach_impl05_macro.rs
+++ b/tests/tests/pos/detached/detach_impl05_macro.rs
@@ -1,0 +1,32 @@
+#![allow(unused)]
+
+extern crate flux_core;
+
+use flux_rs::{assert, attrs::*};
+
+pub mod wrapper {
+
+    use flux_rs::specs;
+
+    #[flux_rs::reflect]
+    #[derive(PartialEq)]
+    pub enum Role {
+        User,
+        Admin,
+    }
+}
+
+use wrapper::Role;
+flux_core::eq!(Role);
+
+fn test() {
+    use wrapper::Role;
+    let r1 = Role::User;
+    let r2 = Role::User;
+    let r3 = Role::Admin;
+    assert(r1 == r2); // checks
+    assert(r1 == r1); // checks
+    assert(r1 != r3); // checks
+}
+
+// --------------------------------------------------------------------------------------

--- a/tests/tests/pos/detached/detach_impl06.rs
+++ b/tests/tests/pos/detached/detach_impl06.rs
@@ -1,0 +1,55 @@
+#![allow(unused)]
+
+extern crate flux_core;
+
+use flux_rs::{assert, attrs::*};
+
+pub mod a {
+    pub mod b {
+        pub trait MyTrait {
+            fn gromp(&self) -> usize;
+        }
+    }
+}
+
+pub mod x {
+    pub mod y {
+        pub struct Thing<T> {
+            inner: T,
+        }
+
+        impl<T> Thing<T> {
+            pub fn new(inner: T) -> Self {
+                Thing { inner }
+            }
+        }
+
+        impl<T> crate::a::b::MyTrait for Thing<T> {
+            fn gromp(&self) -> usize {
+                42
+            }
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+mod test {
+    use crate::a::b::MyTrait;
+
+    #[flux_rs::spec(fn () -> usize[42])]
+    fn test() -> usize {
+        crate::x::y::Thing::new(true).gromp()
+    }
+}
+
+// -------------------------------------------------------------------
+#[flux_rs::specs {
+    mod x {
+        mod y {
+            impl MyTrait for Thing<T> {
+                fn gromp(&Self) -> usize[42];
+            }
+        }
+    }
+}]
+const _: () = ();

--- a/tests/tests/pos/detached/detach_impl06.rs
+++ b/tests/tests/pos/detached/detach_impl06.rs
@@ -46,7 +46,7 @@ mod test {
 #[flux_rs::specs {
     mod x {
         mod y {
-            impl MyTrait for Thing<T> {
+            impl a::b::MyTrait for Thing<T> {
                 fn gromp(&Self) -> usize[42];
             }
         }


### PR DESCRIPTION
Fixes @1311 and perhaps also @enjhnsn2 's issue but I can't seem to find a link to that.

Apologies in advance @nilehmann  -- the more I worked on the correct solution (using the `resolver`) the more difficult it seemed to get, and I really want to just get this working, finish the book chapters, and get back to `verify-std`!

This modest patch

1. Uses the names that are in the current scope of where the detached-spec is, and
2. Handles `TraitImpl` somewhat better (again, using the current scope).