### PR TITLE
Split up opaque sorts from opaque functions

### DIFF
--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -176,6 +176,9 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
                     opaque_fun_defs
                         .push(ecx.fun_decl_to_fixpoint(spec_func.def_id.to_def_id(), &mut scx));
                 }
+                FluxItem::SortDecl(sort_decl) => {
+                    scx.declare_opaque_sort(sort_decl.def_id.to_def_id());
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
Split up opaque sorts from opaque functions to fit struct declarations between them in dependencies. This is needed to be able to write a demo that includes both vectors refined by a Map + a length and vectors refined by an opaque sort.

This doesn't address the ordering of dependencies among declared structures.