### PR TITLE
Allow lossless casts from signed to unsigned

### DIFF
--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -1631,7 +1631,9 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                     (Uint!(uint_ty, idx), RustTy::Int(int_ty)) => {
                         uint_int_cast(idx, *uint_ty, *int_ty)
                     }
-                    (Int!(_, _), RustTy::Uint(uint_ty)) => Ty::uint(*uint_ty),
+                    (Int!(int_ty, idx), RustTy::Uint(uint_ty)) => {
+                        int_uint_cast(idx, *int_ty, *uint_ty)
+                    }
                     (TyKind::Discr(adt_def, _), RustTy::Int(int_ty)) => {
                         Self::discr_to_int_cast(adt_def, BaseTy::Int(*int_ty))
                     }
@@ -2289,6 +2291,21 @@ fn uint_int_cast(idx: &Expr, uint_ty: UintTy, int_ty: IntTy) -> Ty {
     } else {
         Ty::int(int_ty)
     }
+}
+
+fn int_uint_cast(idx: &Expr, int_ty: IntTy, uint_ty: UintTy) -> Ty {
+    let non_neg = Expr::ge(idx.clone(), Expr::zero());
+
+    let guard: Expr = if int_bit_width(int_ty) <= uint_bit_width(uint_ty) {
+        non_neg
+    } else {
+        // Cast is still possible if the value is known to fit.
+        let fits = Expr::le(idx.clone(), Expr::uint_max(uint_ty));
+        Expr::and(non_neg, fits)
+    };
+
+    let eq = Expr::eq(Expr::nu(), idx.clone());
+    Ty::exists_with_constr(BaseTy::Uint(uint_ty), Expr::implies(guard, eq))
 }
 
 fn guarded_uint_ty(idx: &Expr, uint_ty: UintTy) -> Ty {

--- a/tests/tests/neg/casts/int_to_uint.rs
+++ b/tests/tests/neg/casts/int_to_uint.rs
@@ -1,0 +1,31 @@
+use flux_attrs::*;
+
+#[spec(fn(n:i64{n: n < 13}) -> u64{v: v < 13})]
+pub fn i64_u64_lossy_neg(n: i64) -> u64 {
+    n as u64 //~ ERROR refinement type
+}
+
+#[spec(fn({i16[@n] | n >= 0}) -> u8[n])]
+pub fn i16_u8_lossy_mag(n: i16) -> u8 {
+    n as u8 //~ ERROR refinement type
+}
+
+#[spec(fn() -> i8[-1])]
+pub fn i64_i8_lossy_const() -> i8 {
+    -1i8 as u8 as i8 //~ ERROR refinement type
+}
+
+#[spec(fn(x:i32) -> u32[x])]
+pub fn i32_u32_unconstrained(x: i32) -> u32 {
+    x as u32 //~ ERROR refinement type
+}
+
+#[spec(fn(x:i64{0 <= x}) -> u32[x])]
+pub fn i64_u32_missing_upper(x: i64) -> u32 {
+    x as u32 //~ ERROR refinement type
+}
+
+#[spec(fn(x:i64{x <= 5}) -> usize[x])]
+pub fn i64_usize_negative_possible(x: i64) -> usize {
+    x as usize //~ ERROR refinement type
+}

--- a/tests/tests/pos/casts/int_to_uint.rs
+++ b/tests/tests/pos/casts/int_to_uint.rs
@@ -1,0 +1,36 @@
+use flux_attrs::*;
+
+#[spec(fn() -> u64[0x7FFFFFFFFFFFFFFF])]
+pub fn i64_max() -> u64 {
+    i64::MAX as u64
+}
+
+#[spec(fn() -> usize[1])]
+pub fn i16_u16_lossless() -> usize {
+    1isize as usize
+}
+
+#[spec(fn() -> u32[42])]
+pub fn i64_u32_lossless() -> u32 {
+    42i64 as u32
+}
+
+#[spec(fn({i32[@n] | 0 <= n && n < 12}) -> u8{v: v < 12})]
+pub fn i32_u8_lossless_reft(x: i32) -> u8 {
+    x as u8 
+}
+
+#[spec(fn(x:i32{0 <= x}) -> u32[x])]
+pub fn i32_u32_nonneg(x: i32) -> u32 {
+    x as u32
+}
+
+#[spec(fn(x:i64{0 <= x && x <= 4_294_967_295}) -> u32[x])]
+pub fn i64_u32_bounded(x: i64) -> u32 {
+    x as u32
+}
+
+#[spec(fn(x:i64{0 <= x && x <= 100}) -> usize{v: v <= 100})]
+pub fn i64_usize_small(x: i64) -> usize {
+    x as usize
+}


### PR DESCRIPTION
A cast from a signed integer to an unsigned integer preserves idx in two cases:
- The value is known to be non-negative and the destination is at least as wide as the source
- The value is known to be non-negative and known to fit in the destination

Therefore we can use a "lazy" type of the form: `u<n>{v: 0 <= idx && idx <= u<n>::MAX => v == idx}`

The performance of this probably needs investigation, but I think int -> uint casts are rare enough that there shouldn't be a huge regression.

Fixes: #1558