### PR TITLE
Only copy when source exists

### DIFF
--- a/crates/flux-infer/src/lean_encoding.rs
+++ b/crates/flux-infer/src/lean_encoding.rs
@@ -84,7 +84,7 @@ pub fn finalize(genv: GlobalEnv) -> io::Result<()> {
     let project = project();
     let src = genv.temp_dir().path().join(&project);
     let dst = base(genv).join(&project);
-    rename_dir_contents(&src, &dst)
+    if src.exists() { rename_dir_contents(&src, &dst) } else { Ok(()) }
 }
 
 fn project_path(genv: GlobalEnv, kind: FileKind) -> PathBuf {


### PR DESCRIPTION
In `LeanEncoding::finalize` I was getting a crash because the `src` path is not always there. This PR just skips the renaming step if the directory is missing.