### PR TITLE
Visit `no_panic_if` while walking `fn_sig`s

### DIFF
--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -431,6 +431,13 @@ impl<'genv> fhir::visit::Visitor<'genv> for Wf<'_, 'genv, '_> {
         self.check_expr(&ret.idx, &expected);
     }
 
+    fn visit_fn_sig(&mut self, sig: &fhir::FnSig<'genv>) {
+        if let Some(no_panic_if) = &sig.no_panic_if {
+            self.check_expr(no_panic_if, &rty::Sort::Bool);
+        }
+        fhir::visit::walk_fn_sig(self, sig);
+    }
+
     fn visit_fn_decl(&mut self, decl: &fhir::FnDecl<'genv>) {
         fhir::visit::walk_fn_decl(self, decl);
         self.check_output_locs(decl);

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -390,6 +390,9 @@ pub fn walk_where_predicate<'v, V: Visitor<'v>>(vis: &mut V, predicate: &WhereBo
 }
 
 pub fn walk_fn_sig<'v, V: Visitor<'v>>(vis: &mut V, sig: &FnSig<'v>) {
+    if let Some(no_panic_if) = &sig.no_panic_if {
+        vis.visit_expr(no_panic_if);
+    }
     vis.visit_fn_decl(sig.decl);
 }
 

--- a/tests/tests/neg/surface/no_panic07.rs
+++ b/tests/tests/neg/surface/no_panic07.rs
@@ -1,0 +1,24 @@
+#[flux_rs::refined_by(n: int)]
+pub struct MyStruct {
+    #[flux_rs::field(i32[n])]
+    n: i32,
+}
+
+impl MyStruct {
+    #[flux_rs::no_panic_if(n != 0)]
+    #[flux_rs::sig(fn (s: &Self[@n]) -> i32[9])]
+    fn foo(&self) -> i32 {
+        if self.n == 0 {
+            panic!("AHH!");
+        }
+        9
+    }
+}
+
+#[flux_rs::no_panic]
+fn bar() {
+    let s = MyStruct { n: 3 };
+    s.foo(); // this is fine
+    let s = MyStruct { n: 0 };
+    s.foo(); //~ ERROR: may panic
+}

--- a/tests/tests/neg/surface/no_panic08.rs
+++ b/tests/tests/neg/surface/no_panic08.rs
@@ -1,0 +1,5 @@
+#[flux::sig(fn[hrn p: int -> bool](x: i32[@n]) -> bool)]
+#[flux_rs::no_panic_if(true || p(n))] //~ ERROR illegal use of refinement parameter
+fn foo(x: i32) -> bool {
+    true
+}

--- a/tests/tests/pos/surface/no_panic07.rs
+++ b/tests/tests/pos/surface/no_panic07.rs
@@ -1,0 +1,13 @@
+#[flux_rs::no_panic_if(n != 0)]
+#[flux_rs::sig(fn (x: i32[@n]) -> i32[9])]
+fn foo(x: i32) -> i32 {
+    if x == 0 {
+        panic!("AHH!");
+    }
+    9
+}
+
+#[flux_rs::no_panic]
+fn bar() {
+    foo(1); // a okay. :)
+}

--- a/tests/tests/pos/surface/no_panic08.rs
+++ b/tests/tests/pos/surface/no_panic08.rs
@@ -12,6 +12,6 @@ struct Foo;
 
 impl Drop for Foo {
     #[flux_rs::sig(fn(&mut Self[@s]))]
-    #[flux_rs::no_panic_if(s != State::Bad)] // bogus field access
+    #[flux_rs::no_panic_if(s != State::Bad)] // `s` should be a `State`, but my changes seem to have made it a `Foo`...
     fn drop(&mut self) {}
 }

--- a/tests/tests/pos/surface/no_panic08.rs
+++ b/tests/tests/pos/surface/no_panic08.rs
@@ -1,0 +1,17 @@
+#[flux_rs::refined_by(n: int)]
+pub enum State {
+    #[flux_rs::variant(State[0])]
+    Good,
+    #[flux_rs::variant(State[1])]
+    Bad,
+}
+
+#[flux_rs::refined_by(state: State)]
+#[flux_rs::opaque]
+struct Foo;
+
+impl Drop for Foo {
+    #[flux_rs::sig(fn(&mut Self[@s]))]
+    #[flux_rs::no_panic_if(s != State::Bad)] // bogus field access
+    fn drop(&mut self) {}
+}


### PR DESCRIPTION
Closes #1532.

The change to `wf/mod.rs`, to my understanding, helps map the nodes in the `no_panic_if` expression to their sorts. 

And the change to `fhir/visit.rs` also seemed relevant to add. I couldn't pinpoint exactly why, so I had Claude make `neg/surface/no_panic08.rs` which demonstrates an error that we only emit if we visit the `no_panic_if` expression inside `fhir/visit.rs`.