### PR TITLE
Fix typo in tutorial markdown for `05-vectors`

### DIFF
--- a/book/src/tutorial/05-vectors.md
+++ b/book/src/tutorial/05-vectors.md
@@ -71,7 +71,7 @@ the `RVec`'s fields' values.
 
 This is quite _unlike_ [`Positivei32` example](./03-structs.md)
 where the index held the actual value of the field,
-or the [`Timer` example)(./04-enums.md) where the
+or the [`Timer` example](./04-enums.md) where the
 index held the value of the countdown.
 
 Instead, with an _opaque_ `struct` the idea is that the value


### PR DESCRIPTION
It does not render well in markdown, this patch fixes it.

Before: 
<img width="1155" height="121" alt="图片" src="https://github.com/user-attachments/assets/82358e52-9985-483b-aa5a-e14d52916ec9" />
After: 
<img width="2075" height="130" alt="图片" src="https://github.com/user-attachments/assets/2fe2953c-3607-45e2-bfac-99202995ef8f" />
