### PR TITLE
Improve slice spec: add specs for `last`, `get`, `split_first/last`, `split_at_checked`, and mut counterparts

### DIFF
--- a/lib/flux-core/src/slice/index.rs
+++ b/lib/flux-core/src/slice/index.rs
@@ -11,6 +11,9 @@ impl<T, I: SliceIndex<[T]>> ops::Index<I> for [T] {
         }
     )]
 
+    /// Delegates to `SliceIndex::index`, documented as panicking iff out of
+    /// bounds, so `#[no_panic]` is sound under the `in_bounds` precondition.
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/slice/index.rs#L15
     #[no_panic]
     #[sig(fn(&Self[@len], {I[@idx] | <Self as ops::Index<I>>::in_bounds(len, idx)}) -> &I::Output)]
     fn index(&self, index: I) -> &I::Output;
@@ -18,7 +21,7 @@ impl<T, I: SliceIndex<[T]>> ops::Index<I> for [T] {
 
 #[extern_spec(core::slice)]
 impl<T, I: SliceIndex<[T]>> ops::IndexMut<I> for [T] {
-    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/slice/index.rs#L26
+    /// See `index`. Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/slice/index.rs#L26
     #[no_panic]
     #[sig(fn(&mut Self[@len], {I[@idx] | <Self as ops::Index<I>>::in_bounds(len, idx)}) -> &mut I::Output)]
     fn index_mut(&mut self, index: I) -> &mut I::Output;

--- a/lib/flux-core/src/slice/index.rs
+++ b/lib/flux-core/src/slice/index.rs
@@ -17,6 +17,14 @@ impl<T, I: SliceIndex<[T]>> ops::Index<I> for [T] {
 }
 
 #[extern_spec(core::slice)]
+impl<T, I: SliceIndex<[T]>> ops::IndexMut<I> for [T] {
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/slice/index.rs#L26
+    #[no_panic]
+    #[sig(fn(&mut Self[@len], {I[@idx] | <Self as ops::Index<I>>::in_bounds(len, idx)}) -> &mut I::Output)]
+    fn index_mut(&mut self, index: I) -> &mut I::Output;
+}
+
+#[extern_spec(core::slice)]
 trait SliceIndex<T> {
     #![assoc(fn in_bounds(idx: Self, v: T) -> bool { true })] //
 }

--- a/lib/flux-core/src/slice/iter.rs
+++ b/lib/flux-core/src/slice/iter.rs
@@ -6,6 +6,7 @@ struct Iter<'a, T>;
 
 #[extern_spec(core::slice)]
 impl<'a, T> Iter<'a, T> {
+    #[no_panic]
     #[spec(fn(&Self[@it]) -> &[T][it.len])]
     fn as_slice(&self) -> &'a [T];
 }
@@ -17,6 +18,7 @@ impl<'a, T> Iter<'a, T> {
     fn step(x: Iter, y: Iter) -> bool { x.idx + 1 == y.idx && x.len == y.len}
 )]
 impl<'a, T> Iterator for Iter<'a, T> {
+    #[no_panic]
     #[spec(fn(self: &mut Iter<T>[@curr_s]) -> Option<_>[curr_s.idx < curr_s.len]
            ensures self: Iter<T>{next_s: curr_s.idx + 1 == next_s.idx && curr_s.len == next_s.len})]
     fn next(&mut self) -> Option<&'a T>;
