### PR TITLE
Update toolchain path in docs

### DIFF
--- a/book/src/guide/install.md
+++ b/book/src/guide/install.md
@@ -32,7 +32,7 @@ cd flux
 ```
 
 To build the source you need a nightly version of `rustc`.
-We pin the version using a [toolchain file](https://github.com/flux-rs/flux/blob/main/rust-toolchain) (more info [here](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file)).
+We pin the version using a [toolchain file](https://github.com/flux-rs/flux/blob/main/rust-toolchain.toml) (more info [here](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file)).
 If you are using `rustup`, no special action is needed as it should install the correct `rustc` version and components based on the information on that file.
 
 Next, run the following to build and install `flux` binaries


### PR DESCRIPTION
`rust-toolchain` was renamed to `rust-toolchain.toml` in https://github.com/flux-rs/flux/commit/ebafb8d0ca32d8c0fcd2a0cfef6b1b4bd4dc4a6f, but this link was not updated.