### PR TITLE
Add `Span` for better ICE reports

### DIFF
--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1784,10 +1784,12 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
 
                 if P::EXPAND_TYPE_ALIASES {
                     let tcx = self.tcx();
-                    return Ok(self
-                        .genv()
-                        .type_of(def_id)?
-                        .instantiate(tcx, &args, &refine_args));
+                    return Ok(self.genv().type_of(def_id)?.instantiate(
+                        tcx,
+                        &args,
+                        &refine_args,
+                        path.span,
+                    ));
                 } else {
                     rty::BaseTy::Alias(
                         rty::AliasKind::Free,
@@ -1946,7 +1948,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
             let ty = self
                 .genv()
                 .type_of(param.def_id)?
-                .instantiate(self.tcx(), into, &[])
+                .instantiate(self.tcx(), into, &[], span)
                 .to_ty();
             into.push(self.try_to_ty_or_base(param.kind, span, &ty)?.into());
         }

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -481,7 +481,7 @@ impl<'genv> fhir::visit::Visitor<'genv> for Wf<'_, 'genv, '_> {
             let args = self.infcx.path_args(path.fhir_id);
             for (i, expr) in path.refine.iter().enumerate() {
                 let Ok(param) = generics.param_at(i, genv).emit(&self.errors) else { return };
-                let param = param.instantiate(genv.tcx(), &args, &[]);
+                let param = param.instantiate(genv.tcx(), &args, &[], path.span);
                 self.check_expr(expr, &param.sort);
             }
         };

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -140,7 +140,8 @@ impl<'genv, 'tcx> InferCtxtRootBuilder<'_, 'genv, 'tcx> {
             .iter_own_params()
             .enumerate()
         {
-            let param = param.instantiate(self.genv.tcx(), args, &[]);
+            let span = self.genv.tcx().def_span(def_id);
+            let param = param.instantiate(self.genv.tcx(), args, &[], span);
             let sort = param
                 .sort
                 .deeply_normalize_sorts(def_id, self.genv, self.infcx)?;
@@ -335,9 +336,10 @@ impl<'infcx, 'genv, 'tcx> InferCtxt<'infcx, 'genv, 'tcx> {
         &mut self,
         callee_def_id: DefId,
         args: &[rty::GenericArg],
+        span: Span,
     ) -> InferResult<List<Expr>> {
         Ok(RefineArgs::for_item(self.genv, callee_def_id, |param, _| {
-            let param = param.instantiate(self.genv.tcx(), args, &[]);
+            let param = param.instantiate(self.genv.tcx(), args, &[], span);
             Ok(self.fresh_infer_var(&param.sort, param.mode))
         })?)
     }
@@ -671,12 +673,13 @@ impl<'genv, 'tcx> InferCtxtAt<'_, '_, 'genv, 'tcx> {
         fields: &[Ty],
         reason: ConstrReason,
     ) -> InferResult<Ty> {
+        let span = self.span;
         let ret = self.ensure_resolved_evars(|this| {
             // Replace holes in generic arguments with fresh inference variables
             let generic_args = this.instantiate_generic_args(generic_args);
 
             let variant = variant
-                .instantiate(this.tcx(), &generic_args, &[])
+                .instantiate(this.tcx(), &generic_args, &[], span)
                 .replace_bound_refts_with(|sort, mode, _| this.fresh_infer_var(sort, mode));
 
             // Check arguments
@@ -1209,6 +1212,7 @@ impl<'a, E: LocEnv> Sub<'a, E> {
                 infcx.tcx(),
                 &alias_ty.args,
                 &alias_ty.refine_args,
+                self.span,
             );
             for clause in &bounds {
                 if !clause.kind().vars().is_empty() {

--- a/crates/flux-infer/src/projections.rs
+++ b/crates/flux-infer/src/projections.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use flux_common::{bug, iter::IterExt, tracked_span_bug};
+use flux_common::{bug, iter::IterExt, span_bug};
 use flux_middle::{
     global_env::GlobalEnv,
     queries::{QueryErr, QueryResult},
@@ -22,6 +22,7 @@ use rustc_middle::{
     traits::{ImplSource, ObligationCause},
     ty::{TyCtxt, Variance},
 };
+use rustc_span::Span;
 use rustc_trait_selection::{
     solve::deeply_normalize,
     traits::{FulfillmentError, SelectionContext},
@@ -95,7 +96,7 @@ impl<'a, 'infcx, 'genv, 'tcx> Normalizer<'a, 'infcx, 'genv, 'tcx> {
         let mut candidates = vec![];
         self.assemble_candidates_from_param_env(obligation, &mut candidates);
         self.assemble_candidates_from_trait_def(obligation, &mut candidates)
-            .unwrap_or_else(|err| tracked_span_bug!("{err:?}"));
+            .unwrap_or_else(|err| span_bug!(self.infcx.span, "{err:?}"));
         self.assemble_candidates_from_impls(obligation, &mut candidates)?;
         if candidates.is_empty() {
             // TODO: This is a temporary hack that uses rustc's trait selection when FLUX fails;
@@ -189,7 +190,7 @@ impl<'a, 'infcx, 'genv, 'tcx> Normalizer<'a, 'infcx, 'genv, 'tcx> {
                 if tcx.is_fn_trait(parent_id) {
                     let res = self
                         .fn_subtype_projection_ty(pred, obligation)
-                        .unwrap_or_else(|err| tracked_span_bug!("{err:?}"));
+                        .unwrap_or_else(|err| span_bug!(self.infcx.span, "{err:?}"));
                     Ok(res)
                 } else {
                     Ok(pred.skip_binder().term)
@@ -210,7 +211,7 @@ impl<'a, 'infcx, 'genv, 'tcx> Normalizer<'a, 'infcx, 'genv, 'tcx> {
 
                 let generics = self.tcx().generics_of(impl_def_id);
 
-                let mut subst = TVarSubst::new(generics);
+                let mut subst = TVarSubst::new(generics, self.infcx.span);
                 for (a, b) in iter::zip(&impl_trait_ref.args, &obligation.args) {
                     subst.generic_args(a, b);
                 }
@@ -232,7 +233,7 @@ impl<'a, 'infcx, 'genv, 'tcx> Normalizer<'a, 'infcx, 'genv, 'tcx> {
                 Ok(self
                     .genv()
                     .type_of(assoc_type_id)?
-                    .instantiate(tcx, &args, &[])
+                    .instantiate(tcx, &args, &[], self.infcx.span)
                     .expect_subset_ty_ctor())
             }
         }
@@ -352,6 +353,7 @@ impl<'a, 'infcx, 'genv, 'tcx> Normalizer<'a, 'infcx, 'genv, 'tcx> {
                 self.tcx(),
                 &alias_ty.args,
                 &alias_ty.refine_args,
+                self.infcx.span,
             );
             self.assemble_candidates_from_predicates(
                 &bounds,
@@ -379,7 +381,10 @@ impl<'a, 'infcx, 'genv, 'tcx> Normalizer<'a, 'infcx, 'genv, 'tcx> {
         // FIXME(nilehmann) This is a patch to not panic inside rustc so we are
         // able to catch the bug
         if trait_pred.has_escaping_bound_vars() {
-            tracked_span_bug!();
+            span_bug!(
+                self.infcx.span,
+                "unexpected escaping bound vars in trait predicate {trait_pred:?}"
+            )
         }
         match self.selcx.select(&trait_pred) {
             Ok(Some(ImplSource::UserDefined(impl_data))) => {
@@ -438,7 +443,7 @@ impl FallibleTypeFolder for Normalizer<'_, '_, '_, '_> {
                 Ok(self
                     .genv()
                     .type_of(alias_ty.def_id)?
-                    .instantiate(self.tcx(), &alias_ty.args, &alias_ty.refine_args)
+                    .instantiate(self.tcx(), &alias_ty.args, &alias_ty.refine_args, self.infcx.span)
                     .expect_ctor()
                     .replace_bound_reft(idx))
             }
@@ -458,7 +463,7 @@ impl FallibleTypeFolder for Normalizer<'_, '_, '_, '_> {
                 // them here but we don't guaranatee that type aliases expand to a subset ty. If we
                 // ever stop expanding aliases during conv we would need to guarantee that aliases
                 // used as a generic base expand to a subset type.
-                tracked_span_bug!()
+                span_bug!(self.infcx.span, "unexpected alias in subset type: {:?}", _alias_ty)
             }
             BaseTy::Alias(AliasKind::Projection, alias_ty) => {
                 let (changed, ctor) = self.normalize_projection_ty(alias_ty)?;
@@ -477,6 +482,7 @@ impl FallibleTypeFolder for Normalizer<'_, '_, '_, '_> {
                 self.selcx.infcx,
                 alias_pred,
                 refine_args,
+                self.infcx.span,
             )?;
             if changed { e.try_fold_with(self) } else { Ok(e) }
         } else {
@@ -502,6 +508,7 @@ pub enum Candidate {
 #[derive(Debug)]
 struct TVarSubst {
     args: Vec<Option<GenericArg>>,
+    span: Span,
 }
 
 impl GenericsSubstDelegate for &TVarSubst {
@@ -511,7 +518,7 @@ impl GenericsSubstDelegate for &TVarSubst {
         match self.args.get(param_ty.index as usize) {
             Some(Some(GenericArg::Ty(ty))) => Ok(ty.clone()),
             Some(None) => Err(()),
-            arg => tracked_span_bug!("expected type for generic parameter, found `{arg:?}`"),
+            arg => span_bug!(self.span, "expected type for generic parameter, found `{arg:?}`"),
         }
     }
 
@@ -519,7 +526,7 @@ impl GenericsSubstDelegate for &TVarSubst {
         match self.args.get(param_ty.index as usize) {
             Some(Some(GenericArg::Base(ctor))) => Ok(ctor.sort()),
             Some(None) => Err(()),
-            arg => tracked_span_bug!("expected type for generic parameter, found `{arg:?}`"),
+            arg => span_bug!(self.span, "expected type for generic parameter, found `{arg:?}`"),
         }
     }
 
@@ -530,7 +537,7 @@ impl GenericsSubstDelegate for &TVarSubst {
         match self.args.get(param_ty.index as usize) {
             Some(Some(GenericArg::Base(ctor))) => Ok(ctor.clone()),
             Some(None) => Err(()),
-            arg => tracked_span_bug!("expected type for generic parameter, found `{arg:?}`"),
+            arg => span_bug!(self.span, "expected type for generic parameter, found `{arg:?}`"),
         }
     }
 
@@ -541,16 +548,16 @@ impl GenericsSubstDelegate for &TVarSubst {
         match self.args.get(ebr.index as usize) {
             Some(Some(GenericArg::Lifetime(region))) => Ok(*region),
             Some(None) => Err(()),
-            arg => tracked_span_bug!("expected region for generic parameter, found `{arg:?}`"),
+            arg => span_bug!(self.span, "expected region for generic parameter, found `{arg:?}`"),
         }
     }
 
     fn expr_for_param_const(&self, _param_const: rustc_middle::ty::ParamConst) -> Expr {
-        tracked_span_bug!()
+        span_bug!(self.span, "unexpected param_const `{_param_const:?}`")
     }
 
     fn const_for_param(&mut self, _param: &Const) -> Const {
-        tracked_span_bug!()
+        span_bug!(self.span, "unexpected const `{_param:?}`")
     }
 }
 
@@ -595,8 +602,8 @@ impl FallibleTypeFolder for SortNormalizer<'_, '_, '_> {
 }
 
 impl TVarSubst {
-    fn new(generics: &rustc_middle::ty::Generics) -> Self {
-        Self { args: vec![None; generics.count()] }
+    fn new(generics: &rustc_middle::ty::Generics, span: Span) -> Self {
+        Self { args: vec![None; generics.count()], span }
     }
 
     fn instantiate_partial<T: TypeFoldable>(&mut self, pred: EarlyBinder<T>) -> Option<T> {
@@ -715,7 +722,7 @@ impl TVarSubst {
         if let Some(old) = &self.args[idx as usize]
             && old != &arg
         {
-            tracked_span_bug!("ambiguous substitution: old=`{old:?}`, new: `{arg:?}`");
+            span_bug!(self.span, "ambiguous substitution: old=`{old:?}`, new: `{arg:?}`");
         }
         self.args[idx as usize].replace(arg);
     }
@@ -766,8 +773,9 @@ pub fn structurally_normalize_expr<'tcx>(
     infcx: &rustc_infer::infer::InferCtxt<'tcx>,
     expr: &Expr,
 ) -> QueryResult<Expr> {
+    let span = genv.tcx().def_span(def_id);
     if let ExprKind::Alias(alias_pred, refine_args) = expr.kind() {
-        let (_, e) = normalize_alias_reft(genv, def_id, infcx, alias_pred, refine_args)?;
+        let (_, e) = normalize_alias_reft(genv, def_id, infcx, alias_pred, refine_args, span)?;
         Ok(e)
     } else {
         Ok(expr.clone())
@@ -783,6 +791,7 @@ fn normalize_alias_reft<'tcx>(
     infcx: &rustc_infer::infer::InferCtxt<'tcx>,
     alias_reft: &AliasReft,
     refine_args: &RefineArgs,
+    span: Span,
 ) -> QueryResult<(bool, Expr)> {
     let tcx = genv.tcx();
 
@@ -793,7 +802,7 @@ fn normalize_alias_reft<'tcx>(
             .unwrap_or_else(|| {
                 bug!("final associated refinement without body - should be caught in desugar")
             })
-            .instantiate(genv.tcx(), &alias_reft.args, &[])
+            .instantiate(genv.tcx(), &alias_reft.args, &[], span)
             .apply(refine_args);
         return Ok((true, e));
     }
@@ -821,7 +830,7 @@ fn normalize_alias_reft<'tcx>(
             )?;
             let e = genv
                 .assoc_refinement_body_for_impl(alias_reft.assoc_id, impl_def_id)?
-                .instantiate(tcx, &args, &[])
+                .instantiate(tcx, &args, &[], span)
                 .apply(refine_args);
             Ok((true, e))
         }

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -371,8 +371,14 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
 
         // Otherwise, check if the trait has a default body
         if let Some(body) = self.default_assoc_refinement_body(trait_assoc_id)? {
+            let span = self.tcx().def_span(impl_id);
             let impl_trait_ref = self.impl_trait_ref(impl_id)?.instantiate_identity();
-            return Ok(rty::EarlyBinder(body.instantiate(self.tcx(), &impl_trait_ref.args, &[])));
+            return Ok(rty::EarlyBinder(body.instantiate(
+                self.tcx(),
+                &impl_trait_ref.args,
+                &[],
+                span,
+            )));
         }
 
         Err(QueryErr::MissingAssocReft {

--- a/crates/flux-middle/src/rty/binder.rs
+++ b/crates/flux-middle/src/rty/binder.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use rustc_data_structures::unord::UnordMap;
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
 use rustc_middle::ty::{BoundRegionKind, TyCtxt};
-use rustc_span::Symbol;
+use rustc_span::{Span, Symbol};
 
 use super::{
     Expr, GenericArg, InferMode, RefineParam, Sort,
@@ -62,16 +62,28 @@ impl<I: IntoIterator> EarlyBinder<I> {
 }
 
 impl<T: TypeFoldable> EarlyBinder<T> {
-    pub fn instantiate(self, tcx: TyCtxt, args: &[GenericArg], refine_args: &[Expr]) -> T {
-        self.as_ref().instantiate_ref(tcx, args, refine_args)
+    pub fn instantiate(
+        self,
+        tcx: TyCtxt,
+        args: &[GenericArg],
+        refine_args: &[Expr],
+        span: Span,
+    ) -> T {
+        self.as_ref().instantiate_ref(tcx, args, refine_args, span)
     }
 }
 
 impl<T: TypeFoldable> EarlyBinder<&T> {
-    pub fn instantiate_ref(self, tcx: TyCtxt, args: &[GenericArg], refine_args: &[Expr]) -> T {
+    pub fn instantiate_ref(
+        self,
+        tcx: TyCtxt,
+        args: &[GenericArg],
+        refine_args: &[Expr],
+        span: Span,
+    ) -> T {
         self.0
             .try_fold_with(&mut subst::GenericsSubstFolder::new(
-                subst::GenericArgsDelegate(args, tcx),
+                subst::GenericArgsDelegate(args, tcx, span),
                 refine_args,
             ))
             .into_ok()

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1981,9 +1981,11 @@ impl BaseTy {
             BaseTy::Slice(_) => (slice_invariants(overflow_mode), &[][..]),
             _ => (&[][..], &[][..]),
         };
+        let span =
+            if let BaseTy::Adt(adt_def, _) = self { tcx.def_span(adt_def.did()) } else { DUMMY_SP };
         invariants
             .iter()
-            .map(move |inv| EarlyBinder(inv).instantiate_ref(tcx, args, &[]))
+            .map(move |inv| EarlyBinder(inv).instantiate_ref(tcx, args, &[], span))
     }
 
     pub fn to_ty(&self) -> Ty {

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -200,7 +200,8 @@ impl<'genv, 'tcx> Refiner<'genv, 'tcx> {
 
         let refine_args = if let ty::AliasKind::Opaque = alias_kind {
             rty::RefineArgs::for_item(self.genv, def_id, |param, _| {
-                let param = param.instantiate(self.genv.tcx(), &args, &[]);
+                let span = self.genv.tcx().def_span(self.def_id);
+                let param = param.instantiate(self.genv.tcx(), &args, &[], span);
                 Ok(rty::Expr::hole(rty::HoleKind::Expr(param.sort)))
             })?
         } else {

--- a/crates/flux-middle/src/rty/subst.rs
+++ b/crates/flux-middle/src/rty/subst.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use flux_common::{bug, tracked_span_bug};
+use flux_common::{bug, span_bug, tracked_span_bug};
 use rustc_type_ir::DebruijnIndex;
 
 use self::fold::FallibleTypeFolder;
@@ -131,6 +131,7 @@ pub trait GenericsSubstDelegate {
 pub(crate) struct GenericArgsDelegate<'a, 'tcx>(
     pub(crate) &'a [GenericArg],
     pub(crate) TyCtxt<'tcx>,
+    pub(crate) Span,
 );
 
 impl GenericsSubstDelegate for GenericArgsDelegate<'_, '_> {
@@ -138,17 +139,17 @@ impl GenericsSubstDelegate for GenericArgsDelegate<'_, '_> {
         match self.0.get(param_ty.index as usize) {
             Some(GenericArg::Base(ctor)) => Ok(ctor.sort()),
             Some(arg) => {
-                tracked_span_bug!("expected base type for generic parameter, found `{arg:?}`")
+                span_bug!(self.2, "expected base type for generic parameter, found `{arg:?}`")
             }
-            None => tracked_span_bug!("type parameter out of range {param_ty:?}"),
+            None => span_bug!(self.2, "type parameter out of range {param_ty:?}"),
         }
     }
 
     fn ty_for_param(&mut self, param_ty: ParamTy) -> Result<Ty, !> {
         match self.0.get(param_ty.index as usize) {
             Some(GenericArg::Ty(ty)) => Ok(ty.clone()),
-            Some(arg) => tracked_span_bug!("expected type for generic parameter, found `{arg:?}`"),
-            None => tracked_span_bug!("type parameter out of range {param_ty:?}"),
+            Some(arg) => span_bug!(self.2, "expected type for generic parameter, found `{arg:?}`"),
+            None => span_bug!(self.2, "type parameter out of range {param_ty:?}"),
         }
     }
 
@@ -156,17 +157,19 @@ impl GenericsSubstDelegate for GenericArgsDelegate<'_, '_> {
         match self.0.get(param_ty.index as usize) {
             Some(GenericArg::Base(ctor)) => Ok(ctor.clone()),
             Some(arg) => {
-                tracked_span_bug!("expected base type for generic parameter, found `{arg:?}`")
+                span_bug!(self.2, "expected base type for generic parameter, found `{arg:?}`")
             }
-            None => tracked_span_bug!("type parameter out of range"),
+            None => span_bug!(self.2, "type parameter out of range"),
         }
     }
 
     fn region_for_param(&mut self, ebr: EarlyParamRegion) -> Result<Region, !> {
         match self.0.get(ebr.index as usize) {
             Some(GenericArg::Lifetime(re)) => Ok(*re),
-            Some(arg) => bug!("expected region for generic parameter, found `{arg:?}`"),
-            None => bug!("region parameter out of range"),
+            Some(arg) => {
+                span_bug!(self.2, "expected region for generic parameter, found `{arg:?}`")
+            }
+            None => span_bug!(self.2, "region parameter out of range"),
         }
     }
 
@@ -174,8 +177,10 @@ impl GenericsSubstDelegate for GenericArgsDelegate<'_, '_> {
         if let ConstKind::Param(param_const) = &param.kind {
             match self.0.get(param_const.index as usize) {
                 Some(GenericArg::Const(cst)) => cst.clone(),
-                Some(arg) => bug!("expected const for generic parameter, found `{arg:?}`"),
-                None => bug!("generic parameter out of range"),
+                Some(arg) => {
+                    span_bug!(self.2, "expected const for generic parameter, found `{arg:?}`")
+                }
+                None => span_bug!(self.2, "generic parameter out of range"),
             }
         } else {
             param.clone()
@@ -185,8 +190,10 @@ impl GenericsSubstDelegate for GenericArgsDelegate<'_, '_> {
     fn expr_for_param_const(&self, param_const: ParamConst) -> Expr {
         match self.0.get(param_const.index as usize) {
             Some(GenericArg::Const(cst)) => Expr::from_const(self.1, cst),
-            Some(arg) => bug!("expected const for generic parameter, found `{arg:?}`"),
-            None => bug!("generic parameter out of range"),
+            Some(arg) => {
+                span_bug!(self.2, "expected const for generic parameter, found `{arg:?}`")
+            }
+            None => span_bug!(self.2, "generic parameter out of range"),
         }
     }
 }

--- a/crates/flux-middle/src/sort_of.rs
+++ b/crates/flux-middle/src/sort_of.rs
@@ -66,9 +66,10 @@ impl GlobalEnv<'_, '_> {
         match self.def_kind(alias_ty.def_id) {
             DefKind::Impl { .. } => Ok(self.sort_of_self_ty_alias(alias_ty.def_id)?.unwrap()),
             DefKind::TyAlias => {
+                let span = self.tcx().def_span(alias_ty.def_id);
                 Ok(self
                     .type_of(alias_ty.def_id)?
-                    .instantiate(self.tcx(), &alias_ty.args, &alias_ty.refine_args)
+                    .instantiate(self.tcx(), &alias_ty.args, &alias_ty.refine_args, span)
                     .expect_ctor()
                     .sort())
             }
@@ -122,8 +123,9 @@ impl rty::BaseTy {
 
 impl rty::AliasReft {
     pub fn fsort(&self, genv: GlobalEnv) -> QueryResult<rty::FuncSort> {
+        let span = genv.tcx().def_span(self.assoc_id.parent());
         Ok(genv
             .sort_of_assoc_reft(self.assoc_id)?
-            .instantiate(genv.tcx(), &self.args, &[]))
+            .instantiate(genv.tcx(), &self.args, &[], span))
     }
 }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -295,8 +295,8 @@ fn check_fn_subtyping(
         // in subtyping_mono, skip next two steps...
         let sub_sig = match sub_sig {
             SubFn::Poly(def_id, early_sig, sub_args) => {
-                let refine_args = infcx.instantiate_refine_args(def_id, &sub_args)?;
-                early_sig.instantiate(tcx, &sub_args, &refine_args)
+                let refine_args = infcx.instantiate_refine_args(def_id, &sub_args, span)?;
+                early_sig.instantiate(tcx, &sub_args, &refine_args, span)
             }
             SubFn::Mono(sig) => sig,
         };
@@ -394,9 +394,12 @@ pub(crate) fn trait_impl_subtyping<'genv, 'tcx>(
 
     let mut infcx = root_ctxt.infcx(impl_method_id, &rustc_infcx);
 
-    let trait_fn_sig =
-        genv.fn_sig(trait_method_id)?
-            .instantiate(tcx, &trait_method_args, &trait_refine_args);
+    let trait_fn_sig = genv.fn_sig(trait_method_id)?.instantiate(
+        tcx,
+        &trait_method_args,
+        &trait_refine_args,
+        span,
+    );
     let impl_sig = genv.fn_sig(impl_method_id)?;
     let sub_sig = SubFn::Poly(impl_method_id, impl_sig, impl_method_args);
 
@@ -904,7 +907,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         let early_refine_args = match callee_def_id {
             Some(callee_def_id) => {
                 infcx
-                    .instantiate_refine_args(callee_def_id, &generic_args)
+                    .instantiate_refine_args(callee_def_id, &generic_args, span)
                     .with_span(span)?
             }
             None => rty::List::empty(),
@@ -915,7 +918,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 genv.predicates_of(callee_def_id)
                     .with_span(span)?
                     .predicates()
-                    .instantiate(tcx, &generic_args, &early_refine_args)
+                    .instantiate(tcx, &generic_args, &early_refine_args, span)
             }
             None => crate::rty::List::empty(),
         };
@@ -933,7 +936,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         // Instantiate function signature and normalize it
         let late_refine_args = vec![];
         let fn_sig = fn_sig
-            .instantiate(tcx, &generic_args, &early_refine_args)
+            .instantiate(tcx, &generic_args, &early_refine_args, span)
             .replace_bound_vars(
                 |_| rty::ReErased,
                 |sort, mode, _| infcx.fresh_infer_var(sort, mode),

--- a/crates/flux-refineck/src/compare_impl_item.rs
+++ b/crates/flux-refineck/src/compare_impl_item.rs
@@ -101,7 +101,7 @@ fn check_assoc_reft(
         .deeply_normalize(&mut infcx.at(impl_span))?;
 
     let trait_sort = infcx.genv.sort_of_assoc_reft(trait_assoc_id)?;
-    let trait_sort = trait_sort.instantiate(infcx.tcx(), &impl_trait_ref.args, &[]);
+    let trait_sort = trait_sort.instantiate(infcx.tcx(), &impl_trait_ref.args, &[], impl_span);
     let trait_sort = trait_sort.deeply_normalize(&mut infcx.at(impl_span))?;
 
     if impl_sort != trait_sort {

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -818,7 +818,7 @@ fn downcast_struct(
         .map(|proj| idx.proj_and_reduce(proj))
         .collect_vec();
     Ok(struct_variant(infcx.genv, adt.did())?
-        .instantiate(tcx, args, &[])
+        .instantiate(tcx, args, &[], span)
         .replace_bound_refts(&flds)
         .deeply_normalize(&mut infcx.at(span))?
         .fields
@@ -854,7 +854,7 @@ fn downcast_enum(
         .genv
         .variant_sig(adt.did(), variant_idx)?
         .expect("enums cannot be opaque")
-        .instantiate(tcx, args, &[])
+        .instantiate(tcx, args, &[], span)
         .replace_bound_refts_with(|sort, _, kind| {
             Expr::fvar(infcx.define_bound_reft_var(sort, kind))
         })


### PR DESCRIPTION
It's super tedious to have to schlep through stack traces when we have random ICE's inside the projection code; for some reason the `tracked_span_bug` was not working, so I've added `Span` everywhere.