### PR TITLE
Improve option spec

### DIFF
--- a/lib/flux-core/src/option.rs
+++ b/lib/flux-core/src/option.rs
@@ -58,6 +58,33 @@ impl<T> Option<T> {
     #[spec(fn(Option<T>[@a], Option<T>[@b]) -> Option<T>[a || b])]
     fn or(self, optb: Option<T>) -> Option<T>;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/option.rs#L1309
+    #[no_panic]
+    #[spec(fn(Option<T>[@b], E) -> Result<T, E>[b])]
+    fn ok_or<E>(self, err: E) -> Result<T, E>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/option.rs#L1334
+    #[flux_rs::no_panic_if(F::no_panic())]
+    #[spec(fn(Option<T>[@b], F) -> Result<T, E>[b] where F: FnOnce() -> E)]
+    fn ok_or_else<E, F: FnOnce() -> E>(self, err: F) -> Result<T, E>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/option.rs#L1504
+    #[flux_rs::no_panic_if(F::no_panic())]
+    #[spec(fn(Option<T>[@b], F) -> Option<U>{s: s => b} where F: FnOnce(T) -> Option<U>)]
+    fn and_then<U, F: FnOnce(T) -> Option<U>>(self, f: F) -> Option<U>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/option.rs#L1783
+    #[no_panic]
+    #[spec(fn(self: &mut Option<T>[@b]) -> Option<T>[b]
+           ensures self: Option<T>[false])]
+    const fn take(&mut self) -> Option<T>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/option.rs#L1841
+    #[no_panic]
+    #[spec(fn(self: &mut Option<T>[@b], T) -> Option<T>[b]
+           ensures self: Option<T>[true])]
+    const fn replace(&mut self, value: T) -> Option<T>;
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1160
     #[flux_rs::no_panic_if(F::no_panic())]
     #[spec(fn(Option<T>[@b], F) -> Option<U>[b] where F: FnOnce(T) -> U)]

--- a/lib/flux-core/src/option.rs
+++ b/lib/flux-core/src/option.rs
@@ -21,6 +21,21 @@ impl<T> Option<T> {
     #[sig(fn(Option<T>[true]) -> T)]
     const fn unwrap(self) -> T;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L957
+    #[no_panic]
+    #[spec(fn(Option<T>[true], &str) -> T)]
+    const fn expect(self, msg: &str) -> T;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1025
+    #[no_panic]
+    #[spec(fn(Option<T>[@b], T) -> T)]
+    fn unwrap_or(self, default: T) -> T;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1044
+    #[flux_rs::no_panic_if(F::no_panic())]
+    #[spec(fn(Option<T>[@b], F) -> T where F: FnOnce() -> T)]
+    fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T;
+
     #[sig(fn(&Self[@b]) -> Option<&T>[b])]
     fn as_ref(&self) -> Option<&T>;
 
@@ -32,4 +47,24 @@ impl<T> Option<T> {
 
     #[sig(fn(&mut Self[@b]) -> &mut [T][if b { 1 } else { 0 }])]
     fn as_mut_slice(&mut self) -> &mut [T];
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1465
+    #[no_panic]
+    #[spec(fn(Option<T>[@a], Option<U>[@b]) -> Option<U>[a && b])]
+    fn and<U>(self, optb: Option<U>) -> Option<U>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1581
+    #[no_panic]
+    #[spec(fn(Option<T>[@a], Option<T>[@b]) -> Option<T>[a || b])]
+    fn or(self, optb: Option<T>) -> Option<T>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1160
+    #[flux_rs::no_panic_if(F::no_panic())]
+    #[spec(fn(Option<T>[@b], F) -> Option<U>[b] where F: FnOnce(T) -> U)]
+    fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Option<U>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1224
+    #[flux_rs::no_panic_if(F::no_panic())]
+    #[spec(fn(Option<T>[@b], U, F) -> U where F: FnOnce(T) -> U)]
+    fn map_or<U, F: FnOnce(T) -> U>(self, default: U, f: F) -> U;
 }

--- a/lib/flux-core/src/slice/iter.rs
+++ b/lib/flux-core/src/slice/iter.rs
@@ -6,6 +6,7 @@ struct Iter<'a, T>;
 
 #[extern_spec(core::slice)]
 impl<'a, T> Iter<'a, T> {
+    #[no_panic]
     #[spec(fn(&Self[@it]) -> &[T][it.len])]
     fn as_slice(&self) -> &'a [T];
 }
@@ -17,6 +18,7 @@ impl<'a, T> Iter<'a, T> {
     fn step(x: Iter, y: Iter) -> bool { x.idx + 1 == y.idx && x.len == y.len}
 )]
 impl<'a, T> Iterator for Iter<'a, T> {
+    #[no_panic]
     #[spec(fn(self: &mut Iter<T>[@curr_s]) -> Option<_>[curr_s.idx < curr_s.len]
            ensures self: Iter<T>{next_s: curr_s.idx + 1 == next_s.idx && curr_s.len == next_s.len})]
     fn next(&mut self) -> Option<&'a T>;
