### PR TITLE
Add `no_panic` specs for `Option<T>`

### DIFF
--- a/lib/flux-core/src/lib.rs
+++ b/lib/flux-core/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 #![cfg_attr(flux, feature(step_trait))]
 #![cfg_attr(flux, feature(sized_hierarchy))]
+#![feature(const_trait_impl)] // required for const trait impls in option.rs
+#![feature(const_option_ops)] // required for const Option::map_or in option.rs
+#![feature(const_destruct)] // required to specify `[const] Destruct`
 
 mod iter;
 mod ops;

--- a/lib/flux-core/src/option.rs
+++ b/lib/flux-core/src/option.rs
@@ -1,3 +1,5 @@
+use core::marker::Destruct;
+
 use flux_attrs::*;
 
 #[extern_spec]
@@ -32,4 +34,23 @@ impl<T> Option<T> {
 
     #[sig(fn(&mut Self[@b]) -> &mut [T][if b { 1 } else { 0 }])]
     fn as_mut_slice(&mut self) -> &mut [T];
+
+    #[sig(fn(Self[@b], F) -> Option<U>)]
+    #[flux_rs::no_panic_if(F::no_panic())]
+    const fn map<U, F>(self, f: F) -> Option<U>
+    where
+        F: [const] FnOnce(T) -> U + [const] Destruct;
+
+    #[sig(fn(Self, U, F) -> U)]
+    #[flux_rs::no_panic_if(F::no_panic())]
+    const fn map_or<U, F>(self, default: U, f: F) -> U
+    where
+        F: [const] FnOnce(T) -> U + [const] Destruct,
+        U: [const] Destruct;
+
+    #[sig(fn(Self[@b], F) -> Self)]
+    #[flux_rs::no_panic_if(F::no_panic())]
+    const fn inspect<F>(self, f: F) -> Self
+    where
+        F: [const] FnOnce(&T) + [const] Destruct;
 }

--- a/tests/tests/neg/extern_specs/flux_core_option00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_option00.rs
@@ -1,0 +1,21 @@
+extern crate flux_core;
+
+fn will_panic(x: u32) -> u32 {
+    panic!("ahh!!");
+    3
+}
+
+#[flux_rs::sig(fn())]
+#[flux_rs::no_panic_if(true)]
+fn foo() {
+    let opt: Option<u32> = Option::None;
+    opt.map(|x| will_panic(x)); //~ ERROR: may panic
+
+    opt.map_or(42, |x| {
+        will_panic(3) //~ ERROR: may panic
+    });
+
+    opt.inspect(|x| {
+        will_panic(3); //~ ERROR: may panic
+    });
+}

--- a/tests/tests/pos/extern_specs/flux_core_option00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_option00.rs
@@ -1,0 +1,19 @@
+extern crate flux_core;
+
+#[flux_rs::sig(fn(_) -> _)]
+fn will_never_panic(x: u32) -> u32 {
+    3
+}
+
+#[flux_rs::sig(fn())]
+#[flux_rs::no_panic]
+fn foo() {
+    let opt: Option<u32> = Option::None;
+    opt.map(|x| will_never_panic(x));
+
+    opt.map_or(42, |x| will_never_panic(3));
+
+    opt.inspect(|x| {
+        will_never_panic(3);
+    });
+}


### PR DESCRIPTION
Adds `no_panic` specs for `Option::map, `Option::map_or`, and `Option::inspect`.

On my [fork](https://github.com/ninehusky/flux/tree/ninehusky-with-full-stack-trace) of Flux the two tests I've included pass, but they're failing right now. I need to make more progress on vtock verification for tonight, but I'll dig into why the tests currently fail later. (If I had to guess, we need to merge one or more of #1521, #1526)?