### PR TITLE
Include functions used in qualifiers in fixpoint constraint encoding

### DIFF
--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -575,7 +575,6 @@ where
         solver: SmtSolver,
     ) -> QueryResult<fixpoint::Task> {
         let kvars = self.kcx.encode_kvars(&self.kvars, &mut self.scx);
-        let define_funs = self.ecx.define_funs(def_id, &mut self.scx)?;
 
         let qualifiers = self
             .ecx
@@ -589,6 +588,10 @@ where
         let constraint = self.ecx.assume_const_values(constraint, &mut self.scx)?;
 
         let constants = self.ecx.const_env.const_map.values().cloned().collect_vec();
+
+        // Encode function bodies after qualifiers/assumptions so any functions referenced there
+        // are picked up as dependencies.
+        let define_funs = self.ecx.define_funs(def_id, &mut self.scx)?;
 
         // The rust fixpoint implementation does not yet support polymorphic functions.
         // For now we avoid including these by default so that cases where they are not needed can work.

--- a/tests/tests/pos/surface/issue-1505.rs
+++ b/tests/tests/pos/surface/issue-1505.rs
@@ -1,0 +1,15 @@
+flux_rs::defs! {
+    fn foo(x: int) -> bool;
+    qualifier Foo(x: int) {
+        foo(x)
+    }
+}
+
+#[flux::spec(fn(x: usize[@n]) -> usize{ v : v >= 5 })]
+fn test(x: usize) -> usize {
+    let mut i = x;
+    while i < 5 {
+        i += 1;
+    }
+    i
+}


### PR DESCRIPTION
Fixing #1505 (thanks Codex!).