### PR TITLE
Update json parser to track fixpoint

### DIFF
--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -2,7 +2,7 @@ use derive_where::derive_where;
 #[cfg(feature = "rust-fixpoint")]
 use {
     crate::{
-        FixpointResult, Sort, SortCtor,
+        FixpointStatus, Sort, SortCtor,
         cstr2smt2::{Env, is_constraint_satisfiable, new_binding, new_datatype},
         graph,
     },

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -200,19 +200,25 @@ impl fmt::Display for SmtSolver {
     content = "contents",
     bound(deserialize = "Tag: FromStr", serialize = "Tag: ToString")
 )]
-pub enum FixpointResult<Tag> {
+pub enum FixpointStatus<Tag> {
     Safe(Stats),
     Unsafe(Stats, Vec<Error<Tag>>),
     Crash(CrashInfo),
 }
 
-impl<Tag> FixpointResult<Tag> {
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(bound(deserialize = "Tag: FromStr", serialize = "Tag: ToString"))]
+pub struct FixpointResult<Tag> {
+    pub status: FixpointStatus<Tag>,
+}
+
+impl<Tag> FixpointStatus<Tag> {
     pub fn is_safe(&self) -> bool {
-        matches!(self, FixpointResult::Safe(_))
+        matches!(self, FixpointStatus::Safe(_))
     }
 
-    pub fn merge(self, other: FixpointResult<Tag>) -> Self {
-        use FixpointResult as FR;
+    pub fn merge(self, other: FixpointStatus<Tag>) -> Self {
+        use FixpointStatus as FR;
         match (self, other) {
             (FR::Safe(stats1), FR::Safe(stats2)) => FR::Safe(stats1.merge(&stats2)),
             (FR::Safe(stats1), FR::Unsafe(stats2, errors)) => {


### PR DESCRIPTION
This PR https://github.com/ucsd-progsys/liquid-fixpoint/pull/764
changes the JSON output from fixpoint so it returns things besides 
the `status` (in particular, the kvar-solutions).

This PR updates flux so it reads the `.status` field of the returned JSON.