@@ -24,6 +26,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
 #[extern_spec(core::slice)]
 impl<'a, T> IntoIterator for &'a [T] {
+    #[no_panic]
     #[spec(fn(&[T][@n]) -> Iter<T>[0, n])]
     fn into_iter(v: &'a [T]) -> Iter<'a, T>;
 }

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -6,72 +6,51 @@ use flux_attrs::*;
 #[extern_spec(core::slice)]
 impl<T> [T] {
     #[no_panic]
-    #[sig(fn(&Self[@n]) -> usize[n])]
+    #[spec(fn(&Self[@n]) -> usize[n])]
     fn len(&self) -> usize;
 
-    #[sig(fn(&Self[@n]) -> bool[n == 0])]
+    #[spec(fn(&Self[@n]) -> bool[n == 0])]
     fn is_empty(&self) -> bool;
 
-    #[sig(fn(&Self[@n]) -> Option<&T>[n != 0])]
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L154
+    #[spec(fn(&Self[@n]) -> Option<&T>[n != 0])]
     fn first(&self) -> Option<&T>;
 
-    #[sig(fn(&Self[@n]) -> Iter<T>[0, n])]
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L280
+    #[no_panic]
+    #[spec(fn(&Self[@n]) -> Option<&T>[n != 0])]
+    fn last(&self) -> Option<&T>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L570
+    #[no_panic]
+    #[spec(fn(&Self[@n], I[@idx]) -> Option<&I::Output>[<I as SliceIndex<[T]>>::in_bounds(idx, n)])]
+    fn get<I: SliceIndex<[T]>>(&self, index: I) -> Option<&I::Output>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L197
+    #[no_panic]
+    #[spec(fn(&Self[@n]) -> Option<(&T, &[T][n - 1])>[n != 0])]
+    fn split_first(&self) -> Option<(&T, &[T])>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L239
+    #[no_panic]
+    #[spec(fn(&Self[@n]) -> Option<(&T, &[T][n - 1])>[n != 0])]
+    fn split_last(&self) -> Option<(&T, &[T])>;
+
+    #[spec(fn(&Self[@n]) -> Iter<T>[0, n])]
     fn iter(&self) -> Iter<'_, T>;
 
     #[no_panic]
-    #[sig(fn(&Self[@n], mid: usize{mid <= n}) -> (&[T][mid], &[T][n - mid]))]
+    #[spec(fn(&Self[@n], mid: usize{mid <= n}) -> (&[T][mid], &[T][n - mid]))]
     fn split_at(&self, mid: usize) -> (&[T], &[T]);
 
-    #[sig(fn(&Self[@n]) -> *const{p: ptr_size(p) == n} T)]
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L2185
+    #[no_panic]
+    #[spec(fn(&Self[@n], usize[@mid]) -> Option<(&[T][mid], &[T][n - mid])>[mid <= n])]
+    fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])>;
+
+    #[spec(fn(&Self[@n]) -> *const{p: ptr_size(p) == n} T)]
     fn as_ptr(&self) -> *const T;
 
-    #[sig(fn(&mut Self[@n]) -> *mut{p: ptr_size(p) == n} T)]
+    #[spec(fn(&mut Self[@n]) -> *mut{p: ptr_size(p) == n} T)]
     fn as_mut_ptr(&mut self) -> *mut T;
-}
-
-#[cfg(flux_sysroot_test)]
-mod tests {
-    #![allow(dead_code)]
-
-    use flux_attrs::*;
-
-    #[sig(fn(bool[true]))]
-    fn assert(_: bool) {}
-
-    #[should_fail]
-    fn test01(xs: &[i32]) {
-        let _x = xs[0];
-    }
-
-    fn test_len(xs: &[i32]) {
-        if xs.len() > 0 {
-            let _x = xs[0];
-        }
-    }
-
-    fn test_is_empty(xs: &[i32]) {
-        if !xs.is_empty() {
-            let _x = xs[0];
-        }
-    }
-
-    fn test_first00(xs: &[i32]) {
-        if xs.len() > 0 {
-            assert(xs.first().is_some());
-        }
-        if xs.is_empty() {
-            assert(xs.first().is_none());
-        }
-    }
-
-    #[should_fail]
-    fn test_first01(xs: &[i32]) {
-        assert(xs.first().is_some());
-    }
-
-    fn test_iter00(xs: &[i32]) {
-        let it = xs.iter();
-        let ys = it.as_slice();
-        assert(xs.len() == ys.len());
-    }
 }

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -16,15 +16,30 @@ impl<T> [T] {
     #[spec(fn(&Self[@n]) -> Option<&T>[n != 0])]
     fn first(&self) -> Option<&T>;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L177
+    #[no_panic]
+    #[spec(fn(&mut Self[@n]) -> Option<&mut T>[n != 0])]
+    fn first_mut(&mut self) -> Option<&mut T>;
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L280
     #[no_panic]
     #[spec(fn(&Self[@n]) -> Option<&T>[n != 0])]
     fn last(&self) -> Option<&T>;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L303
+    #[no_panic]
+    #[spec(fn(&mut Self[@n]) -> Option<&mut T>[n != 0])]
+    fn last_mut(&mut self) -> Option<&mut T>;
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L570
     #[no_panic]
     #[spec(fn(&Self[@n], I[@idx]) -> Option<&I::Output>[<I as SliceIndex<[T]>>::in_bounds(idx, n)])]
     fn get<I: SliceIndex<[T]>>(&self, index: I) -> Option<&I::Output>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L596
+    #[no_panic]
+    #[spec(fn(&mut Self[@n], I[@idx]) -> Option<&mut I::Output>[<I as SliceIndex<[T]>>::in_bounds(idx, n)])]
+    fn get_mut<I: SliceIndex<[T]>>(&mut self, index: I) -> Option<&mut I::Output>;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L197
     #[no_panic]
@@ -43,10 +58,20 @@ impl<T> [T] {
     #[spec(fn(&Self[@n], mid: usize{mid <= n}) -> (&[T][mid], &[T][n - mid]))]
     fn split_at(&self, mid: usize) -> (&[T], &[T]);
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L2018
+    #[no_panic]
+    #[spec(fn(&mut Self[@n], mid: usize{mid <= n}) -> (&mut [T][mid], &mut [T][n - mid]))]
+    fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]);
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L2185
     #[no_panic]
     #[spec(fn(&Self[@n], usize[@mid]) -> Option<(&[T][mid], &[T][n - mid])>[mid <= n])]
     fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L2224
