### PR TITLE
Don't A-normalize kvars

### DIFF
--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -160,7 +160,6 @@ pub enum SortCtor<T: Types> {
 #[derive_where(Hash, Clone, Debug)]
 pub enum Pred<T: Types> {
     And(Vec<Self>),
-    /// When translating to `Fixpoint`, the arguments should always be `Expr::Var`.
     KVar(T::KVar, Vec<Expr<T>>),
     Expr(Expr<T>),
 }


### PR DESCRIPTION
Since https://github.com/ucsd-progsys/liquid-fixpoint/pull/818, fixpoint accepts kvars with arbitrary expressions as arguments.