@@ -24,6 +26,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
 #[extern_spec(core::slice)]
 impl<'a, T> IntoIterator for &'a [T] {
+    #[no_panic]
     #[spec(fn(&[T][@n]) -> Iter<T>[0, n])]
     fn into_iter(v: &'a [T]) -> Iter<'a, T>;
 }

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -6,72 +6,51 @@ use flux_attrs::*;
 #[extern_spec(core::slice)]
 impl<T> [T] {
     #[no_panic]
-    #[sig(fn(&Self[@n]) -> usize[n])]
+    #[spec(fn(&Self[@n]) -> usize[n])]
     fn len(&self) -> usize;
 
-    #[sig(fn(&Self[@n]) -> bool[n == 0])]
+    #[spec(fn(&Self[@n]) -> bool[n == 0])]
     fn is_empty(&self) -> bool;
 
-    #[sig(fn(&Self[@n]) -> Option<&T>[n != 0])]
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L154
+    #[spec(fn(&Self[@n]) -> Option<&T>[n != 0])]
     fn first(&self) -> Option<&T>;
 
-    #[sig(fn(&Self[@n]) -> Iter<T>[0, n])]
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L280
+    #[no_panic]
+    #[spec(fn(&Self[@n]) -> Option<&T>[n != 0])]
+    fn last(&self) -> Option<&T>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L570
+    #[no_panic]
+    #[spec(fn(&Self[@n], I[@idx]) -> Option<&I::Output>[<I as SliceIndex<[T]>>::in_bounds(idx, n)])]
+    fn get<I: SliceIndex<[T]>>(&self, index: I) -> Option<&I::Output>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L197
+    #[no_panic]
+    #[spec(fn(&Self[@n]) -> Option<(&T, &[T][n - 1])>[n != 0])]
+    fn split_first(&self) -> Option<(&T, &[T])>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L239
+    #[no_panic]
+    #[spec(fn(&Self[@n]) -> Option<(&T, &[T][n - 1])>[n != 0])]
+    fn split_last(&self) -> Option<(&T, &[T])>;
+
+    #[spec(fn(&Self[@n]) -> Iter<T>[0, n])]
     fn iter(&self) -> Iter<'_, T>;
 
     #[no_panic]
-    #[sig(fn(&Self[@n], mid: usize{mid <= n}) -> (&[T][mid], &[T][n - mid]))]
+    #[spec(fn(&Self[@n], mid: usize{mid <= n}) -> (&[T][mid], &[T][n - mid]))]
     fn split_at(&self, mid: usize) -> (&[T], &[T]);
 
-    #[sig(fn(&Self[@n]) -> *const{p: ptr_size(p) == n} T)]
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L2185
+    #[no_panic]
+    #[spec(fn(&Self[@n], usize[@mid]) -> Option<(&[T][mid], &[T][n - mid])>[mid <= n])]
+    fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])>;
+
+    #[spec(fn(&Self[@n]) -> *const{p: ptr_size(p) == n} T)]
     fn as_ptr(&self) -> *const T;
 
