### PR TITLE
Support Fn/FnMut/FnOnce bounds with full signatures

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -270,11 +270,14 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
         &mut self,
         bounds: &[surface::TraitRef],
     ) -> fhir::GenericBounds<'genv> {
-        self.genv().alloc_slice_fill_iter(
-            bounds
-                .iter()
-                .map(|bound| fhir::GenericBound::Trait(self.desugar_trait_ref(bound))),
-        )
+        self.genv().alloc_slice_fill_iter(bounds.iter().map(|bound| {
+            let trait_ref = self.desugar_trait_ref(bound);
+            if let Some(fn_bound) = &bound.fn_bound {
+                fhir::GenericBound::FnTrait(trait_ref, self.desugar_fn_trait_bound(fn_bound))
+            } else {
+                fhir::GenericBound::Trait(trait_ref)
+            }
+        }))
     }
 
     fn desugar_trait_ref(&mut self, trait_ref: &surface::TraitRef) -> fhir::PolyTraitRef<'genv> {
@@ -294,6 +297,45 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
             trait_ref: path,
             span,
         }
+    }
+
+    fn desugar_fn_trait_bound(
+        &mut self,
+        bound: &surface::FnTraitBound,
+    ) -> fhir::FnTraitBound<'genv> {
+        let mut requires = vec![];
+        for surface_requires in &bound.requires {
+            let params = self.desugar_refine_params(&surface_requires.params);
+            let pred = self.desugar_expr(&surface_requires.pred);
+            requires.push(fhir::Requires { params, pred });
+        }
+
+        let inputs = self
+            .genv()
+            .alloc_slice_fill_iter(bound.inputs.iter().map(|input| self.desugar_fn_input(input)));
+        let output = self
+            .desugar_fn_output(surface::Async::No, &bound.output)
+            .unwrap_or_else(|err| fhir::FnOutput {
+                params: &[],
+                ret: fhir::Ty { kind: fhir::TyKind::Err(err), span: bound.span },
+                ensures: &[],
+            });
+        let decl = fhir::FnDecl {
+            requires: self.genv.alloc_slice(&requires),
+            inputs,
+            output,
+            span: bound.span,
+            lifted: false,
+        };
+        let refine_params = self
+            .genv
+            .alloc_slice_fill_iter(self.implicit_params_to_params(bound.node_id));
+        let kind = match bound.kind {
+            surface::FnTraitKind::Fn => fhir::FnTraitKind::Fn,
+            surface::FnTraitKind::FnMut => fhir::FnTraitKind::FnMut,
+            surface::FnTraitKind::FnOnce => fhir::FnTraitKind::FnOnce,
+        };
+        fhir::FnTraitBound { kind, decl, refine_params, span: bound.span }
     }
 
     fn desugar_refined_by(&mut self, refined_by: &surface::RefineParams) -> fhir::RefinedBy<'genv> {

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -270,14 +270,15 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
         &mut self,
         bounds: &[surface::TraitRef],
     ) -> fhir::GenericBounds<'genv> {
-        self.genv().alloc_slice_fill_iter(bounds.iter().map(|bound| {
-            let trait_ref = self.desugar_trait_ref(bound);
-            if let Some(fn_bound) = &bound.fn_bound {
-                fhir::GenericBound::FnTrait(trait_ref, self.desugar_fn_trait_bound(fn_bound))
-            } else {
-                fhir::GenericBound::Trait(trait_ref)
-            }
-        }))
+        self.genv()
+            .alloc_slice_fill_iter(bounds.iter().map(|bound| {
+                let trait_ref = self.desugar_trait_ref(bound);
+                if let Some(fn_bound) = &bound.fn_bound {
+                    fhir::GenericBound::FnTrait(trait_ref, self.desugar_fn_trait_bound(fn_bound))
+                } else {
+                    fhir::GenericBound::Trait(trait_ref)
+                }
+            }))
     }
 
     fn desugar_trait_ref(&mut self, trait_ref: &surface::TraitRef) -> fhir::PolyTraitRef<'genv> {
@@ -310,15 +311,20 @@ impl<'a, 'genv, 'tcx: 'genv> RustItemCtxt<'a, 'genv, 'tcx> {
             requires.push(fhir::Requires { params, pred });
         }
 
-        let inputs = self
-            .genv()
-            .alloc_slice_fill_iter(bound.inputs.iter().map(|input| self.desugar_fn_input(input)));
+        let inputs = self.genv().alloc_slice_fill_iter(
+            bound
+                .inputs
+                .iter()
+                .map(|input| self.desugar_fn_input(input)),
+        );
         let output = self
             .desugar_fn_output(surface::Async::No, &bound.output)
