### PR TITLE
Assume alias reft constants

### DIFF
--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -2232,7 +2232,10 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                         Box::new(constraint),
                     );
                 }
-                _ => {}
+                ConstKey::Alias(..)
+                | ConstKey::Cast(..)
+                | ConstKey::Lambda(..)
+                | ConstKey::PrimOp(..) => {}
             }
         }
         Ok(constraint)


### PR DESCRIPTION
As discussed with @ranjitjhala yesterday. Since these are opaque and only used in the VCs (i.e. not for function definitions too) we can just add them as assumptions to the VC.

Makes the emitted lean for `pos/surface/issue-1025.rs` make sense :)