### PR TITLE
Add flux core specs for `alloc::Layout`

### DIFF
--- a/lib/flux-core/src/alloc/layout.rs
+++ b/lib/flux-core/src/alloc/layout.rs
@@ -15,7 +15,7 @@
 
     // See: https://github.com/rust-lang/rust/blob/dab8d9d1066c4c95008163c7babf275106ce3f32/library/core/src/alloc/layout.rs#L559-L589
     fn is_valid_array_layout(n: int, size: int, align: int) -> bool {
-        size == 0 || is_valid_layout(size * n, align)
+        size == 0 || size * n + align - 1 <= isize::MAX
     }
 )]
 

--- a/lib/flux-core/src/alloc/layout.rs
+++ b/lib/flux-core/src/alloc/layout.rs
@@ -1,0 +1,53 @@
+#![flux::defs(
+    fn pow2(x: int) -> bool { pow2bv(bv_int_to_bv64(x)) }
+    fn pow2bv(x: bitvec<64>) -> bool {
+        bv_and(x, bv_sub(x, bv_int_to_bv64(1))) == bv_int_to_bv64(0)
+    }
+    fn is_valid_layout(s: int, a: int) -> bool {
+        (s + a - 1 <= isize::MAX) && a > 0 && pow2(a)
+    }
+)]
+
+use flux_attrs::*;
+
+#[extern_spec(core::alloc)]
+#[opaque]
+#[refined_by(size: int, align: int)]
+#[invariant(align > 0 && pow2(align))]
+#[invariant(size + align - 1 <= isize::MAX)]
+struct Layout;
+
+#[extern_spec(core::alloc)]
+impl Layout {
+    // Core impl: https://github.com/rust-lang/rust/blob/dab8d9d1066c4c95008163c7babf275106ce3f32/library/core/src/alloc/layout.rs#L206-L208
+    #[no_panic]
+    #[spec(fn() -> Self[T::size_of(), T::align_of()])]
+    const fn new<T>() -> Self;
+
+    // Core impl: https://github.com/rust-lang/rust/blob/dab8d9d1066c4c95008163c7babf275106ce3f32/library/core/src/alloc/layout.rs#L59-L66
+    #[no_panic]
+    #[spec(fn(s: usize, a: usize) -> Result<Self[s,a], _>[is_valid_layout(s, a)])]
+    const fn from_size_align(size: usize, align: usize) -> Result<Layout, LayoutError>;
+
+    // Core impl: https://github.com/rust-lang/rust/blob/dab8d9d1066c4c95008163c7babf275106ce3f32/library/core/src/alloc/layout.rs#L132-L144
+    #[no_panic]
+    #[spec(fn(s: usize, a: usize) -> Self[s, a] requires is_valid_layout(s, a))]
+    const unsafe fn from_size_align_unchecked(size: usize, align: usize) -> Self;
+
+    // Core impl: https://github.com/rust-lang/rust/blob/dab8d9d1066c4c95008163c7babf275106ce3f32/library/core/src/alloc/layout.rs#L175-L177
+    #[no_panic]
+    #[spec(fn(&Self[@s, @a]) -> usize[s])]
+    const fn size(&self) -> usize;
+
+    // Core impl: https://github.com/rust-lang/rust/blob/dab8d9d1066c4c95008163c7babf275106ce3f32/library/core/src/alloc/layout.rs#L187-L189
+    #[no_panic]
+    #[spec(fn(&Self[@s, @a]) -> usize[a])]
+    const fn align(&self) -> usize;
+
+    // Core impl: https://github.com/rust-lang/rust/blob/dab8d9d1066c4c95008163c7babf275106ce3f32/library/core/src/alloc/layout.rs#L559-L589
+    #[no_panic]
+    #[spec(fn(n: usize) -> Result<Self[n * T::size_of(), T::align_of()],_>[
+        T::size_of() == 0 || n * T::size_of() + T::align_of() - 1 <= isize::MAX
+    ])]
+    const fn array<T>(n: usize) -> Result<Layout, LayoutError>;
+}

