### PR TITLE
Translate Flux Bool to Prop in Lean and open Classical everywhere

### DIFF
--- a/crates/flux-infer/src/lean_encoding.rs
+++ b/crates/flux-infer/src/lean_encoding.rs
@@ -419,11 +419,7 @@ impl<'genv, 'tcx> LeanEncoder<'genv, 'tcx> {
             writeln!(file, "{}", &LeanFile::Fluxlib.import(self.genv))?;
             writeln!(file, "{}", self.open_classical())?;
             namespaced(&mut file, |f| {
-                writeln!(
-                    f,
-                    "noncomputable def {} := sorry",
-                    WithLeanCtxt { item: sort, cx: &self.lean_cx() }
-                )
+                writeln!(f, "def {} := sorry", WithLeanCtxt { item: sort, cx: &self.lean_cx() })
             })?;
             file.sync_all()?;
         }
@@ -728,7 +724,7 @@ impl<'genv, 'tcx> LeanEncoder<'genv, 'tcx> {
             writeln!(file, "{}", LeanFile::Vc(def_id).import(self.genv))?;
             writeln!(file, "{}", self.open_classical())?;
             namespaced(&mut file, |f| {
-                writeln!(f, "noncomputable def {proof_name} : {vc_name} := by")?;
+                writeln!(f, "def {proof_name} : {vc_name} := by")?;
                 writeln!(f, "  unfold {vc_name}")?;
                 writeln!(f, "  sorry")
             })?;

--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -622,7 +622,7 @@ impl LeanFmt for KVarDecl {
 impl LeanFmt for (&KVid, &ClosedSolution) {
     fn lean_fmt(&self, f: &mut fmt::Formatter, cx: &LeanCtxt) -> fmt::Result {
         let (kvid, (implicit, (explicit, inner))) = self;
-        write!(f, "noncomputable def k{} ", kvid.as_usize())?;
+        write!(f, "def k{} ", kvid.as_usize())?;
         for (arg, sort) in implicit.iter().chain(explicit) {
             write!(f, "(")?;
             arg.lean_fmt(f, cx)?;
@@ -661,7 +661,7 @@ impl<'a> LeanFmt for LeanKConstraint<'a> {
             writeln!(f, "open {namespace}\n\n")?;
         }
 
-        write!(f, "\n\nnoncomputable def {theorem_name} := ")?;
+        write!(f, "\n\ndef {theorem_name} := ")?;
 
         if self.kvars.is_empty() {
             self.constr.lean_fmt(f, cx)


### PR DESCRIPTION
- remove BoolMode from lean formatter; default to translating all occurrences of bool to Prop
- mark definitions with `noncomputable` to stop lean from complaining if they indeed happen to be non-computable
- open Classical in all lean files

~TODO~
- ~test this out a little~
- ~I'm slightly concerned that the translation might break down when bools appear in non-positive positions, but I don't know of a useful reason we'd do that~

Tested by emitting lean files in `flux-demo` (for sorting related PCs). It seems to work fine. The second point I'm still not sure about, but I think LEM would allow us to do what we need.