### PR TITLE
Improve option spec 

### DIFF
--- a/lib/flux-core/src/option.rs
+++ b/lib/flux-core/src/option.rs
@@ -58,6 +58,33 @@ impl<T> Option<T> {
     #[spec(fn(Option<T>[@a], Option<T>[@b]) -> Option<T>[a || b])]
     fn or(self, optb: Option<T>) -> Option<T>;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/option.rs#L1309
+    #[no_panic]
+    #[spec(fn(Option<T>[@b], E) -> Result<T, E>[b])]
+    fn ok_or<E>(self, err: E) -> Result<T, E>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/option.rs#L1334
+    #[flux_rs::no_panic_if(F::no_panic())]
+    #[spec(fn(Option<T>[@b], F) -> Result<T, E>[b] where F: FnOnce() -> E)]
+    fn ok_or_else<E, F: FnOnce() -> E>(self, err: F) -> Result<T, E>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/option.rs#L1504
+    #[flux_rs::no_panic_if(F::no_panic())]
+    #[spec(fn(Option<T>[@b], F) -> Option<U>{s: s => b} where F: FnOnce(T) -> Option<U>)]
+    fn and_then<U, F: FnOnce(T) -> Option<U>>(self, f: F) -> Option<U>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/option.rs#L1783
+    #[no_panic]
+    #[spec(fn(self: &mut Option<T>[@b]) -> Option<T>[b]
+           ensures self: Option<T>[false])]
+    const fn take(&mut self) -> Option<T>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c6a955468b025dbe3d1de3e8f3e30496d1fb7f40/library/core/src/option.rs#L1841
+    #[no_panic]
+    #[spec(fn(self: &mut Option<T>[@b], T) -> Option<T>[b]
+           ensures self: Option<T>[true])]
+    const fn replace(&mut self, value: T) -> Option<T>;
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1160
     #[flux_rs::no_panic_if(F::no_panic())]
     #[spec(fn(Option<T>[@b], F) -> Option<U>[b] where F: FnOnce(T) -> U)]

