### PR TITLE
Add a `prop` primitive sort

### DIFF
--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -637,6 +637,8 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
             Some(fhir::SortRes::PrimSort(fhir::PrimSort::Str))
         } else if segment.name == sym::ptr {
             Some(fhir::SortRes::PrimSort(fhir::PrimSort::RawPtr))
+        } else if segment.name == sym::prop {
+            Some(fhir::SortRes::PrimSort(fhir::PrimSort::Prop))
         } else {
             None
         }

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -877,6 +877,10 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 self.check_prim_sort_generics(path, fhir::PrimSort::RawPtr)?;
                 return Ok(rty::Sort::RawPtr);
             }
+            fhir::SortRes::PrimSort(fhir::PrimSort::Prop) => {
+                self.check_prim_sort_generics(path, fhir::PrimSort::Prop)?;
+                return Ok(rty::Sort::Prop);
+            }
             fhir::SortRes::SortParam(n) => return Ok(rty::Sort::Var(rty::ParamSort::from(n))),
             fhir::SortRes::TyParam(def_id) => {
                 if !path.args.is_empty() {

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -368,7 +368,7 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
                             Err(self.emit_field_not_found(&sort, fld))
                         }
                     }
-                    rty::Sort::Bool | rty::Sort::Int | rty::Sort::Real => {
+                    rty::Sort::Bool | rty::Sort::Prop | rty::Sort::Int | rty::Sort::Real => {
                         Err(self.emit_err(errors::InvalidPrimitiveDotAccess::new(&sort, fld)))
                     }
                     _ => Err(self.emit_field_not_found(&sort, fld)),
@@ -704,6 +704,7 @@ impl<'genv> InferCtxt<'genv, '_> {
             (rty::Sort::BitVec(size1), rty::Sort::BitVec(size2)) => {
                 self.try_equate_bv_sizes(*size1, *size2)?;
             }
+            (rty::Sort::Bool, rty::Sort::Prop) | (rty::Sort::Prop, rty::Sort::Bool) => {}
             _ if sort1 == sort2 => {}
             _ => return None,
         }

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -312,6 +312,7 @@ impl SortEncodingCtxt {
             rty::Sort::Int => fixpoint::Sort::Int,
             rty::Sort::Real => fixpoint::Sort::Real,
             rty::Sort::Bool => fixpoint::Sort::Bool,
+            rty::Sort::Prop => fixpoint::Sort::Prop,
             rty::Sort::Str => fixpoint::Sort::Str,
             rty::Sort::Char => fixpoint::Sort::Int,
             rty::Sort::BitVec(size) => fixpoint::Sort::BitVec(Box::new(bv_size_to_fixpoint(*size))),

--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -315,6 +315,7 @@ impl LeanFmt for Sort {
     fn lean_fmt(&self, f: &mut std::fmt::Formatter, cx: &LeanCtxt) -> std::fmt::Result {
         match self {
             Sort::Int => write!(f, "Int"),
+            Sort::Prop => write!(f, "Prop"),
             Sort::Bool => {
                 match cx.bool_mode {
                     BoolMode::Bool => write!(f, "Bool"),

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -884,6 +884,7 @@ pub enum PrimSort {
     Map,
     Str,
     RawPtr,
+    Prop,
 }
 
 impl PrimSort {
@@ -897,6 +898,7 @@ impl PrimSort {
             PrimSort::Set => "Set",
             PrimSort::Map => "Map",
             PrimSort::RawPtr => "ptr",
+            PrimSort::Prop => "prop",
         }
     }
 
@@ -908,7 +910,8 @@ impl PrimSort {
             | PrimSort::Real
             | PrimSort::Char
             | PrimSort::Str
-            | PrimSort::RawPtr => 0,
+            | PrimSort::RawPtr
+            | PrimSort::Prop => 0,
             PrimSort::Set => 1,
             PrimSort::Map => 2,
         }
@@ -1689,6 +1692,7 @@ impl fmt::Debug for SortRes {
             SortRes::PrimSort(PrimSort::Set) => write!(f, "Set"),
             SortRes::PrimSort(PrimSort::Map) => write!(f, "Map"),
             SortRes::PrimSort(PrimSort::RawPtr) => write!(f, "ptr"),
+            SortRes::PrimSort(PrimSort::Prop) => write!(f, "prop"),
             SortRes::SortParam(n) => write!(f, "@{n}"),
             SortRes::TyParam(def_id) => write!(f, "{}::sort", def_id_to_string(*def_id)),
             SortRes::SelfParam { trait_id } => {

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -594,6 +594,7 @@ impl TypeSuperVisitable for Sort {
             Sort::Alias(_, alias_ty) => alias_ty.visit_with(visitor),
             Sort::Int
             | Sort::Bool
+            | Sort::Prop
             | Sort::Real
             | Sort::Str
             | Sort::Char
@@ -623,6 +624,7 @@ impl TypeSuperFoldable for Sort {
             Sort::Alias(kind, alias_ty) => Sort::Alias(*kind, alias_ty.try_fold_with(folder)?),
             Sort::Int
             | Sort::Bool
+            | Sort::Prop
             | Sort::Real
             | Sort::Loc
             | Sort::Str

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1032,6 +1032,7 @@ impl ena::unify::EqUnifyValue for BvSize {}
 pub enum Sort {
     Int,
     Bool,
+    Prop,
     Real,
     BitVec(BvSize),
     Str,
@@ -1101,12 +1102,13 @@ impl Sort {
         matches!(self, Sort::Func(fsort) if fsort.skip_binders().output().is_bool())
     }
 
-    /// Returns `true` if the sort is [`Bool`].
+    /// Returns `true` if the sort is [`Bool`] or [`Prop`].
     ///
     /// [`Bool`]: Sort::Bool
+    /// [`Prop`]: Sort::Prop
     #[must_use]
     pub fn is_bool(&self) -> bool {
-        matches!(self, Self::Bool)
+        matches!(self, Self::Bool | Self::Prop)
     }
 
     pub fn cast_kind(self: &Sort, to: &Sort) -> CastKind {
@@ -1114,7 +1116,7 @@ impl Sort {
             || (matches!(self, Sort::Char | Sort::Int) && matches!(to, Sort::Char | Sort::Int))
         {
             CastKind::Identity
-        } else if matches!(self, Sort::Bool) && matches!(to, Sort::Int) {
+        } else if matches!(self, Sort::Bool | Sort::Prop) && matches!(to, Sort::Int) {
             CastKind::BoolToInt
         } else if to.is_unit() {
             CastKind::IntoUnit

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -114,6 +114,7 @@ impl Pretty for Sort {
     fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Sort::Bool => w!(cx, f, "bool"),
+            Sort::Prop => w!(cx, f, "prop"),
             Sort::Int => w!(cx, f, "int"),
             Sort::Real => w!(cx, f, "real"),
             Sort::Str => w!(cx, f, "str"),

--- a/crates/flux-syntax/src/symbols.rs
+++ b/crates/flux-syntax/src/symbols.rs
@@ -26,6 +26,7 @@ symbols! {
         int,
         no_panic,
         no_panic_if,
+        prop,
         ptr_size,
         real,
     }

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -115,6 +115,7 @@ pub struct DataField<T: Types> {
 pub enum Sort<T: Types> {
     Int,
     Bool,
+    Prop,
     Real,
     Str,
     BitVec(Box<Sort<T>>),
@@ -177,6 +178,7 @@ impl<T: Types> Sort<T> {
             Sort::Int
             | Sort::Real
             | Sort::Bool
+            | Sort::Prop
             | Sort::Str
             | Sort::BvSize(..)
             | Sort::BitVec(..) => {}

--- a/lib/liquid-fixpoint/src/cstr2smt2.rs
+++ b/lib/liquid-fixpoint/src/cstr2smt2.rs
@@ -574,7 +574,9 @@ pub(crate) fn new_binding<T: Types>(name: &T::Var, sort: &Sort<T>, env: &Env<T>)
     match &sort {
         Sort::Int => Binding::Variable(ast::Int::new_const(name.display().to_string()).into()),
         Sort::Real => Binding::Variable(ast::Real::new_const(name.display().to_string()).into()),
-        Sort::Bool => Binding::Variable(ast::Bool::new_const(name.display().to_string()).into()),
+        Sort::Bool | Sort::Prop => {
+            Binding::Variable(ast::Bool::new_const(name.display().to_string()).into())
+        }
         Sort::Str => Binding::Variable(ast::String::new_const(name.display().to_string()).into()),
         Sort::Func(sorts) => {
             let mut domain = vec![z3_sort(&sorts[0], env)];
@@ -635,7 +637,7 @@ fn z3_sort<T: Types>(s: &Sort<T>, env: &Env<T>) -> z3::Sort {
     match s {
         Sort::Int => z3::Sort::int(),
         Sort::Real => z3::Sort::real(),
-        Sort::Bool => z3::Sort::bool(),
+        Sort::Bool | Sort::Prop => z3::Sort::bool(),
         Sort::Str => z3::Sort::string(),
         Sort::BitVec(bv_size) => {
             match **bv_size {

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -228,6 +228,7 @@ impl<T: Types> fmt::Display for Sort<T> {
         match self {
             Sort::Int => write!(f, "int"),
             Sort::Bool => write!(f, "bool"),
+            Sort::Prop => write!(f, "bool"),
             Sort::Real => write!(f, "real"),
             Sort::Str => write!(f, "Str"),
             Sort::Var(i) => write!(f, "@({i})"),


### PR DESCRIPTION
Which is treated identical to `bool` as far as `flux` and `fixpoint` and `z3` are concerned, but rendered as `Prop` inside lean. (To let us write lean predicates like `is_sorted` or `is_prime` etc. as `BLAH -> Prop`.)