### PR TITLE
Move eq-macro from under the cfg-flux gate

### DIFF
--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -14,21 +14,3 @@ trait PartialEq<Rhs: PointeeSized = Self>: PointeeSized {
     #[spec(fn(&Self[@s], &Rhs[@t]) -> bool{v: Self::is_ne(s, t, v)})]
     fn ne(&self, other: &Rhs) -> bool;
 }
-
-#[macro_export]
-macro_rules! eq {
-    ($type_name:path) => {
-        #[cfg_attr(flux, flux::specs {
-                    impl std::cmp::PartialEq for $type_name {
-                        #[reft] fn is_eq(self: $type_name, other: $type_name, res: bool) -> bool {
-                            res <=> (self == other)
-                        }
-                        #[reft] fn is_ne(self: $type_name, other: $type_name, res: bool) -> bool {
-                            res <=> (self != other)
-                        }
-                        fn eq(&$type_name[@v1], other: &$type_name[@v2]) -> bool[v1 == v2];
-                    }
-                })]
-        const _: () = ();
-    };
-}

--- a/lib/flux-core/src/lib.rs
+++ b/lib/flux-core/src/lib.rs
@@ -16,3 +16,23 @@ mod clone;
 
 #[cfg(flux)]
 mod slice;
+
+// -------------------------------------------------------------------
+
+#[macro_export]
+macro_rules! eq {
+    ($type_name:path) => {
+        #[cfg_attr(flux, flux::specs {
+                    impl std::cmp::PartialEq for $type_name {
+                        #[reft] fn is_eq(self: $type_name, other: $type_name, res: bool) -> bool {
+                            res <=> (self == other)
+                        }
+                        #[reft] fn is_ne(self: $type_name, other: $type_name, res: bool) -> bool {
+                            res <=> (self != other)
+                        }
+                        fn eq(&$type_name[@v1], other: &$type_name[@v2]) -> bool[v1 == v2];
+                    }
+                })]
+        const _: () = ();
+    };
+}


### PR DESCRIPTION
So we can apply it without any `cfg(flux)`