### PR TITLE
Fix pretty printing of canonical types

### DIFF
--- a/crates/flux-middle/src/rty/canonicalize.rs
+++ b/crates/flux-middle/src/rty/canonicalize.rs
@@ -445,34 +445,25 @@ mod pretty {
                             None
                         };
 
-                        let bound_var_layer = cx.bvar_env.peek_layer().unwrap();
-                        let vars = poly_constr
-                            .vars()
-                            .into_iter()
-                            .enumerate()
-                            .filter_map(|(idx, var)| {
-                                let not_removed = !bound_var_layer
-                                    .successfully_removed_vars
-                                    .contains(&BoundVar::from_usize(idx));
-                                let refine_var = matches!(var, BoundVariableKind::Refine(..));
-                                if not_removed && refine_var { Some(var.clone()) } else { None }
-                            })
-                            .collect_vec();
+                        let vars = cx
+                            .bvar_env
+                            .peek_layer()
+                            .unwrap()
+                            .filter_vars(poly_constr.vars());
 
                         if vars.is_empty() {
                             if let Some(pred_fmt) = pred_fmt {
-                                w!(cx, f, "{{ {} | {} }}", ^ty_fmt, ^pred_fmt)
+                                write!(f, "{{ {ty_fmt} | {pred_fmt} }}")
                             } else {
-                                w!(cx, f, "{}", ^ty_fmt)
+                                write!(f, "{ty_fmt}")
                             }
                         } else {
-                            let left = "{";
-                            let right = if let Some(pred_fmt) = pred_fmt {
-                                format_cx!(cx, ". {} | {} }}", ^ty_fmt, ^pred_fmt)
+                            cx.fmt_bound_vars(false, "{{", &vars, ". ", f)?;
+                            if let Some(pred_fmt) = pred_fmt {
+                                write!(f, "{ty_fmt} | {pred_fmt} }}")
                             } else {
-                                format_cx!(cx, ". {} }}", ^ty_fmt)
-                            };
-                            cx.fmt_bound_vars(false, left, &vars, &right, f)
+                                write!(f, "{ty_fmt} }}")
+                            }
                         }
                     })
                 }

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -73,24 +73,7 @@ fn format_fn_root_binder<T: Pretty + TypeVisitable>(
         // Then remove any vars that we added a decorator to.
         //
         // As well as any vars that we are removing because they are redundant.
-        let BoundVarLayer {
-            successfully_removed_vars,
-            layer_map: BoundVarLayerMap::FnRootLayerMap(fn_root_layer),
-            ..
-        } = cx.bvar_env.peek_layer().unwrap()
-        else {
-            unreachable!()
-        };
-        let filtered_vars = vars
-            .into_iter()
-            .enumerate()
-            .filter_map(|(idx, var)| {
-                let not_removed = !successfully_removed_vars.contains(&BoundVar::from_usize(idx));
-                let refine_var = matches!(var, BoundVariableKind::Refine(..));
-                let not_seen = !fn_root_layer.seen_vars.contains(&BoundVar::from_usize(idx));
-                if not_removed && refine_var && not_seen { Some(var.clone()) } else { None }
-            })
-            .collect_vec();
+        let filtered_vars = cx.bvar_env.peek_layer().unwrap().filter_vars(vars);
         if filtered_vars.is_empty() {
             write!(f, "{}", body)
         } else {


### PR DESCRIPTION
Fixes #1444

This simplifies `PrettyCx::with_bound_vars_removable` and moves to the caller the responsibility to recurse into the value of the binder before printing variables. 