### PR TITLE
Delay resolution of opaque types to desugaring

### DIFF
--- a/crates/flux-desugar/src/errors.rs
+++ b/crates/flux-desugar/src/errors.rs
@@ -141,3 +141,12 @@ impl UnsupportedConstGenericArg {
         Self { span, res_descr }
     }
 }
+
+#[derive(Diagnostic)]
+#[diag(desugar_unsupported_signature, code = E0999)]
+#[note]
+pub(super) struct UnsupportedSignature<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub note: &'a str,
+}

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -427,7 +427,6 @@ pub enum ExternSpecMappingErr {
 #[derive(Default)]
 pub struct ResolverOutput {
     pub path_res_map: UnordMap<NodeId, fhir::PartialRes>,
-    pub impl_trait_res_map: UnordMap<NodeId, LocalDefId>,
     /// Resolution of explicitly and implicitly scoped parameters. The [`fhir::ParamId`] is unique
     /// per item. The [`NodeId`] used as the key corresponds to the node introducing the parameter.
     /// When explicit, this is the id of the [`surface::GenericArg`] or [`surface::RefineParam`],


### PR DESCRIPTION
This is so we can get rid of the need for a `DefId` during name resolution, and we can use the infrastructure to resolve detached specs. 