-    #[sig(fn(&mut Self[@n]) -> *mut{p: ptr_size(p) == n} T)]
+    #[spec(fn(&mut Self[@n]) -> *mut{p: ptr_size(p) == n} T)]
     fn as_mut_ptr(&mut self) -> *mut T;
-}
-
-#[cfg(flux_sysroot_test)]
-mod tests {
-    #![allow(dead_code)]
-
-    use flux_attrs::*;
-
-    #[sig(fn(bool[true]))]
-    fn assert(_: bool) {}
-
-    #[should_fail]
-    fn test01(xs: &[i32]) {
-        let _x = xs[0];
-    }
-
-    fn test_len(xs: &[i32]) {
-        if xs.len() > 0 {
-            let _x = xs[0];
-        }
-    }
-
-    fn test_is_empty(xs: &[i32]) {
-        if !xs.is_empty() {
-            let _x = xs[0];
-        }
-    }
-
-    fn test_first00(xs: &[i32]) {
-        if xs.len() > 0 {
-            assert(xs.first().is_some());
-        }
-        if xs.is_empty() {
-            assert(xs.first().is_none());
-        }
-    }
-
-    #[should_fail]
-    fn test_first01(xs: &[i32]) {
-        assert(xs.first().is_some());
-    }
-
-    fn test_iter00(xs: &[i32]) {
-        let it = xs.iter();
-        let ys = it.as_slice();
-        assert(xs.len() == ys.len());
-    }
 }

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -16,15 +16,30 @@ impl<T> [T] {
     #[spec(fn(&Self[@n]) -> Option<&T>[n != 0])]
     fn first(&self) -> Option<&T>;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L177
+    #[no_panic]
+    #[spec(fn(&mut Self[@n]) -> Option<&mut T>[n != 0])]
+    fn first_mut(&mut self) -> Option<&mut T>;
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L280
     #[no_panic]
     #[spec(fn(&Self[@n]) -> Option<&T>[n != 0])]
     fn last(&self) -> Option<&T>;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L303
+    #[no_panic]
+    #[spec(fn(&mut Self[@n]) -> Option<&mut T>[n != 0])]
+    fn last_mut(&mut self) -> Option<&mut T>;
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L570
     #[no_panic]
     #[spec(fn(&Self[@n], I[@idx]) -> Option<&I::Output>[<I as SliceIndex<[T]>>::in_bounds(idx, n)])]
     fn get<I: SliceIndex<[T]>>(&self, index: I) -> Option<&I::Output>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L596
+    #[no_panic]
+    #[spec(fn(&mut Self[@n], I[@idx]) -> Option<&mut I::Output>[<I as SliceIndex<[T]>>::in_bounds(idx, n)])]
+    fn get_mut<I: SliceIndex<[T]>>(&mut self, index: I) -> Option<&mut I::Output>;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L197
     #[no_panic]
@@ -43,10 +58,20 @@ impl<T> [T] {
     #[spec(fn(&Self[@n], mid: usize{mid <= n}) -> (&[T][mid], &[T][n - mid]))]
     fn split_at(&self, mid: usize) -> (&[T], &[T]);
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L2018
+    #[no_panic]
+    #[spec(fn(&mut Self[@n], mid: usize{mid <= n}) -> (&mut [T][mid], &mut [T][n - mid]))]
+    fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]);
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L2185
     #[no_panic]
     #[spec(fn(&Self[@n], usize[@mid]) -> Option<(&[T][mid], &[T][n - mid])>[mid <= n])]
     fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L2224
