### PR TITLE
Correctly return generics for box when Box is in the local crate

### DIFF
--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -458,10 +458,7 @@ fn generics_of(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult<rty::Gener
         | DefKind::Closure
         | DefKind::TraitAlias
         | DefKind::Ctor(..)
-        | DefKind::Static { .. } => {
-            let rustc_generics = genv.lower_generics_of(def_id);
-            refining::refine_generics(genv, def_id.resolved_id(), &rustc_generics)
-        }
+        | DefKind::Static { .. } => refining::refine_generics(&genv.lower_generics_of(def_id)),
         kind => {
             Err(query_bug!(
                 def_id.local_id(),

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -32,7 +32,7 @@ use crate::{
     global_env::GlobalEnv,
     rty::{
         self, AliasReft, Expr, GenericArg,
-        refining::{self, Refine, Refiner},
+        refining::{self, Refine, Refiner, refine_generic_param_def},
     },
 };
 
@@ -682,15 +682,49 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
     }
 
     pub(crate) fn generics_of(&self, genv: GlobalEnv, def_id: DefId) -> QueryResult<rty::Generics> {
+        // Box is special: its first type parameter (the pointee `T`) is refined as a `Type` rather
+        // than a `Base`. This allows refinements to "see through" the Box, similar to how references
+        // work.
+        if genv.tcx().is_lang_item(def_id, LangItem::OwnedBox) {
+            let generics = genv.lower_generics_of(def_id);
+            debug_assert_eq!(generics.params.len(), 2);
+            let deref_ty = &generics.params[0];
+            let alloc = &generics.params[1];
+            return Ok(rty::Generics {
+                own_params: List::from_arr([
+                    refine_generic_param_def(true, deref_ty),
+                    refine_generic_param_def(false, alloc),
+                ]),
+                parent: generics.parent(),
+                parent_count: generics.parent_count(),
+                has_self: generics.orig.has_self,
+            });
+        }
+        // `MetaSized` is a marker trait with a single `Self` type parameter. We refine it as `Type`
+        // (rather than `Base`) so that a type parameter `T` of kind `Type` can flow through bounds
+        // like `T: MetaSized`. This is required because `Box` is defined as `Box<T: ?Sized, ...>`
+        // which desugars to the bound `T: MetaSized`. This should be mostly fine because parameters
+        // of both kinds should be able to satisfy `MetaSized` bounds, but it will cause problems
+        // if we ever try to add associated refinements to `MetaSized` like we did for `Sized`.
+        if genv.tcx().is_lang_item(def_id, LangItem::MetaSized) {
+            let generics = genv.lower_generics_of(def_id);
+            debug_assert_eq!(generics.params.len(), 1);
+            let self_ty = &generics.params[0];
+            return Ok(rty::Generics {
+                own_params: List::from_arr([refine_generic_param_def(true, self_ty)]),
+                parent: generics.parent(),
+                parent_count: generics.parent_count(),
+                has_self: generics.orig.has_self,
+            });
+        }
+
         run_with_cache(&self.generics_of, def_id, || {
             def_id.dispatch_query(
                 genv,
                 self,
                 |def_id| (self.providers.generics_of)(genv, def_id),
                 |def_id| genv.cstore().generics_of(def_id),
-                |def_id| {
-                    Ok(refining::refine_generics(genv, def_id, &genv.lower_generics_of(def_id)))
-                },
+                |def_id| Ok(refining::refine_generics(&genv.lower_generics_of(def_id))),
             )
         })
     }

--- a/crates/flux-middle/src/rty/canonicalize.rs
+++ b/crates/flux-middle/src/rty/canonicalize.rs
@@ -203,10 +203,7 @@ impl<D: HoisterDelegate> TypeFolder for Hoister<D> {
         match bty {
             BaseTy::Adt(adt_def, args) if adt_def.is_box() && self.in_boxes => {
                 let (boxed, alloc) = args.box_args();
-                let args = List::from_arr([
-                    GenericArg::Ty(boxed.fold_with(self)),
-                    GenericArg::Ty(alloc.clone()),
-                ]);
+                let args = List::from_arr([GenericArg::Ty(boxed.fold_with(self)), alloc.clone()]);
                 BaseTy::Adt(adt_def.clone(), args)
             }
             BaseTy::Ref(re, ty, mutability) if is_indexed_slice(ty) && self.slices => {

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -8,7 +8,7 @@ use flux_common::bug;
 use flux_rustc_bridge::{ty, ty::GenericArgsExt as _};
 use itertools::Itertools;
 use rustc_abi::VariantIdx;
-use rustc_hir::{def::DefKind, def_id::DefId};
+use rustc_hir::def_id::DefId;
 use rustc_middle::ty::ParamTy;
 
 use super::{RefineArgsExt, fold::TypeFoldable};
@@ -19,23 +19,11 @@ use crate::{
     rty::{self, Expr},
 };
 
-pub fn refine_generics(genv: GlobalEnv, def_id: DefId, generics: &ty::Generics) -> rty::Generics {
-    let is_box = if let DefKind::Struct = genv.def_kind(def_id) {
-        genv.tcx().adt_def(def_id).is_box()
-    } else {
-        false
-    };
+pub fn refine_generics(generics: &ty::Generics) -> rty::Generics {
     let params = generics
         .params
         .iter()
-        .map(|param| {
-            rty::GenericParamDef {
-                kind: refine_generic_param_def_kind(is_box, param.kind),
-                index: param.index,
-                name: param.name,
-                def_id: param.def_id,
-            }
-        })
+        .map(|param| refine_generic_param_def(false, param))
         .collect();
 
     rty::Generics {
@@ -46,14 +34,26 @@ pub fn refine_generics(genv: GlobalEnv, def_id: DefId, generics: &ty::Generics) 
     }
 }
 
-pub fn refine_generic_param_def_kind(
-    is_box: bool,
+pub(crate) fn refine_generic_param_def(
+    as_type: bool,
+    param: &ty::GenericParamDef,
+) -> rty::GenericParamDef {
+    rty::GenericParamDef {
+        kind: refine_generic_param_def_kind(as_type, param.kind),
+        index: param.index,
+        name: param.name,
+        def_id: param.def_id,
+    }
+}
+
+fn refine_generic_param_def_kind(
+    as_type: bool,
     kind: ty::GenericParamDefKind,
 ) -> rty::GenericParamDefKind {
     match kind {
         ty::GenericParamDefKind::Lifetime => rty::GenericParamDefKind::Lifetime,
         ty::GenericParamDefKind::Type { has_default } => {
-            if is_box {
+            if as_type {
                 rty::GenericParamDefKind::Type { has_default }
             } else {
                 rty::GenericParamDefKind::Base { has_default }

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -33,7 +33,7 @@ pub(crate) struct Binding {
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub(crate) enum LocKind {
     Local,
-    Box(Ty),
+    Box(GenericArg),
     // An &mut T unfolded "locally" at a call-site; with the super-type T
     LocalPtr(Ty),
     Universal,
@@ -471,7 +471,7 @@ impl<'a, 'infcx, 'genv, 'tcx> Unfolder<'a, 'infcx, 'genv, 'tcx> {
                 if self.in_ref.is_some() {
                     let args = List::from_arr([
                         GenericArg::Ty(deref_ty.try_fold_with(self)?),
-                        GenericArg::Ty(alloc.clone()),
+                        alloc.clone(),
                     ]);
                     Ty::indexed(BaseTy::Adt(adt.clone(), args), idx.clone())
                 } else {
@@ -500,7 +500,7 @@ impl<'a, 'infcx, 'genv, 'tcx> Unfolder<'a, 'infcx, 'genv, 'tcx> {
         self.insertions.push((loc, Binding { kind, ty }));
     }
 
-    fn unfold_box(&mut self, deref_ty: &Ty, alloc: &Ty) -> Loc {
+    fn unfold_box(&mut self, deref_ty: &Ty, alloc: &GenericArg) -> Loc {
         let name = self.infcx.define_unknown_var(&Sort::Loc);
         let loc = Loc::from(name);
         self.insertions
@@ -650,10 +650,8 @@ where
         match ty.kind() {
             TyKind::Indexed(BaseTy::Adt(adt, args), idx) if adt.is_box() => {
                 let (deref_ty, alloc_ty) = args.box_args();
-                let args = List::from_arr([
-                    GenericArg::Ty(self.fold_ty(deref_ty)),
-                    GenericArg::Ty(alloc_ty.clone()),
-                ]);
+                let args =
+                    List::from_arr([GenericArg::Ty(self.fold_ty(deref_ty)), alloc_ty.clone()]);
                 Ty::indexed(BaseTy::Adt(adt.clone(), args), idx.clone())
             }
             TyKind::Ptr(..) => {


### PR DESCRIPTION
This PR makes a few changes

1. Intercept the `generics_of` queries before dispatching them, such that the special casing works when defined in the current crate (when we are analyzing `alloc`)
2. Make the first argument of Box `GenericArg::Base` and the second `GenericArg::Ty`
3. Special case `MetaSized` to make the bound `T: MetaSized` in the definition of `Box` well-formed (since `T` is `GenericArg::Ty` in that definition)