### PR TITLE
Add missing shift_in_escaping in BaseTy::to_ty

### DIFF
--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1858,7 +1858,10 @@ impl BaseTy {
         if sort.is_unit() {
             Ty::indexed(self.clone(), Expr::unit())
         } else {
-            Ty::exists(Binder::bind_with_sort(Ty::indexed(self.clone(), Expr::nu()), sort))
+            Ty::exists(Binder::bind_with_sort(
+                Ty::indexed(self.shift_in_escaping(1), Expr::nu()),
+                sort,
+            ))
         }
     }
 


### PR DESCRIPTION
`BaseTy::to_ty` puts the `BaseTy` under one more binder, so we need to shift in everything one level.