--- a/lib/flux-core/src/alloc/layout.rs
+++ b/lib/flux-core/src/alloc/layout.rs
@@ -3,8 +3,19 @@
     fn pow2bv(x: bitvec<64>) -> bool {
         bv_and(x, bv_sub(x, bv_int_to_bv64(1))) == bv_int_to_bv64(0)
     }
+    // For a layout to be valid, align must be a power of two and size must not overflow
+    // isize when rounded up to the nearest multiple of align.
+    //
+    // The rounding formula `(size + align - 1) & !(align - 1)` is maximized when just past the
+    // alignment boundary, and thus bounded by `size + align - 1`.
+    // See: https://github.com/rust-lang/rust/blob/dab8d9d1066c4c95008163c7babf275106ce3f32/library/core/src/alloc/layout.rs#L80-L93
     fn is_valid_layout(s: int, a: int) -> bool {
         (s + a - 1 <= isize::MAX) && a > 0 && pow2(a)
+    }
+
+    // See: https://github.com/rust-lang/rust/blob/dab8d9d1066c4c95008163c7babf275106ce3f32/library/core/src/alloc/layout.rs#L559-L589
+    fn is_valid_array_layout(n: int, size: int, align: int) -> bool {
+        size == 0 || is_valid_layout(size * n, align)
     }
 )]
 
@@ -47,7 +58,7 @@ impl Layout {
     // Core impl: https://github.com/rust-lang/rust/blob/dab8d9d1066c4c95008163c7babf275106ce3f32/library/core/src/alloc/layout.rs#L559-L589
     #[no_panic]
     #[spec(fn(n: usize) -> Result<Self[n * T::size_of(), T::align_of()],_>[
-        T::size_of() == 0 || n * T::size_of() + T::align_of() - 1 <= isize::MAX
+        is_valid_array_layout(n, T::size_of(), T::align_of())
     ])]
     const fn array<T>(n: usize) -> Result<Layout, LayoutError>;
 }

--- a/lib/flux-core/src/alloc/mod.rs
+++ b/lib/flux-core/src/alloc/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(flux)]
+mod layout;

--- a/lib/flux-core/src/lib.rs
+++ b/lib/flux-core/src/lib.rs
@@ -32,6 +32,9 @@ mod ptr;
 #[cfg(flux)]
 mod convert;
 
+#[cfg(flux)]
+mod alloc;
+
 // -------------------------------------------------------------------
 
 #[macro_export]

--- a/tests/tests/neg/extern_specs/flux_core_alloc00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_alloc00.rs
@@ -7,9 +7,6 @@ use flux_rs::assert;
 struct Foo(u8);
 struct Zst;
 