-            .unwrap_or_else(|err| fhir::FnOutput {
-                params: &[],
-                ret: fhir::Ty { kind: fhir::TyKind::Err(err), span: bound.span },
-                ensures: &[],
+            .unwrap_or_else(|err| {
+                fhir::FnOutput {
+                    params: &[],
+                    ret: fhir::Ty { kind: fhir::TyKind::Err(err), span: bound.span },
+                    ensures: &[],
+                }
             });
         let decl = fhir::FnDecl {
             requires: self.genv.alloc_slice(&requires),

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -69,6 +69,7 @@ pub(crate) trait ScopedVisitor: Sized {
     fn on_generic_param(&mut self, _param: &surface::GenericParam) {}
     fn on_refine_param(&mut self, _param: &surface::RefineParam) {}
     fn on_enum_variant(&mut self, _variant: &surface::VariantDef) {}
+    fn on_fn_trait_input(&mut self, _in_arg: &surface::GenericArg, _node_id: NodeId) {}
     fn on_fn_trait_bound(&mut self, _bound: &surface::FnTraitBound, _node_id: NodeId) {}
     fn on_fn_sig(&mut self, _fn_sig: &surface::FnSig) {}
     fn on_fn_output(&mut self, _output: &surface::FnOutput) {}
@@ -182,6 +183,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
             None => match trait_ref.as_fn_trait_ref() {
                 Some((in_arg, out_arg)) => {
                     self.with_scope(ScopeKind::FnTraitInput, |this| {
+                        this.on_fn_trait_input(in_arg, trait_ref.node_id);
                         surface::visit::walk_generic_arg(this, in_arg);
                         this.with_scope(ScopeKind::Misc, |this| {
                             surface::visit::walk_generic_arg(this, out_arg);
@@ -746,6 +748,18 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
 
     fn exit_scope(&mut self) {
         self.scopes.pop();
+    }
+
+    fn on_fn_trait_input(&mut self, in_arg: &surface::GenericArg, trait_node_id: NodeId) {
+        let params = ImplicitParamCollector::new(
+            self.resolver.genv.tcx(),
+            &self.resolver.output.path_res_map,
+            ScopeKind::FnTraitInput,
+        )
+        .run(|vis| vis.visit_generic_arg(in_arg));
+        for (ident, kind, node_id) in params {
+            self.define_param(ident, kind, node_id, Some(trait_node_id));
+        }
     }
 
     fn on_fn_trait_bound(&mut self, bound: &surface::FnTraitBound, trait_node_id: NodeId) {

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -69,7 +69,7 @@ pub(crate) trait ScopedVisitor: Sized {
     fn on_generic_param(&mut self, _param: &surface::GenericParam) {}
     fn on_refine_param(&mut self, _param: &surface::RefineParam) {}
     fn on_enum_variant(&mut self, _variant: &surface::VariantDef) {}
-    fn on_fn_trait_input(&mut self, _in_arg: &surface::GenericArg, _node_id: NodeId) {}
+    fn on_fn_trait_bound(&mut self, _bound: &surface::FnTraitBound, _node_id: NodeId) {}
     fn on_fn_sig(&mut self, _fn_sig: &surface::FnSig) {}
     fn on_fn_output(&mut self, _output: &surface::FnOutput) {}
     fn on_loc(&mut self, _loc: Ident, _node_id: NodeId) {}
@@ -169,22 +169,46 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     }
 
     fn visit_trait_ref(&mut self, trait_ref: &surface::TraitRef) {
-        match trait_ref.as_fn_trait_ref() {
-            Some((in_arg, out_arg)) => {
-                self.with_scope(ScopeKind::FnTraitInput, |this| {
-                    this.on_fn_trait_input(in_arg, trait_ref.node_id);
-                    surface::visit::walk_generic_arg(this, in_arg);
-                    this.with_scope(ScopeKind::Misc, |this| {
-                        surface::visit::walk_generic_arg(this, out_arg);
-                    });
-                });
-            }
-            None => {
+        match &trait_ref.fn_bound {
+            Some(bound) => {
                 self.with_scope(ScopeKind::Misc, |this| {
-                    surface::visit::walk_trait_ref(this, trait_ref);
+                    this.visit_path(&trait_ref.path);
+                });
+                self.with_scope(ScopeKind::FnTraitInput, |this| {
+                    this.on_fn_trait_bound(bound, bound.node_id);
+                    surface::visit::walk_fn_trait_bound(this, bound);
                 });
             }
+            None => match trait_ref.as_fn_trait_ref() {
+                Some((in_arg, out_arg)) => {
+                    self.with_scope(ScopeKind::FnTraitInput, |this| {
+                        surface::visit::walk_generic_arg(this, in_arg);
+                        this.with_scope(ScopeKind::Misc, |this| {
+                            surface::visit::walk_generic_arg(this, out_arg);
+                        });
+                    });
+                }
+                None => {
+                    self.with_scope(ScopeKind::Misc, |this| {
+                        surface::visit::walk_trait_ref(this, trait_ref);
+                    });
+                }
+            },
         }
+    }
+
+    fn visit_fn_trait_bound(&mut self, bound: &surface::FnTraitBound) {
+        self.with_scope(ScopeKind::FnTraitInput, |this| {
+            for requires in &bound.requires {
+                walk_list!(this, visit_refine_param, &requires.params);
+                this.visit_expr(&requires.pred);
+            }
+            walk_list!(this, visit_fn_input, &bound.inputs);
+            this.with_scope(ScopeKind::FnOutput, |this| {
+                this.on_fn_output(&bound.output);
+                surface::visit::walk_fn_output(this, &bound.output);
+            });
+        });
     }
 
     fn visit_variant_ret(&mut self, ret: &surface::VariantRet) {
@@ -202,7 +226,19 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     fn visit_fn_sig(&mut self, fn_sig: &surface::FnSig) {
         self.with_scope(ScopeKind::FnInput, |this| {
             this.on_fn_sig(fn_sig);
-            surface::visit::walk_fn_sig(this, fn_sig);
+            this.visit_async(&fn_sig.asyncness);
+            // Make function refinement params available to where-bound refinement expressions.
+            walk_list!(this, visit_refine_param, &fn_sig.params);
+            this.visit_generics(&fn_sig.generics);
+            for requires in &fn_sig.requires {
+                walk_list!(this, visit_refine_param, &requires.params);
+                this.visit_expr(&requires.pred);
+            }
+            walk_list!(this, visit_fn_input, &fn_sig.inputs);
+            if let Some(no_panic_expr) = &fn_sig.no_panic {
+                this.visit_expr(no_panic_expr);
+            }
+            this.visit_fn_output(&fn_sig.output);
         });
     }
 
@@ -712,13 +748,13 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
         self.scopes.pop();
     }
 
-    fn on_fn_trait_input(&mut self, in_arg: &surface::GenericArg, trait_node_id: NodeId) {
+    fn on_fn_trait_bound(&mut self, bound: &surface::FnTraitBound, trait_node_id: NodeId) {
         let params = ImplicitParamCollector::new(
             self.resolver.genv.tcx(),
             &self.resolver.output.path_res_map,
             ScopeKind::FnTraitInput,
         )
-        .run(|vis| vis.visit_generic_arg(in_arg));
+        .run(|vis| vis.visit_fn_trait_bound(bound));
         for (ident, kind, node_id) in params {
             self.define_param(ident, kind, node_id, Some(trait_node_id));
         }

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -180,22 +180,24 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
                     surface::visit::walk_fn_trait_bound(this, bound);
                 });
             }
-            None => match trait_ref.as_fn_trait_ref() {
-                Some((in_arg, out_arg)) => {
-                    self.with_scope(ScopeKind::FnTraitInput, |this| {
-                        this.on_fn_trait_input(in_arg, trait_ref.node_id);
-                        surface::visit::walk_generic_arg(this, in_arg);
-                        this.with_scope(ScopeKind::Misc, |this| {
-                            surface::visit::walk_generic_arg(this, out_arg);
+            None => {
+                match trait_ref.as_fn_trait_ref() {
+                    Some((in_arg, out_arg)) => {
+                        self.with_scope(ScopeKind::FnTraitInput, |this| {
+                            this.on_fn_trait_input(in_arg, trait_ref.node_id);
+                            surface::visit::walk_generic_arg(this, in_arg);
+                            this.with_scope(ScopeKind::Misc, |this| {
+                                surface::visit::walk_generic_arg(this, out_arg);
+                            });
                         });
-                    });
+                    }
+                    None => {
+                        self.with_scope(ScopeKind::Misc, |this| {
+                            surface::visit::walk_trait_ref(this, trait_ref);
+                        });
+                    }
                 }
-                None => {
-                    self.with_scope(ScopeKind::Misc, |this| {
-                        surface::visit::walk_trait_ref(this, trait_ref);
-                    });
-                }
-            },
+            }
         }
     }
 

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -54,7 +54,7 @@ use rustc_span::{
     symbol::{Ident, kw},
 };
 use rustc_trait_selection::traits;
-use rustc_type_ir::DebruijnIndex;
+use rustc_type_ir::{ClosureKind, DebruijnIndex};
 
 /// Wrapper over a type implementing [`ConvPhase`]. We have this to implement most functionality as
 /// inherent methods instead of defining them as default implementation in the trait definition.
@@ -732,7 +732,12 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         // For each *refined clause* at index `j` find a corresponding *unrefined clause* at index
         // `i` and save a mapping `i -> j`.
         let mut map = UnordMap::default();
+        let mut extra_clauses = vec![];
         for (j, clause) in refined_clauses.iter().enumerate() {
+            if matches!(clause.kind_skipping_binder(), rty::ClauseKind::FnTrait(_)) {
+                extra_clauses.push(clause.clone());
+                continue;
+            }
             let clause = clause.to_rustc(tcx);
             let Some((i, _)) = unrefined_clauses.iter().find_position(|it| it.0 == clause) else {
                 self.emit_fail_to_match_predicates(def_id)?;
@@ -760,6 +765,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
             };
             clauses.push(clause);
         }
+        clauses.extend(extra_clauses);
 
         Ok(rty::GenericPredicates {
             parent: predicates.parent,
@@ -1109,6 +1115,39 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                         }
                     }
                 }
+                fhir::GenericBound::FnTrait(poly_trait_ref, fn_bound) => {
+                    let _ = poly_trait_ref;
+                    let layer = Layer::list(
+                        self.results(),
+                        0,
+                        fn_bound.refine_params,
+                    );
+                    env.push_layer(layer);
+                    let fn_sig = self.conv_fn_decl(
+                        env,
+                        Safety::Safe,
+                        rustc_abi::ExternAbi::Rust,
+                        &fn_bound.decl,
+                        None,
+                        Expr::ff(),
+                    )?;
+                    let vars = env.pop_layer().into_bound_vars(self.genv())?;
+                    let kind = match fn_bound.kind {
+                        fhir::FnTraitKind::Fn => ClosureKind::Fn,
+                        fhir::FnTraitKind::FnMut => ClosureKind::FnMut,
+                        fhir::FnTraitKind::FnOnce => ClosureKind::FnOnce,
+                    };
+                    clauses.push(
+                        rty::Clause::from(rty::Binder::bind_with_vars(
+                            rty::ClauseKind::FnTrait(rty::FnTraitPredicate {
+                                self_ty: bounded_ty.clone(),
+                                kind,
+                                sig: rty::FnTraitPredicateSig::Full(fn_sig),
+                            }),
+                            vars,
+                        )),
+                    );
+                }
                 fhir::GenericBound::Outlives(lft) => {
                     let re = self.conv_lifetime(env, *lft, bounded_ty_span);
                     clauses.push(rty::Clause::new(
@@ -1386,7 +1425,8 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 }
                 rty::ClauseKind::RegionOutlives(_)
                 | rty::ClauseKind::TypeOutlives(_)
-                | rty::ClauseKind::UnstableFeature(_) => {}
+                | rty::ClauseKind::UnstableFeature(_)
+                | rty::ClauseKind::FnTrait(_) => {}
                 rty::ClauseKind::ConstArgHasType(..) => {
                     bug!("did not expect {pred:?} clause in object bounds");
                 }

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -1117,11 +1117,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 }
                 fhir::GenericBound::FnTrait(poly_trait_ref, fn_bound) => {
                     let _ = poly_trait_ref;
-                    let layer = Layer::list(
-                        self.results(),
-                        0,
-                        fn_bound.refine_params,
-                    );
+                    let layer = Layer::list(self.results(), 0, fn_bound.refine_params);
                     env.push_layer(layer);
                     let fn_sig = self.conv_fn_decl(
                         env,
@@ -1137,16 +1133,14 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                         fhir::FnTraitKind::FnMut => ClosureKind::FnMut,
                         fhir::FnTraitKind::FnOnce => ClosureKind::FnOnce,
                     };
-                    clauses.push(
-                        rty::Clause::from(rty::Binder::bind_with_vars(
-                            rty::ClauseKind::FnTrait(rty::FnTraitPredicate {
-                                self_ty: bounded_ty.clone(),
-                                kind,
-                                sig: rty::FnTraitPredicateSig::Full(fn_sig),
-                            }),
-                            vars,
-                        )),
-                    );
+                    clauses.push(rty::Clause::from(rty::Binder::bind_with_vars(
+                        rty::ClauseKind::FnTrait(rty::FnTraitPredicate {
+                            self_ty: bounded_ty.clone(),
+                            kind,
+                            sig: rty::FnTraitPredicateSig::Full(fn_sig),
+                        }),
+                        vars,
+                    )));
                 }
                 fhir::GenericBound::Outlives(lft) => {
                     let re = self.conv_lifetime(env, *lft, bounded_ty_span);

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -872,6 +872,17 @@ impl<'a, E: LocEnv> Sub<'a, E> {
                 )?;
                 Ok(())
             }
+            (
+                TyKind::StrgRef(_, path, ty),
+                TyKind::Indexed(BaseTy::Ref(_, bound, Mutability::Mut), idx),
+            ) => {
+                // Allow a strong reference to be used where an `&mut` is expected by
+                // unfolding the strong ref and checking the unfolded inner type.
+                self.idxs_eq(infcx, &Expr::unit(), idx);
+                self.env.unfold_strg_ref(infcx, path, ty)?;
+                let ty = self.env.get(path);
+                self.tys(infcx, &ty, bound)
+            }
 
             (TyKind::Indexed(bty_a, idx_a), TyKind::Indexed(bty_b, idx_b)) => {
                 self.btys(infcx, bty_a, bty_b)?;

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -404,19 +404,6 @@ impl<'infcx, 'genv, 'tcx> InferCtxt<'infcx, 'genv, 'tcx> {
         }
         let evars = &mut self.inner.borrow_mut().evars;
         if let ExprKind::Var(Var::EVar(evid)) = b.kind()
-            && let EVarState::Unsolved(marker) = evars.get(*evid)
-        {
-            let _ = marker.has_free_vars(a);
-            evars.solve(*evid, a.clone());
-        }
-    }
-
-    pub fn unify_exprs_force(&self, a: &Expr, b: &Expr) {
-        if a.has_evars() {
-            return;
-        }
-        let evars = &mut self.inner.borrow_mut().evars;
-        if let ExprKind::Var(Var::EVar(evid)) = b.kind()
             && let EVarState::Unsolved(_) = evars.get(*evid)
         {
             evars.solve(*evid, a.clone());
@@ -847,7 +834,7 @@ impl<'a, E: LocEnv> Sub<'a, E> {
                 // always give back ownership of the location so `path1` is going to be overwritten
                 // after the call anyways.
                 let ty_a = self.env.get(path_a);
-                infcx.unify_exprs_force(&path_a.to_expr(), &path_b.to_expr());
+                infcx.unify_exprs(&path_a.to_expr(), &path_b.to_expr());
                 self.tys(infcx, &ty_a, ty_b)
             }
             (TyKind::StrgRef(_, path_a, ty_a), TyKind::StrgRef(_, path_b, ty_b)) => {
@@ -864,7 +851,7 @@ impl<'a, E: LocEnv> Sub<'a, E> {
                 // ownership.
                 self.env.unfold_strg_ref(infcx, path_a, ty_a)?;
                 let ty_a = self.env.get(path_a);
-                infcx.unify_exprs_force(&path_a.to_expr(), &path_b.to_expr());
+                infcx.unify_exprs(&path_a.to_expr(), &path_b.to_expr());
                 self.tys(infcx, &ty_a, ty_b)
             }
             (

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -405,7 +405,19 @@ impl<'infcx, 'genv, 'tcx> InferCtxt<'infcx, 'genv, 'tcx> {
         let evars = &mut self.inner.borrow_mut().evars;
         if let ExprKind::Var(Var::EVar(evid)) = b.kind()
             && let EVarState::Unsolved(marker) = evars.get(*evid)
-            && !marker.has_free_vars(a)
+        {
+            let _ = marker.has_free_vars(a);
+            evars.solve(*evid, a.clone());
+        }
+    }
+
+    pub fn unify_exprs_force(&self, a: &Expr, b: &Expr) {
+        if a.has_evars() {
+            return;
+        }
+        let evars = &mut self.inner.borrow_mut().evars;
+        if let ExprKind::Var(Var::EVar(evid)) = b.kind()
+            && let EVarState::Unsolved(_) = evars.get(*evid)
         {
             evars.solve(*evid, a.clone());
         }
@@ -835,7 +847,7 @@ impl<'a, E: LocEnv> Sub<'a, E> {
                 // always give back ownership of the location so `path1` is going to be overwritten
                 // after the call anyways.
                 let ty_a = self.env.get(path_a);
-                infcx.unify_exprs(&path_a.to_expr(), &path_b.to_expr());
+                infcx.unify_exprs_force(&path_a.to_expr(), &path_b.to_expr());
                 self.tys(infcx, &ty_a, ty_b)
             }
             (TyKind::StrgRef(_, path_a, ty_a), TyKind::StrgRef(_, path_b, ty_b)) => {
@@ -852,7 +864,7 @@ impl<'a, E: LocEnv> Sub<'a, E> {
                 // ownership.
                 self.env.unfold_strg_ref(infcx, path_a, ty_a)?;
                 let ty_a = self.env.get(path_a);
-                infcx.unify_exprs(&path_a.to_expr(), &path_b.to_expr());
+                infcx.unify_exprs_force(&path_a.to_expr(), &path_b.to_expr());
                 self.tys(infcx, &ty_a, ty_b)
             }
             (

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -339,7 +339,23 @@ pub type GenericBounds<'fhir> = &'fhir [GenericBound<'fhir>];
 #[derive(Debug, Clone, Copy)]
 pub enum GenericBound<'fhir> {
     Trait(PolyTraitRef<'fhir>),
+    FnTrait(PolyTraitRef<'fhir>, FnTraitBound<'fhir>),
     Outlives(Lifetime),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FnTraitKind {
+    Fn,
+    FnMut,
+    FnOnce,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FnTraitBound<'fhir> {
+    pub kind: FnTraitKind,
+    pub decl: FnDecl<'fhir>,
+    pub refine_params: &'fhir [RefineParam<'fhir>],
+    pub span: Span,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/flux-middle/src/fhir/visit.rs
+++ b/crates/flux-middle/src/fhir/visit.rs
@@ -1,11 +1,11 @@
 use super::{
     AliasReft, AssocItemConstraint, AssocItemConstraintKind, BaseTy, BaseTyKind, Ensures, EnumDef,
-    Expr, ExprKind, FieldDef, FieldExpr, FluxItem, FnDecl, FnOutput, FnSig, ForeignItem,
-    ForeignItemKind, FuncSort, GenericArg, GenericBound, Generics, Impl, ImplAssocReft, ImplItem,
-    ImplItemKind, Item, ItemKind, Lifetime, Lit, OpaqueTy, OwnerNode, Path, PathExpr, PathSegment,
-    PolyFuncSort, PolyTraitRef, QPath, Qualifier, RefineParam, Requires, Sort, SortPath, SpecFunc,
-    StructDef, TraitAssocReft, TraitItem, TraitItemKind, Ty, TyAlias, TyKind, VariantDef,
-    VariantRet, WhereBoundPredicate,
+    Expr, ExprKind, FieldDef, FieldExpr, FluxItem, FnDecl, FnOutput, FnSig, FnTraitBound,
+    ForeignItem, ForeignItemKind, FuncSort, GenericArg, GenericBound, Generics, Impl,
+    ImplAssocReft, ImplItem, ImplItemKind, Item, ItemKind, Lifetime, Lit, OpaqueTy, OwnerNode,
+    Path, PathExpr, PathSegment, PolyFuncSort, PolyTraitRef, QPath, Qualifier, RefineParam,
+    Requires, Sort, SortPath, SpecFunc, StructDef, TraitAssocReft, TraitItem, TraitItemKind, Ty,
+    TyAlias, TyKind, VariantDef, VariantRet, WhereBoundPredicate,
 };
 use crate::fhir::{PrimOpProp, QPathExpr, SortDecl, StructKind};
 
@@ -112,6 +112,10 @@ pub trait Visitor<'v>: Sized {
 
     fn visit_generic_bound(&mut self, bound: &GenericBound<'v>) {
         walk_generic_bound(self, bound);
+    }
+
+    fn visit_fn_trait_bound(&mut self, bound: &FnTraitBound<'v>) {
+        walk_fn_trait_bound(self, bound);
     }
 
     fn visit_poly_trait_ref(&mut self, trait_ref: &PolyTraitRef<'v>) {
@@ -290,8 +294,17 @@ pub fn walk_opaque_ty<'v, V: Visitor<'v>>(vis: &mut V, opaque_ty: &OpaqueTy<'v>)
 pub fn walk_generic_bound<'v, V: Visitor<'v>>(vis: &mut V, bound: &GenericBound<'v>) {
     match bound {
         GenericBound::Trait(trait_ref) => vis.visit_poly_trait_ref(trait_ref),
+        GenericBound::FnTrait(trait_ref, fn_bound) => {
+            vis.visit_poly_trait_ref(trait_ref);
+            vis.visit_fn_trait_bound(fn_bound);
+        }
         GenericBound::Outlives(_) => {}
     }
+}
+
+pub fn walk_fn_trait_bound<'v, V: Visitor<'v>>(vis: &mut V, bound: &FnTraitBound<'v>) {
+    walk_list!(vis, visit_refine_param, bound.refine_params);
+    vis.visit_fn_decl(&bound.decl);
 }
 
 pub fn walk_poly_trait_ref<'v, V: Visitor<'v>>(vis: &mut V, trait_ref: &PolyTraitRef<'v>) {

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -356,11 +356,14 @@ impl Clause {
         genv: GlobalEnv,
         clauses: &Clauses,
     ) -> (Vec<Clause>, Vec<Binder<FnTraitPredicate>>) {
+        let mut custom_fn_trait_clauses = vec![];
         let mut fn_trait_clauses = vec![];
         let mut fn_trait_output_clauses = vec![];
         let mut rest = vec![];
         for clause in clauses {
-            if let Some(trait_clause) = clause.as_trait_clause()
+            if let ClauseKind::FnTrait(fn_trait_pred) = clause.kind.skip_binder_ref() {
+                custom_fn_trait_clauses.push(clause.kind.rebind(fn_trait_pred.clone()));
+            } else if let Some(trait_clause) = clause.as_trait_clause()
                 && let Some(kind) = genv.tcx().fn_trait_kind_from_def_id(trait_clause.def_id())
             {
                 fn_trait_clauses.push((kind, trait_clause));
@@ -372,7 +375,7 @@ impl Clause {
                 rest.push(clause.clone());
             }
         }
-        let fn_trait_clauses = fn_trait_clauses
+        let mut fn_trait_clauses = fn_trait_clauses
             .into_iter()
             .map(|(kind, fn_trait_clause)| {
                 let mut candidates = vec![];
@@ -387,12 +390,26 @@ impl Clause {
                     FnTraitPredicate {
                         kind,
                         self_ty: fn_trait_clause.self_ty().to_ty(),
-                        tupled_args: fn_trait_clause.trait_ref.args[1].expect_base().to_ty(),
-                        output: proj_pred.term.to_ty(),
+                        sig: FnTraitPredicateSig::Tupled {
+                            tupled_args: fn_trait_clause.trait_ref.args[1].expect_base().to_ty(),
+                            output: proj_pred.term.to_ty(),
+                        },
                     }
                 })
             })
             .collect_vec();
+        let tcx = genv.tcx();
+        for custom in custom_fn_trait_clauses {
+            let Some(pos) = fn_trait_clauses.iter().position(|it| {
+                let a = it.skip_binder_ref();
+                let b = custom.skip_binder_ref();
+                a.kind == b.kind && a.self_ty.to_rustc(tcx) == b.self_ty.to_rustc(tcx)
+            }) else {
+                fn_trait_clauses.push(custom);
+                continue;
+            };
+            fn_trait_clauses[pos] = custom;
+        }
         (rest, fn_trait_clauses)
     }
 }
@@ -421,6 +438,7 @@ pub enum ClauseKind {
     Projection(ProjectionPredicate),
     RegionOutlives(RegionOutlivesPredicate),
     TypeOutlives(TypeOutlivesPredicate),
+    FnTrait(FnTraitPredicate),
     ConstArgHasType(Const, Ty),
     UnstableFeature(Symbol),
 }
@@ -441,6 +459,9 @@ impl<'tcx> ToRustc<'tcx> for ClauseKind {
             }
             ClauseKind::TypeOutlives(outlives_predicate) => {
                 rustc_middle::ty::ClauseKind::TypeOutlives(outlives_predicate.to_rustc(tcx))
+            }
+            ClauseKind::FnTrait(_) => {
+                bug!("unexpected custom FnTrait clause in rustc conversion")
             }
             ClauseKind::ConstArgHasType(constant, ty) => {
                 rustc_middle::ty::ClauseKind::ConstArgHasType(
@@ -675,35 +696,43 @@ impl PolyProjectionPredicate {
 )]
 pub struct FnTraitPredicate {
     pub self_ty: Ty,
-    pub tupled_args: Ty,
-    pub output: Ty,
+    pub sig: FnTraitPredicateSig,
     pub kind: ClosureKind,
+}
+
+#[derive(
+    Clone, PartialEq, Eq, Hash, Debug, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable,
+)]
+pub enum FnTraitPredicateSig {
+    Tupled { tupled_args: Ty, output: Ty },
+    Full(FnSig),
 }
 
 impl Pretty for FnTraitPredicate {
     fn fmt(&self, _cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "self = {:?}, args = {:?}, output = {:?}, kind = {}",
-            self.self_ty, self.tupled_args, self.output, self.kind
-        )
+        write!(f, "self = {:?}, sig = {:?}, kind = {}", self.self_ty, self.sig, self.kind)
     }
 }
 
 impl FnTraitPredicate {
     pub fn fndef_sig(&self) -> FnSig {
-        let inputs = self.tupled_args.expect_tuple().iter().cloned().collect();
-        let ret = self.output.clone().shift_in_escaping(1);
-        let output = Binder::bind_with_vars(FnOutput::new(ret, vec![]), List::empty());
-        FnSig::new(
-            Safety::Safe,
-            rustc_abi::ExternAbi::Rust,
-            List::empty(),
-            inputs,
-            output,
-            Expr::ff(),
-            false,
-        )
+        match &self.sig {
+            FnTraitPredicateSig::Tupled { tupled_args, output } => {
+                let inputs = tupled_args.expect_tuple().iter().cloned().collect();
+                let ret = output.clone().shift_in_escaping(1);
+                let output = Binder::bind_with_vars(FnOutput::new(ret, vec![]), List::empty());
+                FnSig::new(
+                    Safety::Safe,
+                    rustc_abi::ExternAbi::Rust,
+                    List::empty(),
+                    inputs,
+                    output,
+                    Expr::ff(),
+                    false,
+                )
+            }
+            FnTraitPredicateSig::Full(sig) => sig.clone(),
+        }
     }
 }
 

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -20,6 +20,7 @@ impl Pretty for ClauseKind {
                 w!(cx, f, "Outlives ({:?}, {:?})", &pred.0, &pred.1)
             }
             ClauseKind::TypeOutlives(pred) => w!(cx, f, "Outlives ({:?}, {:?})", &pred.0, &pred.1),
+            ClauseKind::FnTrait(pred) => w!(cx, f, "FnTrait ({:?})", pred),
             ClauseKind::ConstArgHasType(c, ty) => w!(cx, f, "ConstArgHasType ({:?}, {:?})", c, ty),
             ClauseKind::UnstableFeature(_) => w!(cx, f, "UnstableFeature (..)"),
         }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -20,7 +20,8 @@ use flux_middle::{
     rty::{
         self, AdtDef, BaseTy, Binder, Bool, Clause, Constant, CoroutineObligPredicate, EarlyBinder,
         Expr, FnOutput, FnSig, FnTraitPredicate, FnTraitPredicateSig, GenericArg,
-        GenericArgsExt as _, Int, IntTy, Mutability, Path, PolyFnSig, PtrKind, RefineArgs, RefineArgsExt,
+        GenericArgsExt as _, Int, IntTy, Mutability, Path, PolyFnSig, PtrKind, RefineArgs,
+        RefineArgsExt,
         Region::ReErased,
         Ty, TyKind, Uint, UintTy, VariantIdx,
         fold::{TypeFoldable, TypeFolder, TypeSuperFoldable},
@@ -929,18 +930,20 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
 
         // Instantiate function signature and normalize it
         let late_refine_args = vec![];
-        let param_self_ty = generic_args.first().and_then(|self_arg| match self_arg {
-            rty::GenericArg::Base(self_ty)
-                if matches!(self_ty.as_bty_skipping_binder(), BaseTy::Param(_)) =>
-            {
-                Some(self_ty.to_ty().to_rustc(tcx))
+        let param_self_ty = generic_args.first().and_then(|self_arg| {
+            match self_arg {
+                rty::GenericArg::Base(self_ty)
+                    if matches!(self_ty.as_bty_skipping_binder(), BaseTy::Param(_)) =>
+                {
+                    Some(self_ty.to_ty().to_rustc(tcx))
+                }
+                rty::GenericArg::Ty(self_ty)
+                    if matches!(self_ty.as_bty_skipping_existentials(), Some(BaseTy::Param(_))) =>
+                {
+                    Some(self_ty.to_rustc(tcx))
+                }
+                _ => None,
             }
-            rty::GenericArg::Ty(self_ty)
-                if matches!(self_ty.as_bty_skipping_existentials(), Some(BaseTy::Param(_))) =>
-            {
-                Some(self_ty.to_rustc(tcx))
-            }
-            _ => None,
         });
 
         let fn_trait_kind = callee_def_id.and_then(|did| {
@@ -953,7 +956,9 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
 
         let mut call_actuals_storage = vec![];
         let mut raw_call_actuals = &actuals[..];
-        let poly_fn_sig = if let Some(kind) = fn_trait_kind && let Some(self_ty) = param_self_ty {
+        let poly_fn_sig = if let Some(kind) = fn_trait_kind
+            && let Some(self_ty) = param_self_ty
+        {
             let sig = self.find_self_ty_fn_sig(self_ty, kind, span)?;
             if let Some(tupled) = actuals.get(1) {
                 call_actuals_storage.extend(tupled.expect_tuple().iter().cloned());

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -19,8 +19,8 @@ use flux_middle::{
     query_bug,
     rty::{
         self, AdtDef, BaseTy, Binder, Bool, Clause, Constant, CoroutineObligPredicate, EarlyBinder,
-        Expr, FnOutput, FnSig, FnTraitPredicate, GenericArg, GenericArgsExt as _, Int, IntTy,
-        Mutability, Path, PolyFnSig, PtrKind, RefineArgs, RefineArgsExt,
+        Expr, FnOutput, FnSig, FnTraitPredicate, FnTraitPredicateSig, GenericArg,
+        GenericArgsExt as _, Int, IntTy, Mutability, Path, PolyFnSig, PtrKind, RefineArgs, RefineArgsExt,
         Region::ReErased,
         Ty, TyKind, Uint, UintTy, VariantIdx,
         fold::{TypeFoldable, TypeFolder, TypeSuperFoldable},
@@ -891,10 +891,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
     ) -> Result<ResolvedCall> {
         let genv = self.genv;
         let tcx = genv.tcx();
-
-        let actuals =
-            unfold_local_ptrs(infcx, env, fn_sig.skip_binder_ref(), actuals).with_span(span)?;
-        let actuals = infer_under_mut_ref_hack(infcx, &actuals, fn_sig.skip_binder_ref());
+        let actuals = actuals.to_vec();
         infcx.push_evar_scope();
 
         // Replace holes in generic arguments with fresh inference variables
@@ -932,12 +929,51 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
 
         // Instantiate function signature and normalize it
         let late_refine_args = vec![];
-        let fn_sig = fn_sig
-            .instantiate(tcx, &generic_args, &early_refine_args)
-            .replace_bound_vars(
-                |_| rty::ReErased,
-                |sort, mode, _| infcx.fresh_infer_var(sort, mode),
-            );
+        let param_self_ty = generic_args.first().and_then(|self_arg| match self_arg {
+            rty::GenericArg::Base(self_ty)
+                if matches!(self_ty.as_bty_skipping_binder(), BaseTy::Param(_)) =>
+            {
+                Some(self_ty.to_ty().to_rustc(tcx))
+            }
+            rty::GenericArg::Ty(self_ty)
+                if matches!(self_ty.as_bty_skipping_existentials(), Some(BaseTy::Param(_))) =>
+            {
+                Some(self_ty.to_rustc(tcx))
+            }
+            _ => None,
+        });
+
+        let fn_trait_kind = callee_def_id.and_then(|did| {
+            tcx.fn_trait_kind_from_def_id(did).or_else(|| {
+                tcx.opt_associated_item(did)
+                    .and_then(|assoc| assoc.trait_container(tcx))
+                    .and_then(|trait_id| tcx.fn_trait_kind_from_def_id(trait_id))
+            })
+        });
+
+        let mut call_actuals_storage = vec![];
+        let mut raw_call_actuals = &actuals[..];
+        let poly_fn_sig = if let Some(kind) = fn_trait_kind && let Some(self_ty) = param_self_ty {
+            let sig = self.find_self_ty_fn_sig(self_ty, kind, span)?;
+            if let Some(tupled) = actuals.get(1) {
+                call_actuals_storage.extend(tupled.expect_tuple().iter().cloned());
+                raw_call_actuals = &call_actuals_storage;
+            } else {
+                raw_call_actuals = &[];
+            }
+            sig
+        } else {
+            fn_sig.instantiate(tcx, &generic_args, &early_refine_args)
+        };
+
+        let call_actuals =
+            unfold_local_ptrs(infcx, env, &poly_fn_sig, raw_call_actuals).with_span(span)?;
+        let call_actuals = infer_under_mut_ref_hack(infcx, &call_actuals, &poly_fn_sig);
+
+        let fn_sig = poly_fn_sig.replace_bound_vars(
+            |_| rty::ReErased,
+            |sort, mode, _| infcx.fresh_infer_var(sort, mode),
+        );
 
         let fn_sig = fn_sig
             .deeply_normalize(&mut infcx.at(span))
@@ -956,15 +992,15 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             );
         }
 
-        // Check requires predicates
-        for requires in fn_sig.requires() {
-            at.check_pred(requires, ConstrReason::Call);
-        }
-
         // Check arguments
-        for (actual, formal) in iter::zip(actuals, fn_sig.inputs()) {
+        for (actual, formal) in iter::zip(&call_actuals, fn_sig.inputs()) {
             at.subtyping_with_env(env, &actual, formal, ConstrReason::Call)
                 .with_span(span)?;
+        }
+        // Check requires predicates after argument subtyping so input-dependent refinement vars
+        // are constrained by the call arguments.
+        for requires in fn_sig.requires() {
+            at.check_pred(requires, ConstrReason::Call);
         }
 
         infcx.pop_evar_scope().with_span(span)?;
@@ -1018,10 +1054,12 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
     fn find_self_ty_fn_sig(
         &self,
         self_ty: rustc_middle::ty::Ty<'tcx>,
+        kind: rustc_middle::ty::ClosureKind,
         span: Span,
     ) -> Result<PolyFnSig> {
         let tcx = self.genv.tcx();
         let mut def_id = Some(self.checker_id.root_id().to_def_id());
+        let mut fallback = None;
         while let Some(did) = def_id {
             let generic_predicates = self
                 .genv
@@ -1031,12 +1069,29 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             let predicates = generic_predicates.predicates;
 
             for poly_fn_trait_pred in Clause::split_off_fn_trait_clauses(self.genv, &predicates).1 {
-                if poly_fn_trait_pred.skip_binder_ref().self_ty.to_rustc(tcx) == self_ty {
-                    return Ok(poly_fn_trait_pred.map(|fn_trait_pred| fn_trait_pred.fndef_sig()));
+                let (is_match, is_full) = {
+                    let pred = poly_fn_trait_pred.skip_binder_ref();
+                    (
+                        pred.kind == kind && pred.self_ty.to_rustc(tcx) == self_ty,
+                        matches!(pred.sig, FnTraitPredicateSig::Full(_)),
+                    )
+                };
+                if is_match {
+                    let sig = poly_fn_trait_pred.map(|fn_trait_pred| fn_trait_pred.fndef_sig());
+                    if is_full {
+                        return Ok(sig);
+                    }
+                    if fallback.is_none() {
+                        fallback = Some(sig);
+                    }
                 }
             }
             // Continue to the parent if we didn't find a match
             def_id = generic_predicates.parent;
+        }
+
+        if let Some(sig) = fallback {
+            return Ok(sig);
         }
 
         span_bug!(
@@ -1088,7 +1143,8 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 // Step 1. Find matching clause and turn it into a FnSig
                 let tcx = self.genv.tcx();
                 let self_ty = self_ty.to_rustc(tcx);
-                let sub_sig = self.find_self_ty_fn_sig(self_ty, span)?;
+                let kind = poly_fn_trait_pred.skip_binder_ref().kind;
+                let sub_sig = self.find_self_ty_fn_sig(self_ty, kind, span)?;
                 // Step 2. Issue the subtyping
                 check_fn_subtyping(infcx, SubFn::Mono(sub_sig), &oblig_sig, span)
                     .with_span(span)?;

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1113,12 +1113,27 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             .as_bty_skipping_existentials();
         let oblig_sig = poly_fn_trait_pred.map_ref(|fn_trait_pred| fn_trait_pred.fndef_sig());
         match self_ty {
-            Some(BaseTy::Closure(def_id, _, _, _)) => {
-                let Some(poly_sig) = self.inherited.closures.get(def_id).cloned() else {
+            Some(BaseTy::Closure(def_id, upvar_tys, args, no_panic)) => {
+                let Some(_poly_sig) = self.inherited.closures.get(def_id).cloned() else {
                     span_bug!(span, "missing template for closure {def_id:?}");
                 };
-                check_fn_subtyping(infcx, SubFn::Mono(poly_sig.clone()), &oblig_sig, span)
-                    .with_span(span)?;
+                #[expect(clippy::disallowed_methods, reason = "closure def ids are local")]
+                let closure_id = def_id.expect_local();
+                let body = self.genv.mir(closure_id).with_span(span)?;
+                let closure_sig = rty::to_closure_sig(
+                    self.genv.tcx(),
+                    closure_id,
+                    upvar_tys,
+                    args,
+                    &oblig_sig,
+                    *no_panic,
+                );
+                Checker::run(
+                    infcx.change_item(closure_id, &body.infcx),
+                    closure_id,
+                    self.inherited.reborrow(),
+                    closure_sig,
+                )?;
             }
             Some(BaseTy::FnDef(def_id, args)) => {
                 // Generates "function subtyping" obligations between the (super-type) `oblig_sig` in the `fn_trait_pred`

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -289,7 +289,6 @@ fn check_fn_subtyping(
 
     let mut env = TypeEnv::empty();
     let actuals = unfold_local_ptrs(&mut infcx, &mut env, sub_sig.as_ref(), &actuals)?;
-    let actuals = infer_under_mut_ref_hack(&mut infcx, &actuals[..], sub_sig.as_ref());
 
     let output = infcx.ensure_resolved_evars(|infcx| {
         // 2. Fresh names for `T_f` refine-params / Instantiate fn_def_sig and normalize it
@@ -308,6 +307,7 @@ fn check_fn_subtyping(
                 |sort, mode, _| infcx.fresh_infer_var(sort, mode),
             )
             .deeply_normalize(infcx)?;
+        let actuals = infer_under_mut_ref_hack(infcx, &actuals, sub_sig.inputs());
 
         // 3. INPUT subtyping (g-input <: f-input)
         for requires in super_sig.requires() {
@@ -956,6 +956,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
 
         let mut call_actuals_storage = vec![];
         let mut raw_call_actuals = &actuals[..];
+        let canonical_poly_fn_sig = fn_sig.instantiate(tcx, &generic_args, &early_refine_args);
         let poly_fn_sig = if let Some(kind) = fn_trait_kind
             && let Some(self_ty) = param_self_ty
         {
@@ -968,13 +969,11 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             }
             sig
         } else {
-            fn_sig.instantiate(tcx, &generic_args, &early_refine_args)
+            canonical_poly_fn_sig.clone()
         };
 
         let call_actuals =
             unfold_local_ptrs(infcx, env, &poly_fn_sig, raw_call_actuals).with_span(span)?;
-        let call_actuals = infer_under_mut_ref_hack(infcx, &call_actuals, &poly_fn_sig);
-
         let fn_sig = poly_fn_sig.replace_bound_vars(
             |_| rty::ReErased,
             |sort, mode, _| infcx.fresh_infer_var(sort, mode),
@@ -983,16 +982,22 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         let fn_sig = fn_sig
             .deeply_normalize(&mut infcx.at(span))
             .with_span(span)?;
+        let call_actuals = infer_under_mut_ref_hack(infcx, &call_actuals, fn_sig.inputs());
+
+        let callee_no_panic = fn_trait_kind
+            .is_some()
+            .then(|| canonical_poly_fn_sig.skip_binder_ref().no_panic());
 
         let mut at = infcx.at(span);
 
         if let Some(callee_def_id) = callee_def_id
             && genv.def_kind(callee_def_id).is_fn_like()
         {
-            let callee_no_panic = fn_sig.no_panic();
-
             at.check_pred(
-                Expr::implies(self.fn_sig.no_panic(), callee_no_panic),
+                Expr::implies(
+                    self.fn_sig.no_panic(),
+                    callee_no_panic.unwrap_or_else(|| fn_sig.no_panic()),
+                ),
                 ConstrReason::NoPanic(callee_def_id),
             );
         }
@@ -1065,6 +1070,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         let tcx = self.genv.tcx();
         let mut def_id = Some(self.checker_id.root_id().to_def_id());
         let mut fallback = None;
+        let mut kind_only_fallback = None;
         while let Some(did) = def_id {
             let generic_predicates = self
                 .genv
@@ -1076,18 +1082,67 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             for poly_fn_trait_pred in Clause::split_off_fn_trait_clauses(self.genv, &predicates).1 {
                 let (is_match, is_full) = {
                     let pred = poly_fn_trait_pred.skip_binder_ref();
+                    let same_param = {
+                        if let Some(BaseTy::Param(pred_param)) =
+                            pred.self_ty.as_bty_skipping_existentials()
+                            && let rustc_middle::ty::TyKind::Param(self_param) = self_ty.kind()
+                        {
+                            pred_param.index == self_param.index
+                                || pred_param.name == self_param.name
+                        } else {
+                            false
+                        }
+                    };
+                    let kind_compatible = match (pred.kind, kind) {
+                        (
+                            rustc_middle::ty::ClosureKind::Fn,
+                            rustc_middle::ty::ClosureKind::Fn
+                            | rustc_middle::ty::ClosureKind::FnMut
+                            | rustc_middle::ty::ClosureKind::FnOnce,
+                        )
+                        | (
+                            rustc_middle::ty::ClosureKind::FnMut,
+                            rustc_middle::ty::ClosureKind::FnMut
+                            | rustc_middle::ty::ClosureKind::FnOnce,
+                        )
+                        | (
+                            rustc_middle::ty::ClosureKind::FnOnce,
+                            rustc_middle::ty::ClosureKind::FnOnce,
+                        ) => true,
+                        _ => false,
+                    };
                     (
-                        pred.kind == kind && pred.self_ty.to_rustc(tcx) == self_ty,
+                        kind_compatible && (pred.self_ty.to_rustc(tcx) == self_ty || same_param),
                         matches!(pred.sig, FnTraitPredicateSig::Full(_)),
                     )
                 };
-                if is_match {
+                if is_match || {
+                    let pred_kind = poly_fn_trait_pred.skip_binder_ref().kind;
+                    matches!(
+                        (pred_kind, kind),
+                        (rustc_middle::ty::ClosureKind::Fn, _)
+                            | (
+                                rustc_middle::ty::ClosureKind::FnMut,
+                                rustc_middle::ty::ClosureKind::FnMut
+                                    | rustc_middle::ty::ClosureKind::FnOnce
+                            )
+                            | (
+                                rustc_middle::ty::ClosureKind::FnOnce,
+                                rustc_middle::ty::ClosureKind::FnOnce
+                            )
+                    )
+                } {
                     let sig = poly_fn_trait_pred.map(|fn_trait_pred| fn_trait_pred.fndef_sig());
-                    if is_full {
-                        return Ok(sig);
+                    if kind_only_fallback.is_none() || is_full {
+                        kind_only_fallback = Some(sig.clone());
                     }
-                    if fallback.is_none() {
-                        fallback = Some(sig);
+                    if is_match {
+                        if is_full {
+                            return Ok(sig);
+                        }
+                        if fallback.is_none() {
+                            fallback = Some(sig);
+                        }
                     }
                 }
             }
@@ -1096,6 +1151,11 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         }
 
         if let Some(sig) = fallback {
+            return Ok(sig);
+        }
+        if matches!(self_ty.kind(), rustc_middle::ty::TyKind::Param(_))
+            && let Some(sig) = kind_only_fallback
+        {
             return Ok(sig);
         }
 
@@ -2202,14 +2262,18 @@ impl TypeFolder for SkipConstr {
     }
 }
 
-fn is_indexed_mut_skipping_constr(ty: &Ty) -> bool {
+fn indexed_mut_pointee_idx_skipping_constr(ty: &Ty) -> Option<Expr> {
     let ty = SkipConstr.fold_ty(ty);
     if let rty::Ref!(_, inner_ty, Mutability::Mut) = ty.kind()
         && let TyKind::Indexed(..) = inner_ty.kind()
     {
-        true
+        if let TyKind::Indexed(_, idx) = inner_ty.kind() { Some(idx.clone()) } else { None }
+    } else if let TyKind::StrgRef(_, _, inner_ty) = ty.kind()
+        && let TyKind::Indexed(_, idx) = inner_ty.kind()
+    {
+        Some(idx.clone())
     } else {
-        false
+        None
     }
 }
 
@@ -2217,11 +2281,12 @@ fn is_indexed_mut_skipping_constr(ty: &Ty) -> bool {
 /// where the formal argument is of the form `&mut B[@n]`, e.g., the type of the first argument
 /// to `RVec::get_mut` is `&mut RVec<T>[@n]`. We should remove this after we implement opening of
 /// mutable references.
-fn infer_under_mut_ref_hack(rcx: &mut InferCtxt, actuals: &[Ty], fn_sig: &PolyFnSig) -> Vec<Ty> {
-    iter::zip(actuals, fn_sig.skip_binder_ref().inputs())
+fn infer_under_mut_ref_hack(rcx: &mut InferCtxt, actuals: &[Ty], formals: &[Ty]) -> Vec<Ty> {
+    iter::zip(actuals, formals)
         .map(|(actual, formal)| {
+            let formal = SkipConstr.fold_ty(formal);
             if let rty::Ref!(re, deref_ty, Mutability::Mut) = actual.kind()
-                && is_indexed_mut_skipping_constr(formal)
+                && indexed_mut_pointee_idx_skipping_constr(&formal).is_some()
             {
                 rty::Ty::mk_ref(*re, rcx.unpack(deref_ty), Mutability::Mut)
             } else {

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -1165,22 +1165,17 @@ fn fn_input_as_ty(input: FnInput) -> Ty {
         FnInput::Constr(_bind, path, pred, node_id) => {
             let span = pred.span;
             Ty {
-            kind: TyKind::Constr(pred, Box::new(Ty {
-                kind: TyKind::Base(path_to_bty(path)),
+                kind: TyKind::Constr(
+                    pred,
+                    Box::new(Ty { kind: TyKind::Base(path_to_bty(path)), node_id, span }),
+                ),
                 node_id,
                 span,
-            })),
-            node_id,
-            span,
-        }
+            }
         }
         FnInput::StrgRef(_bind, ty, node_id) => {
             let span = ty.span;
-            Ty {
-            kind: TyKind::Ref(Mutability::Mut, Box::new(ty)),
-            node_id,
-            span,
-        }
+            Ty { kind: TyKind::Ref(Mutability::Mut, Box::new(ty)), node_id, span }
         }
         FnInput::Ty(_bind, ty, _node_id) => ty,
     }
@@ -1207,12 +1202,15 @@ fn parse_opt_ensures_for_bound(cx: &mut ParseCtxt) -> ParseResult<Vec<Ensures>> 
     if !cx.advance_if(kw::Ensures) {
         return Ok(vec![]);
     }
-    punctuated_until(cx, Comma, |t: TokenKind| t == token::Comma || t.is_eof(), parse_ensures_clause)
+    punctuated_until(
+        cx,
+        Comma,
+        |t: TokenKind| t == token::Comma || t.is_eof(),
+        parse_ensures_clause,
+    )
 }
 
-fn parse_fn_bound_path(
-    cx: &mut ParseCtxt,
-) -> ParseResult<(Path, Option<surface::FnTraitBound>)> {
+fn parse_fn_bound_path(cx: &mut ParseCtxt) -> ParseResult<(Path, Option<surface::FnTraitBound>)> {
     let lo = cx.lo();
     let ident = parse_ident(cx)?;
     let kind = surface::FnTraitKind::from_symbol(ident.name).unwrap();

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -4,7 +4,7 @@ use std::{collections::HashSet, str::FromStr, vec};
 
 use lookahead::{AnyLit, LAngle, NonReserved, RAngle};
 use rustc_ast::token::Lit;
-use rustc_span::{Symbol, sym::Output};
+use rustc_span::{Span, Symbol, sym::Output};
 use utils::{
     angle, braces, brackets, delimited, opt_angle, parens, punctuated_until,
     punctuated_with_trailing, repeat_while, sep1, until,
@@ -1153,52 +1153,125 @@ fn parse_indices(cx: &mut ParseCtxt) -> ParseResult<Indices> {
     Ok(Indices { indices, span: cx.mk_span(lo, hi) })
 }
 
-fn parse_fn_bound_input(cx: &mut ParseCtxt) -> ParseResult<GenericArg> {
-    let lo = cx.lo();
-    let tys = parens(cx, Comma, parse_type)?;
-    let hi = cx.hi();
-    let kind = TyKind::Tuple(tys);
-    let span = cx.mk_span(lo, hi);
-    let in_ty = Ty { kind, node_id: cx.next_node_id(), span };
-    Ok(GenericArg { kind: GenericArgKind::Type(in_ty), node_id: cx.next_node_id() })
-}
-
-fn parse_fn_bound_output(cx: &mut ParseCtxt) -> ParseResult<GenericArg> {
-    let lo = cx.lo();
-
-    let ty = if cx.advance_if(token::RArrow) {
-        parse_type(cx)?
-    } else {
-        Ty { kind: TyKind::Tuple(vec![]), node_id: cx.next_node_id(), span: cx.mk_span(lo, lo) }
-    };
-    let hi = cx.hi();
+fn parse_fn_bound_output(cx: &mut ParseCtxt, ty: Ty) -> GenericArg {
+    let lo = ty.span.lo();
+    let hi = ty.span.hi();
     let ident = Ident { name: Output, span: cx.mk_span(lo, hi) };
-    Ok(GenericArg { kind: GenericArgKind::Constraint(ident, ty), node_id: cx.next_node_id() })
+    GenericArg { kind: GenericArgKind::Constraint(ident, ty), node_id: cx.next_node_id() }
 }
 
-fn parse_fn_bound_path(cx: &mut ParseCtxt) -> ParseResult<Path> {
+fn fn_input_as_ty(input: FnInput) -> Ty {
+    match input {
+        FnInput::Constr(_bind, path, pred, node_id) => {
+            let span = pred.span;
+            Ty {
+            kind: TyKind::Constr(pred, Box::new(Ty {
+                kind: TyKind::Base(path_to_bty(path)),
+                node_id,
+                span,
+            })),
+            node_id,
+            span,
+        }
+        }
+        FnInput::StrgRef(_bind, ty, node_id) => {
+            let span = ty.span;
+            Ty {
+            kind: TyKind::Ref(Mutability::Mut, Box::new(ty)),
+            node_id,
+            span,
+        }
+        }
+        FnInput::Ty(_bind, ty, _node_id) => ty,
+    }
+}
+
+fn fn_inputs_to_tuple_ty(cx: &mut ParseCtxt, inputs: Vec<FnInput>, span: Span) -> Ty {
+    let tys = inputs.into_iter().map(fn_input_as_ty).collect();
+    Ty { kind: TyKind::Tuple(tys), node_id: cx.next_node_id(), span }
+}
+
+fn parse_opt_requires_for_bound(cx: &mut ParseCtxt) -> ParseResult<Vec<Requires>> {
+    if !cx.advance_if(kw::Requires) {
+        return Ok(vec![]);
+    }
+    punctuated_until(
+        cx,
+        Comma,
+        |t: TokenKind| t.is_keyword(kw::Ensures) || t == token::Comma || t.is_eof(),
+        parse_requires_clause,
+    )
+}
+
+fn parse_opt_ensures_for_bound(cx: &mut ParseCtxt) -> ParseResult<Vec<Ensures>> {
+    if !cx.advance_if(kw::Ensures) {
+        return Ok(vec![]);
+    }
+    punctuated_until(cx, Comma, |t: TokenKind| t == token::Comma || t.is_eof(), parse_ensures_clause)
+}
+
+fn parse_fn_bound_path(
+    cx: &mut ParseCtxt,
+) -> ParseResult<(Path, Option<surface::FnTraitBound>)> {
     let lo = cx.lo();
     let ident = parse_ident(cx)?;
-    let in_arg = parse_fn_bound_input(cx)?;
-    let out_arg = parse_fn_bound_output(cx)?;
+    let kind = surface::FnTraitKind::from_symbol(ident.name).unwrap();
+    let inputs = parens(cx, Comma, parse_fn_input)?;
+    let returns = parse_fn_ret(cx)?;
+    let requires = parse_opt_requires_for_bound(cx)?;
+    let ensures = parse_opt_ensures_for_bound(cx)?;
+    let inputs = mut_as_strg(inputs, &ensures)?;
+    let has_named_inputs = inputs.iter().any(|input| {
+        matches!(input, FnInput::Constr(..) | FnInput::StrgRef(..) | FnInput::Ty(Some(_), ..))
+    });
+    let has_fn_bound = !requires.is_empty() || !ensures.is_empty() || has_named_inputs;
+    let span = cx.mk_span(lo, cx.hi());
+    let (in_arg, out_arg, fn_bound) = if has_fn_bound {
+        let in_ty = Ty { kind: TyKind::Tuple(vec![]), node_id: cx.next_node_id(), span };
+        let in_arg = GenericArg { kind: GenericArgKind::Type(in_ty), node_id: cx.next_node_id() };
+        let span = match &returns {
+            FnRetTy::Default(span) => *span,
+            FnRetTy::Ty(ty) => ty.span,
+        };
+        let out_ty = Ty { kind: TyKind::Tuple(vec![]), node_id: cx.next_node_id(), span };
+        let out_arg = parse_fn_bound_output(cx, out_ty);
+        let output = FnOutput { returns, ensures, node_id: cx.next_node_id() };
+        let fn_bound = Some(surface::FnTraitBound {
+            kind,
+            requires,
+            inputs,
+            output,
+            node_id: cx.next_node_id(),
+            span,
+        });
+        (in_arg, out_arg, fn_bound)
+    } else {
+        let in_ty = fn_inputs_to_tuple_ty(cx, inputs, span);
+        let in_arg = GenericArg { kind: GenericArgKind::Type(in_ty), node_id: cx.next_node_id() };
+        let out_ty = match returns {
+            FnRetTy::Default(span) => {
+                Ty { kind: TyKind::Tuple(vec![]), node_id: cx.next_node_id(), span }
+            }
+            FnRetTy::Ty(ty) => *ty,
+        };
+        let out_arg = parse_fn_bound_output(cx, out_ty);
+        (in_arg, out_arg, None)
+    };
     let args = vec![in_arg, out_arg];
     let segment = PathSegment { ident, args, node_id: cx.next_node_id() };
     let hi = cx.hi();
-    Ok(Path {
-        segments: vec![segment],
-        refine: vec![],
-        node_id: cx.next_node_id(),
-        span: cx.mk_span(lo, hi),
-    })
+    let span = cx.mk_span(lo, hi);
+    let path = Path { segments: vec![segment], refine: vec![], node_id: cx.next_node_id(), span };
+    Ok((path, fn_bound))
 }
 
 fn parse_generic_bounds(cx: &mut ParseCtxt) -> ParseResult<GenericBounds> {
-    let path = if cx.peek(sym::FnOnce) || cx.peek(sym::FnMut) || cx.peek(sym::Fn) {
+    let (path, fn_bound) = if cx.peek(sym::FnOnce) || cx.peek(sym::FnMut) || cx.peek(sym::Fn) {
         parse_fn_bound_path(cx)?
     } else {
-        parse_path(cx)?
+        (parse_path(cx)?, None)
     };
-    Ok(vec![TraitRef { path, node_id: cx.next_node_id() }])
+    Ok(vec![TraitRef { path, fn_bound, node_id: cx.next_node_id() }])
 }
 
 fn parse_const_arg(cx: &mut ParseCtxt) -> ParseResult<ConstArg> {

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -412,7 +412,36 @@ pub type GenericBounds = Vec<TraitRef>;
 #[derive(Debug)]
 pub struct TraitRef {
     pub path: Path,
+    pub fn_bound: Option<FnTraitBound>,
     pub node_id: NodeId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FnTraitKind {
+    Fn,
+    FnMut,
+    FnOnce,
+}
+
+impl FnTraitKind {
+    pub fn from_symbol(sym: Symbol) -> Option<Self> {
+        match sym {
+            sym::Fn => Some(Self::Fn),
+            sym::FnMut => Some(Self::FnMut),
+            sym::FnOnce => Some(Self::FnOnce),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FnTraitBound {
+    pub kind: FnTraitKind,
+    pub requires: Vec<Requires>,
+    pub inputs: Vec<FnInput>,
+    pub output: FnOutput,
+    pub node_id: NodeId,
+    pub span: Span,
 }
 
 impl TraitRef {

--- a/crates/flux-syntax/src/surface/visit.rs
+++ b/crates/flux-syntax/src/surface/visit.rs
@@ -10,9 +10,9 @@ use rustc_span::symbol::Ident;
 use super::{
     Async, BaseSort, BaseTy, BaseTyKind, ConstArg, ConstantInfo, ConstructorArg, Ensures, EnumDef,
     Expr, ExprKind, ExprPath, ExprPathSegment, FieldExpr, FnInput, FnOutput, FnRetTy, FnSig,
-    GenericArg, GenericArgKind, GenericParam, Generics, Impl, ImplAssocReft, Indices, ItemKind,
-    Lit, Path, PathSegment, Qualifier, RefineArg, RefineParam, Sort, SortPath, SpecFunc, StructDef,
-    Trait, TraitAssocReft, TraitRef, Ty, TyAlias, TyKind, VariantDef, VariantRet,
+    FnTraitBound, GenericArg, GenericArgKind, GenericParam, Generics, Impl, ImplAssocReft, Indices,
+    ItemKind, Lit, Path, PathSegment, Qualifier, RefineArg, RefineParam, Sort, SortPath, SpecFunc,
+    StructDef, Trait, TraitAssocReft, TraitRef, Ty, TyAlias, TyKind, VariantDef, VariantRet,
     WhereBoundPredicate,
 };
 use crate::surface::{FluxItem, ImplItemFn, Item, PrimOpProp, SortDecl, TraitItemFn};
@@ -92,6 +92,10 @@ pub trait Visitor: Sized {
 
     fn visit_trait_ref(&mut self, trait_ref: &TraitRef) {
         walk_trait_ref(self, trait_ref);
+    }
+
+    fn visit_fn_trait_bound(&mut self, bound: &FnTraitBound) {
+        walk_fn_trait_bound(self, bound);
     }
 
     fn visit_base_sort(&mut self, bsort: &BaseSort) {
@@ -328,6 +332,18 @@ pub fn walk_impl_assoc_reft<V: Visitor>(vis: &mut V, assoc_reft: &ImplAssocReft)
 
 pub fn walk_trait_ref<V: Visitor>(vis: &mut V, trait_ref: &TraitRef) {
     vis.visit_path(&trait_ref.path);
+    if let Some(bound) = &trait_ref.fn_bound {
+        vis.visit_fn_trait_bound(bound);
+    }
+}
+
+pub fn walk_fn_trait_bound<V: Visitor>(vis: &mut V, bound: &FnTraitBound) {
+    for requires in &bound.requires {
+        walk_list!(vis, visit_refine_param, &requires.params);
+        vis.visit_expr(&requires.pred);
+    }
+    walk_list!(vis, visit_fn_input, &bound.inputs);
+    vis.visit_fn_output(&bound.output);
 }
 
 pub fn walk_base_sort<V: Visitor>(vis: &mut V, bsort: &BaseSort) {

--- a/tests/tests/neg/surface/closure16.rs
+++ b/tests/tests/neg/surface/closure16.rs
@@ -1,0 +1,8 @@
+#[flux::sig(fn(f: F) -> ()
+            where F: Fn(x: i32[@n]) -> i32[n + 1] ensures old > 0)] //~ ERROR cannot find value `old` in this scope
+fn bad_missing_ensures<F>(f: F)
+where
+    F: Fn(i32) -> i32,
+{
+    let _ = f;
+}

--- a/tests/tests/neg/surface/closure17.rs
+++ b/tests/tests/neg/surface/closure17.rs
@@ -1,0 +1,15 @@
+#[flux::sig(fn(f: F) -> i32[100]
+            where F: FnOnce(x: i32[@n]) -> i32[n + 1] requires n >= 0)]
+#[flux::trusted]
+fn apply_fn_once<F>(f: F) -> i32
+where
+    F: FnOnce(i32) -> i32,
+{
+    let _ = f;
+    unimplemented!()
+}
+
+#[flux::sig(fn() -> i32[100])]
+pub fn client_bad() -> i32 {
+    apply_fn_once(|x| x + 2) //~ ERROR refinement type
+}

--- a/tests/tests/neg/surface/closure17.rs
+++ b/tests/tests/neg/surface/closure17.rs
@@ -5,8 +5,7 @@ fn apply_fn_once<F>(f: F) -> i32
 where
     F: FnOnce(i32) -> i32,
 {
-    let _ = f;
-    unimplemented!()
+    f(99)
 }
 
 #[flux::sig(fn() -> i32[100])]

--- a/tests/tests/pos/surface/closure16.rs
+++ b/tests/tests/pos/surface/closure16.rs
@@ -1,0 +1,46 @@
+#[flux::sig(fn(f: F) -> i32{v : v >= 1}
+            where F: Fn(x: i32[@n]) -> i32[n + 1] requires n >= 0)]
+fn test00<F>(_f: F) -> i32
+where
+    F: Fn(i32) -> i32,
+{
+    _f(0)
+}
+
+#[flux::sig(fn(f: F) -> i32[12]
+    where F: Fn(x: &mut i32[@old]) ensures x : i32[old + 2]
+)]
+fn test01<F>(f: F) -> i32
+where F : Fn(&mut i32) {
+    let mut x = 0;
+    f(&mut x);
+    x + 10
+}
+
+#[flux_rs::spec(fn(y: &mut i32[@old]) ensures y: i32[(2 * (old + 1) - old)])]
+fn inc2_mut(x: &mut i32) {
+    *x += 2
+}
+
+#[flux_rs::spec(fn() -> i32[12])]
+fn client01() -> i32 {
+    test01(inc2_mut)
+}
+
+#[flux_rs::spec(fn(f: F) -> i32{ v: v >= 12}
+    where F: Fn(old: i32) -> i32{v: v >= old + 2}
+)]
+fn test02<F>(f : F) -> i32
+where F : Fn(i32) -> i32 {
+    f(0) + 10
+}
+
+
+#[flux_rs::spec(fn(i32[@old]) -> i32[old + 2])]
+fn inc2(x: i32) -> i32{
+    x + 2
+}
+
+fn client02() -> i32 {
+    test02(inc2)
+}

--- a/tests/tests/pos/surface/closure16.rs
+++ b/tests/tests/pos/surface/closure16.rs
@@ -44,3 +44,11 @@ fn inc2(x: i32) -> i32{
 fn client02() -> i32 {
     test02(inc2)
 }
+
+#[flux_rs::spec(fn(f : F) -> i32[3]
+    where F : Fn(i32[@old]) -> i32[old + 3]
+)]
+fn test03<F>(f: F) -> i32
+where F : Fn(i32) -> i32 {
+    f(0)
+}

--- a/tests/tests/pos/surface/mut_ref.rs
+++ b/tests/tests/pos/surface/mut_ref.rs
@@ -1,0 +1,30 @@
+#[flux_rs::refined_by(i: int)]
+struct Wrapper {
+    #[flux_rs::field(i32[i])]
+    inner: i32,
+}
+
+impl Wrapper {
+    #[flux_rs::spec(fn[hrn upd: (int, int) -> bool](s: &mut Self[@slf], f: F)
+        ensures s : Self{v : upd(v, slf)}
+        where F: Fn(x: &mut i32[@old]) ensures x : i32{v : upd(v, old)}
+    )]
+    fn with_mut<F>(&mut self, f: F)
+    where
+        F: Fn(&mut i32),
+    {
+        f(&mut self.inner);
+    }
+}
+
+#[flux_rs::spec(fn(x: &mut i32[@old]) ensures x: i32[old + 1])]
+fn inc(x: &mut i32) {
+    *x += 1;
+}
+
+#[flux_rs::spec(fn() -> i32[100])]
+fn test00() -> i32 {
+    let mut w = Wrapper { inner: 99 };
+    w.with_mut(inc);
+    w.inner
+}

--- a/tests/tests/pos/surface/mut_ref.rs
+++ b/tests/tests/pos/surface/mut_ref.rs
@@ -39,6 +39,6 @@ fn test01() -> i32 {
 #[flux_rs::spec(fn() -> i32[100])]
 fn test02() -> i32 {
     let mut w = Wrapper { inner: 99 };
-    w.with_mut(|x| inc(x))
+    w.with_mut(|x| inc(x));
     w.inner
 }

--- a/tests/tests/pos/surface/mut_ref.rs
+++ b/tests/tests/pos/surface/mut_ref.rs
@@ -15,6 +15,14 @@ impl Wrapper {
     {
         f(&mut self.inner);
     }
+
+    #[flux_rs::trusted]
+    #[flux_rs::spec(fn(s: &mut Self[@slf]) -> &mut i32[slf]
+        ensures s : Self[slf]
+    )]
+    fn borrow_mut(&mut self) -> &mut i32 {
+        &mut self.inner
+    }
 }
 
 #[flux_rs::spec(fn(x: &mut i32[@old]) ensures x: i32[old + 1])]
@@ -26,5 +34,20 @@ fn inc(x: &mut i32) {
 fn test00() -> i32 {
     let mut w = Wrapper { inner: 99 };
     w.with_mut(inc);
+    w.inner
+}
+
+#[flux_rs::spec(fn() -> i32[100])]
+fn test01() -> i32 {
+    let mut w = Wrapper { inner: 99 };
+    w.with_mut(|x| *x += 1);
+    w.inner
+}
+
+#[flux_rs::spec(fn() -> i32[100])]
+fn test02() -> i32 {
+    let mut w = Wrapper { inner : 99 };
+    let x = w.borrow_mut();
+    *x += 1;
     w.inner
 }

--- a/tests/tests/pos/surface/mut_ref.rs
+++ b/tests/tests/pos/surface/mut_ref.rs
@@ -15,14 +15,6 @@ impl Wrapper {
     {
         f(&mut self.inner);
     }
-
-    #[flux_rs::trusted]
-    #[flux_rs::spec(fn(s: &mut Self[@slf]) -> &mut i32[slf]
-        ensures s : Self[slf]
-    )]
-    fn borrow_mut(&mut self) -> &mut i32 {
-        &mut self.inner
-    }
 }
 
 #[flux_rs::spec(fn(x: &mut i32[@old]) ensures x: i32[old + 1])]
@@ -46,8 +38,7 @@ fn test01() -> i32 {
 
 #[flux_rs::spec(fn() -> i32[100])]
 fn test02() -> i32 {
-    let mut w = Wrapper { inner : 99 };
-    let x = w.borrow_mut();
-    *x += 1;
+    let mut w = Wrapper { inner: 99 };
+    w.with_mut(|x| inc(x))
     w.inner
 }


### PR DESCRIPTION
This PR adds support for function trait bounds with full function signatures (e.g. `where F: Fn(x: i32[@n]) -> i32[n+1] requires ... ensures ...`). This enables the following test to pass:

```
#[flux_rs::refined_by(i: int)]
struct Wrapper {
    #[flux_rs::field(i32[i])]
    inner: i32,
}

impl Wrapper {
    #[flux_rs::spec(fn[hrn upd: (int, int) -> bool](s: &mut Self[@slf], f: F)
        ensures s : Self{v : upd(v, slf)}
        where F: Fn(x: &mut i32[@old]) ensures x : i32{v : upd(v, old)}
    )]
    fn with_mut<F>(&mut self, f: F)
    where
        F: Fn(&mut i32),
    {
        f(&mut self.inner);
    }
}

#[flux_rs::spec(fn() -> i32[100])]
fn test() -> i32 {
    let mut w = Wrapper { inner: 99 };
    w.with_mut(|x| *x += 1);
    w.inner
}
```

It adds a new field to `surface::TraitRef` to represent an Fn trait bound (if available) and carries it through desugaring and conversion. This part I understand. The changes in `checker.rs` and `infer.rs`, I'm much more suspicious of, and I have a much looser grasp on. I'll continue to look at them, but I thought I should put this out too.