### PR TITLE
Add saturating_add/saturating_sub specs for u64

### DIFF
--- a/lib/flux-core/src/num/mod.rs
+++ b/lib/flux-core/src/num/mod.rs
@@ -25,3 +25,16 @@ impl u32 {
     #[spec(fn(num: u32, rhs: u32) -> u32[if num + rhs > u32::MAX { u32::MAX } else { num + rhs }])]
     fn saturating_add(self, rhs: u32) -> u32;
 }
+
+#[extern_spec(core::num)]
+impl u64 {
+    /// Core impl: https://github.com/rust-lang/rust/blob/0e95a0f4c677002a5d4ac5bc59d97885e6f51f71/library/core/src/num/uint_macros.rs#L2384-L2400
+    #[no_panic]
+    #[spec(fn(num: u64, rhs: u64) -> u64[if num < rhs { 0 } else { num - rhs }])]
+    fn saturating_sub(self, rhs: u64) -> u64;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/0e95a0f4c677002a5d4ac5bc59d97885e6f51f71/library/core/src/num/uint_macros.rs#L2340-L2356
+    #[no_panic]
+    #[spec(fn(num: u64, rhs: u64) -> u64[if num + rhs > u64::MAX { u64::MAX } else { num + rhs }])]
+    fn saturating_add(self, rhs: u64) -> u64;
+}

--- a/tests/tests/neg/extern_specs/flux_core_num00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_num00.rs
@@ -17,3 +17,11 @@ pub fn test_saturating_u32(x: u32, y: u32, z: u32) {
     // Not true if x + y > u32::MAX, as it saturates
     assert(x.saturating_add(y) == x + y); //~ ERROR refinement type error
 }
+
+pub fn test_saturating_u64(x: u64, y: u64, z: u64) {
+    // Not true if x < y, as it saturates
+    let sub = x - y; //~ ERROR arithmetic operation may underflow 
+    assert(x.saturating_sub(y) == sub); //~ ERROR refinement type error
+    // Not true if x + y > u64::MAX, as it saturates
+    assert(x.saturating_add(y) == x + y); //~ ERROR refinement type error
+}

--- a/tests/tests/pos/extern_specs/flux_core_num00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_num00.rs
@@ -28,3 +28,17 @@ pub fn saturating_u32() {
     // saturating_add: saturated case
     assert(z.saturating_add(y) == u32::MAX);
 }
+
+pub fn test_saturating_u64() {
+    let x: u64 = 5;
+    let y: u64 = 10;
+    let z: u64 = u64::MAX - 5;
+    // saturating_sub: unsaturated case
+    assert(y.saturating_sub(x) == 5);
+    // saturating_sub: saturated case
+    assert(x.saturating_sub(y) == 0);
+    // saturating_add: unsaturated case
+    assert(x.saturating_add(y) == 15);
+    // saturating_add: saturated case
+    assert(z.saturating_add(y) == u64::MAX);
+}


### PR DESCRIPTION
- Adds `saturating_add` and `saturating_sub` specs for `u64` based on the existing specs for `usize` and `i32`
- Adds positive and negative tests for these specs