### PR TITLE
Don't ICE when normalizing associated refinements on dynamic objects

### DIFF
--- a/tests/tests/neg/surface/assoc_reft11.rs
+++ b/tests/tests/neg/surface/assoc_reft11.rs
@@ -1,0 +1,11 @@
+// Test that we don't fail when normalizing an associated refinement on a dynamic object
+
+#[flux::assoc(fn blueberry_assoc(x: int) -> bool)]
+pub trait MyTrait {
+    #[flux::sig(fn(&Self, x: i32{Self::blueberry_assoc(x)}))]
+    fn blueberry(&self, x: i32);
+}
+
+fn foo(s: &dyn MyTrait) {
+    s.blueberry(0); //~ ERROR refinement type error
+}

--- a/tests/tests/pos/surface/assoc_reft11.rs
+++ b/tests/tests/pos/surface/assoc_reft11.rs
@@ -1,0 +1,11 @@
+// Test that we don't fail when normalizing an associated refinement on a dynamic object
+
+#[flux::assoc(fn blueberry_assoc(x: int) -> bool)]
+pub trait MyTrait {
+    #[flux::sig(fn(&Self) -> i32{v: Self::blueberry_assoc(v) })]
+    fn blueberry(&self) -> i32;
+}
+
+fn foo(s: &dyn MyTrait) {
+    s.blueberry();
+}


### PR DESCRIPTION
Closes #1519 