+    #[no_panic]
+    #[spec(fn(&mut Self[@n], usize[@mid]) -> Option<(&mut [T][mid], &mut [T][n - mid])>[mid <= n])]
+    fn split_at_mut_checked(&mut self, mid: usize) -> Option<(&mut [T], &mut [T])>;
 
     #[spec(fn(&Self[@n]) -> *const{p: ptr_size(p) == n} T)]
     fn as_ptr(&self) -> *const T;

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -9,10 +9,12 @@ impl<T> [T] {
     #[spec(fn(&Self[@n]) -> usize[n])]
     fn len(&self) -> usize;
 
+    #[no_panic]
     #[spec(fn(&Self[@n]) -> bool[n == 0])]
     fn is_empty(&self) -> bool;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L154
+    #[no_panic]
     #[spec(fn(&Self[@n]) -> Option<&T>[n != 0])]
     fn first(&self) -> Option<&T>;
 
@@ -51,6 +53,7 @@ impl<T> [T] {
     #[spec(fn(&Self[@n]) -> Option<(&T, &[T][n - 1])>[n != 0])]
     fn split_last(&self) -> Option<(&T, &[T])>;
 
+    #[no_panic]
     #[spec(fn(&Self[@n]) -> Iter<T>[0, n])]
     fn iter(&self) -> Iter<'_, T>;
 
@@ -73,9 +76,11 @@ impl<T> [T] {
     #[spec(fn(&mut Self[@n], usize[@mid]) -> Option<(&mut [T][mid], &mut [T][n - mid])>[mid <= n])]
     fn split_at_mut_checked(&mut self, mid: usize) -> Option<(&mut [T], &mut [T])>;
 
+    #[no_panic]
     #[spec(fn(&Self[@n]) -> *const{p: ptr_size(p) == n} T)]
     fn as_ptr(&self) -> *const T;
 
+    #[no_panic]
     #[spec(fn(&mut Self[@n]) -> *mut{p: ptr_size(p) == n} T)]
     fn as_mut_ptr(&mut self) -> *mut T;
 }

--- a/tests/tests/neg/extern_specs/flux_core_option00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_option00.rs
@@ -24,3 +24,45 @@ pub fn test_or(x: Option<i32>, y: Option<i32>) {
 pub fn test_map(x: Option<i32>) {
     assert(x.map(|v| v + 1).is_some()); //~ ERROR refinement type error
 }
+
+// --- take ---
+
+pub fn test_take_result_always_some(x: Option<i32>) {
+    let mut x = x;
+    assert(x.take().is_some()); //~ ERROR refinement type error
+}
+
+pub fn test_take_self_still_some(mut x: Option<i32>) {
+    let _ = x.take();
+    assert(x.is_some()); //~ ERROR refinement type error
+}
+
+// --- replace ---
+
+pub fn test_replace_result_always_some(x: Option<i32>) {
+    let mut x = x;
+    assert(x.replace(1).is_some()); //~ ERROR refinement type error
+}
+
+pub fn test_replace_self_still_none(mut x: Option<i32>) {
+    let _ = x.replace(1);
+    assert(x.is_none()); //~ ERROR refinement type error
+}
+
+// --- ok_or ---
+
+pub fn test_ok_or(x: Option<i32>) {
+    assert(x.ok_or("err").is_ok()); //~ ERROR refinement type error
+}
+
+// --- ok_or_else ---
+
+pub fn test_ok_or_else(x: Option<i32>) {
+    assert(x.ok_or_else(|| "err").is_ok()); //~ ERROR refinement type error
+}
+
+// --- and_then ---
+
+pub fn test_and_then(x: Option<i32>) {
+    assert(x.and_then(|v| Some(v + 1)).is_some()); //~ ERROR refinement type error
+}

--- a/tests/tests/neg/extern_specs/flux_core_option00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_option00.rs
@@ -1,0 +1,26 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- expect ---
+
+pub fn test_expect(x: Option<i32>) {
+    let _ = x.expect("oops"); //~ ERROR refinement type error
+}
+
+// --- and ---
+
+pub fn test_and(x: Option<i32>, y: Option<i32>) {
+    assert(x.and(y).is_some()); //~ ERROR refinement type error
+}
+
+// --- or ---
+
+pub fn test_or(x: Option<i32>, y: Option<i32>) {
+    assert(x.or(y).is_none()); //~ ERROR refinement type error
+}
+
+// --- map ---
+
+pub fn test_map(x: Option<i32>) {
+    assert(x.map(|v| v + 1).is_some()); //~ ERROR refinement type error
+}

--- a/tests/tests/neg/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_slice00.rs
@@ -29,6 +29,28 @@ pub fn test_get_unchecked_index(xs: &[i32], i: usize) {
     assert(xs.get(i).is_some()); //~ ERROR refinement type error
 }
 
+// --- first_mut / last_mut ---
+
+pub fn test_first_mut(xs: &mut [i32]) {
+    assert(xs.first_mut().is_some()); //~ ERROR refinement type error
+}
+
+pub fn test_last_mut(xs: &mut [i32]) {
+    assert(xs.last_mut().is_some()); //~ ERROR refinement type error
+}
+
+// --- get_mut ---
+
+pub fn test_get_mut(xs: &mut [i32], i: usize) {
+    assert(xs.get_mut(i).is_some()); //~ ERROR refinement type error
+}
+
+// --- split_at_mut_checked ---
+
+pub fn test_split_at_mut_checked(xs: &mut [i32], mid: usize) {
+    assert(xs.split_at_mut_checked(mid).is_some()); //~ ERROR refinement type error
+}
+
 // --- split_first ---
 
 pub fn test_split_first(xs: &[i32]) {

--- a/tests/tests/neg/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_slice00.rs
@@ -1,0 +1,48 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- index ---
+
+pub fn test_index_oob(xs: &[i32]) {
+    let _x = xs[0]; //~ ERROR possible out-of-bounds access
+}
+
+// --- first ---
+
+pub fn test_first(xs: &[i32]) {
+    assert(xs.first().is_some()); //~ ERROR refinement type error
+}
+
+// --- last ---
+
+pub fn test_last(xs: &[i32]) {
+    assert(xs.last().is_some()); //~ ERROR refinement type error
+}
+
+// --- get ---
+
+pub fn test_get(xs: &[i32]) {
+    assert(xs.get(0).is_some()); //~ ERROR refinement type error
+}
+
+pub fn test_get_unchecked_index(xs: &[i32], i: usize) {
+    assert(xs.get(i).is_some()); //~ ERROR refinement type error
+}
+
+// --- split_first ---
+
+pub fn test_split_first(xs: &[i32]) {
+    assert(xs.split_first().is_some()); //~ ERROR refinement type error
+}
+
+// --- split_last ---
+
+pub fn test_split_last(xs: &[i32]) {
+    assert(xs.split_last().is_some()); //~ ERROR refinement type error
+}
+
+// --- split_at_checked ---
+
+pub fn test_split_at_checked(xs: &[i32], mid: usize) {
+    assert(xs.split_at_checked(mid).is_some()); //~ ERROR refinement type error
+}

--- a/tests/tests/pos/extern_specs/flux_core_option00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_option00.rs
@@ -1,0 +1,84 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- expect ---
+
+pub fn test_expect() {
+    let x: Option<i32> = Some(1);
+    let _ = x.expect("should be some");
+}
+
+pub fn test_expect_after_check(x: Option<i32>) {
+    if x.is_some() {
+        let _ = x.expect("should be some");
+    }
+}
+
+// --- unwrap_or ---
+
+pub fn test_unwrap_or(x: Option<i32>) {
+    let _ = x.unwrap_or(0);
+}
+
+// --- unwrap_or_else ---
+
+pub fn test_unwrap_or_else(x: Option<i32>) {
+    let _ = x.unwrap_or_else(|| 0);
+}
+
+// --- and ---
+
+pub fn test_and_none_left(x: Option<i32>) {
+    assert(x.and(Some(1)).is_some() == x.is_some());
+}
+
+pub fn test_and_none_right(x: Option<i32>) {
+    let n: Option<i32> = None;
+    assert(x.and(n).is_none());
+}
+
+pub fn test_and_both_some() {
+    let a: Option<i32> = Some(1);
+    let b: Option<i32> = Some(2);
+    assert(a.and(b).is_some());
+}
+
+// --- or ---
+
+pub fn test_or_some_left() {
+    let a: Option<i32> = Some(1);
+    let b: Option<i32> = None;
+    assert(a.or(b).is_some());
+}
+
+pub fn test_or_some_right(x: Option<i32>) {
+    assert(x.or(Some(0)).is_some());
+}
+
+pub fn test_or_both_none() {
+    let a: Option<i32> = None;
+    let b: Option<i32> = None;
+    assert(a.or(b).is_none());
+}
+
+// --- map ---
+
+pub fn test_map_preserves_some() {
+    let x: Option<i32> = Some(1);
+    assert(x.map(|v| v + 1).is_some());
+}
+
+pub fn test_map_preserves_none() {
+    let x: Option<i32> = None;
+    assert(x.map(|v| v + 1).is_none());
+}
+
+pub fn test_map_branch(x: Option<i32>) {
+    assert(x.map(|v| v + 1).is_some() == x.is_some());
+}
+
+// --- map_or ---
+
+pub fn test_map_or_branch(x: Option<i32>) {
+    let _ = x.map_or(0, |v| v + 1);
+}

--- a/tests/tests/pos/extern_specs/flux_core_option00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_option00.rs
@@ -82,3 +82,92 @@ pub fn test_map_branch(x: Option<i32>) {
 pub fn test_map_or_branch(x: Option<i32>) {
     let _ = x.map_or(0, |v| v + 1);
 }
+
+// --- take ---
+
+pub fn test_take_some() {
+    let mut x: Option<i32> = Some(1);
+    assert(x.take().is_some());
+    assert(x.is_none());
+}
+
+pub fn test_take_none() {
+    let mut x: Option<i32> = None;
+    assert(x.take().is_none());
+    assert(x.is_none());
+}
+
+pub fn test_take_return_matches_original(x: Option<i32>) {
+    let mut x = x;
+    let was_some = x.is_some();
+    let result = x.take();
+    assert(result.is_some() == was_some);
+    assert(x.is_none());
+}
+
+// --- replace ---
+
+pub fn test_replace_leaves_some() {
+    let mut x: Option<i32> = None;
+    let _ = x.replace(1);
+    assert(x.is_some());
+}
+
+pub fn test_replace_returns_old_none() {
+    let mut x: Option<i32> = None;
+    assert(x.replace(1).is_none());
+}
+
+pub fn test_replace_returns_old_some() {
+    let mut x: Option<i32> = Some(0);
+    assert(x.replace(1).is_some());
+}
+
+pub fn test_replace_return_matches_original(x: Option<i32>) {
+    let mut x = x;
+    let was_some = x.is_some();
+    let result = x.replace(42);
+    assert(result.is_some() == was_some);
+    assert(x.is_some());
+}
+
+// --- ok_or ---
+
+pub fn test_ok_or_some() {
+    let x: Option<i32> = Some(1);
+    assert(x.ok_or("err").is_ok());
+}
+
+pub fn test_ok_or_none() {
+    let x: Option<i32> = None;
+    assert(x.ok_or("err").is_err());
+}
+
+pub fn test_ok_or_branch(x: Option<i32>) {
+    assert(x.ok_or("err").is_ok() == x.is_some());
+}
+
+// --- ok_or_else ---
+
+pub fn test_ok_or_else_some() {
+    let x: Option<i32> = Some(1);
+    assert(x.ok_or_else(|| "err").is_ok());
+}
+
+pub fn test_ok_or_else_branch(x: Option<i32>) {
+    assert(x.ok_or_else(|| "err").is_ok() == x.is_some());
+}
+
+// --- and_then ---
+
+pub fn test_and_then_none_propagates(x: Option<i32>) {
+    let result = x.and_then(|v| if v > 0 { Some(v) } else { None });
+    if x.is_none() {
+        assert(result.is_none());
+    }
+}
+
+pub fn test_and_then_none_input() {
+    let x: Option<i32> = None;
+    assert(x.and_then(|v| Some(v + 1)).is_none());
+}

--- a/tests/tests/pos/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_slice00.rs
@@ -1,0 +1,152 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- len / is_empty / index ---
+
+pub fn test_index_after_len(xs: &[i32]) {
+    if xs.len() > 0 {
+        let _x = xs[0];
+    }
+}
+
+pub fn test_index_after_is_empty(xs: &[i32]) {
+    if !xs.is_empty() {
+        let _x = xs[0];
+    }
+}
+
+// --- first ---
+
+pub fn test_first_branch(xs: &[i32]) {
+    if xs.len() > 0 {
+        assert(xs.first().is_some());
+    }
+    if xs.is_empty() {
+        assert(xs.first().is_none());
+    }
+}
+
+// --- iter ---
+
+pub fn test_iter_as_slice_len(xs: &[i32]) {
+    let it = xs.iter();
+    let ys = it.as_slice();
+    assert(xs.len() == ys.len());
+}
+
+// --- last ---
+
+pub fn test_last_concrete() {
+    let v = [10, 40, 30];
+    assert(v.last().is_some());
+}
+
+pub fn test_last_empty() {
+    let w: &[i32] = &[];
+    assert(w.last().is_none());
+}
+
+pub fn test_last_branch(xs: &[i32]) {
+    if xs.is_empty() {
+        assert(xs.last().is_none());
+    } else {
+        assert(xs.last().is_some());
+    }
+}
+
+// --- get ---
+
+pub fn test_get_in_bounds(xs: &[i32], i: usize) {
+    if i < xs.len() {
+        assert(xs.get(i).is_some());
+    }
+}
+
+pub fn test_get_out_of_bounds(xs: &[i32], i: usize) {
+    if i >= xs.len() {
+        assert(xs.get(i).is_none());
+    }
+}
+
+pub fn test_get_concrete() {
+    let v = [10, 40, 30];
+    assert(v.get(0).is_some());
+    assert(v.get(2).is_some());
+    assert(v.get(3).is_none());
+}
+
+// --- split_first ---
+
+pub fn test_split_first_empty() {
+    let w: &[i32] = &[];
+    assert(w.split_first().is_none());
+}
+
+pub fn test_split_first_nonempty() {
+    let v = [1, 2, 3];
+    assert(v.split_first().is_some());
+}
+
+pub fn test_split_first_branch(xs: &[i32]) {
+    if xs.is_empty() {
+        assert(xs.split_first().is_none());
+    } else {
+        assert(xs.split_first().is_some());
+    }
+}
+
+pub fn test_split_first_tail_len(xs: &[i32]) {
+    let n = xs.len();
+    if let Some((_, tail)) = xs.split_first() {
+        assert(tail.len() == n - 1);
+    }
+}
+
+// --- split_last ---
+
+pub fn test_split_last_empty() {
+    let w: &[i32] = &[];
+    assert(w.split_last().is_none());
+}
+
+pub fn test_split_last_nonempty() {
+    let v = [1, 2, 3];
+    assert(v.split_last().is_some());
+}
+
+pub fn test_split_last_branch(xs: &[i32]) {
+    if xs.is_empty() {
+        assert(xs.split_last().is_none());
+    } else {
+        assert(xs.split_last().is_some());
+    }
+}
+
+pub fn test_split_last_init_len(xs: &[i32]) {
+    let n = xs.len();
+    if let Some((_, init)) = xs.split_last() {
+        assert(init.len() == n - 1);
+    }
+}
+
+// --- split_at_checked ---
+
+pub fn test_split_at_checked_in_bounds(xs: &[i32], mid: usize) {
+    if mid <= xs.len() {
+        assert(xs.split_at_checked(mid).is_some());
+    }
+}
+
+pub fn test_split_at_checked_out_of_bounds(xs: &[i32], mid: usize) {
+    if mid > xs.len() {
+        assert(xs.split_at_checked(mid).is_none());
+    }
+}
+
+pub fn test_split_at_checked_lengths(xs: &[i32], mid: usize) {
+    let n = xs.len();
+    if let Some((left, right)) = xs.split_at_checked(mid) {
+        assert(left.len() == mid);
+        assert(right.len() == n - mid);
+    }
+}

--- a/tests/tests/pos/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_slice00.rs
@@ -34,6 +34,34 @@ pub fn test_iter_as_slice_len(xs: &[i32]) {
     assert(xs.len() == ys.len());
 }
 
+// --- first_mut / last_mut ---
+
+pub fn test_first_mut_empty() {
+    let mut w: [i32; 0] = [];
+    assert(w.first_mut().is_none());
+}
+
+pub fn test_first_mut_nonempty() {
+    let mut v = [1, 2, 3];
+    assert(v.first_mut().is_some());
+}
+
+pub fn test_first_mut_branch(xs: &mut [i32]) {
+    if xs.is_empty() {
+        assert(xs.first_mut().is_none());
+    } else {
+        assert(xs.first_mut().is_some());
+    }
+}
+
+pub fn test_last_mut_branch(xs: &mut [i32]) {
+    if xs.is_empty() {
+        assert(xs.last_mut().is_none());
+    } else {
+        assert(xs.last_mut().is_some());
+    }
+}
+
 // --- last ---
 
 pub fn test_last_concrete() {
@@ -126,6 +154,47 @@ pub fn test_split_last_init_len(xs: &[i32]) {
     let n = xs.len();
     if let Some((_, init)) = xs.split_last() {
         assert(init.len() == n - 1);
+    }
+}
+
+// --- get_mut ---
+
+pub fn test_get_mut_in_bounds(xs: &mut [i32], i: usize) {
+    if i < xs.len() {
+        assert(xs.get_mut(i).is_some());
+    }
+}
+
+pub fn test_get_mut_out_of_bounds(xs: &mut [i32], i: usize) {
+    if i >= xs.len() {
+        assert(xs.get_mut(i).is_none());
+    }
+}
+
+// --- split_at_mut ---
+
+pub fn test_split_at_mut_lengths(xs: &mut [i32], mid: usize) {
+    let n = xs.len();
+    if mid <= n {
+        let (left, right) = xs.split_at_mut(mid);
+        assert(left.len() == mid);
+        assert(right.len() == n - mid);
+    }
+}
+
+// --- split_at_mut_checked ---
+
+pub fn test_split_at_mut_checked_in_bounds(xs: &mut [i32], mid: usize) {
+    if mid <= xs.len() {
+        assert(xs.split_at_mut_checked(mid).is_some());
+    }
+}
+
+pub fn test_split_at_mut_checked_lengths(xs: &mut [i32], mid: usize) {
+    let n = xs.len();
+    if let Some((left, right)) = xs.split_at_mut_checked(mid) {
+        assert(left.len() == mid);
+        assert(right.len() == n - mid);
     }
 }
 


### PR DESCRIPTION
Added some boring specs for common `Option<T>` functions.
Mostly supercedes #1539 but I couldn't get `Option::inspect` to work. 
It seems to fail with: 
```
fails with "cannot determine corresponding unrefined predicate" for FnOnce(&T) + [const] Destruct bounds
```

Interestingly, some functions with `[const] Destruct` work like `map`, but the implicit `()` return type in `inspect` seems to cause issues.