### PR TITLE
Add rudimentary support for pattern types

### DIFF
--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -896,6 +896,7 @@ impl TypeSuperVisitable for BaseTy {
             }
             BaseTy::Dynamic(exi_preds, _) => exi_preds.visit_with(visitor),
             BaseTy::Int(_)
+            | BaseTy::Pat
             | BaseTy::Uint(_)
             | BaseTy::Bool
             | BaseTy::Float(_)
@@ -948,6 +949,7 @@ impl TypeSuperFoldable for BaseTy {
             BaseTy::Dynamic(preds, region) => {
                 BaseTy::Dynamic(preds.try_fold_with(folder)?, region.try_fold_with(folder)?)
             }
+            BaseTy::Pat => BaseTy::Pat,
             BaseTy::Int(_)
             | BaseTy::Param(_)
             | BaseTy::Uint(_)

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1825,6 +1825,7 @@ pub enum BaseTy {
     Param(ParamTy),
     Infer(TyVid),
     Foreign(DefId),
+    Pat,
 }
 
 impl BaseTy {
@@ -2055,6 +2056,7 @@ impl BaseTy {
             | BaseTy::Param(_)
             | BaseTy::Dynamic(..)
             | BaseTy::Infer(_) => None,
+            BaseTy::Pat => todo!(),
         }
     }
 }
@@ -2122,6 +2124,7 @@ impl<'tcx> ToRustc<'tcx> for BaseTy {
                     RawPtrKind::FakeForPtrMetadata.to_mutbl_lossy(),
                 )
             }
+            BaseTy::Pat => todo!(),
         }
     }
 }

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -595,6 +595,7 @@ impl Pretty for BaseTy {
             BaseTy::Foreign(def_id) => {
                 w!(cx, f, "{:?}", def_id)
             }
+            BaseTy::Pat => todo!(),
         }
     }
 }
@@ -848,6 +849,7 @@ impl PrettyNested for BaseTy {
                 let children = float_children(kidss);
                 Ok(NestedString { text, children, key: None })
             }
+            BaseTy::Pat => todo!(),
         }
     }
 }

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -284,6 +284,7 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
                     .try_collect()?;
                 rty::BaseTy::Dynamic(exi_preds, *r)
             }
+            ty::TyKind::Pat => rty::BaseTy::Pat,
         };
         Ok(rty::TyOrBase::Base((self.refine)(bty)))
     }

--- a/crates/flux-middle/src/sort_of.rs
+++ b/crates/flux-middle/src/sort_of.rs
@@ -114,6 +114,7 @@ impl rty::BaseTy {
             | rty::BaseTy::Never
             | rty::BaseTy::Foreign(..) => rty::Sort::unit(),
             rty::BaseTy::Infer(_) => tracked_span_bug!(),
+            rty::BaseTy::Pat => rty::Sort::unit()
         }
     }
 }

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -536,6 +536,9 @@ impl BasicBlockEnvShape {
                     bty.clone()
                 }
             }
+            BaseTy::Pat => {
+                todo!()
+            }
             BaseTy::Infer(..) => {
                 tracked_span_bug!("unexpected infer type")
             }

--- a/crates/flux-rustc-bridge/src/lowering.rs
+++ b/crates/flux-rustc-bridge/src/lowering.rs
@@ -853,6 +853,7 @@ impl<'tcx> Lower<'tcx> for rustc_ty::Ty<'tcx> {
                 Ok(Ty::mk_dynamic(exi_preds, region))
             }
             rustc_ty::Foreign(def_id) => Ok(Ty::mk_foreign(*def_id)),
+            rustc_ty::Pat(..) => Ok(Ty::mk_pat()),
             _ => Err(UnsupportedReason::new(format!("unsupported type `{self:?}`"))),
         }
     }

--- a/crates/flux-rustc-bridge/src/ty/mod.rs
+++ b/crates/flux-rustc-bridge/src/ty/mod.rs
@@ -234,6 +234,7 @@ pub enum TyKind {
     RawPtr(Ty, Mutability),
     Dynamic(List<Binder<ExistentialPredicate>>, Region),
     Foreign(DefId),
+    Pat,
 }
 
 #[derive(PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
@@ -818,6 +819,10 @@ impl Ty {
         TyKind::Foreign(def_id).intern()
     }
 
+    pub fn mk_pat() -> Ty {
+        TyKind::Pat.intern()
+    }
+
     pub fn deref(&self) -> Ty {
         match self.kind() {
             TyKind::Adt(adt_def, args) if adt_def.is_box() => args[0].expect_type().clone(),
@@ -969,6 +974,7 @@ impl<'tcx> ToRustc<'tcx> for Ty {
                 let preds = tcx.mk_poly_existential_predicates(&preds);
                 rustc_ty::Ty::new_dynamic(tcx, preds, re.to_rustc(tcx))
             }
+            TyKind::Pat => todo!(),
             TyKind::Coroutine(_, _) | TyKind::CoroutineWitness(_, _) => {
                 bug!("TODO: to_rustc for `{self:?}`")
             }
@@ -1130,6 +1136,7 @@ impl fmt::Debug for Ty {
             TyKind::Foreign(def_id) => {
                 write!(f, "Foreign {def_id:?}")
             }
+            TyKind::Pat => todo!(),
         }
     }
 }

--- a/crates/flux-rustc-bridge/src/ty/subst.rs
+++ b/crates/flux-rustc-bridge/src/ty/subst.rs
@@ -52,6 +52,7 @@ impl Subst for Ty {
             TyKind::FnPtr(fn_sig) => Ty::mk_fn_ptr(fn_sig.subst(args)),
             TyKind::Dynamic(exi_preds, re) => Ty::mk_dynamic(exi_preds.subst(args), *re),
             TyKind::Foreign(def_id) => Ty::mk_foreign(*def_id),
+            TyKind::Pat => todo!(),
             TyKind::Bool
             | TyKind::Uint(_)
             | TyKind::Str


### PR DESCRIPTION
This adds variants for pattern types and enough support to be able to process the pattern type impls in `core/src/pat.rs`, such as

```rust
impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<pattern_type!(U is !null)> for pattern_type!(T is !null) {}
```

This will panic if a pattern type is used in any other way.

fixes #1439 