+    #[no_panic]
+    #[spec(fn(&mut Self[@n], usize[@mid]) -> Option<(&mut [T][mid], &mut [T][n - mid])>[mid <= n])]
+    fn split_at_mut_checked(&mut self, mid: usize) -> Option<(&mut [T], &mut [T])>;
 
     #[spec(fn(&Self[@n]) -> *const{p: ptr_size(p) == n} T)]
     fn as_ptr(&self) -> *const T;

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -9,10 +9,12 @@ impl<T> [T] {
     #[spec(fn(&Self[@n]) -> usize[n])]
     fn len(&self) -> usize;
 
+    #[no_panic]
     #[spec(fn(&Self[@n]) -> bool[n == 0])]
     fn is_empty(&self) -> bool;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L154
+    #[no_panic]
     #[spec(fn(&Self[@n]) -> Option<&T>[n != 0])]
     fn first(&self) -> Option<&T>;
 
@@ -51,6 +53,7 @@ impl<T> [T] {
     #[spec(fn(&Self[@n]) -> Option<(&T, &[T][n - 1])>[n != 0])]
     fn split_last(&self) -> Option<(&T, &[T])>;
 
+    #[no_panic]
     #[spec(fn(&Self[@n]) -> Iter<T>[0, n])]
     fn iter(&self) -> Iter<'_, T>;
 
@@ -73,9 +76,11 @@ impl<T> [T] {
     #[spec(fn(&mut Self[@n], usize[@mid]) -> Option<(&mut [T][mid], &mut [T][n - mid])>[mid <= n])]
     fn split_at_mut_checked(&mut self, mid: usize) -> Option<(&mut [T], &mut [T])>;
 
+    #[no_panic]
     #[spec(fn(&Self[@n]) -> *const{p: ptr_size(p) == n} T)]
     fn as_ptr(&self) -> *const T;
 
+    #[no_panic]
     #[spec(fn(&mut Self[@n]) -> *mut{p: ptr_size(p) == n} T)]
     fn as_mut_ptr(&mut self) -> *mut T;
 }

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -1,3 +1,13 @@
+//! Extern specs for [`core::slice`].
+//!
+//! # Soundness of `SliceIndex`-based annotations
+//!
+//! Several annotations rely on [`SliceIndex`] being a sealed trait: it
+//! requires `private_slice_index::Sealed`, which has no public path outside of
+//! `core`, so its set of implementations is fixed and exhaustive. The sealed implementations
+//! were inspected to ensure these specs are sound.
+// Perhaps one day we can properly verify them with Flux.
+
 mod index;
 mod iter;
 
@@ -33,22 +43,26 @@ impl<T> [T] {
     #[spec(fn(&mut Self[@n]) -> Option<&mut T>[n != 0])]
     fn last_mut(&mut self) -> Option<&mut T>;
 
+    /// Delegates to `SliceIndex::get`. All sealed impls return `None` out of
+    /// bounds (never panic), and `Some` iff `in_bounds` holds.
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L570
     #[no_panic]
     #[spec(fn(&Self[@n], I[@idx]) -> Option<&I::Output>[<I as SliceIndex<[T]>>::in_bounds(idx, n)])]
     fn get<I: SliceIndex<[T]>>(&self, index: I) -> Option<&I::Output>;
 
-    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L596
+    /// See `get`. Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L596
     #[no_panic]
     #[spec(fn(&mut Self[@n], I[@idx]) -> Option<&mut I::Output>[<I as SliceIndex<[T]>>::in_bounds(idx, n)])]
     fn get_mut<I: SliceIndex<[T]>>(&mut self, index: I) -> Option<&mut I::Output>;
 
+    /// Delegates to `SliceIndex::get_unchecked`. `SliceIndex` documents calling
+    /// with an out-of-bounds index as UB; `in_bounds` encodes that contract.
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L635
     #[no_panic]
     #[spec(fn(&Self[@n], {I[@idx] | <I as SliceIndex<[T]>>::in_bounds(idx, n)}) -> &I::Output)]
     unsafe fn get_unchecked<I: SliceIndex<[T]>>(&self, index: I) -> &I::Output;
 
-    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L679
+    /// See `get_unchecked`. Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L679
     #[no_panic]
     #[spec(fn(&mut Self[@n], {I[@idx] | <I as SliceIndex<[T]>>::in_bounds(idx, n)}) -> &mut I::Output)]
     unsafe fn get_unchecked_mut<I: SliceIndex<[T]>>(&mut self, index: I) -> &mut I::Output;

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -43,6 +43,16 @@ impl<T> [T] {
     #[spec(fn(&mut Self[@n], I[@idx]) -> Option<&mut I::Output>[<I as SliceIndex<[T]>>::in_bounds(idx, n)])]
     fn get_mut<I: SliceIndex<[T]>>(&mut self, index: I) -> Option<&mut I::Output>;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L635
+    #[no_panic]
+    #[spec(fn(&Self[@n], {I[@idx] | <I as SliceIndex<[T]>>::in_bounds(idx, n)}) -> &I::Output)]
+    unsafe fn get_unchecked<I: SliceIndex<[T]>>(&self, index: I) -> &I::Output;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L679
+    #[no_panic]
+    #[spec(fn(&mut Self[@n], {I[@idx] | <I as SliceIndex<[T]>>::in_bounds(idx, n)}) -> &mut I::Output)]
+    unsafe fn get_unchecked_mut<I: SliceIndex<[T]>>(&mut self, index: I) -> &mut I::Output;
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L197
     #[no_panic]
     #[spec(fn(&Self[@n]) -> Option<(&T, &[T][n - 1])>[n != 0])]

--- a/tests/tests/neg/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_slice00.rs
@@ -29,6 +29,28 @@ pub fn test_get_unchecked_index(xs: &[i32], i: usize) {
     assert(xs.get(i).is_some()); //~ ERROR refinement type error
 }
 
+// --- first_mut / last_mut ---
+
+pub fn test_first_mut(xs: &mut [i32]) {
+    assert(xs.first_mut().is_some()); //~ ERROR refinement type error
+}
+
+pub fn test_last_mut(xs: &mut [i32]) {
+    assert(xs.last_mut().is_some()); //~ ERROR refinement type error
+}
+
+// --- get_mut ---
+
+pub fn test_get_mut(xs: &mut [i32], i: usize) {
+    assert(xs.get_mut(i).is_some()); //~ ERROR refinement type error
+}
+
+// --- split_at_mut_checked ---
+
+pub fn test_split_at_mut_checked(xs: &mut [i32], mid: usize) {
+    assert(xs.split_at_mut_checked(mid).is_some()); //~ ERROR refinement type error
+}
+
 // --- split_first ---
 
 pub fn test_split_first(xs: &[i32]) {

--- a/tests/tests/neg/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_slice00.rs
@@ -1,0 +1,48 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- index ---
+
+pub fn test_index_oob(xs: &[i32]) {
+    let _x = xs[0]; //~ ERROR possible out-of-bounds access
+}
+
+// --- first ---
+
+pub fn test_first(xs: &[i32]) {
+    assert(xs.first().is_some()); //~ ERROR refinement type error
+}
+
+// --- last ---
+
+pub fn test_last(xs: &[i32]) {
+    assert(xs.last().is_some()); //~ ERROR refinement type error
+}
+
+// --- get ---
+
+pub fn test_get(xs: &[i32]) {
+    assert(xs.get(0).is_some()); //~ ERROR refinement type error
+}
+
+pub fn test_get_unchecked_index(xs: &[i32], i: usize) {
+    assert(xs.get(i).is_some()); //~ ERROR refinement type error
+}
+
+// --- split_first ---
+
+pub fn test_split_first(xs: &[i32]) {
+    assert(xs.split_first().is_some()); //~ ERROR refinement type error
+}
+
+// --- split_last ---
+
+pub fn test_split_last(xs: &[i32]) {
+    assert(xs.split_last().is_some()); //~ ERROR refinement type error
+}
+
+// --- split_at_checked ---
+
+pub fn test_split_at_checked(xs: &[i32], mid: usize) {
+    assert(xs.split_at_checked(mid).is_some()); //~ ERROR refinement type error
+}

--- a/tests/tests/pos/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_slice00.rs
@@ -1,0 +1,152 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- len / is_empty / index ---
+
+pub fn test_index_after_len(xs: &[i32]) {
+    if xs.len() > 0 {
+        let _x = xs[0];
+    }
+}
+
+pub fn test_index_after_is_empty(xs: &[i32]) {
+    if !xs.is_empty() {
+        let _x = xs[0];
+    }
+}
+
+// --- first ---
+
+pub fn test_first_branch(xs: &[i32]) {
+    if xs.len() > 0 {
+        assert(xs.first().is_some());
+    }
+    if xs.is_empty() {
+        assert(xs.first().is_none());
+    }
+}
+
+// --- iter ---
+
+pub fn test_iter_as_slice_len(xs: &[i32]) {
+    let it = xs.iter();
+    let ys = it.as_slice();
+    assert(xs.len() == ys.len());
+}
+
+// --- last ---
+
+pub fn test_last_concrete() {
+    let v = [10, 40, 30];
+    assert(v.last().is_some());
+}
+
+pub fn test_last_empty() {
+    let w: &[i32] = &[];
+    assert(w.last().is_none());
+}
+
+pub fn test_last_branch(xs: &[i32]) {
+    if xs.is_empty() {
+        assert(xs.last().is_none());
+    } else {
+        assert(xs.last().is_some());
+    }
+}
+
+// --- get ---
+
+pub fn test_get_in_bounds(xs: &[i32], i: usize) {
+    if i < xs.len() {
+        assert(xs.get(i).is_some());
+    }
+}
+
+pub fn test_get_out_of_bounds(xs: &[i32], i: usize) {
+    if i >= xs.len() {
+        assert(xs.get(i).is_none());
+    }
+}
+
+pub fn test_get_concrete() {
+    let v = [10, 40, 30];
+    assert(v.get(0).is_some());
+    assert(v.get(2).is_some());
+    assert(v.get(3).is_none());
+}
+
+// --- split_first ---
+
+pub fn test_split_first_empty() {
+    let w: &[i32] = &[];
+    assert(w.split_first().is_none());
+}
+
+pub fn test_split_first_nonempty() {
+    let v = [1, 2, 3];
+    assert(v.split_first().is_some());
+}
+
+pub fn test_split_first_branch(xs: &[i32]) {
+    if xs.is_empty() {
+        assert(xs.split_first().is_none());
+    } else {
+        assert(xs.split_first().is_some());
+    }
+}
+
+pub fn test_split_first_tail_len(xs: &[i32]) {
+    let n = xs.len();
+    if let Some((_, tail)) = xs.split_first() {
+        assert(tail.len() == n - 1);
+    }
+}
+
+// --- split_last ---
+
+pub fn test_split_last_empty() {
+    let w: &[i32] = &[];
+    assert(w.split_last().is_none());
+}
+
+pub fn test_split_last_nonempty() {
+    let v = [1, 2, 3];
+    assert(v.split_last().is_some());
+}
+
+pub fn test_split_last_branch(xs: &[i32]) {
+    if xs.is_empty() {
+        assert(xs.split_last().is_none());
+    } else {
+        assert(xs.split_last().is_some());
+    }
+}
+
+pub fn test_split_last_init_len(xs: &[i32]) {
+    let n = xs.len();
+    if let Some((_, init)) = xs.split_last() {
+        assert(init.len() == n - 1);
+    }
+}
+
+// --- split_at_checked ---
+
+pub fn test_split_at_checked_in_bounds(xs: &[i32], mid: usize) {
+    if mid <= xs.len() {
+        assert(xs.split_at_checked(mid).is_some());
+    }
+}
+
+pub fn test_split_at_checked_out_of_bounds(xs: &[i32], mid: usize) {
+    if mid > xs.len() {
+        assert(xs.split_at_checked(mid).is_none());
+    }
+}
+
+pub fn test_split_at_checked_lengths(xs: &[i32], mid: usize) {
+    let n = xs.len();
+    if let Some((left, right)) = xs.split_at_checked(mid) {
+        assert(left.len() == mid);
+        assert(right.len() == n - mid);
+    }
+}

--- a/tests/tests/pos/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_slice00.rs
@@ -34,6 +34,34 @@ pub fn test_iter_as_slice_len(xs: &[i32]) {
     assert(xs.len() == ys.len());
 }
 
+// --- first_mut / last_mut ---
+
+pub fn test_first_mut_empty() {
+    let mut w: [i32; 0] = [];
+    assert(w.first_mut().is_none());
+}
+
+pub fn test_first_mut_nonempty() {
+    let mut v = [1, 2, 3];
+    assert(v.first_mut().is_some());
+}
+
+pub fn test_first_mut_branch(xs: &mut [i32]) {
+    if xs.is_empty() {
+        assert(xs.first_mut().is_none());
+    } else {
+        assert(xs.first_mut().is_some());
+    }
+}
+
+pub fn test_last_mut_branch(xs: &mut [i32]) {
+    if xs.is_empty() {
+        assert(xs.last_mut().is_none());
+    } else {
+        assert(xs.last_mut().is_some());
+    }
+}
+
 // --- last ---
 
 pub fn test_last_concrete() {
@@ -126,6 +154,47 @@ pub fn test_split_last_init_len(xs: &[i32]) {
     let n = xs.len();
     if let Some((_, init)) = xs.split_last() {
         assert(init.len() == n - 1);
+    }
+}
+
+// --- get_mut ---
+
+pub fn test_get_mut_in_bounds(xs: &mut [i32], i: usize) {
+    if i < xs.len() {
+        assert(xs.get_mut(i).is_some());
+    }
+}
+
+pub fn test_get_mut_out_of_bounds(xs: &mut [i32], i: usize) {
+    if i >= xs.len() {
+        assert(xs.get_mut(i).is_none());
+    }
+}
+
+// --- split_at_mut ---
+
+pub fn test_split_at_mut_lengths(xs: &mut [i32], mid: usize) {
+    let n = xs.len();
+    if mid <= n {
+        let (left, right) = xs.split_at_mut(mid);
+        assert(left.len() == mid);
+        assert(right.len() == n - mid);
+    }
+}
+
+// --- split_at_mut_checked ---
+
+pub fn test_split_at_mut_checked_in_bounds(xs: &mut [i32], mid: usize) {
+    if mid <= xs.len() {
+        assert(xs.split_at_mut_checked(mid).is_some());
+    }
+}
+
+pub fn test_split_at_mut_checked_lengths(xs: &mut [i32], mid: usize) {
+    let n = xs.len();
+    if let Some((left, right)) = xs.split_at_mut_checked(mid) {
+        assert(left.len() == mid);
+        assert(right.len() == n - mid);
     }
 }
 


### PR DESCRIPTION
Extends `flux-core`'s slice extern specs with refinement types for several previously unspecced methods, and adds `#[no_panic]` to existing specs that were missing it.

## New specs

- `last`, `last_mut` — `Option<&T>[n != 0]`, symmetric with `first`
- `first_mut` — mutable counterpart of `first`
- `get`, `get_mut` — `Option<...>[<I as SliceIndex<[T]>>::in_bounds(idx, n)]`, reusing the existing `in_bounds` predicate from the `Index` impl
- `split_first`, `split_last` — `Option<(&T, &[T][n - 1])>[n != 0]`, tail/init length tracked precisely
- `split_at_mut` — mutable counterpart of `split_at`, same precondition `mid <= n`
- `split_at_checked`, `split_at_mut_checked` — `Option<(&[T][mid], &[T][n - mid])>[mid <= n]`

## `#[no_panic]` retrofits

Added `#[no_panic]` to pre-existing specs that were missing it: `is_empty`, `first`, `iter`, `as_ptr`, `as_mut_ptr` — all unconditionally panic-free.

## Other

- Migrated `#[sig(...)]` → `#[spec(...)]` on all pre-existing specs
- Moved inline `cfg(flux_sysroot_test)` tests from `mod.rs` into the dedicated `tests/` directory

```rust
// get: provably Some when in bounds
fn get_in_bounds(xs: &[i32], i: usize) {
    if i < xs.len() {
        assert(xs.get(i).is_some()); // verified ✓
    }
}

// split_first: tail length tracked precisely
fn split_first_tail_len(xs: &[i32]) {
    let n = xs.len();
    if let Some((_, tail)) = xs.split_first() {
        assert(tail.len() == n - 1); // verified ✓
    }
}

// split_at_checked: lengths flow through the Option
fn split_at_checked_lengths(xs: &[i32], mid: usize) {
    let n = xs.len();
    if let Some((left, right)) = xs.split_at_checked(mid) {
        assert(left.len() == mid);      // verified ✓
        assert(right.len() == n - mid); // verified ✓
    }
}
```