### PR TITLE
Correctly shift in predicate in `CanonicalTy::as_ty_or_base`

### DIFF
--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1848,24 +1848,17 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         let len = into.len();
         for (idx, arg) in segment.args.iter().enumerate() {
             let param = generics.param_at(idx + len, self.genv())?;
-            match arg {
+            let arg = match arg {
                 fhir::GenericArg::Lifetime(lft) => {
-                    into.push(rty::GenericArg::Lifetime(self.conv_lifetime(
-                        env,
-                        *lft,
-                        segment.ident.span,
-                    )));
+                    rty::GenericArg::Lifetime(self.conv_lifetime(env, *lft, segment.ident.span))
                 }
-                fhir::GenericArg::Type(ty) => {
-                    into.push(self.conv_ty_to_generic_arg(env, &param, ty)?);
-                }
-                fhir::GenericArg::Const(cst) => {
-                    into.push(rty::GenericArg::Const(self.conv_const_arg(*cst)));
-                }
+                fhir::GenericArg::Type(ty) => self.conv_ty_to_generic_arg(env, &param, ty)?,
+                fhir::GenericArg::Const(cst) => rty::GenericArg::Const(self.conv_const_arg(*cst)),
                 fhir::GenericArg::Infer => {
-                    into.push(self.conv_generic_arg_hole(env, param, segment.ident.span)?);
+                    self.conv_generic_arg_hole(env, param, segment.ident.span)?
                 }
-            }
+            };
+            into.push(arg);
         }
         self.fill_generic_args_defaults(def_id, into)
     }

--- a/crates/flux-middle/src/rty/canonicalize.rs
+++ b/crates/flux-middle/src/rty/canonicalize.rs
@@ -386,9 +386,12 @@ impl CanonicalTy {
                     // only check for syntactical equality. We should change those cases to handle
                     // refined types and/or ensure some canonical representation for unrefined types.
                     let pred = if idx.is_unit() {
-                        constr_ty.pred.clone()
+                        constr_ty.pred.shift_in_escaping(1)
                     } else {
-                        Expr::and(&constr_ty.pred, Expr::eq(Expr::nu(), idx.shift_in_escaping(1)))
+                        Expr::and(
+                            constr_ty.pred.shift_in_escaping(1),
+                            Expr::eq(Expr::nu(), idx.shift_in_escaping(1)),
+                        )
                     };
                     let sort = bty.sort();
                     let constr = SubsetTy::new(bty.shift_in_escaping(1), Expr::nu(), pred);

--- a/tests/tests/pos/surface/issue-1463.rs
+++ b/tests/tests/pos/surface/issue-1463.rs
@@ -1,0 +1,9 @@
+type Unit = ();
+
+#[flux_rs::spec(fn(a : &mut i32[@foo]) -> Result<Unit { v : (new_foo == foo + 10)}, Unit>
+    ensures a : i32[#new_foo]
+)]
+fn test(a: &mut i32) -> Result<Unit, Unit> {
+    *a += 10;
+    Ok(())
+}


### PR DESCRIPTION
Fixes #1463 