--- a/lib/flux-core/src/option.rs
+++ b/lib/flux-core/src/option.rs
@@ -21,6 +21,21 @@ impl<T> Option<T> {
     #[sig(fn(Option<T>[true]) -> T)]
     const fn unwrap(self) -> T;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L957
+    #[no_panic]
+    #[spec(fn(Option<T>[true], &str) -> T)]
+    const fn expect(self, msg: &str) -> T;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1025
+    #[no_panic]
+    #[spec(fn(Option<T>[@b], T) -> T)]
+    fn unwrap_or(self, default: T) -> T;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1044
+    #[flux_rs::no_panic_if(F::no_panic())]
+    #[spec(fn(Option<T>[@b], F) -> T where F: FnOnce() -> T)]
+    fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T;
+
     #[sig(fn(&Self[@b]) -> Option<&T>[b])]
     fn as_ref(&self) -> Option<&T>;
 
@@ -32,4 +47,24 @@ impl<T> Option<T> {
 
     #[sig(fn(&mut Self[@b]) -> &mut [T][if b { 1 } else { 0 }])]
     fn as_mut_slice(&mut self) -> &mut [T];
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1465
+    #[no_panic]
+    #[spec(fn(Option<T>[@a], Option<U>[@b]) -> Option<U>[a && b])]
+    fn and<U>(self, optb: Option<U>) -> Option<U>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1581
+    #[no_panic]
+    #[spec(fn(Option<T>[@a], Option<T>[@b]) -> Option<T>[a || b])]
+    fn or(self, optb: Option<T>) -> Option<T>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1160
+    #[flux_rs::no_panic_if(F::no_panic())]
+    #[spec(fn(Option<T>[@b], F) -> Option<U>[b] where F: FnOnce(T) -> U)]
+    fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Option<U>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/option.rs#L1224
+    #[flux_rs::no_panic_if(F::no_panic())]
+    #[spec(fn(Option<T>[@b], U, F) -> U where F: FnOnce(T) -> U)]
+    fn map_or<U, F: FnOnce(T) -> U>(self, default: U, f: F) -> U;
 }

--- a/tests/tests/neg/extern_specs/flux_core_option00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_option00.rs
@@ -24,3 +24,45 @@ pub fn test_or(x: Option<i32>, y: Option<i32>) {
 pub fn test_map(x: Option<i32>) {
     assert(x.map(|v| v + 1).is_some()); //~ ERROR refinement type error
 }
+
+// --- take ---
+
+pub fn test_take_result_always_some(x: Option<i32>) {
+    let mut x = x;
+    assert(x.take().is_some()); //~ ERROR refinement type error
+}
+
+pub fn test_take_self_still_some(mut x: Option<i32>) {
+    let _ = x.take();
+    assert(x.is_some()); //~ ERROR refinement type error
+}
+
+// --- replace ---
+
+pub fn test_replace_result_always_some(x: Option<i32>) {
+    let mut x = x;
+    assert(x.replace(1).is_some()); //~ ERROR refinement type error
+}
+
+pub fn test_replace_self_still_none(mut x: Option<i32>) {
+    let _ = x.replace(1);
+    assert(x.is_none()); //~ ERROR refinement type error
+}
+
+// --- ok_or ---
+
+pub fn test_ok_or(x: Option<i32>) {
+    assert(x.ok_or("err").is_ok()); //~ ERROR refinement type error
+}
+
+// --- ok_or_else ---
+
+pub fn test_ok_or_else(x: Option<i32>) {
+    assert(x.ok_or_else(|| "err").is_ok()); //~ ERROR refinement type error
+}
+
+// --- and_then ---
+
+pub fn test_and_then(x: Option<i32>) {
+    assert(x.and_then(|v| Some(v + 1)).is_some()); //~ ERROR refinement type error
+}

--- a/tests/tests/neg/extern_specs/flux_core_option00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_option00.rs
@@ -1,0 +1,26 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- expect ---
+
+pub fn test_expect(x: Option<i32>) {
+    let _ = x.expect("oops"); //~ ERROR refinement type error
+}
+
+// --- and ---
+
+pub fn test_and(x: Option<i32>, y: Option<i32>) {
+    assert(x.and(y).is_some()); //~ ERROR refinement type error
+}
+
+// --- or ---
+
+pub fn test_or(x: Option<i32>, y: Option<i32>) {
+    assert(x.or(y).is_none()); //~ ERROR refinement type error
+}
+
+// --- map ---
+
+pub fn test_map(x: Option<i32>) {
+    assert(x.map(|v| v + 1).is_some()); //~ ERROR refinement type error
+}

--- a/tests/tests/pos/extern_specs/flux_core_option00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_option00.rs
@@ -1,0 +1,84 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- expect ---
+
+pub fn test_expect() {
+    let x: Option<i32> = Some(1);
+    let _ = x.expect("should be some");
+}
+
+pub fn test_expect_after_check(x: Option<i32>) {
+    if x.is_some() {
+        let _ = x.expect("should be some");
+    }
+}
+
+// --- unwrap_or ---
+
+pub fn test_unwrap_or(x: Option<i32>) {
+    let _ = x.unwrap_or(0);
+}
+
+// --- unwrap_or_else ---
+
+pub fn test_unwrap_or_else(x: Option<i32>) {
+    let _ = x.unwrap_or_else(|| 0);
+}
+
+// --- and ---
+
+pub fn test_and_none_left(x: Option<i32>) {
+    assert(x.and(Some(1)).is_some() == x.is_some());
+}
+
+pub fn test_and_none_right(x: Option<i32>) {
+    let n: Option<i32> = None;
+    assert(x.and(n).is_none());
+}
+
+pub fn test_and_both_some() {
+    let a: Option<i32> = Some(1);
+    let b: Option<i32> = Some(2);
+    assert(a.and(b).is_some());
+}
+
+// --- or ---
+
+pub fn test_or_some_left() {
+    let a: Option<i32> = Some(1);
+    let b: Option<i32> = None;
+    assert(a.or(b).is_some());
+}
+
+pub fn test_or_some_right(x: Option<i32>) {
+    assert(x.or(Some(0)).is_some());
+}
+
+pub fn test_or_both_none() {
+    let a: Option<i32> = None;
+    let b: Option<i32> = None;
+    assert(a.or(b).is_none());
+}
+
+// --- map ---
+
+pub fn test_map_preserves_some() {
+    let x: Option<i32> = Some(1);
+    assert(x.map(|v| v + 1).is_some());
+}
+
+pub fn test_map_preserves_none() {
+    let x: Option<i32> = None;
+    assert(x.map(|v| v + 1).is_none());
+}
+
+pub fn test_map_branch(x: Option<i32>) {
+    assert(x.map(|v| v + 1).is_some() == x.is_some());
+}
+
+// --- map_or ---
+
+pub fn test_map_or_branch(x: Option<i32>) {
+    let _ = x.map_or(0, |v| v + 1);
+}

--- a/tests/tests/pos/extern_specs/flux_core_option00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_option00.rs
@@ -82,3 +82,92 @@ pub fn test_map_branch(x: Option<i32>) {
 pub fn test_map_or_branch(x: Option<i32>) {
     let _ = x.map_or(0, |v| v + 1);
 }
+
+// --- take ---
+
+pub fn test_take_some() {
+    let mut x: Option<i32> = Some(1);
+    assert(x.take().is_some());
+    assert(x.is_none());
+}
+
+pub fn test_take_none() {
+    let mut x: Option<i32> = None;
+    assert(x.take().is_none());
+    assert(x.is_none());
+}
+
+pub fn test_take_return_matches_original(x: Option<i32>) {
+    let mut x = x;
+    let was_some = x.is_some();
+    let result = x.take();
+    assert(result.is_some() == was_some);
+    assert(x.is_none());
+}
+
+// --- replace ---
+
+pub fn test_replace_leaves_some() {
+    let mut x: Option<i32> = None;
+    let _ = x.replace(1);
+    assert(x.is_some());
+}
+
+pub fn test_replace_returns_old_none() {
+    let mut x: Option<i32> = None;
+    assert(x.replace(1).is_none());
+}
+
+pub fn test_replace_returns_old_some() {
+    let mut x: Option<i32> = Some(0);
+    assert(x.replace(1).is_some());
+}
+
+pub fn test_replace_return_matches_original(x: Option<i32>) {
+    let mut x = x;
+    let was_some = x.is_some();
+    let result = x.replace(42);
+    assert(result.is_some() == was_some);
+    assert(x.is_some());
+}
+
+// --- ok_or ---
+
+pub fn test_ok_or_some() {
+    let x: Option<i32> = Some(1);
+    assert(x.ok_or("err").is_ok());
+}
+
+pub fn test_ok_or_none() {
+    let x: Option<i32> = None;
+    assert(x.ok_or("err").is_err());
+}
+
+pub fn test_ok_or_branch(x: Option<i32>) {
+    assert(x.ok_or("err").is_ok() == x.is_some());
+}
+
+// --- ok_or_else ---
+
+pub fn test_ok_or_else_some() {
+    let x: Option<i32> = Some(1);
+    assert(x.ok_or_else(|| "err").is_ok());
+}
+
+pub fn test_ok_or_else_branch(x: Option<i32>) {
+    assert(x.ok_or_else(|| "err").is_ok() == x.is_some());
+}
+
+// --- and_then ---
+
+pub fn test_and_then_none_propagates(x: Option<i32>) {
+    let result = x.and_then(|v| if v > 0 { Some(v) } else { None });
+    if x.is_none() {
+        assert(result.is_none());
+    }
+}
+
+pub fn test_and_then_none_input() {
+    let x: Option<i32> = None;
+    assert(x.and_then(|v| Some(v + 1)).is_none());
+}


### PR DESCRIPTION
Added some boring specs for common `Option<T>` functions.
Mostly supercedes #1539 but I couldn't get `Option::inspect` to work. 
It seems to fail with: 
```
fails with "cannot determine corresponding unrefined predicate" for FnOnce(&T) + [const] Destruct bounds
```

Interestingly, some functions with `[const] Destruct` work like `map`, but the implicit `()` return type in `inspect` seems to cause issues.