### PR TITLE
Fix code in equality chapter

### DIFF
--- a/book/src/tutorial/02-ownership.md
+++ b/book/src/tutorial/02-ownership.md
@@ -303,7 +303,7 @@ hence, that upon return `x: i32[11]`.
 ```rust, editable
 fn test_incr() {
   let mut z = 10;
-  incr_inv(&mut z);
+  incr(&mut z);
   assert(z == 11);
 }
 ```

--- a/book/src/tutorial/11-equality.md
+++ b/book/src/tutorial/11-equality.md
@@ -37,7 +37,7 @@ using a Rust `enum`:
 ```rust, editable
 #[reflect]
 #[derive(Debug, Clone)]
-pub enum Roles {
+pub enum Role {
     Admin,
     Member,
     Guest,
@@ -130,15 +130,15 @@ not.
 
 ```rust, editable
 #[assoc(
-    fn is_eq(x: Self, y: Rhs, res: bool) -> bool { res <=> (r1 == r2) }
-    fn is_ne(x: Self, y: Rhs, res: bool) -> bool { true }
+    fn is_eq(x: Self, y: Self, res: bool) -> bool { res <=> (x == y) }
+    fn is_ne(x: Self, y: Self, res: bool) -> bool { true }
 )]
 impl PartialEq for Role {
-    #[spec(fn(&Self[@r1], &Self[@r2]) -> bool[r1 == r2]))]
+    #[spec(fn(&Self[@r1], &Self[@r2]) -> bool[r1 == r2])]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Role::Admin, Role::Admin) => true,
-            (Role::User, Role::User) => true,
+            (Role::Member, Role::Member) => true,
             (Role::Guest, Role::Guest) => true,
             _ => false,
         }
@@ -246,7 +246,17 @@ pub struct User {
 impl User {
     // fill in the spec
     pub fn new(name: String, role: Role) -> Self {
-        User { name, role  }
+        User { name, role }
+    }
+
+    #[spec(fn(&User[@u]) -> bool[u == Role::Admin])]
+    pub fn is_admin(&self) -> bool {
+        is_admin(&self.role);
+    }
+
+    #[spec(fn(&User[@u]) -> bool[u == Role::Guest])]
+    pub fn is_guest(&self) -> bool {
+        is_guest(&self.role);
     }
 }
 
@@ -296,6 +306,10 @@ impl User {
   fn read(&self) { /* ... */ }
   #[spec(fn(&Self[@u]) requires permitted(u.role, Permissions::Write))]
   fn write(&self) { /* ... */ }
+  #[spec(fn(&Self[@u]) requires permitted(u.role, Permissions::Configure))]
+  fn configure(&self) { /* ... */ }
+  #[spec(fn(&Self[@u]) requires permitted(u.role, Permissions::Delete))]
+  fn delete(&self) { /* ... */ }
 }
 ```
 
@@ -325,7 +339,7 @@ fn test_access_bad() {
 
 To recap, in this chapter we saw how to use
 
-- *Reflect* `enum`s, *e.g.* to refer to variants like `Role::User` in
+- *Reflect* `enum`s, *e.g.* to refer to variants like `Role::Member` in
   refinements,
 
 - *Detached* specifications for (derived) code *e.g.* `PartialEq`

--- a/book/src/tutorial/11-equality.md
+++ b/book/src/tutorial/11-equality.md
@@ -101,7 +101,7 @@ comparisons.
 
 **A Refined PartialEq Trait** The Flux standard library refines `std`‘s
 `PartialEq` trait with two *associated refinements* (see
-[this chapter](ch09_traits).md) `is_eq` and `is_ne` that respectively specify when two
+[this chapter](08-traits.md)) `is_eq` and `is_ne` that respectively specify when two
 values of the type implementing `PartialEq` are equal or not. The
 *methods* `eq` and `ne` return boolean values `v` such that the
 predicate `is_eq(r1, r2, v)` and `is_ne(r1, r2, v)` hold. By default,


### PR DESCRIPTION
- enum was declared as `Roles` but code uses `Role`
- `Role::User` is used in some parts of the code even though such a variant does not exist. (I imagine it was renamed to `Role::Member` after adding the `User` struct)
- add `is_{admin,guest}` methods for `User`. The fact that these did not exist caused an error that prevented earlier verifier failures. I also added specs to these to make the later assertions fail due to lack of a `new` spec, which is the behavior described in the chapter
- Similiar fixes for the `Role` `PartialEq` impl. The broken neq comparison is still there, I just fixed it up enough so it doesn't stop the rest of the code blocks from checking due to undeclared symbols.
- Also added `configure` and `delete` methods for `User`. The fact that they are missing prevents other code blocks from being checked and I don't think they were omitted on purpose.
- Bonus fix in ownership chapter: test was checking the wrong function