### PR TITLE
Fix documentation errors

### DIFF
--- a/book/src/tutorial/01-refinements.md
+++ b/book/src/tutorial/01-refinements.md
@@ -161,7 +161,7 @@ non-negative.
 
 | **Type**         | **Meaning**                                          |
 | :--------------- | :--------------------------------------------------- |
-| `i32{v: 0 <  v}` | The set of `i32` values that positive                |
+| `i32{v: 0 <  v}` | The set of `i32` values that are positive            |
 | `i32{v: n <= v}` | The set of `i32` values greater than or equal to `n` |
 
 Flux allows such specifications by pairing plain Rust types

--- a/book/src/tutorial/02-ownership.md
+++ b/book/src/tutorial/02-ownership.md
@@ -71,7 +71,7 @@ then `i32[2]` and finally, the returned type `i32[3]`.
 ## Exclusive Ownership and Loops
 
 This exclusive ownership mechanism is at work in the `factorial` example
-we signed off with [previously](./01-introducing-flux.md)
+we signed off with [previously](./01-refinements.md#example-factorial)
 
 ```rust, editable
 #[flux_rs::spec(fn (n:i32{0 <= n}) -> i32{v:n <= v})]


### PR DESCRIPTION
1. Fixed grammar: "values that positive" -> "values that are positive"
2. Fixed dead link in ownership chapter