-// https://github.com/flux-rs/flux/issues/1558
-const ISIZE_MAX: usize = (1 << (isize::BITS - 1)) - 1;
-
 pub fn test_layout_new() {
     let x = Layout::new::<Foo>();
     let y = Layout::new::<u16>();
@@ -31,13 +28,13 @@ pub unsafe fn test_from_zero_align() -> Layout {
 
 pub unsafe fn test_from_size_overflow() -> Layout {
     // size, when rounded up to the nearest multiple of alignment, must not overflow isize.
-    Layout::from_size_align_unchecked(ISIZE_MAX - 2, 4) //~ ERROR refinement type
+    Layout::from_size_align_unchecked(isize::MAX as usize - 2, 4) //~ ERROR refinement type
 }
 
 pub fn test_from_valid() {
     assert(Layout::from_size_align(4, 4).is_err()); //~ ERROR refinement type
     assert(Layout::from_size_align(0, 8).is_err()); //~ ERROR refinement type
-    assert(Layout::from_size_align(ISIZE_MAX - 7, 8).is_err()); //~ ERROR refinement type
+    assert(Layout::from_size_align(isize::MAX as usize - 7, 8).is_err()); //~ ERROR refinement type
 }
 
 pub fn test_from_invalid() {
@@ -46,7 +43,7 @@ pub fn test_from_invalid() {
     // align must not be zero
     assert(Layout::from_size_align(4, 0).is_ok()); //~ ERROR refinement type
     // size, when rounded up to the nearest multiple of alignment, must not overflow isize.
-    assert(Layout::from_size_align(ISIZE_MAX - 2, 3).is_ok()); //~ ERROR refinement type
+    assert(Layout::from_size_align(isize::MAX as usize - 2, 3).is_ok()); //~ ERROR refinement type
 }
 
 pub fn test_array() {

--- a/tests/tests/neg/extern_specs/flux_core_alloc00.rs
+++ b/tests/tests/neg/extern_specs/flux_core_alloc00.rs
@@ -1,0 +1,68 @@
+extern crate flux_core;
+
+use core::alloc::Layout;
+use flux_rs::assert;
+
+#[repr(align(4))]
+struct Foo(u8);
+struct Zst;
+
+// https://github.com/flux-rs/flux/issues/1558
+const ISIZE_MAX: usize = (1 << (isize::BITS - 1)) - 1;
+
+pub fn test_layout_new() {
+    let x = Layout::new::<Foo>();
+    let y = Layout::new::<u16>();
+    assert(x.align() != 4); //~ ERROR refinement type
+    assert(x.size() != 4); //~ ERROR refinement type
+    assert(y.align() == 3); //~ ERROR refinement type
+    assert(y.size() == 8); //~ ERROR refinement type
+}
+
+pub unsafe fn test_from_nonpow2_align() -> Layout {
+    // align must be a power of two
+    Layout::from_size_align_unchecked(0, 3) //~ ERROR refinement type
+}
+
+pub unsafe fn test_from_zero_align() -> Layout {
+    // align must not be zero
+    Layout::from_size_align_unchecked(4, 0) //~ ERROR refinement type
+}
+
+pub unsafe fn test_from_size_overflow() -> Layout {
+    // size, when rounded up to the nearest multiple of alignment, must not overflow isize.
+    Layout::from_size_align_unchecked(ISIZE_MAX - 2, 4) //~ ERROR refinement type
+}
+
+pub fn test_from_valid() {
+    assert(Layout::from_size_align(4, 4).is_err()); //~ ERROR refinement type
+    assert(Layout::from_size_align(0, 8).is_err()); //~ ERROR refinement type
+    assert(Layout::from_size_align(ISIZE_MAX - 7, 8).is_err()); //~ ERROR refinement type
+}
+
+pub fn test_from_invalid() {
+    // align must be a power of two
+    assert(Layout::from_size_align(0, 3).is_ok()); //~ ERROR refinement type
+    // align must not be zero
+    assert(Layout::from_size_align(4, 0).is_ok()); //~ ERROR refinement type
+    // size, when rounded up to the nearest multiple of alignment, must not overflow isize.
+    assert(Layout::from_size_align(ISIZE_MAX - 2, 3).is_ok()); //~ ERROR refinement type
+}
+
+pub fn test_array() {
+    assert(Layout::array::<i32>(10).is_err()); //~ ERROR refinement type
+    assert(Layout::array::<Foo>(12).is_err()); //~ ERROR refinement type
+    assert(Layout::array::<u64>(usize::MAX).is_ok()); //~ ERROR refinement type
+}
+
+pub fn test_array_unwrap() {
+    let x = Layout::array::<u32>(10).unwrap();
+    let y = Layout::array::<Foo>(5).unwrap();
+    let z = Layout::array::<Zst>(20).unwrap();
+    assert(x.size() != size_of::<u32>() * 10); //~ ERROR refinement type
+    assert(x.align() != align_of::<u32>()); //~ ERROR refinement type
+    assert(y.size() != size_of::<Foo>() * 5); //~ ERROR refinement type
+    assert(y.align() != align_of::<Foo>()); //~ ERROR refinement type
+    assert(z.size() != 0); //~ ERROR refinement type
+    assert(z.align() != align_of::<Zst>()); //~ ERROR refinement type
+}

--- a/tests/tests/pos/extern_specs/flux_core_alloc00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_alloc00.rs
@@ -7,9 +7,6 @@ use core::alloc::Layout;
 struct Foo(u8);
 struct Zst;
 
-// https://github.com/flux-rs/flux/issues/1558
-const ISIZE_MAX: usize = (1 << (isize::BITS - 1)) - 1;
-
 pub fn test_layout_new() {
     let x = Layout::new::<Foo>();
     let y = Layout::new::<i64>();
@@ -28,7 +25,7 @@ pub unsafe fn test_unchecked_from() {
 pub fn test_from_valid() {
     assert(Layout::from_size_align(4, 4).is_ok());
     assert(Layout::from_size_align(0, 8).is_ok());
-    assert(Layout::from_size_align(ISIZE_MAX - 7, 8).is_ok());
+    assert(Layout::from_size_align(isize::MAX as usize - 7, 8).is_ok());
 }
 
 pub fn test_from_invalid() {
@@ -37,7 +34,7 @@ pub fn test_from_invalid() {
     // align must not be zero
     assert(Layout::from_size_align(4, 0).is_err());
     // size, when rounded up to the nearest multiple of alignment, must not overflow isize.
-    assert(Layout::from_size_align(ISIZE_MAX - 2, 3).is_err());
+    assert(Layout::from_size_align(isize::MAX as usize - 2, 3).is_err());
 }
 
 pub fn test_from_valid_unwrap() {

--- a/tests/tests/pos/extern_specs/flux_core_alloc00.rs
+++ b/tests/tests/pos/extern_specs/flux_core_alloc00.rs
@@ -1,0 +1,66 @@
+extern crate flux_core;
+
+use flux_rs::assert;
+use core::alloc::Layout;
+
+#[repr(align(4))]
+struct Foo(u8);
+struct Zst;
+
+// https://github.com/flux-rs/flux/issues/1558
+const ISIZE_MAX: usize = (1 << (isize::BITS - 1)) - 1;
+
+pub fn test_layout_new() {
+    let x = Layout::new::<Foo>();
+    let y = Layout::new::<i64>();
+    assert(x.align() == 4);
+    assert(x.size() == 4);
+    assert(y.align() != 3);
+    assert(y.size() == 8);
+}
+
+pub unsafe fn test_unchecked_from() {
+    let x = Layout::from_size_align_unchecked(size_of::<i32>(), align_of::<i32>());
+    assert(x.size() == size_of::<i32>());
+    assert(x.align() == align_of::<i32>());
+}
+
+pub fn test_from_valid() {
+    assert(Layout::from_size_align(4, 4).is_ok());
+    assert(Layout::from_size_align(0, 8).is_ok());
+    assert(Layout::from_size_align(ISIZE_MAX - 7, 8).is_ok());
+}
+
+pub fn test_from_invalid() {
+    // align must be a power of two
+    assert(Layout::from_size_align(0, 3).is_err());
+    // align must not be zero
+    assert(Layout::from_size_align(4, 0).is_err());
+    // size, when rounded up to the nearest multiple of alignment, must not overflow isize.
+    assert(Layout::from_size_align(ISIZE_MAX - 2, 3).is_err());
+}
+
+pub fn test_from_valid_unwrap() {
+    let x = Layout::from_size_align(4, 4).unwrap();
+    let y = Layout::from_size_align(size_of::<Foo>(), align_of::<Foo>()).unwrap();
+    assert(x.size() == 4 && x.align() == 4);
+    assert(y.size() == size_of::<Foo>() && y.align() == align_of::<Foo>());
+}
+
+pub fn test_array() {
+    assert(Layout::array::<i32>(10).is_ok());
+    assert(Layout::array::<Foo>(12).is_ok());
+    assert(Layout::array::<u64>(usize::MAX).is_err());
+}
+
+pub fn test_array_unwrap() {
+    let x = Layout::array::<u32>(10).unwrap();
+    let y = Layout::array::<Foo>(5).unwrap();
+    let z = Layout::array::<Zst>(20).unwrap();
+    assert(x.size() == size_of::<u32>() * 10);
+    assert(x.align() == align_of::<u32>());
+    assert(y.size() == size_of::<Foo>() * 5);
+    assert(y.align() == align_of::<Foo>());
+    assert(z.size() == 0);
+    assert(z.align() == align_of::<Zst>());
+}


### PR DESCRIPTION
Adds some initial specs for alloc::Layout:
- `Layout::new`
- `Layout::from_size_align`, `Layout::from_size_align_unchecked`
- `Layout::size`, `Layout::align`
- `Layout::array`

Related: https://github.com/flux-rs/flux/issues/1546