### PR TITLE
Refinement suggestions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,6 @@ name = "liquid-fixpoint"
 version = "0.1.0"
 dependencies = [
  "derive-where",
- "indexmap",
  "itertools 0.14.0",
  "serde",
  "serde_json",

--- a/crates/flux-config/src/flags.rs
+++ b/crates/flux-config/src/flags.rs
@@ -74,6 +74,10 @@ pub struct Flags {
     pub lean: LeanMode,
     /// If `true`, every function is implicitly labeled with a `no_panic` by default.
     pub no_panic: bool,
+    /// If `true`, all code will have suggestions disabled. This is manifest by
+    /// no weak kvars being added to any signature. If you explicitly add a weak
+    /// kvar, it will still have suggestions given.
+    pub no_suggestions_default: bool,
 }
 
 impl Default for Flags {
@@ -107,6 +111,7 @@ impl Default for Flags {
             ignore_default: false,
             lean: LeanMode::default(),
             no_panic: false,
+            no_suggestions_default: false,
         }
     }
 }
@@ -148,6 +153,7 @@ pub(crate) static FLAGS: LazyLock<Flags> = LazyLock::new(|| {
             "ignore" => parse_bool(&mut flags.ignore_default, value),
             "lean" => parse_lean_mode(&mut flags.lean, value),
             "no-panic" => parse_bool(&mut flags.no_panic, value),
+            "no-suggestions" => parse_bool(&mut flags.no_suggestions_default, value),
             _ => {
                 eprintln!("error: unknown flux option: `{key}`");
                 process::exit(EXIT_FAILURE);

--- a/crates/flux-config/src/lib.rs
+++ b/crates/flux-config/src/lib.rs
@@ -138,6 +138,10 @@ pub fn full_compilation() -> bool {
     FLAGS.full_compilation
 }
 
+pub fn no_suggestions_default() -> bool {
+    FLAGS.no_suggestions_default
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(try_from = "String")]
 pub struct Pos {

--- a/crates/flux-desugar/src/lib.rs
+++ b/crates/flux-desugar/src/lib.rs
@@ -206,6 +206,7 @@ fn fhir_attr_map<'genv>(genv: GlobalEnv<'genv, '_>, def_id: LocalDefId) -> fhir:
                         surface::Attr::ShouldFail => Some(fhir::Attr::ShouldFail),
                         surface::Attr::InferOpts(opts) => Some(fhir::Attr::InferOpts(opts)),
                         surface::Attr::NoPanic => Some(fhir::Attr::NoPanic),
+                        surface::Attr::NoSuggestions => Some(fhir::Attr::NoSuggestions),
                         surface::Attr::Qualifiers(_) | surface::Attr::Reveal(_) => None,
                     }
                 })

--- a/crates/flux-driver/src/collector/mod.rs
+++ b/crates/flux-driver/src/collector/mod.rs
@@ -622,6 +622,7 @@ impl<'a, 'tcx> SpecCollector<'a, 'tcx> {
             ("extern_spec", hir::AttrArgs::Empty) => FluxAttrKind::ExternSpec,
             ("no_panic", hir::AttrArgs::Empty) => FluxAttrKind::NoPanic,
             ("should_fail", hir::AttrArgs::Empty) => FluxAttrKind::ShouldFail,
+            ("no_suggestions", hir::AttrArgs::Empty) => FluxAttrKind::NoSuggestions,
             ("specs", hir::AttrArgs::Delimited(dargs)) => {
                 self.parse(dargs, ParseSess::parse_detached_specs, FluxAttrKind::DetachedSpecs)?
             }
@@ -745,6 +746,7 @@ enum FluxAttrKind {
     ExternSpec,
     NoPanic,
     NoPanicIf(surface::Expr),
+    NoSuggestions,
     /// See `detachXX.rs`
     DetachedSpecs(surface::DetachedSpecs),
 }
@@ -902,6 +904,7 @@ impl FluxAttrs {
                 FluxAttrKind::Ignore(ignored) => surface::Attr::Ignore(ignored),
                 FluxAttrKind::ShouldFail => surface::Attr::ShouldFail,
                 FluxAttrKind::NoPanic => surface::Attr::NoPanic,
+                FluxAttrKind::NoSuggestions => surface::Attr::NoSuggestions,
                 FluxAttrKind::Opaque
                 | FluxAttrKind::Reflect
                 | FluxAttrKind::FnSig(_)
@@ -955,6 +958,7 @@ impl FluxAttrKind {
             FluxAttrKind::DetachedSpecs(_) => attr_name!(DetachedSpecs),
             FluxAttrKind::NoPanic => attr_name!(NoPanic),
             FluxAttrKind::NoPanicIf(_) => attr_name!(NoPanicIf),
+            FluxAttrKind::NoSuggestions => attr_name!(NoSuggestions),
         }
     }
 }

--- a/crates/flux-fhir-analysis/Cargo.toml
+++ b/crates/flux-fhir-analysis/Cargo.toml
@@ -24,3 +24,6 @@ rustc_private = true
 
 [lints]
 workspace = true
+
+[features]
+wick = []

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -679,8 +679,10 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
 
         let no_panic = if let Some(e) = fn_sig.no_panic_if {
             self.conv_expr(&mut env, &e)?
+        } else if self.genv().no_panic(fn_id) {
+            Expr::tt()
         } else {
-            if self.genv().no_panic(fn_id) { Expr::tt() } else { Expr::ff() }
+            Expr::ff()
         };
 
         let fn_sig =

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -615,7 +615,9 @@ fn fn_sig(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult<rty::EarlyBinde
             #[cfg(feature = "wick")]
             let mut fn_sig = fn_sig.hoist_input_binders();
             #[cfg(feature = "wick")]
-            if !genv.no_suggestions(def_id.local_id()) {
+            if !genv.no_suggestions(def_id.local_id())
+                && !matches!(fhir_node, fhir::Node::TraitItem(..) | fhir::Node::ForeignItem(..) | fhir::Node::ImplItem(..))
+            {
                 let id = match def_id {
                     MaybeExternId::Extern(_local_id, def_id) => def_id,
                     MaybeExternId::Local(local_id) => local_id.into(),

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -611,16 +611,15 @@ fn fn_sig(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult<rty::EarlyBinde
             let fn_sig = AfterSortck::new(genv, &wfckresults)
                 .into_conv_ctxt()
                 .conv_fn_sig(def_id, fhir_fn_sig)?;
-            if fn_sig.vars().is_empty() {
-                fn_sig = fn_sig.hoist_input_binders();
+            let fn_sig = struct_compat::fn_sig(genv, fhir_fn_sig.decl, &fn_sig, def_id)?;
+            let mut fn_sig = fn_sig.hoist_input_binders();
+            if !genv.no_suggestions(def_id.local_id()) {
+                let id = match def_id {
+                    MaybeExternId::Extern(_local_id, def_id) => def_id,
+                    MaybeExternId::Local(local_id) => local_id.into(),
+                };
+                fn_sig = fn_sig.add_weak_kvars(genv, id)?;
             }
-            // println!("adding wkvars for {:?}", def_id);
-            fn_sig = fn_sig.hoist_input_binders();
-            let id = match def_id {
-                MaybeExternId::Extern(_local_id, def_id) => def_id,
-                MaybeExternId::Local(local_id) => local_id.into(),
-            };
-            fn_sig = fn_sig.add_weak_kvars(genv, id)?;
 
             if config::dump_rty() {
                 let generics = genv.generics_of(def_id)?;

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -611,8 +611,16 @@ fn fn_sig(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult<rty::EarlyBinde
             let fn_sig = AfterSortck::new(genv, &wfckresults)
                 .into_conv_ctxt()
                 .conv_fn_sig(def_id, fhir_fn_sig)?;
-            let fn_sig = struct_compat::fn_sig(genv, fhir_fn_sig.decl, &fn_sig, def_id)?;
-            let fn_sig = fn_sig.hoist_input_binders();
+            if fn_sig.vars().is_empty() {
+                fn_sig = fn_sig.hoist_input_binders();
+            }
+            // println!("adding wkvars for {:?}", def_id);
+            fn_sig = fn_sig.hoist_input_binders();
+            let id = match def_id {
+                MaybeExternId::Extern(_local_id, def_id) => def_id,
+                MaybeExternId::Local(local_id) => local_id.into(),
+            };
+            fn_sig = fn_sig.add_weak_kvars(genv, id)?;
 
             if config::dump_rty() {
                 let generics = genv.generics_of(def_id)?;

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -612,7 +612,9 @@ fn fn_sig(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult<rty::EarlyBinde
                 .into_conv_ctxt()
                 .conv_fn_sig(def_id, fhir_fn_sig)?;
             let fn_sig = struct_compat::fn_sig(genv, fhir_fn_sig.decl, &fn_sig, def_id)?;
+            #[cfg(feature = "wick")]
             let mut fn_sig = fn_sig.hoist_input_binders();
+            #[cfg(feature = "wick")]
             if !genv.no_suggestions(def_id.local_id()) {
                 let id = match def_id {
                     MaybeExternId::Extern(_local_id, def_id) => def_id,

--- a/crates/flux-infer/Cargo.toml
+++ b/crates/flux-infer/Cargo.toml
@@ -30,3 +30,4 @@ rustc_private = true
 
 [features]
 rust-fixpoint = ["liquid-fixpoint/rust-fixpoint"]
+wick = ["liquid-fixpoint/wick"]

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -37,8 +37,6 @@ use liquid_fixpoint::{
     FixpointStatus, KVarBind, SmtSolver, VerificationResult,
     parser::{FromSexp, ParseError},
     sexp::Parser,
-    check_validity,
-    qe_and_simplify,
 };
 use rustc_data_structures::{
     fx::{FxIndexMap, FxIndexSet},
@@ -635,22 +633,8 @@ where
         // all constants.
         let constraint = self.ecx.assume_const_values(constraint, &mut self.scx)?;
 
-        let mut flat_constraint_map: HashMap<TagIdx, fixpoint::FlatConstraint> = constraint
-            .flatten(|var| matches!(var, fixpoint::Var::Underscore), |var| false)
-            .into_iter()
-            .flat_map(|flat_constraint| {
-                // We can't send a kvar to the SMT. If there's a kvar on the LHS we
-                // can underapproximate it with TRUE, but if it's in head position
-                // we don't know what to do.
-                if let Some(tag) = flat_constraint.tag
-                    && !flat_constraint.head.has_kvar()
-                {
-                    Some((tag.clone(), flat_constraint))
-                } else {
-                    None
-                }
-            })
-            .collect();
+        #[cfg(feature = "wick")]
+        let flat_constraint_map = make_flat_constraint_map(&constraint);
 
         let constants = self.ecx.const_env.const_map.values().cloned().collect_vec();
         // Encode function bodies after qualifiers/assumptions so any functions referenced there
@@ -756,29 +740,12 @@ where
                 tags.into_iter()
                     .map(|tag_idx| {
                         let tag = self.tags[tag_idx];
-                        #[cfg(not(feature = "wick"))]
-                        let possible_solutions = FxIndexMap::default();
-                        #[cfg(feature = "wick")]
-                        let mut possible_solutions: FxIndexMap<rty::WKVid, Vec<rty::Binder<rty::Expr>>> = FxIndexMap::default();
-                        if let Some(flat_constraint) = flat_constraint_map.get(&tag_idx) {
-                            let head_expr = match &flat_constraint.head {
-                                fixpoint::Pred::Expr(e) => Some(e.clone()),
-                                _ => None,
-                            };
-                            // FIXME: this should be a better source of fresh names, but 100000
-                            // should be safe.
-                            let mut fresh_rty_name: usize = 100_000;
-                            let mut fresh_var = || {
-                                let local_var = self.ecx.local_var_env.fresh_name();
-                                let rty_var = rty::Expr::fvar(rty::Name::from_usize(fresh_rty_name));
-                                self.ecx.local_var_env.reverse_map.insert(local_var, rty_var);
-                                fresh_rty_name += 1;
-                                fixpoint::Var::Local(local_var)
-                            };
-                        FixpointCheckError::new(
-                            tag,
-                            possible_solutions,
-                        )
+                        let possible_solutions = if let Some(suggestion_ctx) = &suggestion_ctx {
+                            find_possible_solutions(self, tag_idx, &suggestion_ctx)
+                        } else {
+                            Default::default()
+                        };
+                        FixpointCheckError::new(tag, possible_solutions)
                     })
                     .collect_vec()
             }

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -2352,7 +2352,7 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
         self_args: usize,
         scx: &mut SortEncodingCtxt,
     ) -> Option<fixpoint::Var> {
-        if matches!(
+        if !matches!(
             self.genv.resolve_id(wkvid.parent_fn),
             ResolvedDefId::Local(..) | ResolvedDefId::ExternSpec(..)
         ) {

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -342,17 +342,18 @@ impl SortEncodingCtxt {
                 fixpoint::Sort::App(fixpoint::SortCtor::Map, args)
             }
             rty::Sort::App(rty::SortCtor::Adt(sort_def), args) => {
-                if let Some(variant) = sort_def.opt_struct_variant() {
-                    let sorts = variant.field_sorts(args);
-                    // do not generate 1-tuples
-                    if let [sort] = &sorts[..] {
-                        self.sort_to_fixpoint(sort)
-                    } else {
-                        let adt_id = self.declare_adt(sort_def.did());
-                        let ctor = fixpoint::SortCtor::Data(fixpoint::DataSort::Adt(adt_id));
-                        let args = args.iter().map(|s| self.sort_to_fixpoint(s)).collect_vec();
-                        fixpoint::Sort::App(ctor, args)
-                    }
+                if let Some(_variant) = sort_def.opt_struct_variant() {
+                    // NOTE(ck): We previously had an optimization which didn't
+                    // emit a Ctor in cases of a 1-tuple, but this makes the
+                    // conversion back from fixpoint unfaithful (we can't
+                    // distinguish between e.g. `usize` and `(usize,)`).
+                    //
+                    // So this optimization has since been removed. Arguably
+                    // it's better-suited for fixpoint.
+                    let adt_id = self.declare_adt(sort_def.did());
+                    let ctor = fixpoint::SortCtor::Data(fixpoint::DataSort::Adt(adt_id));
+                    let args = args.iter().map(|s| self.sort_to_fixpoint(s)).collect_vec();
+                    fixpoint::Sort::App(ctor, args)
                 } else {
                     debug_assert!(args.is_empty());
                     let adt_id = self.declare_adt(sort_def.did());
@@ -371,15 +372,11 @@ impl SortEncodingCtxt {
                 )
             }
             rty::Sort::Tuple(sorts) => {
-                // do not generate 1-tuples
-                if let [sort] = &sorts[..] {
-                    self.sort_to_fixpoint(sort)
-                } else {
-                    self.declare_tuple(sorts.len());
-                    let ctor = fixpoint::SortCtor::Data(fixpoint::DataSort::Tuple(sorts.len()));
-                    let args = sorts.iter().map(|s| self.sort_to_fixpoint(s)).collect();
-                    fixpoint::Sort::App(ctor, args)
-                }
+                // NOTE(cK): See above note about not generating 1-tuples.
+                self.declare_tuple(sorts.len());
+                let ctor = fixpoint::SortCtor::Data(fixpoint::DataSort::Tuple(sorts.len()));
+                let args = sorts.iter().map(|s| self.sort_to_fixpoint(s)).collect();
+                fixpoint::Sort::App(ctor, args)
             }
             rty::Sort::Func(sort) => self.func_sort_to_fixpoint(sort).into_sort(),
             rty::Sort::Var(k) => fixpoint::Sort::Var(k.index()),

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -37,6 +37,8 @@ use liquid_fixpoint::{
     FixpointStatus, KVarBind, SmtSolver, VerificationResult,
     parser::{FromSexp, ParseError},
     sexp::Parser,
+    check_validity,
+    qe_and_simplify,
 };
 use rustc_data_structures::{
     fx::{FxIndexMap, FxIndexSet},
@@ -181,7 +183,7 @@ pub mod fixpoint {
         }
     }
 
-    #[derive(Hash, Clone, Debug)]
+    #[derive(Hash, Clone, Debug, PartialEq, Eq)]
     pub struct SymStr(pub Symbol);
 
     #[cfg(feature = "rust-fixpoint")]
@@ -262,7 +264,7 @@ pub struct ParsedResult {
 
 #[derive(Debug, Clone, Default)]
 pub struct Answer<Tag> {
-    pub errors: Vec<Tag>,
+    pub errors: Vec<FixpointCheckError<Tag>>,
     pub cut_solution: Solution,
     pub non_cut_solution: Solution,
 }
@@ -536,7 +538,7 @@ pub type FunDeclMap = FxIndexMap<FluxDefId, fixpoint::Var>;
 type ConstMap<'tcx> = FxIndexMap<ConstKey<'tcx>, fixpoint::ConstDecl>;
 
 #[derive(Eq, Hash, PartialEq, Clone)]
-enum ConstKey<'tcx> {
+pub(crate) enum ConstKey<'tcx> {
     RustConst(DefId),
     Alias(FluxDefId, rustc_middle::ty::GenericArgsRef<'tcx>),
     Lambda(Lambda),
@@ -558,12 +560,25 @@ pub struct FixpointCtxt<'genv, 'tcx, T: Eq + Hash> {
     kvars: KVarGen,
     scx: SortEncodingCtxt,
     kcx: KVarEncodingCtxt,
-    ecx: ExprEncodingCtxt<'genv, 'tcx>,
+    pub(crate) ecx: ExprEncodingCtxt<'genv, 'tcx>,
     tags: IndexVec<TagIdx, T>,
     tags_inv: UnordMap<T, TagIdx>,
 }
 
 pub type FixQueryCache = QueryCache<VerificationResult<TagIdx>>;
+pub type PossibleSolutions = FxIndexMap<rty::WKVid, Vec<rty::Binder<rty::Expr>>>;
+
+#[derive(Debug, Clone)]
+pub struct FixpointCheckError<Tag> {
+    pub tag: Tag,
+    pub possible_solutions: PossibleSolutions,
+}
+
+impl<Tag> FixpointCheckError<Tag> {
+    pub fn new(tag: Tag, possible_solutions: PossibleSolutions) -> Self {
+        Self { tag, possible_solutions }
+    }
+}
 
 pub use liquid_fixpoint::LeanStatus;
 
@@ -620,11 +635,30 @@ where
         // all constants.
         let constraint = self.ecx.assume_const_values(constraint, &mut self.scx)?;
 
-        let constants = self.ecx.const_env.const_map.values().cloned().collect_vec();
+        let mut flat_constraint_map: HashMap<TagIdx, fixpoint::FlatConstraint> = constraint
+            .flatten(|var| matches!(var, fixpoint::Var::Underscore), |var| false)
+            .into_iter()
+            .flat_map(|flat_constraint| {
+                // We can't send a kvar to the SMT. If there's a kvar on the LHS we
+                // can underapproximate it with TRUE, but if it's in head position
+                // we don't know what to do.
+                if let Some(tag) = flat_constraint.tag
+                    && !flat_constraint.head.has_kvar()
+                {
+                    Some((tag.clone(), flat_constraint))
+                } else {
+                    None
+                }
+            })
+            .collect();
 
+        let constants = self.ecx.const_env.const_map.values().cloned().collect_vec();
         // Encode function bodies after qualifiers/assumptions so any functions referenced there
         // are picked up as dependencies.
         let define_funs = self.ecx.define_funs(def_id, &mut self.scx)?;
+
+        #[cfg(feature = "wick")]
+        let constants_without_inequalities = constants.clone();
 
         // The rust fixpoint implementation does not yet support polymorphic functions.
         // For now we avoid including these by default so that cases where they are not needed can work.
@@ -650,6 +684,8 @@ where
         // We are done encoding expressions. Check if there are any errors.
         self.ecx.errors.to_result()?;
 
+        let data_decls = self.scx.encode_data_decls(self.genv)?;
+
         let task = fixpoint::Task {
             comments: self.comments.clone(),
             constants,
@@ -659,11 +695,11 @@ where
             qualifiers,
             scrape_quals,
             solver,
-            data_decls: self.scx.encode_data_decls(self.genv)?,
+            data_decls: data_decls.clone(),
         };
-
+        let id = def_id.resolved_id();
         if config::dump_constraint() {
-            dbg::dump_item_info(self.genv.tcx(), def_id.resolved_id(), "smt2", &task).unwrap();
+            dbg::dump_item_info(self.genv.tcx(), id, "smt2", &task).unwrap();
         }
 
         Ok(task)
@@ -695,16 +731,55 @@ where
         }
     }
 
-    pub(crate) fn result_to_answer(&mut self, result: ParsedResult) -> Answer<Tag> {
+    pub(crate) fn result_to_answer(
+        &mut self,
+        result: ParsedResult,
+        #[allow(unused)] mut suggestion_ctx: Option<SuggestionCtxt>,
+    ) -> Answer<Tag> {
+        #[cfg(feature = "wick")]
+        suggestion_ctx.as_mut().map(|suggestion_ctx| {
+            for constraint in suggestion_ctx.flat_constraints.values_mut() {
+                subst_fixpoint_solutions(constraint, &result.solution);
+                subst_fixpoint_solutions(constraint, &result.non_cut_solution);
+                // clear the remaining kvars
+                constraint
+                    .assumptions
+                    .retain(|assumption| !matches!(assumption, fixpoint::Pred::KVar(..)));
+            }
+        });
         let def_span = self.ecx.def_span();
         let errors = match result.status {
             FixpointStatus::Safe(_) => vec![],
             FixpointStatus::Unsafe(_, errors) => {
                 metrics::incr_metric(Metric::CsError, errors.len() as u32);
-                errors
-                    .into_iter()
-                    .map(|err| self.tags[err.tag])
-                    .unique()
+                let tags = errors.into_iter().map(|err| err.tag).unique().collect_vec();
+                tags.into_iter()
+                    .map(|tag_idx| {
+                        let tag = self.tags[tag_idx];
+                        #[cfg(not(feature = "wick"))]
+                        let possible_solutions = FxIndexMap::default();
+                        #[cfg(feature = "wick")]
+                        let mut possible_solutions: FxIndexMap<rty::WKVid, Vec<rty::Binder<rty::Expr>>> = FxIndexMap::default();
+                        if let Some(flat_constraint) = flat_constraint_map.get(&tag_idx) {
+                            let head_expr = match &flat_constraint.head {
+                                fixpoint::Pred::Expr(e) => Some(e.clone()),
+                                _ => None,
+                            };
+                            // FIXME: this should be a better source of fresh names, but 100000
+                            // should be safe.
+                            let mut fresh_rty_name: usize = 100_000;
+                            let mut fresh_var = || {
+                                let local_var = self.ecx.local_var_env.fresh_name();
+                                let rty_var = rty::Expr::fvar(rty::Name::from_usize(fresh_rty_name));
+                                self.ecx.local_var_env.reverse_map.insert(local_var, rty_var);
+                                fresh_rty_name += 1;
+                                fixpoint::Var::Local(local_var)
+                            };
+                        FixpointCheckError::new(
+                            tag,
+                            possible_solutions,
+                        )
+                    })
                     .collect_vec()
             }
             FixpointStatus::Crash(err) => span_bug!(def_span, "fixpoint crash: {err:?}"),
@@ -911,11 +986,11 @@ where
     where
         Tag: std::fmt::Debug,
     {
-        *self.tags_inv.entry(tag).or_insert_with(|| {
-            let idx = self.tags.push(tag);
-            self.comments.push(format!("Tag {idx}: {tag:?}"));
-            idx
-        })
+        // *self.tags_inv.entry(tag).or_insert_with(|| {
+        let idx = self.tags.push(tag);
+        self.comments.push(format!("Tag {idx}: {tag:?}"));
+        idx
+        // })
     }
 
     pub(crate) fn with_early_param(&mut self, param: &EarlyReftParam) {
@@ -967,11 +1042,23 @@ where
                     .try_collect()?;
                 Ok(fixpoint::Constraint::conj(cstrs))
             }
-            rty::ExprKind::BinaryOp(rty::BinOp::Imp, e1, e2) => {
-                let (bindings, assumption) = self.assumption_to_fixpoint(e1)?;
-                let cstr = self.head_to_fixpoint(e2, mk_tag)?;
-                Ok(fixpoint::Constraint::foralls(bindings, mk_implies(assumption, cstr)))
-            }
+            // NOTE(ck): We remove the below "optimization" to make the
+            // suggestions we give better.
+            //
+            // Because we only presently offer fix suggestions that use
+            // the constraint head, if we have an implication like
+            // `a => b` as the head and we translate it to
+            // `forall _ : int. a => b`, then we will only offer suggestions
+            // of the form `b`. By removing this optimization, we ensure
+            // that we offer suggestions of the form `a => b`, which is
+            // often more desirable.
+            //
+            // rty::ExprKind::BinaryOp(rty::BinOp::Imp, e1, e2) => {
+            //     let (bindings, assumption) =
+            //         self.assumption_to_fixpoint(e1)?;
+            //     let cstr = self.head_to_fixpoint(e2, mk_tag)?;
+            //     Ok(fixpoint::Constraint::foralls(bindings, mk_implies(assumption, cstr)))
+            // }
             rty::ExprKind::KVar(kvar) => {
                 let mut bindings = vec![];
                 let pred = self.kvar_to_fixpoint(kvar, &mut bindings)?;
@@ -1232,7 +1319,7 @@ impl KVarEncodingCtxt {
 }
 
 /// Environment used to map from [`rty::Var`] to a [`fixpoint::LocalVar`].
-struct LocalVarEnv {
+pub(crate) struct LocalVarEnv {
     local_var_gen: IndexGen<fixpoint::LocalVar>,
     fvars: UnordMap<rty::Name, fixpoint::LocalVar>,
     /// Layers of late bound variables
@@ -1241,7 +1328,7 @@ struct LocalVarEnv {
     /// [`UnordMap<fixpoint::LocalVar, rty::Var>`], we encode the arguments to
     /// kvars (which can be arbitrary expressions) as local variables; thus we
     /// need to keep the output as an [`rty::Expr`] to reflect this.
-    reverse_map: UnordMap<fixpoint::LocalVar, rty::Expr>,
+    pub(crate) reverse_map: UnordMap<fixpoint::LocalVar, rty::Expr>,
     pretty_var_map: PrettyMap<fixpoint::LocalVar>,
 }
 
@@ -1258,7 +1345,7 @@ impl LocalVarEnv {
 
     // This doesn't require to be mutable because `IndexGen` uses atomics, but we make it mutable
     // to better declare the intent.
-    fn fresh_name(&mut self) -> fixpoint::LocalVar {
+    pub(crate) fn fresh_name(&mut self) -> fixpoint::LocalVar {
         self.local_var_gen.fresh()
     }
 
@@ -1441,7 +1528,7 @@ impl std::str::FromStr for TagIdx {
 }
 
 #[derive(Default)]
-struct ConstEnv<'tcx> {
+pub(crate) struct ConstEnv<'tcx> {
     const_map: ConstMap<'tcx>,
     const_map_rev: HashMap<fixpoint::GlobalVar, ConstKey<'tcx>>,
     pub(crate) wkvar_map_rev: HashMap<fixpoint::Var, ConstKey<'tcx>>,
@@ -1466,8 +1553,8 @@ impl<'tcx> ConstEnv<'tcx> {
 
 pub struct ExprEncodingCtxt<'genv, 'tcx> {
     genv: GlobalEnv<'genv, 'tcx>,
-    local_var_env: LocalVarEnv,
-    const_env: ConstEnv<'tcx>,
+    pub(crate) local_var_env: LocalVarEnv,
+    pub(crate) const_env: ConstEnv<'tcx>,
     errors: Errors<'genv>,
     /// Id of the item being checked. This is a [`MaybeExternId`] because we may be encoding
     /// invariants for an extern spec on an enum.
@@ -1602,18 +1689,17 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
         flds: &[rty::Expr],
         scx: &mut SortEncodingCtxt,
     ) -> QueryResult<fixpoint::Expr> {
-        // do not generate 1-tuples
-        if let [fld] = flds {
-            self.expr_to_fixpoint(fld, scx)
-        } else {
-            let adt_id = scx.declare_adt(*did);
-            let ctor = fixpoint::Expr::Var(fixpoint::Var::DataCtor(adt_id, VariantIdx::ZERO));
-            let args = flds
-                .iter()
-                .map(|fld| self.expr_to_fixpoint(fld, scx))
-                .try_collect()?;
-            Ok(fixpoint::Expr::App(Box::new(ctor), None, args, None))
-        }
+        // NOTE(ck): See note in `sort_to_fixpoint` in the case of
+        // ````
+        // rty::Sort::App(rty::SortCtor::Adt(sort_def), args)
+        // ````
+        let adt_id = scx.declare_adt(*did);
+        let ctor = fixpoint::Expr::Var(fixpoint::Var::DataCtor(adt_id, VariantIdx::ZERO));
+        let args = flds
+            .iter()
+            .map(|fld| self.expr_to_fixpoint(fld, scx))
+            .try_collect()?;
+        Ok(fixpoint::Expr::App(Box::new(ctor), None, args, None))
     }
 
     fn fields_to_fixpoint(
@@ -1621,18 +1707,17 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
         flds: &[rty::Expr],
         scx: &mut SortEncodingCtxt,
     ) -> QueryResult<fixpoint::Expr> {
-        // do not generate 1-tuples
-        if let [fld] = flds {
-            self.expr_to_fixpoint(fld, scx)
-        } else {
-            scx.declare_tuple(flds.len());
-            let ctor = fixpoint::Expr::Var(fixpoint::Var::TupleCtor { arity: flds.len() });
-            let args = flds
-                .iter()
-                .map(|fld| self.expr_to_fixpoint(fld, scx))
-                .try_collect()?;
-            Ok(fixpoint::Expr::App(Box::new(ctor), None, args, None))
-        }
+        // NOTE(ck): See note in `sort_to_fixpoint` in the case of
+        // ````
+        // rty::Sort::App(rty::SortCtor::Adt(sort_def), args)
+        // ````
+        scx.declare_tuple(flds.len());
+        let ctor = fixpoint::Expr::Var(fixpoint::Var::TupleCtor { arity: flds.len() });
+        let args = flds
+            .iter()
+            .map(|fld| self.expr_to_fixpoint(fld, scx))
+            .try_collect()?;
+        Ok(fixpoint::Expr::App(Box::new(ctor), None, args, None))
     }
 
     fn internal_func_to_fixpoint(
@@ -1836,29 +1921,22 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
         proj: rty::FieldProj,
         scx: &mut SortEncodingCtxt,
     ) -> QueryResult<fixpoint::Expr> {
-        let arity = proj.arity(self.genv)?;
-        // we encode 1-tuples as the single element inside so no projection necessary here
-        if arity == 1 {
-            self.expr_to_fixpoint(e, scx)
-        } else {
-            let proj = match proj {
-                rty::FieldProj::Tuple { arity, field } => {
-                    scx.declare_tuple(arity);
-                    fixpoint::Var::TupleProj { arity, field }
-                }
-                rty::FieldProj::Adt { def_id, field } => {
-                    let adt_id = scx.declare_adt(def_id);
-                    fixpoint::Var::DataProj { adt_id, field }
-                }
-            };
-            let proj = fixpoint::Expr::Var(proj);
-            Ok(fixpoint::Expr::App(
-                Box::new(proj),
-                None,
-                vec![self.expr_to_fixpoint(e, scx)?],
-                None,
-            ))
-        }
+        // NOTE(ck): See note in `sort_to_fixpoint` in the case of
+        // ````
+        // rty::Sort::App(rty::SortCtor::Adt(sort_def), args)
+        // ````
+        let proj = match proj {
+            rty::FieldProj::Tuple { arity, field } => {
+                scx.declare_tuple(arity);
+                fixpoint::Var::TupleProj { arity, field }
+            }
+            rty::FieldProj::Adt { def_id, field } => {
+                let adt_id = scx.declare_adt(def_id);
+                fixpoint::Var::DataProj { adt_id, field }
+            }
+        };
+        let proj = fixpoint::Expr::Var(proj);
+        Ok(fixpoint::Expr::App(Box::new(proj), None, vec![self.expr_to_fixpoint(e, scx)?], None))
     }
 
     fn un_op_to_fixpoint(
@@ -2488,17 +2566,6 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
     }
 }
 
-fn mk_implies(assumption: fixpoint::Pred, cstr: fixpoint::Constraint) -> fixpoint::Constraint {
-    fixpoint::Constraint::ForAll(
-        fixpoint::Bind {
-            name: fixpoint::Var::Underscore,
-            sort: fixpoint::Sort::Int,
-            pred: assumption,
-        },
-        Box::new(cstr),
-    )
-}
-
 fn parse_kvid(kvid: &str) -> fixpoint::KVid {
     if kvid.starts_with("k")
         && let Some(kvid) = kvid[1..].parse::<u32>().ok()
@@ -2629,6 +2696,9 @@ impl FromSexp<FixpointTypes> for SexpParseCtxt<'_> {
             return Ok(var);
         }
         if let Some(var) = parse_global_var(name, self.fun_decl_map, self.const_decl_map) {
+            return Ok(var);
+        }
+        if let Some(var) = parse_weak_kvar(name) {
             return Ok(var);
         }
         if let Some(var) = parse_param(name) {

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -20,7 +20,7 @@ use flux_errors::Errors;
 use flux_macros::DebugAsJson;
 use flux_middle::{
     FixpointQueryKind,
-    def_id::{FluxDefId, MaybeExternId},
+    def_id::{FluxDefId, MaybeExternId, ResolvedDefId},
     def_id_to_string,
     global_env::GlobalEnv,
     metrics::{self, Metric, TimingKind},
@@ -2353,7 +2353,10 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
         self_args: usize,
         scx: &mut SortEncodingCtxt,
     ) -> Option<fixpoint::Var> {
-        if !wkvid.parent_fn.is_local() {
+        if matches!(
+            self.genv.resolve_id(wkvid.parent_fn),
+            ResolvedDefId::Local(..) | ResolvedDefId::ExternSpec(..)
+        ) {
             return None;
         }
         let key = ConstKey::WKVar(wkvid.clone(), self_args);

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -821,9 +821,11 @@ where
         let mut sexp_ctx =
             SexpParseCtxt::new(&mut self.ecx.local_var_env, &fun_decl_map, &const_decl_map)
                 .into_wrapper();
-        sexp_ctx.parse_solution(&sexp).unwrap_or_else(|err| {
+        let mut sol = sexp_ctx.parse_solution(&sexp).unwrap_or_else(|err| {
             tracked_span_bug!("failed to parse solution sexp {sexp:?}: {err:?}");
-        })
+        });
+        parse_wkvars(&mut sol.1);
+        sol
     }
 
     fn is_assumed_constant(&self, const_decl: &fixpoint::ConstDecl) -> bool {
@@ -2707,5 +2709,55 @@ impl FromSexp<FixpointTypes> for SexpParseCtxt<'_> {
         }
 
         Err(ParseError::err(format!("Unknown sort: {name}")))
+    }
+}
+
+fn parse_wkvars(expr: &mut fixpoint::Expr) {
+    use fixpoint::*;
+    match expr {
+        Expr::Constant(_) | Expr::ThyFunc(_) | Expr::Var(_) => {}
+        Expr::App(head, _sort_args, args, _out_sort) => {
+            match &mut **head {
+                Expr::Var(v @ Var::WKVar(..)) => {
+                    *expr = Expr::WKVar(WKVar { wkvid: *v, args: args.clone() });
+                }
+                e => {
+                    parse_wkvars(e);
+                }
+            }
+        }
+        Expr::Neg(e) | Expr::Not(e) => parse_wkvars(e),
+        Expr::BinaryOp(_, exprs) | Expr::Imp(exprs) | Expr::Iff(exprs) | Expr::Atom(_, exprs) => {
+            let [e1, e2] = &mut **exprs;
+            parse_wkvars(e1);
+            parse_wkvars(e2);
+        }
+        Expr::IfThenElse(exprs) => {
+            let [p, e1, e2] = &mut **exprs;
+            parse_wkvars(p);
+            parse_wkvars(e1);
+            parse_wkvars(e2);
+        }
+        Expr::And(exprs) | Expr::Or(exprs) => {
+            for e in exprs {
+                parse_wkvars(e);
+            }
+        }
+        Expr::Let(_, exprs) => {
+            let [var_e, body_e] = &mut **exprs;
+            parse_wkvars(var_e);
+            parse_wkvars(body_e);
+        }
+        Expr::IsCtor(_v, expr) => {
+            parse_wkvars(expr);
+        }
+        Expr::Exists(_binder, expr) => {
+            parse_wkvars(expr);
+        }
+        Expr::WKVar(fixpoint::WKVar { wkvid: _, args }) => {
+            for e in args {
+                parse_wkvars(e);
+            }
+        }
     }
 }

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -50,6 +50,10 @@ use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_type_ir::{BoundVar, DebruijnIndex};
 use serde::{Deserialize, Deserializer, Serialize};
 
+#[cfg(feature = "wick")]
+use crate::suggestions::{
+    find_possible_solutions, make_flat_constraint_map, subst_fixpoint_solutions,
+};
 use crate::{
     fixpoint_encoding::fixpoint::FixpointTypes, fixpoint_qualifiers::FIXPOINT_QUALIFIERS,
     lean_encoding::LeanEncoder, projections::structurally_normalize_expr,
@@ -686,7 +690,16 @@ where
             dbg::dump_item_info(self.genv.tcx(), id, "smt2", &task).unwrap();
         }
 
-        Ok(task)
+        #[cfg(feature = "wick")]
+        let suggestion_ctx = Some(SuggestionCtxt {
+            flat_constraints: flat_constraint_map,
+            const_decls: constants_without_inequalities,
+            data_decls,
+        });
+        #[cfg(not(feature = "wick"))]
+        let suggestion_ctx = None;
+
+        Ok((task, suggestion_ctx))
     }
 
     pub(crate) fn run_task(
@@ -700,6 +713,7 @@ where
 
         if config::dump_checker_trace_info()
             || self.genv.proven_externally(def_id.local_id()).is_some()
+            || cfg!(feature = "wick")
         {
             Ok(ParsedResult {
                 status: result.status,
@@ -740,6 +754,9 @@ where
                 tags.into_iter()
                     .map(|tag_idx| {
                         let tag = self.tags[tag_idx];
+                        #[cfg(not(feature = "wick"))]
+                        let possible_solutions = Default::default();
+                        #[cfg(feature = "wick")]
                         let possible_solutions = if let Some(suggestion_ctx) = &suggestion_ctx {
                             find_possible_solutions(self, tag_idx, &suggestion_ctx)
                         } else {

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -1360,7 +1360,6 @@ impl LocalVarEnv {
     fn push_layer_with_fresh_names(&mut self, count: usize) {
         let layer = (0..count).map(|_| self.fresh_name()).collect();
         self.layers.push(layer);
-        // FIXME: (ck) what to put in reverse_map here?
     }
 
     fn push_layer(&mut self, layer: Vec<fixpoint::LocalVar>) {

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -561,7 +561,10 @@ pub struct FixpointCtxt<'genv, 'tcx, T: Eq + Hash> {
     kcx: KVarEncodingCtxt,
     pub(crate) ecx: ExprEncodingCtxt<'genv, 'tcx>,
     tags: IndexVec<TagIdx, T>,
-    tags_inv: UnordMap<T, TagIdx>,
+    // NOTE: We originally used this to dedup tags, since they were only used as
+    // a means of identifying spans. But we use them for suggestions, so, this
+    // is no longer true.
+    // tags_inv: UnordMap<T, TagIdx>,
 }
 
 pub type FixQueryCache = QueryCache<VerificationResult<TagIdx>>;
@@ -586,6 +589,7 @@ pub fn lean_task_key(tcx: rustc_middle::ty::TyCtxt, def_id: DefId) -> String {
     FixpointQueryKind::Body.task_key(tcx, def_id)
 }
 
+#[allow(unused)]
 pub(crate) struct SuggestionCtxt {
     pub(crate) flat_constraints: FxIndexMap<TagIdx, fixpoint::FlatConstraint>,
     pub(crate) const_decls: Vec<fixpoint::ConstDecl>,
@@ -610,7 +614,7 @@ where
             ecx: ExprEncodingCtxt::new(genv, Some(def_id), backend),
             kcx: Default::default(),
             tags: IndexVec::new(),
-            tags_inv: Default::default(),
+            // tags_inv: Default::default(),
         }
     }
 
@@ -969,6 +973,9 @@ where
     where
         Tag: std::fmt::Debug,
     {
+        // Once we added refinement suggestions, we now need to have unique tags for each
+        // head, even if they correspond to the same tag.
+        //
         // *self.tags_inv.entry(tag).or_insert_with(|| {
         let idx = self.tags.push(tag);
         self.comments.push(format!("Tag {idx}: {tag:?}"));

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -104,6 +104,7 @@ pub mod fixpoint {
         Underscore,
         Global(GlobalVar, FluxDefId),
         Const(GlobalVar, Option<DefId>),
+        WKVar(Symbol, u32),
         Local(LocalVar),
         DataCtor(AdtId, VariantIdx),
         TupleCtor { arity: usize },
@@ -131,6 +132,7 @@ pub mod fixpoint {
             match self {
                 Var::Global(v, did) => write!(f, "f${}${}", did.name(), v.as_u32()),
                 Var::Const(v, _) => write!(f, "c{}", v.as_u32()),
+                Var::WKVar(def, idx) => write!(f, "wk${}${}", def, idx),
                 Var::Local(v) => write!(f, "a{}", v.as_u32()),
                 Var::DataCtor(adt_id, variant_idx) => {
                     write!(f, "mkadt{}${}", adt_id.as_u32(), variant_idx.as_u32())
@@ -541,6 +543,7 @@ enum ConstKey<'tcx> {
     PrimOp(rty::BinOp),
     Cast(rty::Sort, rty::Sort),
     PtrSize,
+    WKVar(rty::WKVid, usize),
 }
 
 #[derive(Clone)]
@@ -567,6 +570,12 @@ pub use liquid_fixpoint::LeanStatus;
 /// Returns the cache key used for a function-body lean query.
 pub fn lean_task_key(tcx: rustc_middle::ty::TyCtxt, def_id: DefId) -> String {
     FixpointQueryKind::Body.task_key(tcx, def_id)
+}
+
+pub(crate) struct SuggestionCtxt {
+    pub(crate) flat_constraints: FxIndexMap<TagIdx, fixpoint::FlatConstraint>,
+    pub(crate) const_decls: Vec<fixpoint::ConstDecl>,
+    pub(crate) data_decls: Vec<fixpoint::DataDecl>,
 }
 
 impl<'genv, 'tcx, Tag> FixpointCtxt<'genv, 'tcx, Tag>
@@ -597,7 +606,7 @@ where
         constraint: fixpoint::Constraint,
         scrape_quals: bool,
         solver: SmtSolver,
-    ) -> QueryResult<fixpoint::Task> {
+    ) -> QueryResult<(fixpoint::Task, Option<SuggestionCtxt>)> {
         let kvars = self.kcx.encode_kvars(&self.kvars, &mut self.scx);
 
         let qualifiers = self
@@ -968,6 +977,12 @@ where
                 let pred = self.kvar_to_fixpoint(kvar, &mut bindings)?;
                 Ok(fixpoint::Constraint::foralls(bindings, fixpoint::Constraint::Pred(pred, None)))
             }
+            rty::ExprKind::WKVar(_wkvar) => {
+                // We don't translate the weak kvar here because we don't want to
+                // send it to fixpoint to check (we only care about it appearing
+                // in assumptions)
+                Ok(fixpoint::Constraint::TRUE)
+            }
             rty::ExprKind::ForAll(pred) => {
                 self.ecx
                     .local_var_env
@@ -1024,6 +1039,9 @@ where
             rty::ExprKind::KVar(kvar) => {
                 preds.push(self.kvar_to_fixpoint(kvar, bindings)?);
             }
+            rty::ExprKind::WKVar(wkvar) => {
+                preds.push(self.wkvar_to_fixpoint(wkvar)?);
+            }
             rty::ExprKind::ForAll(_) => {
                 // If a forall appears in assumptive position replace it with true. This is sound
                 // because we are weakening the context, i.e., anything true without the assumption
@@ -1075,6 +1093,23 @@ where
             .collect_vec();
 
         Ok(fixpoint::Pred::And(kvars))
+    }
+
+    fn wkvar_to_fixpoint(&mut self, wkvar: &rty::WKVar) -> QueryResult<fixpoint::Pred> {
+        if let Some(var) =
+            self.ecx
+                .define_const_for_wkvar(&wkvar.wkvid, wkvar.self_args, &mut self.scx)
+        {
+            let args: Vec<fixpoint::Expr> = wkvar
+                .args
+                .iter()
+                .map(|arg| self.ecx.expr_to_fixpoint(arg, &mut self.scx))
+                .collect::<QueryResult<Vec<fixpoint::Expr>>>()?;
+            Ok(fixpoint::Pred::Expr(fixpoint::Expr::WKVar(fixpoint::WKVar { wkvid: var, args })))
+        } else {
+            // println!("WARN: Skipping encoding wkvar {:?} because it isn't in the global map", wkvar.wkvid);
+            Ok(fixpoint::Pred::Expr(fixpoint::Expr::Constant(fixpoint::Constant::Boolean(true))))
+        }
     }
 }
 
@@ -1409,6 +1444,7 @@ impl std::str::FromStr for TagIdx {
 struct ConstEnv<'tcx> {
     const_map: ConstMap<'tcx>,
     const_map_rev: HashMap<fixpoint::GlobalVar, ConstKey<'tcx>>,
+    pub(crate) wkvar_map_rev: HashMap<fixpoint::Var, ConstKey<'tcx>>,
     global_var_gen: IndexGen<fixpoint::GlobalVar>,
     fun_decl_map: FunDeclMap,
 }
@@ -1737,7 +1773,8 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                 let expr = self.body_to_fixpoint(expr, scx)?;
                 fixpoint::Expr::Exists(expr.0, Box::new(expr.1))
             }
-            rty::ExprKind::Hole(..)
+            rty::ExprKind::WKVar(_)
+            | rty::ExprKind::Hole(..)
             | rty::ExprKind::KVar(_)
             | rty::ExprKind::Local(_)
             | rty::ExprKind::PathProj(..)
@@ -2235,6 +2272,54 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
             .name
     }
 
+    /// We encode weak kvars as UIFs when we send them to fixpoint, but
+    /// represent them in fixpoint as their own Expr. This is necessary to add
+    /// the const declaration for the UIF.
+    ///
+    /// Currently returns an Option in case weak kvars generated automatically
+    /// don't track the sorts of their arguments, but there is no reason why
+    /// they shouldn't --- we could probably unwrap the Option.
+    fn define_const_for_wkvar(
+        &mut self,
+        wkvid: &rty::WKVid,
+        self_args: usize,
+        scx: &mut SortEncodingCtxt,
+    ) -> Option<fixpoint::Var> {
+        if !wkvid.parent_fn.is_local() {
+            return None;
+        }
+        let key = ConstKey::WKVar(wkvid.clone(), self_args);
+        let arg_sorts = self
+            .genv
+            .weak_kvars_for(wkvid.parent_fn)
+            .and_then(|wkvars_map| {
+                wkvars_map
+                    .get(&wkvid.id.as_u32())
+                    .map(|wkvars| wkvars.sorts.clone())
+            });
+        arg_sorts.map(|arg_sorts| {
+            self.const_env
+                .const_map
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    let comment = Some(format!("weak kvar: {:?}", wkvid));
+                    let def_name = self.genv.tcx().def_path_str(wkvid.parent_fn);
+                    let sanitized_name: String = def_name
+                        .chars()
+                        .map(|c| if !c.is_alphanumeric() { '_' } else { c })
+                        .collect();
+                    let name =
+                        fixpoint::Var::WKVar(Symbol::intern(&sanitized_name), wkvid.id.as_u32());
+                    let func_sort =
+                        rty::FuncSort::new(arg_sorts.clone(), rty::Sort::Bool).to_poly();
+                    let sort = scx.func_sort_to_fixpoint(&func_sort).into_sort();
+                    self.const_env.wkvar_map_rev.insert(name, key);
+                    fixpoint::ConstDecl { name, comment, sort }
+                })
+                .name
+        })
+    }
+
     fn assume_const_values(
         &mut self,
         mut constraint: fixpoint::Constraint,
@@ -2289,7 +2374,8 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                 | ConstKey::Cast(..)
                 | ConstKey::Lambda(..)
                 | ConstKey::PrimOp(..)
-                | ConstKey::PtrSize => {}
+                | ConstKey::PtrSize
+                | ConstKey::WKVar(..) => {}
             }
         }
         Ok(constraint)
@@ -2493,6 +2579,18 @@ fn parse_data_ctor(name: &str) -> Option<fixpoint::Var> {
         let adt_id = fixpoint::AdtId::from(adt_id);
         let variant_idx = VariantIdx::from(variant_idx);
         return Some(fixpoint::Var::DataCtor(adt_id, variant_idx));
+    }
+    None
+}
+
+fn parse_weak_kvar(name: &str) -> Option<fixpoint::Var> {
+    if let Some(rest) = name.strip_prefix("wk$")
+        && let parts = rest.split('$').collect::<Vec<_>>()
+        && parts.len() == 2
+        && let Ok(index) = parts[1].parse::<u32>()
+    {
+        let name = Symbol::intern(parts[0]);
+        return Some(fixpoint::Var::WKVar(name, index));
     }
     None
 }

--- a/crates/flux-infer/src/fixpoint_encoding/decoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding/decoding.rs
@@ -5,7 +5,7 @@ use flux_middle::{
 };
 use flux_rustc_bridge::lowering::Lower;
 use itertools::Itertools;
-use rustc_hir::def_id::DefId;
+use rustc_hir::{def::DefKind, def_id::DefId};
 use rustc_type_ir::BoundVar;
 
 use super::{ConstKey, FixpointCtxt, fixpoint};
@@ -225,6 +225,21 @@ where
                             Ok(rty::Expr::tuple(eargs))
                         } else {
                             Err(FixpointParseError::TupleCtorArityMismatch(*arity, fargs.len()))
+                        }
+                    }
+                    fixpoint::Expr::Var(fixpoint::Var::DataCtor(adt_id, field)) => {
+                        let eargs = fargs
+                            .iter()
+                            .map(|farg| self.fixpoint_to_expr(farg))
+                            .try_collect()?;
+                        let def_id = self.scx.adt_sorts[adt_id.as_usize()];
+                        match self.genv.tcx().def_kind(def_id) {
+                            DefKind::Struct => Ok(rty::Expr::ctor_struct(def_id, eargs)),
+                            DefKind::Enum => {
+                                let ctor = rty::Ctor::Enum(def_id, *field);
+                                Ok(rty::Expr::ctor(ctor, eargs))
+                            }
+                            _ => Err(FixpointParseError::InvalidDefKindForCtor),
                         }
                     }
                     fixpoint::Expr::Var(fixpoint::Var::UIFRel(fbinrel)) => {
@@ -487,4 +502,5 @@ pub enum FixpointParseError {
     /// Expecting fixpoint::Var::LocalVar
     WrongVarInBinder(fixpoint::Var),
     UnknownAdt(DefId),
+    InvalidDefKindForCtor,
 }

--- a/crates/flux-infer/src/fixpoint_encoding/decoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding/decoding.rs
@@ -162,7 +162,17 @@ where
                             }
                         }
 
-                        Err(FixpointParseError::NoLocalVar(*fname))
+                        // HACK: this is a free var generated from an existential
+                        // we got from fixpoint. We just will add enough to it so it
+                        // is likely to not conflict with exisitng free vars, but in an
+                        // ideal world we would properly add it to the fvars map and
+                        // make a fresh name for it.
+                        //
+                        // But since we just need to be consistent about the value we
+                        // give these vars, this should suffice for now --- they won't
+                        // actually appear in any solutions because we anti-unify.
+                        Ok(rty::Expr::fvar(rty::Name::from_u32(fname.as_u32() + 100_000)))
+                        // Err(FixpointParseError::NoLocalVar(*fname))
                     }
                     fixpoint::Var::DataCtor(adt_id, variant_idx) => {
                         let def_id = self.scx.adt_sorts[adt_id.as_usize()];
@@ -496,7 +506,7 @@ pub enum FixpointParseError {
     /// Casts should only have 1 arg
     CastArityMismatch(usize),
     PrimOpArityMismatch(usize),
-    NoLocalVar(fixpoint::LocalVar),
+    // NoLocalVar(fixpoint::LocalVar),
     /// Expecting fixpoint::Var::DataCtor
     WrongVarInIsCtor(fixpoint::Var),
     /// Expecting fixpoint::Var::LocalVar

--- a/crates/flux-infer/src/fixpoint_encoding/decoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding/decoding.rs
@@ -136,6 +136,9 @@ where
                                 ConstKey::PtrSize => {
                                     Ok(rty::Expr::internal_func(InternalFuncKind::PtrSize))
                                 }
+                                ConstKey::WKVar(_, _) => {
+                                    unreachable!("Weak kvars are not global vars");
+                                }
                             }
                         } else {
                             Err(FixpointParseError::NoGlobalVar(*global_var))
@@ -178,6 +181,11 @@ where
                     }
                     fixpoint::Var::ConstGeneric(const_generic) => {
                         Ok(rty::Expr::const_generic(*const_generic))
+                    }
+                    fixpoint::Var::WKVar(..) => {
+                        unreachable!(
+                            "Weak kvar ids should be converted as part of fixpoint::Expr::WKVar"
+                        );
                     }
                 }
             }
@@ -288,6 +296,9 @@ where
                                         .map(|farg| self.fixpoint_to_expr(farg))
                                         .try_collect()?;
                                     Ok(rty::Expr::alias(alias_reft, args))
+                                }
+                                ConstKey::WKVar(..) => {
+                                    unreachable!("WKVars should not appear in global vars");
                                 }
                                 ConstKey::RustConst(..)
                                 | ConstKey::Lambda(..)
@@ -417,6 +428,28 @@ where
                 let body = self.fixpoint_to_expr(body)?;
                 self.ecx.local_var_env.pop_layer();
                 Ok(rty::Expr::exists(Binder::bind_with_sorts(body, &sorts)))
+            }
+            fixpoint::Expr::WKVar(fixpoint::WKVar { wkvid, args }) => {
+                let e_args: Vec<rty::Expr> = args
+                    .iter()
+                    .map(|fexpr| self.fixpoint_to_expr(fexpr))
+                    .try_collect()?;
+                if let Some(const_key) = self.ecx.const_env.wkvar_map_rev.get(wkvid) {
+                    match const_key {
+                        ConstKey::WKVar(wkvid, self_args) => {
+                            Ok(rty::Expr::wkvar(rty::WKVar {
+                                wkvid: wkvid.clone(),
+                                self_args: *self_args,
+                                args: List::from_vec(e_args),
+                            }))
+                        }
+                        _ => {
+                            unreachable!("Weak KVar has a const_key that is not a wkvid");
+                        }
+                    }
+                } else {
+                    unreachable!("missing weak kvar {:?} in const_env", wkvid);
+                }
             }
         }
     }

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -228,7 +228,7 @@ impl<'genv, 'tcx> InferCtxtRoot<'genv, 'tcx> {
         let mut fcx = FixpointCtxt::new(self.genv, def_id, kvars, Backend::Lean);
         let cstr = refine_tree.to_fixpoint(&mut fcx)?;
         let cstr_variable_sorts = cstr.variable_sorts();
-        let task = fcx.create_task(def_id, cstr, self.opts.scrape_quals, solver)?;
+        let (task, _) = fcx.create_task(def_id, cstr, self.opts.scrape_quals, solver)?;
 
         log_proof(self.genv, def_id)?;
         // Skip re-generation if task is already cached (same hash → same lean files on disk).
@@ -295,9 +295,10 @@ impl<'genv, 'tcx> InferCtxtRoot<'genv, 'tcx> {
             return Ok(Answer::trivial());
         }
 
-        let task = fcx.create_task(def_id, cstr, self.opts.scrape_quals, backend)?;
+        let (task, suggestion_ctx) =
+            fcx.create_task(def_id, cstr, self.opts.scrape_quals, backend)?;
         let result = fcx.run_task(cache, def_id, kind, &task)?;
-        Ok(fcx.result_to_answer(result))
+        Ok(fcx.result_to_answer(result, suggestion_ctx))
     }
 
     pub fn split(self) -> (RefineTree, KVarGen) {

--- a/crates/flux-infer/src/lean_encoding.rs
+++ b/crates/flux-infer/src/lean_encoding.rs
@@ -109,6 +109,7 @@ fn constant_deps(expr: &fixpoint::Expr, acc: &mut FxIndexSet<fixpoint::Var>) {
             constant_deps(inner, acc);
         }
         fixpoint::Expr::Var(..) | fixpoint::Expr::Constant(..) | fixpoint::Expr::ThyFunc(..) => {}
+        fixpoint::Expr::WKVar(..) => unimplemented!(),
     }
 }
 

--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -429,7 +429,7 @@ impl LeanFmt for Expr {
                 write!(f, ")")?;
                 if let Some(out_sort) = out_sort {
                     write!(f, " : (")?;
-                    out_sort.lean_fmt(f, &cx)?;
+                    out_sort.lean_fmt(f, cx)?;
                     write!(f, "))")?;
                 }
                 Ok(())
@@ -648,7 +648,7 @@ impl<'a> LeanFmt for LeanKConstraint<'a> {
             if !cx.kvar_solutions.cut_solutions.is_empty() {
                 writeln!(f, "-- cyclic (cut) kvars")?;
                 for kvar_solution in &cx.kvar_solutions.cut_solutions {
-                    kvar_solution.lean_fmt(f, &cx)?;
+                    kvar_solution.lean_fmt(f, cx)?;
                     writeln!(f)?;
                 }
             }
@@ -656,7 +656,7 @@ impl<'a> LeanFmt for LeanKConstraint<'a> {
             if !cx.kvar_solutions.non_cut_solutions.is_empty() {
                 writeln!(f, "-- acyclic (non-cut) kvars")?;
                 for kvar_solution in &cx.kvar_solutions.non_cut_solutions {
-                    kvar_solution.lean_fmt(f, &cx)?;
+                    kvar_solution.lean_fmt(f, cx)?;
                     writeln!(f)?;
                 }
             }

--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -519,6 +519,9 @@ impl LeanFmt for Expr {
                 write!(f, ")")?;
                 Ok(())
             }
+            Expr::WKVar(_) => {
+                todo!("not yet implemented")
+            }
         }
     }
 }

--- a/crates/flux-infer/src/lib.rs
+++ b/crates/flux-infer/src/lib.rs
@@ -19,3 +19,6 @@ pub mod lean_encoding;
 pub mod lean_format;
 pub mod projections;
 pub mod refine_tree;
+#[cfg(feature = "wick")]
+pub mod suggestions;
+pub mod wkvars;

--- a/crates/flux-infer/src/suggestions.rs
+++ b/crates/flux-infer/src/suggestions.rs
@@ -1,0 +1,220 @@
+use std::collections::HashSet;
+
+use flux_middle::rty;
+use itertools::Itertools;
+use liquid_fixpoint::{check_validity, qe_and_simplify};
+use rustc_data_structures::fx::FxIndexMap;
+
+use crate::{
+    fixpoint_encoding::{
+        ConstKey, FixpointCtxt, FixpointSolution, PossibleSolutions, SuggestionCtxt, TagIdx,
+        fixpoint,
+    },
+    wkvars::WKVarInstantiator,
+};
+
+pub type TagToFlatConstraint = FxIndexMap<TagIdx, fixpoint::FlatConstraint>;
+
+pub(crate) fn make_flat_constraint_map(constraint: &fixpoint::Constraint) -> TagToFlatConstraint {
+    constraint
+        .flatten(|var| matches!(var, fixpoint::Var::Underscore))
+        .into_iter()
+        .flat_map(|flat_constraint| {
+            // We can't send a kvar to the SMT. If there's a kvar on the LHS we
+            // can underapproximate it with TRUE, but if it's in head position
+            // we don't know what to do.
+            if let Some(tag) = flat_constraint.tag
+                && !flat_constraint.head.has_kvar()
+            {
+                Some((tag.clone(), flat_constraint))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn subst_fixpoint_solutions(
+    flat_constraint: &mut fixpoint::FlatConstraint,
+    fixpoint_solution: &FxIndexMap<fixpoint::KVid, FixpointSolution>,
+) {
+    flat_constraint.assumptions = flat_constraint
+        .assumptions
+        .iter()
+        .flat_map(|pred| {
+            // Remove all trivially true assumptions
+            if pred.is_trivially_true() {
+                vec![].into_iter()
+            // Substitute the kvar solutions in
+            } else if let fixpoint::Pred::KVar(kvid, args) = pred
+                && let Some((var_sorts, solution)) = &fixpoint_solution.get(kvid)
+            {
+                assert!(var_sorts.len() == args.len());
+                let subst = args
+                    .into_iter()
+                    .zip(var_sorts.iter())
+                    .map(|(arg, (subst_var, _))| (subst_var.clone(), arg.clone()))
+                    .collect();
+                let subst_solution = solution.substitute(&subst);
+                subst_solution
+                    .as_conjunction()
+                    .into_iter()
+                    .map(|expr| fixpoint::Pred::Expr(expr))
+                    .collect_vec()
+                    .into_iter()
+            } else {
+                vec![pred.clone()].into_iter()
+            }
+        })
+        .collect();
+}
+
+pub(crate) fn find_possible_solutions<'genv, 'tcx, Tag>(
+    fxctx: &mut FixpointCtxt<'genv, 'tcx, Tag>,
+    tag_idx: TagIdx,
+    suggestion_ctx: &SuggestionCtxt,
+) -> PossibleSolutions
+where
+    Tag: std::hash::Hash + Eq + Copy,
+{
+    let Some(flat_constraint) = suggestion_ctx.flat_constraints.get(&tag_idx) else {
+        return Default::default();
+    };
+    let head_expr = match &flat_constraint.head {
+        fixpoint::Pred::Expr(e) => Some(e.clone()),
+        _ => None,
+    };
+    let mut possible_solutions: PossibleSolutions = Default::default();
+    let wkvars_and_constraints = flat_constraint.wkvars_and_constrs();
+    for (wkvar, flat_constraint, other_constrs) in wkvars_and_constraints {
+        if !other_constrs.iter().all(|other_constr| {
+            let binder_consts = other_constr
+                .binders
+                .iter()
+                .map(|(var, sort)| {
+                    fixpoint::ConstDecl { name: *var, sort: sort.clone(), comment: None }
+                })
+                .collect_vec();
+            check_validity(
+                &other_constr,
+                &binder_consts,
+                &suggestion_ctx.const_decls,
+                suggestion_ctx.data_decls.clone(),
+            )
+        }) {
+            continue;
+        }
+        let ConstKey::WKVar(wkvid, self_args) = fxctx
+            .ecx
+            .const_env
+            .wkvar_map_rev
+            .get(&wkvar.wkvid)
+            .cloned()
+            .unwrap()
+        else {
+            panic!()
+        };
+        let fvars: HashSet<fixpoint::Var> = wkvar
+            .args
+            .iter()
+            .flat_map(|arg| {
+                arg.free_vars().into_iter().filter(|fvar| {
+                    match fvar {
+                        fixpoint::Var::Local(_) | fixpoint::Var::Param(_) => true,
+                        _ => false,
+                    }
+                })
+            })
+            .collect();
+        let rty_args: Vec<rty::Expr> = wkvar
+            .args
+            .iter()
+            .map(|arg| fxctx.fixpoint_to_expr(arg))
+            .try_collect()
+            .unwrap();
+        let (binder_consts, mut new_flat_constraint) = flat_constraint.remove_binders(&fvars);
+        // Remove any wkvars and drop assumptions that are just wkvars or true
+        new_flat_constraint.assumptions = new_flat_constraint
+            .assumptions
+            .into_iter()
+            .filter_map(|assumption| {
+                let assumption = assumption.strip_wkvars();
+                if !assumption.is_trivially_true() { Some(assumption) } else { None }
+            })
+            .collect();
+        match qe_and_simplify(
+            &new_flat_constraint,
+            &binder_consts,
+            &suggestion_ctx.const_decls,
+            suggestion_ctx.data_decls.clone(),
+        ) {
+            Ok(fe) => {
+                match fxctx.fixpoint_to_expr(&fe) {
+                    Ok(e) => {
+                        if !e.is_trivially_false() && !e.is_trivially_true() {
+                            if let Some(binder_e) = WKVarInstantiator::try_instantiate_wkvar_args(
+                                self_args, &rty_args, &e,
+                            ) {
+                                if fe.total_num_disjuncts() > 3 {
+                                    // NOTE: previously used blame_ctx.expr
+                                    if let Some(binder_e) =
+                                        WKVarInstantiator::try_instantiate_wkvar_args(
+                                            self_args,
+                                            &rty_args,
+                                            &fxctx
+                                                .fixpoint_to_expr(head_expr.as_ref().unwrap())
+                                                .unwrap(),
+                                        )
+                                    {
+                                        possible_solutions
+                                            .entry(wkvid.clone())
+                                            .or_default()
+                                            .push(binder_e);
+                                    }
+                                } else {
+                                    possible_solutions
+                                        .entry(wkvid.clone())
+                                        .or_default()
+                                        .push(binder_e);
+                                }
+                            } else {
+                                // NOTE: previously used blame_ctx.expr
+                                if let Some(binder_e) =
+                                    WKVarInstantiator::try_instantiate_wkvar_args(
+                                        self_args,
+                                        &rty_args,
+                                        &fxctx
+                                            .fixpoint_to_expr(head_expr.as_ref().unwrap())
+                                            .unwrap(),
+                                    )
+                                {
+                                    possible_solutions
+                                        .entry(wkvid.clone())
+                                        .or_default()
+                                        .push(binder_e);
+                                }
+                            }
+                        } else {
+                            // skip trivial solution
+                        }
+                    }
+                    Err(_err) => {}
+                }
+            }
+            Err(_err) => {
+                // NOTE: previously used blame_ctx.expr
+                if let Some(binder_e) = WKVarInstantiator::try_instantiate_wkvar_args(
+                    self_args,
+                    &rty_args,
+                    &fxctx.fixpoint_to_expr(head_expr.as_ref().unwrap()).unwrap(),
+                ) {
+                    possible_solutions
+                        .entry(wkvid.clone())
+                        .or_default()
+                        .push(binder_e);
+                }
+            }
+        }
+    }
+    possible_solutions
+}

--- a/crates/flux-infer/src/wkvars.rs
+++ b/crates/flux-infer/src/wkvars.rs
@@ -83,7 +83,7 @@ impl WKVarInstantiator<'_> {
     /// that it is purely syntactic. We currently try to eagerly eta reduce any
     /// Ctor/Tuples + eta expand any args which aren't of that form
     ///
-    /// FIXME: This does not properly deal with expressions that have bound variables:
+    /// FIXME(ck): This does not properly deal with expressions that have bound variables:
     /// if the expression has a bound variable, we might fail the instantiation
     /// when it should succeed.
     pub fn try_instantiate_wkvar_args(

--- a/crates/flux-infer/src/wkvars.rs
+++ b/crates/flux-infer/src/wkvars.rs
@@ -1,0 +1,248 @@
+use std::{
+    collections::{HashMap, HashSet},
+    ops::ControlFlow,
+};
+
+use flux_middle::rty::{
+    self,
+    fold::{
+        FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitable, TypeVisitor,
+    },
+};
+use itertools::Itertools;
+use rustc_type_ir::{DebruijnIndex, INNERMOST};
+
+pub struct WKVarInstantiator<'a> {
+    /// Map from the actuals passed to this Weak KVar to its params
+    ///
+    /// In theory this could be a Vec<rty::Expr>, but the instantiator
+    /// is configured right now to only return a single solution.
+    args_to_param: &'a HashMap<rty::Expr, rty::Expr>,
+    /// Set of self args
+    self_args: &'a HashSet<rty::Expr>,
+    /// Were any of the self args used in the expr?
+    any_self_args_used: bool,
+    /// In theory, this could (and probably should) map to multiple
+    /// solutions, i.e. a Vec<rty::Expr>.
+    memo: &'a mut HashMap<rty::Expr, rty::Expr>,
+    current_index: DebruijnIndex,
+}
+
+impl FallibleTypeFolder for WKVarInstantiator<'_> {
+    /// We fail instantiation if we can't replace all free variables;
+    /// return the name of the first unreplaceable free variable found.
+    type Error = rty::Var;
+
+    fn try_enter_binder(&mut self, _vars: &rty::BoundVariableKinds) {
+        self.current_index.shift_in(1);
+    }
+
+    fn try_exit_binder(&mut self) {
+        self.current_index.shift_out(1);
+    }
+
+    fn try_fold_expr(&mut self, e: &rty::Expr) -> Result<rty::Expr, rty::Var> {
+        if let Some(instantiated_e) = self.memo.get(e) {
+            return Ok(instantiated_e.clone());
+        }
+
+        // NOTE: In theory there is a choice here: either we substitute the
+        // current expression for the parameter or we ignore it and continue
+        // going. We'll choose to be greedy and always substitute if possible,
+        // which I think will guarantee a solution if it exists, but I am not
+        // sure.
+        if let Some(param) = self.args_to_param.get(e) {
+            // Check if this expression is a self_arg (if we haven't seen a
+            // self_arg) yet.
+            self.any_self_args_used |= self.self_args.contains(e);
+            let param_expr = param.shift_in_escaping(self.current_index.as_u32());
+            self.memo.insert(e.clone(), param_expr.clone());
+            return Ok(param_expr);
+        }
+
+        if let rty::ExprKind::Var(var) = e.kind() {
+            // This is an escaping free var
+            Err(*var)
+        } else {
+            let instantiated_expr = e.try_super_fold_with(self)?;
+            self.memo.insert(e.clone(), instantiated_expr.clone());
+            Ok(instantiated_expr)
+        }
+    }
+}
+
+impl WKVarInstantiator<'_> {
+    /// If it succeeds: creates an expression that can replace the weak kvar,
+    /// which when used as a refinement will produce the original expr in this
+    /// branch after all substitutions have happened.
+    ///
+    /// It requires that the expression uses at least one of the first
+    /// `self_args` number of `wkvar_args`.
+    ///
+    /// There are a lot of patches we put in this algorithm to get around the fact
+    /// that it is purely syntactic. We currently try to eagerly eta reduce any
+    /// Ctor/Tuples + eta expand any args which aren't of that form
+    ///
+    /// FIXME: This does not properly deal with expressions that have bound variables:
+    /// if the expression has a bound variable, we might fail the instantiation
+    /// when it should succeed.
+    pub fn try_instantiate_wkvar_args(
+        self_args: usize,
+        wkvar_args: &[rty::Expr],
+        expr: &rty::Expr,
+    ) -> Option<rty::Binder<rty::Expr>> {
+        // println!("trying to instantiate {:?} using args {:?}", expr, wkvar_args);
+        let expr_without_metadata = expr.erase_metadata();
+        let expr_eta_expanded_rel = expr_without_metadata.expand_bin_rels();
+        let mut args_to_param = HashMap::new();
+        std::iter::zip(
+            // Eta reduce and erase metadata.
+            wkvar_args
+                .iter()
+                .map(|arg| arg.eta_reduce_projs().erase_metadata()),
+            // We'll make an instantiator that is generic because this instatiation
+            // may (and probably will) be used in multiple places
+            (0..wkvar_args.len()).map(|var_num| {
+                rty::Expr::bvar(INNERMOST, var_num.into(), rty::BoundReftKind::Anon)
+            }),
+        )
+        .for_each(|(arg, param)| {
+            ProductEtaExpander::eta_expand_products(param, arg, &mut args_to_param);
+        });
+        let self_args = wkvar_args[..self_args].iter().cloned().collect();
+        let mut instantiator = WKVarInstantiator {
+            args_to_param: &args_to_param,
+            self_args: &self_args,
+            any_self_args_used: false,
+            memo: &mut HashMap::new(),
+            // This remains 0 because we use it to track how to shift our params,
+            // so the scope is the same.
+            current_index: INNERMOST,
+        };
+        // println!("eta expanded args: {:?}", args_to_param);
+        instantiator
+            .try_fold_expr(&expr_eta_expanded_rel)
+            // .map_err(|e| println!("Couldn't unify with {:?}", e))
+            .ok()
+            .and_then(|instantiated_e| {
+                if !instantiator.any_self_args_used && !instantiator.self_args.is_empty() {
+                    // println!("Dropping instantiation {:?} because no self args were used", instantiated_e);
+                    None
+                } else {
+                    Some(rty::Binder::bind_with_sorts(
+                        instantiated_e,
+                        &std::iter::repeat_n(rty::Sort::Err, wkvar_args.len()).collect_vec(),
+                    ))
+                }
+            })
+    }
+}
+
+pub struct WKVarSubst {
+    /// A map from wkvid to each of the substitutions we made for it
+    /// in whatever we folded over.
+    ///
+    /// In theory there should only ever be one value in this map.
+    pub subst_instantiations: HashMap<rty::WKVid, Vec<rty::Expr>>,
+    pub wkvar_instantiations: HashMap<rty::WKVid, rty::Binder<rty::Expr>>,
+    /// Keep wkvars after substituting
+    pub keep_wkvars: bool,
+}
+
+impl WKVarSubst {
+    pub fn new(
+        wkvar_instantiations: HashMap<rty::WKVid, rty::Binder<rty::Expr>>,
+        keep_wkvars: bool,
+    ) -> Self {
+        WKVarSubst { subst_instantiations: Default::default(), wkvar_instantiations, keep_wkvars }
+    }
+}
+
+impl TypeFolder for WKVarSubst {
+    fn fold_expr(&mut self, e: &rty::Expr) -> rty::Expr {
+        match e.kind() {
+            rty::ExprKind::WKVar(wkvar @ rty::WKVar { wkvid, .. })
+                if let Some(bound_e) = self.wkvar_instantiations.get(wkvid) =>
+            {
+                // The bound expression has bound vars that need to be replaced
+                // by the args given to the wkvar (in order).
+                let instantiated_e = bound_e.replace_bound_refts(&wkvar.args);
+                self.subst_instantiations
+                    .entry(wkvid.clone())
+                    .and_modify(|insts| insts.push(instantiated_e.clone()))
+                    .or_insert_with(|| vec![instantiated_e.clone()]);
+                if self.keep_wkvars {
+                    rty::Expr::and(instantiated_e, e.clone())
+                } else {
+                    instantiated_e
+                }
+            }
+            // Replace wkvars with true (i.e. eliminate them) if we aren't keeping them
+            rty::ExprKind::WKVar(_) if !self.keep_wkvars => rty::Expr::tt(),
+            _ => e.super_fold_with(self),
+        }
+    }
+}
+
+struct ProductEtaExpander<'a> {
+    // An expression that evalutes to the current_expr
+    current_path: rty::Expr,
+    // Maps an interior part of the product to its eta expansion.
+    expr_to_eta_expansion: &'a mut HashMap<rty::Expr, rty::Expr>,
+}
+
+impl TypeVisitor for ProductEtaExpander<'_> {
+    fn visit_expr(&mut self, expr: &rty::Expr) -> ControlFlow<Self::BreakTy> {
+        match expr.kind() {
+            rty::ExprKind::Tuple(subexprs) | rty::ExprKind::Ctor(_, subexprs) => {
+                let current_path = self.current_path.clone();
+                let mk_proj = |field| {
+                    if let rty::ExprKind::Ctor(ctor, _) = expr.kind() {
+                        rty::FieldProj::Adt { def_id: ctor.def_id(), field }
+                    } else {
+                        rty::FieldProj::Tuple { arity: subexprs.len(), field }
+                    }
+                };
+                for (i, subexpr) in subexprs.iter().enumerate() {
+                    self.current_path = rty::Expr::field_proj(&current_path, mk_proj(i as u32));
+                    subexpr.visit_with(self)?;
+                }
+                ControlFlow::Continue(())
+            }
+            _ => {
+                // NOTE: in theory this should be appending to a vec, not
+                // clobbering whatever lives at expr currently. But we don't
+                // currently support making multiple solutions in the weak kvar
+                // instantiation so I'm not bothering.
+                self.expr_to_eta_expansion
+                    .insert(expr.clone(), self.current_path.clone());
+                ControlFlow::Continue(())
+            }
+        }
+    }
+}
+
+/// Recursively "unpacks" a product by eta-expanding each part of it.
+/// Maps each part of the product to its eta-expanded path.
+///
+/// e.g.
+///
+///     in = {
+///       current_path: self,
+///       expr: TwoFields { 0: (a0.0, a0.1), 1: 42 })
+///     }
+///
+///     out =
+///       a0.0 => self.0.0
+///       a0.1 => self.0.1
+///       42 => self.1
+impl<'a> ProductEtaExpander<'a> {
+    fn eta_expand_products(
+        current_path: rty::Expr,
+        expr: rty::Expr,
+        expr_to_eta_expansion: &'a mut HashMap<rty::Expr, rty::Expr>,
+    ) {
+        let mut expander = ProductEtaExpander { current_path, expr_to_eta_expansion };
+        let _ = expr.visit_with(&mut expander);
+    }
+}

--- a/crates/flux-middle/Cargo.toml
+++ b/crates/flux-middle/Cargo.toml
@@ -37,3 +37,6 @@ rustc_private = true
 
 [lints]
 workspace = true
+
+[features]
+wick = []

--- a/crates/flux-middle/src/big_int.rs
+++ b/crates/flux-middle/src/big_int.rs
@@ -69,6 +69,71 @@ impl BigInt {
     pub fn uint_max(bit_width: u32) -> BigInt {
         (u128::MAX >> (128 - bit_width)).into()
     }
+
+    pub fn neg(&self) -> Self {
+        if self.val == 0 {
+            Self::ZERO // Avoid negative zero
+        } else {
+            Self {
+                sign: match self.sign {
+                    Sign::Negative => Sign::NonNegative,
+                    Sign::NonNegative => Sign::Negative,
+                },
+                val: self.val,
+            }
+        }
+    }
+
+    pub fn checked_add(&self, other: &Self) -> Option<Self> {
+        if self.sign == other.sign {
+            Some(Self { sign: self.sign, val: self.val.checked_add(other.val)? })
+        } else if self.val >= other.val {
+            let val = self.val - other.val;
+            if val == 0 { Some(Self::ZERO) } else { Some(Self { sign: self.sign, val }) }
+        } else {
+            Some(Self { sign: other.sign, val: other.val - self.val })
+        }
+    }
+
+    pub fn checked_sub(&self, other: &Self) -> Option<Self> {
+        self.checked_add(&other.neg())
+    }
+
+    pub fn checked_mul(&self, other: &Self) -> Option<Self> {
+        let val = self.val.checked_mul(other.val)?;
+        if val == 0 {
+            Some(Self::ZERO)
+        } else {
+            let sign = if self.sign == other.sign { Sign::NonNegative } else { Sign::Negative };
+            Some(Self { sign, val })
+        }
+    }
+
+    pub fn checked_div(&self, other: &Self) -> Option<Self> {
+        if other.val == 0 {
+            return None;
+        } // Divide by zero
+        let val = self.val / other.val;
+        if val == 0 {
+            Some(Self::ZERO)
+        } else {
+            let sign = if self.sign == other.sign { Sign::NonNegative } else { Sign::Negative };
+            Some(Self { sign, val })
+        }
+    }
+
+    pub fn checked_rem(&self, other: &Self) -> Option<Self> {
+        if other.val == 0 {
+            return None;
+        } // Divide by zero
+        let val = self.val % other.val;
+        if val == 0 {
+            Some(Self::ZERO)
+        } else {
+            // In Rust modulo, the remainder takes the sign of the dividend (self)
+            Some(Self { sign: self.sign, val })
+        }
+    }
 }
 
 impl From<usize> for BigInt {

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -54,6 +54,7 @@ pub enum Attr {
     ShouldFail,
     InferOpts(PartialInferOpts),
     NoPanic,
+    NoSuggestions,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -102,6 +103,12 @@ impl AttrMap<'_> {
 
     pub(crate) fn no_panic(&self) -> bool {
         self.attrs.iter().any(|attr| matches!(attr, Attr::NoPanic))
+    }
+
+    pub(crate) fn no_suggestions(&self) -> bool {
+        self.attrs
+            .iter()
+            .any(|attr| matches!(attr, Attr::NoSuggestions))
     }
 }
 

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -722,6 +722,20 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         annotation || self.matches_trusted_impl_pattern(MaybeExternId::Local(def_id))
     }
 
+    /// Same behavior as [`trusted`], but for the `#[no_suggestions]` attribute.
+    pub fn no_suggestions(self, def_id: LocalDefId) -> bool {
+        self.traverse_parents(def_id, |did| {
+            // A parent has no_suggestions, we inherit it
+            if self.fhir_attr_map(did).no_suggestions() {
+                Some(true)
+            // It doesn't have it, keep trying
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(config::no_suggestions_default)
+    }
+
     /// Whether the item is a dummy item created by the extern spec macro.
     ///
     /// See [`crate::Specs::dummy_extern`]

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -1,5 +1,6 @@
 use std::{
     alloc,
+    cell::RefCell,
     path::{Path, PathBuf},
     ptr,
     rc::Rc,
@@ -12,7 +13,7 @@ use flux_config::{self as config, IncludePattern};
 use flux_errors::FluxSession;
 use flux_rustc_bridge::{self, lowering::Lower, mir, ty};
 use flux_syntax::symbols::sym;
-use rustc_data_structures::unord::UnordSet;
+use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_hir::{
     LangItem,
     def::DefKind,
@@ -43,6 +44,16 @@ pub struct GlobalEnv<'genv, 'tcx> {
     inner: &'genv GlobalEnvInner<'genv, 'tcx>,
 }
 
+pub struct WeakKvarInfo {
+    /// Solutions (if provided as ground truth annotations). Each soution is
+    /// part of a conjunction that constitutes the full ground truth.
+    pub solutions: Vec<rty::Binder<rty::Expr>>,
+    /// The sorts of the weak kvar in the order in which they appear in the
+    /// arguments.
+    pub sorts: Vec<rty::Sort>,
+}
+pub type WeakKvarMap = UnordMap<u32, WeakKvarInfo>;
+
 struct GlobalEnvInner<'genv, 'tcx> {
     tcx: TyCtxt<'tcx>,
     sess: &'genv FluxSession,
@@ -50,6 +61,7 @@ struct GlobalEnvInner<'genv, 'tcx> {
     cstore: Box<CrateStoreDyn>,
     queries: Queries<'genv, 'tcx>,
     tempdir: TempDir,
+    weak_kvars: RefCell<UnordMap<DefId, Rc<WeakKvarMap>>>,
 }
 
 impl<'tcx> GlobalEnv<'_, 'tcx> {
@@ -65,7 +77,15 @@ impl<'tcx> GlobalEnv<'_, 'tcx> {
         // files in it.
         let tempdir = TempDir::new_in(lean_parent_dir(tcx)).unwrap();
         let queries = Queries::new(providers);
-        let inner = GlobalEnvInner { tcx, sess, cstore, arena, queries, tempdir };
+        let inner = GlobalEnvInner {
+            tcx,
+            sess,
+            cstore,
+            arena,
+            queries,
+            tempdir,
+            weak_kvars: Default::default(),
+        };
         f(GlobalEnv { inner: &inner })
     }
 }
@@ -434,6 +454,17 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         def_id: impl IntoQueryParam<DefId>,
     ) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
         self.inner.queries.fn_sig(self, def_id.into_query_param())
+    }
+
+    pub fn feed_weak_kvars(self, def_id: DefId, wk: WeakKvarMap) {
+        self.inner
+            .weak_kvars
+            .borrow_mut()
+            .insert(def_id, Rc::new(wk));
+    }
+
+    pub fn weak_kvars_for(self, def_id: DefId) -> Option<Rc<WeakKvarMap>> {
+        self.inner.weak_kvars.borrow().get(&def_id).cloned()
     }
 
     pub fn variants_of(

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -961,7 +961,6 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                         .skip_binder()
                         .refine(&Refiner::default_for_item(genv, def_id)?)?
                         .hoist_input_binders();
-
                     if genv.is_fn_call(def_id) {
                         let fn_once_id = tcx.require_lang_item(LangItem::FnOnce, DUMMY_SP);
 
@@ -981,6 +980,11 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                         });
                     }
 
+                    // We only will add weak kvars if
+                    //   1. There are no weak kvars already
+                    if genv.weak_kvars_for(def_id).is_none() {
+                        fn_sig = fn_sig.add_weak_kvars(genv, def_id)?;
+                    }
                     Ok(rty::EarlyBinder(poly_sig))
                 },
             )

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -987,6 +987,7 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                     //      in its parent.
                     #[cfg(feature = "wick")]
                     if genv.weak_kvars_for(def_id).is_none()
+                        && genv.resolve_id(def_id).as_maybe_extern().is_some()
                         && def_id
                             .as_local()
                             .map(|local_id| !genv.no_suggestions(local_id))

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -981,9 +981,11 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                     }
 
                     // We only will add weak kvars if
+                    //   0. If suggestions are enabled.
                     //   1. There are no weak kvars already
                     //   2. The function does NOT have a `#[no_suggestions]` annotation
                     //      in its parent.
+                    #[cfg(feature = "wick")]
                     if genv.weak_kvars_for(def_id).is_none()
                         && def_id
                             .as_local()

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -982,8 +982,15 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
 
                     // We only will add weak kvars if
                     //   1. There are no weak kvars already
-                    if genv.weak_kvars_for(def_id).is_none() {
-                        fn_sig = fn_sig.add_weak_kvars(genv, def_id)?;
+                    //   2. The function does NOT have a `#[no_suggestions]` annotation
+                    //      in its parent.
+                    if genv.weak_kvars_for(def_id).is_none()
+                        && def_id
+                            .as_local()
+                            .map(|local_id| !genv.no_suggestions(local_id))
+                            .unwrap_or(false)
+                    {
+                        poly_sig = poly_sig.add_weak_kvars(genv, def_id)?;
                     }
                     Ok(rty::EarlyBinder(poly_sig))
                 },

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -652,6 +652,184 @@ impl Expr {
         }
         self.fold_with(&mut SpanEraser)
     }
+
+    /// Replaces [`BoundReftKind::Named(..)`] in [`Var::Bound(..)`] with
+    /// [`BoundReftKind::Anon`]. This is to ensure that expr equality works
+    /// properly --- the names are just annotations that do not change the
+    /// expressions themselves.
+    ///
+    /// If you think you need this function, you may be looking for
+    /// [`Expr::erase_metadata()`].
+    pub fn erase_bound_reft_kind(&self) -> Expr {
+        struct BoundReftKindEraser;
+        impl TypeFolder for BoundReftKindEraser {
+            fn fold_expr(&mut self, expr: &Expr) -> Expr {
+                if let ExprKind::Var(Var::Bound(
+                    db_index,
+                    BoundReft { var, kind: BoundReftKind::Named(_) },
+                )) = expr.kind()
+                {
+                    Expr::bvar(*db_index, *var, BoundReftKind::Anon)
+                } else {
+                    expr.super_fold_with(self)
+                }
+            }
+        }
+        self.fold_with(&mut BoundReftKindEraser)
+    }
+
+    pub fn erase_metadata(&self) -> Expr {
+        self.erase_spans().erase_bound_reft_kind()
+    }
+
+    /// Binary relations are lifted to tuples and ADTs, so e.g.
+    ///
+    ///     (1, false) > (0, true)
+    ///
+    /// is treated as
+    ///
+    ///     1 > 0 && false > true
+    ///
+    /// This "expands" the binary relations on tuples and ADTs to the second
+    /// form where their elements are individually compared.
+    ///
+    /// Only some binary relations are lifted in this manner, see
+    /// `bin_op_to_fixpoint` in `fixpoint_encoding.rs`.
+    pub fn expand_bin_rels(&self) -> Expr {
+        struct BinRelExpander;
+        impl BinRelExpander {
+            fn expand_bin_rel(&mut self, sort: &Sort, rel: &BinOp, e1: &Expr, e2: &Expr) -> Expr {
+                match sort {
+                    Sort::Tuple(sorts) => {
+                        let arity = sorts.len();
+                        self.apply_bin_rel_rec(sorts, rel, e1, e2, |field| {
+                            FieldProj::Tuple { arity, field }
+                        })
+                    }
+                    Sort::App(SortCtor::Adt(sort_def), args)
+                        if let Some(variant) = sort_def.opt_struct_variant() =>
+                    {
+                        let def_id = sort_def.did();
+                        let sorts = variant.field_sorts(args);
+                        self.apply_bin_rel_rec(&sorts, rel, e1, e2, |field| {
+                            FieldProj::Adt { def_id, field }
+                        })
+                    }
+                    _ => {
+                        Expr::binary_op(
+                            rel.clone(),
+                            e1.super_fold_with(self),
+                            e2.super_fold_with(self),
+                        )
+                    }
+                }
+            }
+            /// Apply binary relation recursively over aggregate expressions
+            fn apply_bin_rel_rec(
+                &mut self,
+                sorts: &[Sort],
+                rel: &BinOp,
+                e1: &Expr,
+                e2: &Expr,
+                mk_proj: impl Fn(u32) -> FieldProj,
+            ) -> Expr {
+                Expr::and_from_iter(sorts.iter().enumerate().map(|(idx, s)| {
+                    let proj = mk_proj(idx as u32);
+                    let e1 = e1.proj_and_reduce(proj);
+                    let e2 = e2.proj_and_reduce(proj);
+                    self.expand_bin_rel(s, rel, &e1, &e2)
+                }))
+            }
+        }
+        impl TypeFolder for BinRelExpander {
+            fn fold_expr(&mut self, expr: &Expr) -> Expr {
+                if let ExprKind::BinaryOp(
+                    rel @ (BinOp::Le(sort) | BinOp::Lt(sort) | BinOp::Ge(sort) | BinOp::Gt(sort)),
+                    e1,
+                    e2,
+                ) = expr.kind()
+                {
+                    self.expand_bin_rel(sort, rel, e1, e2)
+                } else {
+                    expr.super_fold_with(self)
+                }
+            }
+        }
+
+        let mut expander = BinRelExpander {};
+        self.fold_with(&mut expander)
+    }
+
+    /// This is really dumb but we sometimes have the following:
+    ///     Vec { k.0 }
+    /// And we want to really have it rendered as
+    ///     k
+    /// So what we do is look for Tuple or Ctor exprs whose subfields are all
+    /// projections of the same expr, and reduce them if so. Note that we
+    /// **also** require that these are in the same order.
+    pub fn eta_reduce_projs(&self) -> Self {
+        struct EtaReducer;
+        impl TypeFolder for EtaReducer {
+            fn fold_expr(&mut self, expr: &Expr) -> Expr {
+                match expr.kind() {
+                    ExprKind::Tuple(subexprs) => {
+                        let new_subexprs = subexprs
+                            .iter()
+                            .map(|subexpr| subexpr.fold_with(self))
+                            .collect_vec();
+                        if let Some(ExprKind::FieldProj(
+                            e_inner,
+                            FieldProj::Tuple { arity: _, field: 0 },
+                        )) = subexprs.first().map(|e| e.kind())
+                            && new_subexprs[1..].iter().zip(1..).all(|(other_e, i)| {
+                                if let ExprKind::FieldProj(
+                                    other_e_inner,
+                                    FieldProj::Tuple { arity: _, field },
+                                ) = other_e.kind()
+                                {
+                                    field == &i && &e_inner.erase_metadata() == other_e_inner
+                                } else {
+                                    false
+                                }
+                            })
+                        {
+                            e_inner.clone()
+                        } else {
+                            expr.clone()
+                        }
+                    }
+                    ExprKind::Ctor(_ctor, subexprs) => {
+                        let new_subexprs = subexprs
+                            .iter()
+                            .map(|subexpr| subexpr.fold_with(self))
+                            .collect_vec();
+                        if let Some(ExprKind::FieldProj(
+                            e_inner,
+                            FieldProj::Adt { def_id: _, field: 0 },
+                        )) = subexprs.first().map(|e| e.kind())
+                            && new_subexprs[1..].iter().zip(1..).all(|(other_e, i)| {
+                                if let ExprKind::FieldProj(
+                                    other_e_inner,
+                                    FieldProj::Adt { def_id: _, field },
+                                ) = other_e.kind()
+                                {
+                                    field == &i && &e_inner.erase_metadata() == other_e_inner
+                                } else {
+                                    false
+                                }
+                            })
+                        {
+                            e_inner.clone()
+                        } else {
+                            expr.clone()
+                        }
+                    }
+                    _ => expr.super_fold_with(self),
+                }
+            }
+        }
+        self.fold_with(&mut EtaReducer)
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable, Debug)]

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -2001,16 +2001,16 @@ pub(crate) mod pretty {
     impl Pretty for BinOp {
         fn fmt(&self, _cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
-                BinOp::Iff => w!(cx, f, "⇔"),
-                BinOp::Imp => w!(cx, f, "⇒"),
-                BinOp::Or => w!(cx, f, "∨"),
-                BinOp::And => w!(cx, f, "∧"),
-                BinOp::Eq => w!(cx, f, "="),
-                BinOp::Ne => w!(cx, f, "≠"),
+                BinOp::Iff => w!(cx, f, "<=>"),
+                BinOp::Imp => w!(cx, f, "=>"),
+                BinOp::Or => w!(cx, f, "||"),
+                BinOp::And => w!(cx, f, "&&"),
+                BinOp::Eq => w!(cx, f, "=="),
+                BinOp::Ne => w!(cx, f, "!="),
                 BinOp::Gt(_) => w!(cx, f, ">"),
-                BinOp::Ge(_) => w!(cx, f, "≥"),
+                BinOp::Ge(_) => w!(cx, f, ">="),
                 BinOp::Lt(_) => w!(cx, f, "<"),
-                BinOp::Le(_) => w!(cx, f, "≤"),
+                BinOp::Le(_) => w!(cx, f, "<="),
                 BinOp::Add(_) => w!(cx, f, "+"),
                 BinOp::Sub(_) => w!(cx, f, "-"),
                 BinOp::Mul(_) => w!(cx, f, "*"),
@@ -2028,7 +2028,7 @@ pub(crate) mod pretty {
     impl Pretty for UnOp {
         fn fmt(&self, _cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
-                UnOp::Not => w!(cx, f, "¬"),
+                UnOp::Not => w!(cx, f, "!"),
                 UnOp::Neg => w!(cx, f, "-"),
             }
         }
@@ -2269,6 +2269,301 @@ pub(crate) mod pretty {
                     })
                 }
             }
+        }
+    }
+}
+
+impl Expr {
+    /// Applies transformations to simplify and humanize canonical Z3 outputs.
+    pub fn prettify(&self) -> Self {
+        self.fold_constants()
+            .push_negations()
+            .simplify_arithmetic()
+            .simplify_bounds()
+    }
+
+    /// Evaluates expressions with constant operands recursively.
+    pub fn fold_constants(&self) -> Self {
+        let span = self.span();
+        match self.kind() {
+            ExprKind::UnaryOp(op, a) => {
+                let a_fold = a.fold_constants();
+
+                if let ExprKind::Constant(c) = a_fold.kind() {
+                    match (op, c) {
+                        (UnOp::Not, Constant::Bool(b)) => {
+                            return Expr::constant(Constant::Bool(!b)).at_opt(span);
+                        }
+                        (UnOp::Neg, Constant::Int(n)) => {
+                            return Expr::constant(Constant::Int(n.neg())).at_opt(span);
+                        }
+                        _ => {}
+                    }
+                }
+                Expr::unary_op(*op, a_fold).at_opt(span)
+            }
+
+            ExprKind::BinaryOp(op, a, b) => {
+                let a_fold = a.fold_constants();
+                let b_fold = b.fold_constants();
+
+                if let (ExprKind::Constant(c1), ExprKind::Constant(c2)) =
+                    (a_fold.kind(), b_fold.kind())
+                {
+                    // 1. Leverage existing const_op logic (handles Bools, Eq, Ne, and Int comparisons)
+                    if let Some(c3) = Expr::const_op(op, c1, c2) {
+                        return Expr::constant(c3).at_opt(span);
+                    }
+
+                    // 2. Handle integer arithmetic
+                    if let (Constant::Int(n1), Constant::Int(n2)) = (c1, c2) {
+                        let result = match op {
+                            BinOp::Add(_) => n1.checked_add(n2),
+                            BinOp::Sub(_) => n1.checked_sub(n2),
+                            BinOp::Mul(_) => n1.checked_mul(n2),
+                            BinOp::Div(_) => n1.checked_div(n2),
+                            BinOp::Mod(_) => n1.checked_rem(n2),
+                            _ => None,
+                        };
+
+                        if let Some(res) = result {
+                            return Expr::constant(Constant::Int(res)).at_opt(span);
+                        }
+                    }
+                }
+
+                Expr::binary_op(op.clone(), a_fold, b_fold).at_opt(span)
+            }
+
+            ExprKind::IfThenElse(p, e1, e2) => {
+                let p_fold = p.fold_constants();
+
+                // Short-circuit the ITE if the predicate is a constant boolean
+                if let ExprKind::Constant(Constant::Bool(b)) = p_fold.kind() {
+                    if *b {
+                        return e1.fold_constants().at_opt(span);
+                    } else {
+                        return e2.fold_constants().at_opt(span);
+                    }
+                }
+
+                Expr::ite(p_fold, e1.fold_constants(), e2.fold_constants()).at_opt(span)
+            }
+
+            // Other variants (Tuple, App, FieldProj, etc.) recursively fall through
+            // untouched to avoid making assumptions about how your inner types construct.
+            _ => self.clone(),
+        }
+    }
+
+    /// Pass 1: Eliminate `Not` over inequalities and boolean operations.
+    pub fn push_negations(&self) -> Self {
+        let span = self.span();
+        match self.kind() {
+            ExprKind::UnaryOp(UnOp::Not, inner) => {
+                match inner.kind() {
+                    // Double negation
+                    ExprKind::UnaryOp(UnOp::Not, a) => a.push_negations().at_opt(span),
+
+                    // Flipped Inequalities
+                    ExprKind::BinaryOp(BinOp::Le(s), a, b) => {
+                        Expr::binary_op(
+                            BinOp::Gt(s.clone()),
+                            a.push_negations(),
+                            b.push_negations(),
+                        )
+                        .at_opt(span)
+                    }
+                    ExprKind::BinaryOp(BinOp::Lt(s), a, b) => {
+                        Expr::binary_op(
+                            BinOp::Ge(s.clone()),
+                            a.push_negations(),
+                            b.push_negations(),
+                        )
+                        .at_opt(span)
+                    }
+                    ExprKind::BinaryOp(BinOp::Ge(s), a, b) => {
+                        Expr::binary_op(
+                            BinOp::Lt(s.clone()),
+                            a.push_negations(),
+                            b.push_negations(),
+                        )
+                        .at_opt(span)
+                    }
+                    ExprKind::BinaryOp(BinOp::Gt(s), a, b) => {
+                        Expr::binary_op(
+                            BinOp::Le(s.clone()),
+                            a.push_negations(),
+                            b.push_negations(),
+                        )
+                        .at_opt(span)
+                    }
+
+                    // Equalities
+                    ExprKind::BinaryOp(BinOp::Eq, a, b) => {
+                        Expr::binary_op(BinOp::Ne, a.push_negations(), b.push_negations())
+                            .at_opt(span)
+                    }
+                    ExprKind::BinaryOp(BinOp::Ne, a, b) => {
+                        Expr::binary_op(BinOp::Eq, a.push_negations(), b.push_negations())
+                            .at_opt(span)
+                    }
+
+                    // De Morgan's
+                    ExprKind::BinaryOp(BinOp::Or, a, b) => {
+                        Expr::binary_op(
+                            BinOp::And,
+                            a.not().push_negations(),
+                            b.not().push_negations(),
+                        )
+                        .at_opt(span)
+                    }
+                    ExprKind::BinaryOp(BinOp::And, a, b) => {
+                        Expr::binary_op(
+                            BinOp::Or,
+                            a.not().push_negations(),
+                            b.not().push_negations(),
+                        )
+                        .at_opt(span)
+                    }
+
+                    // Otherwise just wrap and stop
+                    _ => Expr::unary_op(UnOp::Not, inner.push_negations()).at_opt(span),
+                }
+            }
+            ExprKind::BinaryOp(op, a, b) => {
+                Expr::binary_op(op.clone(), a.push_negations(), b.push_negations()).at_opt(span)
+            }
+            ExprKind::UnaryOp(op, a) => Expr::unary_op(*op, a.push_negations()).at_opt(span),
+            ExprKind::IfThenElse(p, e1, e2) => {
+                Expr::ite(p.push_negations(), e1.push_negations(), e2.push_negations()).at_opt(span)
+            }
+            _ => self.clone(),
+        }
+    }
+
+    /// Pass 2: Clean up canonicalized arithmetic (e.g. `b0 * -1 + b1` -> `b1 - b0`)
+    pub fn simplify_arithmetic(&self) -> Self {
+        let span = self.span();
+        match self.kind() {
+            ExprKind::BinaryOp(BinOp::Mul(s), a, b) => {
+                let a_simp = a.simplify_arithmetic();
+                let b_simp = b.simplify_arithmetic();
+
+                let is_minus_one = |e: &Expr| matches!(e.kind(), ExprKind::Constant(c) if *c == Constant::from(-1));
+
+                if is_minus_one(&b_simp) {
+                    return a_simp.neg().at_opt(span);
+                }
+                if is_minus_one(&a_simp) {
+                    return b_simp.neg().at_opt(span);
+                }
+
+                Expr::binary_op(BinOp::Mul(s.clone()), a_simp, b_simp).at_opt(span)
+            }
+            ExprKind::BinaryOp(BinOp::Add(s), a, b) => {
+                let a_simp = a.simplify_arithmetic();
+                let b_simp = b.simplify_arithmetic();
+
+                if let ExprKind::UnaryOp(UnOp::Neg, x) = a_simp.kind() {
+                    return Expr::binary_op(BinOp::Sub(s.clone()), b_simp, x.clone()).at_opt(span);
+                }
+                if let ExprKind::UnaryOp(UnOp::Neg, y) = b_simp.kind() {
+                    return Expr::binary_op(BinOp::Sub(s.clone()), a_simp, y.clone()).at_opt(span);
+                }
+
+                Expr::binary_op(BinOp::Add(s.clone()), a_simp, b_simp).at_opt(span)
+            }
+            ExprKind::BinaryOp(op, a, b) => {
+                Expr::binary_op(op.clone(), a.simplify_arithmetic(), b.simplify_arithmetic())
+                    .at_opt(span)
+            }
+            ExprKind::UnaryOp(op, a) => Expr::unary_op(*op, a.simplify_arithmetic()).at_opt(span),
+            ExprKind::IfThenElse(p, e1, e2) => {
+                Expr::ite(
+                    p.simplify_arithmetic(),
+                    e1.simplify_arithmetic(),
+                    e2.simplify_arithmetic(),
+                )
+                .at_opt(span)
+            }
+            _ => self.clone(),
+        }
+    }
+
+    /// Pass 3: Integer shifts and inequality rearrangement
+    pub fn simplify_bounds(&self) -> Self {
+        let span = self.span();
+        match self.kind() {
+            ExprKind::BinaryOp(op, a, b) => {
+                let a_simp = a.simplify_bounds();
+                let b_simp = b.simplify_bounds();
+
+                let is_minus_one = |e: &Expr| matches!(e.kind(), ExprKind::Constant(c) if *c == Constant::from(-1));
+                let is_zero =
+                    |e: &Expr| matches!(e.kind(), ExprKind::Constant(c) if *c == Constant::from(0));
+
+                // Important: this logic only applies if the operators are specifically typed for integers
+                match op {
+                    BinOp::Gt(Sort::Int) => {
+                        // X > -1  ==>  X >= 0
+                        if is_minus_one(&b_simp) {
+                            return Expr::binary_op(BinOp::Ge(Sort::Int), a_simp, Expr::zero())
+                                .at_opt(span)
+                                .simplify_bounds();
+                        }
+                        // X - Y > 0  ==>  X > Y
+                        if is_zero(&b_simp)
+                            && let ExprKind::BinaryOp(BinOp::Sub(s_sub), x, y) = a_simp.kind()
+                        {
+                            return Expr::binary_op(BinOp::Gt(s_sub.clone()), x.clone(), y.clone())
+                                .at_opt(span);
+                        }
+                    }
+                    BinOp::Ge(Sort::Int) => {
+                        // X - Y >= 0  ==>  X >= Y
+                        if is_zero(&b_simp)
+                            && let ExprKind::BinaryOp(BinOp::Sub(s_sub), x, y) = a_simp.kind()
+                        {
+                            return Expr::binary_op(BinOp::Ge(s_sub.clone()), x.clone(), y.clone())
+                                .at_opt(span);
+                        }
+                    }
+                    BinOp::Lt(Sort::Int) => {
+                        // X - Y < 0  ==>  X < Y
+                        if is_zero(&b_simp)
+                            && let ExprKind::BinaryOp(BinOp::Sub(s_sub), x, y) = a_simp.kind()
+                        {
+                            return Expr::binary_op(BinOp::Lt(s_sub.clone()), x.clone(), y.clone())
+                                .at_opt(span);
+                        }
+                    }
+                    BinOp::Le(Sort::Int) => {
+                        // X <= -1  ==>  X < 0
+                        if is_minus_one(&b_simp) {
+                            return Expr::binary_op(BinOp::Lt(Sort::Int), a_simp, Expr::zero())
+                                .at_opt(span)
+                                .simplify_bounds();
+                        }
+                        // X - Y <= 0  ==>  X <= Y
+                        if is_zero(&b_simp)
+                            && let ExprKind::BinaryOp(BinOp::Sub(s_sub), x, y) = a_simp.kind()
+                        {
+                            return Expr::binary_op(BinOp::Le(s_sub.clone()), x.clone(), y.clone())
+                                .at_opt(span);
+                        }
+                    }
+                    _ => {}
+                }
+
+                Expr::binary_op(op.clone(), a_simp, b_simp).at_opt(span)
+            }
+            ExprKind::UnaryOp(op, a) => Expr::unary_op(*op, a.simplify_bounds()).at_opt(span),
+            ExprKind::IfThenElse(p, e1, e2) => {
+                Expr::ite(p.simplify_bounds(), e1.simplify_bounds(), e2.simplify_bounds())
+                    .at_opt(span)
+            }
+            _ => self.clone(),
         }
     }
 }

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -34,10 +34,10 @@ use crate::{
     pretty::*,
     queries::QueryResult,
     rty::{
-        BoundVariableKind, SortArg, SubsetTyCtor,
+        BoundVariableKind, SortArg, SortCtor, SubsetTyCtor,
         fold::{
-            TypeFoldable, TypeFolder, TypeSuperFoldable, TypeSuperVisitable, TypeVisitable as _,
-            TypeVisitor,
+            FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeSuperVisitable,
+            TypeVisitable, TypeVisitor,
         },
     },
 };
@@ -326,6 +326,10 @@ impl Expr {
 
     pub fn kvar(kvar: KVar) -> Expr {
         ExprKind::KVar(kvar).intern()
+    }
+
+    pub fn wkvar(wkvar: WKVar) -> Expr {
+        ExprKind::WKVar(wkvar).intern()
     }
 
     pub fn alias(alias: AliasReft, args: List<Expr>) -> Expr {
@@ -778,6 +782,7 @@ pub enum ExprKind {
     PathProj(Expr, FieldIdx),
     IfThenElse(Expr, Expr, Expr),
     KVar(KVar),
+    WKVar(WKVar),
     Alias(AliasReft, List<Expr>),
     Let(Expr, Binder<Expr>),
     /// Function application. The syntax allows arbitrary expressions in function position, but in
@@ -890,6 +895,87 @@ pub struct KVar {
     /// The list of *all* arguments with the self arguments at the beginning, i.e., the
     /// list of self arguments followed by the scope.
     pub args: List<Expr>,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable,
+)]
+pub struct WKVid {
+    /// Weak KVars right now are always associated with a function definition.
+    /// Weak KVars can in theory be put wherever we can validly add a refinement
+    pub parent_fn: DefId,
+    /// There's no reason why this has to be KVid, and in principle it may be
+    /// better served as just a number or a new index unto itself.
+    pub id: KVid,
+}
+
+impl WKVid {
+    pub fn new(parent_fn: DefId, id: KVid) -> Self {
+        Self { parent_fn, id }
+    }
+}
+
+/// A weak kvar is like a kvar with the exception that it infers the weakest
+/// condition necessary instead of the strongest condition. Due to the way we
+/// generate these kvars (on fn_sigs, rather than during constraint generation),
+/// they also in theory are global.
+#[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
+pub struct WKVar {
+    pub wkvid: WKVid,
+    /// Analagous to KVar self arguments except we require that instantiations
+    /// use *at least one* of the self_args (unless there are none, in which
+    /// case there is no such requirement).
+    ///
+    /// This is mostly relevant for weak kvars corresponding to function
+    /// *outputs*. Consider the signature
+    ///
+    ///     foo: fn(x: usize) -> bool{b: $wk1(b, x)}
+    ///            requires $wk0(x)
+    ///
+    /// In this case self_args would be 1 (corresponding to the bool `b`).
+    /// Consider now the snippet
+    ///
+    ///     let b = foo(x);
+    ///     assert(x > 0);
+    ///
+    /// Suppose the assertion fails. Without the self_args requirement, we
+    /// could validly instantiate
+    ///
+    ///     $wk1(b, x) := x > 0
+    ///
+    /// But this is somewhat nonsensical because only in exceptional cases
+    /// does it make sense for `foo` to somehow "add" information to its
+    /// **argument** (`x`).
+    ///
+    /// By checking for the presence of **at least one** self arg, we
+    /// ensure that the self argument is "used"; fixpoint does a similar check.
+    ///
+    /// This is a syntactic underapproximation and doesn't preclude things like
+    ///
+    ///     $wk1(b, x) := (b => true) && (x > 0)
+    ///
+    /// But we could conceive of a more sophisticated check using the self_args.
+    pub self_args: usize,
+    /// All arguments with self arguments at the beginning.
+    pub args: List<Expr>,
+}
+
+impl TypeVisitable for WKVar {
+    fn visit_with<V: TypeVisitor>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
+        self.wkvid.visit_with(visitor)?;
+        // NOTE: the params shouldn't need to be visited I think
+        self.args.visit_with(visitor)
+    }
+}
+
+impl TypeFoldable for WKVar {
+    fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
+        Ok(WKVar {
+            wkvid: self.wkvid.try_fold_with(folder)?,
+            self_args: self.self_args,
+            args: self.args.try_fold_with(folder)?,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
@@ -1018,6 +1104,16 @@ impl KVar {
         KVar { kvid, self_args, args: List::from_vec(args) }
     }
 
+    fn self_args(&self) -> &[Expr] {
+        &self.args[..self.self_args]
+    }
+
+    fn scope(&self) -> &[Expr] {
+        &self.args[self.self_args..]
+    }
+}
+
+impl WKVar {
     fn self_args(&self) -> &[Expr] {
         &self.args[..self.self_args]
     }
@@ -1538,6 +1634,9 @@ pub(crate) mod pretty {
                 ExprKind::KVar(kvar) => {
                     w!(cx, f, "{:?}", kvar)
                 }
+                ExprKind::WKVar(wkvar) => {
+                    w!(cx, f, "{:?}", wkvar)
+                }
                 ExprKind::Alias(alias, args) => {
                     w!(cx, f, "{:?}({:?})", alias, join!(", ", args))
                 }
@@ -1678,6 +1777,16 @@ pub(crate) mod pretty {
         }
     }
 
+    impl Pretty for WKVar {
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            // Since we reuse KVId, we need to make the serialization custom.
+            // Also we will not serialize the parameters for now.
+            w!(cx, f, "$wk{}_{}", ^self.wkvid.id.index(), ^cx.tcx().def_path_str(self.wkvid.parent_fn))?;
+            w!(cx, f, "({:?})[{:?}]", join!(", ", self.self_args()), join!(", ", self.scope()))?;
+            Ok(())
+        }
+    }
+
     impl Pretty for Path {
         fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             w!(cx, f, "{:?}", &self.loc)?;
@@ -1733,7 +1842,7 @@ pub(crate) mod pretty {
         }
     }
 
-    impl_debug_with_default_cx!(Expr, Loc, Path, Var, KVar, Lambda, AliasReft);
+    impl_debug_with_default_cx!(Expr, Loc, Path, Var, KVar, WKVar, Lambda, AliasReft);
 
     impl PrettyNested for Lambda {
         fn fmt_nested(&self, cx: &PrettyCx) -> Result<NestedString, fmt::Error> {
@@ -1807,6 +1916,7 @@ pub(crate) mod pretty {
                 | ExprKind::Hole(..)
                 | ExprKind::GlobalFunc(..)
                 | ExprKind::InternalFunc(..) => debug_nested(cx, &e),
+                ExprKind::WKVar(..) => debug_nested(cx, &e),
                 ExprKind::KVar(kvar) => {
                     let kv = format!("{:?}", kvar.kvid);
                     let mut strs = vec![kv];

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -1127,6 +1127,20 @@ impl Var {
     pub fn to_expr(&self) -> Expr {
         Expr::var(*self)
     }
+
+    pub fn shift_in(&self, amount: u32) -> Self {
+        match self {
+            Var::Bound(idx, breft) => Var::Bound(idx.shifted_in(amount), *breft),
+            _ => *self,
+        }
+    }
+
+    pub fn shift_out(&self, amount: u32) -> Self {
+        match self {
+            Var::Bound(idx, breft) => Var::Bound(idx.shifted_out(amount), *breft),
+            _ => *self,
+        }
+    }
 }
 
 impl Path {

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -1052,6 +1052,7 @@ impl TypeSuperVisitable for Expr {
                 e2.visit_with(visitor)
             }
             ExprKind::KVar(kvar) => kvar.visit_with(visitor),
+            ExprKind::WKVar(wkvar) => wkvar.visit_with(visitor),
             ExprKind::Alias(alias, args) => {
                 alias.visit_with(visitor)?;
                 args.visit_with(visitor)
@@ -1119,6 +1120,7 @@ impl TypeSuperFoldable for Expr {
             }
             ExprKind::Hole(kind) => Expr::hole(kind.try_fold_with(folder)?),
             ExprKind::KVar(kvar) => Expr::kvar(kvar.try_fold_with(folder)?),
+            ExprKind::WKVar(wkvar) => Expr::wkvar(wkvar.try_fold_with(folder)?),
             ExprKind::Abs(lam) => Expr::abs(lam.try_fold_with(folder)?),
             ExprKind::BoundedQuant(kind, rng, body) => {
                 Expr::bounded_quant(*kind, *rng, body.try_fold_with(folder)?)
@@ -1148,6 +1150,17 @@ where
     }
 }
 
+impl<S, T> TypeVisitable for (S, T)
+where
+    S: TypeVisitable,
+    T: TypeVisitable,
+{
+    fn visit_with<V: TypeVisitor>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
+        self.0.visit_with(visitor)?;
+        self.1.visit_with(visitor)
+    }
+}
+
 impl<T> TypeFoldable for List<T>
 where
     T: TypeFoldable,
@@ -1155,6 +1168,16 @@ where
 {
     fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
         self.iter().map(|t| t.try_fold_with(folder)).try_collect()
+    }
+}
+
+impl<S, T> TypeFoldable for (S, T)
+where
+    S: TypeFoldable,
+    T: TypeFoldable,
+{
+    fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
+        Ok((self.0.try_fold_with(folder)?, self.1.try_fold_with(folder)?))
     }
 }
 

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1148,6 +1148,10 @@ impl Sort {
         }
         go(self, &mut f, &mut vec![]);
     }
+
+    pub fn is_param(&self) -> bool {
+        matches!(self, Self::Param(_))
+    }
 }
 
 /// The size of a [bit-vector]

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -20,7 +20,7 @@ use bitflags::bitflags;
 pub use expr::{
     AggregateKind, AliasReft, BinOp, BoundReft, Constant, Ctor, ESpan, EVid, EarlyReftParam, Expr,
     ExprKind, FieldProj, HoleKind, InternalFuncKind, KVar, KVid, Lambda, Loc, Name, NameProvenance,
-    Path, PrettyMap, PrettyVar, Real, SpecFuncKind, UnOp, Var,
+    Path, PrettyMap, PrettyVar, Real, SpecFuncKind, UnOp, Var, WKVar, WKVid,
 };
 pub use flux_arc_interner::List;
 use flux_arc_interner::{Interned, impl_internable, impl_slice_internable};

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -209,8 +209,13 @@ impl Pretty for FnSig {
             join!(", ", self.inputs.iter().map(|input| input.shallow_canonicalize())),
             &self.output
         )?;
-        if !self.requires.is_empty() {
-            w!(cx, f, " requires {:?}", join!(" ∧ ", &self.requires))?;
+        let filtered_requires = self
+            .requires
+            .iter()
+            .filter(|r| !r.is_trivially_true())
+            .collect_vec();
+        if !filtered_requires.is_empty() {
+            w!(cx, f, " requires {:?}", join!(" && ", &filtered_requires))?;
         }
         Ok(())
     }
@@ -225,8 +230,18 @@ impl Pretty for Binder<FnOutput> {
 impl Pretty for FnOutput {
     fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         w!(cx, f, "{:?}", &self.ret.shallow_canonicalize())?;
-        if !self.ensures.is_empty() {
-            w!(cx, f, " ensures {:?}", join!(" ∧ ", &self.ensures))?;
+        let filtered_ensures = self
+            .ensures
+            .iter()
+            .filter(|e| {
+                match e {
+                    Ensures::Pred(p) => !p.is_trivially_true(),
+                    _ => true,
+                }
+            })
+            .collect_vec();
+        if !filtered_ensures.is_empty() {
+            w!(cx, f, " ensures {:?}", join!(" && ", &filtered_ensures))?;
         }
         Ok(())
     }
@@ -285,23 +300,26 @@ impl Pretty for IdxFmt {
                 if let Some(var_fields) = fields
                     .iter()
                     .map(|field| {
-                        if let ExprKind::Var(Var::Bound(debruijn, BoundReft { var, .. })) =
-                            field.value.kind()
-                        {
-                            Some((*debruijn, *var, field.value.clone()))
-                        } else {
-                            None
-                        }
+                        if let ExprKind::Var(var) = field.value.kind() { Some(*var) } else { None }
                     })
                     .collect::<Option<Vec<_>>>()
                 {
                     // If they are all meant to be removed, we can elide the entire index.
-                    if var_fields.iter().all(|(debruijn, var, _e)| {
-                        cx.bvar_env
-                            .should_remove_var(*debruijn, *var)
-                            .unwrap_or(false)
+                    if var_fields.iter().all(|var| {
+                        if let Var::Bound(debruijn, BoundReft { var, .. }) = var {
+                            cx.bvar_env
+                                .should_remove_var(*debruijn, *var)
+                                .unwrap_or(false)
+                        } else {
+                            false
+                        }
                     }) {
-                        var_fields.iter().for_each(|(debruijn, var, _e)| {
+                        var_fields.iter().for_each(|var| {
+                            let Var::Bound(debruijn, BoundReft { var, .. }) = var else {
+                                // We just checked that all of the vars are bound
+                                // and meant to be removed
+                                unreachable!();
+                            };
                             cx.bvar_env.mark_var_as_removed(*debruijn, *var);
                         });
                         // We write nothing here: we can erase the index
@@ -310,21 +328,33 @@ impl Pretty for IdxFmt {
                         //
                         // NOTE: this is heavily copied from the var case below.
                     } else {
-                        let mut fields = var_fields.into_iter().map(|(debruijn, var, e)| {
-                            if let Some((seen, layer_type)) =
-                                cx.bvar_env.check_if_seen_fn_root_bvar(debruijn, var)
-                                && !seen
-                            {
-                                match layer_type {
-                                    FnRootLayerType::FnArgs => {
-                                        format_cx!(cx, "@{:?}", e)
-                                    }
-                                    FnRootLayerType::FnRet => {
-                                        format_cx!(cx, "#{:?}", e)
+                        let mut fields = var_fields.into_iter().map(|var_e| {
+                            match var_e {
+                                Var::Bound(debruijn, BoundReft { var, .. })
+                                    if let Some((seen, layer_type)) =
+                                        cx.bvar_env.check_if_seen_fn_root_bvar(debruijn, var)
+                                        && !seen =>
+                                {
+                                    match layer_type {
+                                        FnRootLayerType::FnArgs => {
+                                            format_cx!(cx, "@{:?}", var_e)
+                                        }
+                                        FnRootLayerType::FnRet => {
+                                            format_cx!(cx, "#{:?}", var_e)
+                                        }
                                     }
                                 }
-                            } else {
-                                format_cx!(cx, "{:?}", e)
+                                Var::EarlyParam(ep)
+                                    if cx
+                                        .earlyparam_env
+                                        .borrow_mut()
+                                        .as_mut()
+                                        .unwrap()
+                                        .insert(ep) =>
+                                {
+                                    format_cx!(cx, "@{:?}", var_e)
+                                }
+                                _ => format_cx!(cx, "{:?}", var_e),
                             }
                         });
                         buf.write_str(&fields.join(", "))?;
@@ -702,12 +732,12 @@ impl PrettyNested for SubsetTy {
         let bty_d = self.bty.fmt_nested(cx)?;
         let idx_d = IdxFmt(self.idx.clone()).fmt_nested(cx)?;
         if self.pred.is_trivially_true() || matches!(self.pred.kind(), ExprKind::KVar(..)) {
-            let text = format!("{}[{}]", bty_d.text, idx_d.text);
+            let text = format!("{}{}", bty_d.text, idx_d.text);
             let children = float_children(vec![bty_d.children, idx_d.children]);
             Ok(NestedString { text, children, key: None })
         } else {
             let pred_d = self.pred.fmt_nested(cx)?;
-            let text = format!("{{ {}[{}] | {} }}", bty_d.text, idx_d.text, pred_d.text);
+            let text = format!("{{ {}{} | {} }}", bty_d.text, idx_d.text, pred_d.text);
             let children = float_children(vec![bty_d.children, idx_d.children, pred_d.children]);
             Ok(NestedString { text, children, key: None })
         }
@@ -840,7 +870,7 @@ impl PrettyNested for Ty {
                 let text = if idx_d.text.is_empty() {
                     bty_d.text
                 } else {
-                    format!("{}[{}]", bty_d.text, idx_d.text)
+                    format!("{}{}", bty_d.text, idx_d.text)
                 };
                 let children = float_children(vec![bty_d.children, idx_d.children]);
                 Ok(NestedString { text, children, key: None })

--- a/crates/flux-middle/src/rty/pretty.rs
+++ b/crates/flux-middle/src/rty/pretty.rs
@@ -436,7 +436,13 @@ impl Pretty for Ty {
                 w!(cx, f, "{:?}", self.shallow_canonicalize())
             }
             TyKind::Uninit => w!(cx, f, "uninit"),
-            TyKind::StrgRef(re, loc, ty) => w!(cx, f, "&{:?} strg <{:?}: {:?}>", re, loc, ty),
+            TyKind::StrgRef(re, loc, ty) => {
+                if cx.hide_regions {
+                    w!(cx, f, "{:?}: &strg {:?}", loc, ty)
+                } else {
+                    w!(cx, f, "{:?}: &{:?} strg {:?}", loc, re, ty)
+                }
+            }
             TyKind::Ptr(pk, loc) => w!(cx, f, "ptr({:?}, {:?})", pk, loc),
             TyKind::Discr(adt_def, place) => {
                 w!(cx, f, "discr({:?}, {:?})", adt_def.did(), ^place)

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -8,15 +8,21 @@ use flux_common::bug;
 use flux_rustc_bridge::{ty, ty::GenericArgsExt as _};
 use itertools::Itertools;
 use rustc_abi::VariantIdx;
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::ParamTy;
+use rustc_span::Symbol;
+use rustc_type_ir::INNERMOST;
 
-use super::{RefineArgsExt, fold::TypeFoldable};
+use super::{
+    RefineArgsExt,
+    fold::{TypeFoldable, TypeFolder, TypeVisitable},
+};
 use crate::{
-    global_env::GlobalEnv,
+    global_env::{GlobalEnv, WeakKvarInfo, WeakKvarMap},
     queries::{QueryErr, QueryResult},
     query_bug,
-    rty::{self, Expr},
+    rty::{self, Expr, fold::TypeSuperFoldable},
 };
 
 pub fn refine_generics(generics: &ty::Generics) -> rty::Generics {
@@ -496,4 +502,301 @@ pub fn refine_bound_variables(vars: &[ty::BoundVariableKind]) -> List<rty::Bound
             }
         })
         .collect()
+}
+
+impl rty::PolyFnSig {
+    pub fn add_weak_kvars(self, genv: GlobalEnv, def_id: DefId) -> QueryResult<Self> {
+        let refinement_generics = genv.refinement_generics_of(def_id)?;
+        let early_param_sorts: FxHashMap<Symbol, rty::Sort> = refinement_generics
+            .0
+            .own_params
+            .iter()
+            .map(|param| (param.name, param.sort.clone()))
+            .collect();
+        let early_vars = self
+            .early_params()
+            .into_iter()
+            .filter_map(|param| {
+                let sort = early_param_sorts.get(&param.name).unwrap().clone();
+                if !sort.is_param() && !sort.is_loc() {
+                    Some((rty::Var::EarlyParam(param), sort))
+                } else {
+                    None
+                }
+            })
+            .collect_vec();
+        let late_vars = make_vars_and_sorts_from_bound_vars(self.vars());
+        Ok(self.map(|fn_sig| {
+            let mut params = late_vars.into_iter().chain(early_vars).collect_vec();
+            let mut wkvar_inserter = WeakKVarInserter {
+                wkvar_map: WeakKvarMap::default(),
+                def_id,
+                kvid: rty::KVid::from(0_usize),
+                existential_params: Vec::new(),
+                params: params.clone(),
+            };
+            let requires_wkvar = make_weak_kvar(
+                &mut wkvar_inserter.wkvar_map,
+                def_id,
+                &mut wkvar_inserter.kvid,
+                Vec::new(),
+                params.clone(),
+            );
+            let inputs = fn_sig
+                .inputs
+                .iter()
+                .map(|input| wkvar_inserter.fold_ty(input))
+                .collect();
+            shift_in_vars(&mut params);
+            let output_binder_params = make_vars_and_sorts_from_bound_vars(fn_sig.output.vars());
+            params.extend(output_binder_params);
+            wkvar_inserter.params = params.clone();
+            let ensures = if !fn_sig.output.vars().is_empty() {
+                let ensures_wkvar = make_weak_kvar(
+                    &mut wkvar_inserter.wkvar_map,
+                    def_id,
+                    &mut wkvar_inserter.kvid,
+                    make_vars_and_sorts_from_bound_vars(fn_sig.output.vars()),
+                    params.clone(),
+                );
+                fn_sig
+                    .output
+                    .skip_binder_ref()
+                    .ensures
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(rty::Ensures::Pred(rty::Expr::wkvar(ensures_wkvar))))
+                    .collect()
+            } else {
+                fn_sig.output.skip_binder_ref().ensures.clone()
+            };
+            let output = fn_sig
+                .output
+                .map(|output| rty::FnOutput { ret: wkvar_inserter.fold_ty(&output.ret), ensures });
+            genv.feed_weak_kvars(def_id, wkvar_inserter.wkvar_map);
+
+            rty::FnSig {
+                abi: fn_sig.abi,
+                safety: fn_sig.safety,
+                inputs,
+                // NOTE(CK): Not sure whether we can avoid the clone.
+                requires: fn_sig
+                    .requires
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(rty::Expr::wkvar(requires_wkvar)))
+                    .collect(),
+                output,
+                lifted: fn_sig.lifted,
+                no_panic: fn_sig.no_panic,
+            }
+        }))
+    }
+}
+
+struct WeakKVarInserter {
+    wkvar_map: WeakKvarMap,
+    def_id: DefId,
+    kvid: rty::KVid,
+    existential_params: Vec<Vec<(rty::Var, rty::Sort)>>,
+    params: Vec<(rty::Var, rty::Sort)>,
+}
+
+impl TypeFolder for WeakKVarInserter {
+    fn fold_ty(&mut self, ty: &rty::Ty) -> rty::Ty {
+        use rty::{Expr, Ty, TyKind::*};
+        match ty.kind() {
+            // This is the only recursive case where we need to update the params
+            // since we're going under a binder.
+            //
+            // We handle the shifting in and out explicitly rather than using
+            // the enter_binder and exit_binder methods because we immediately
+            // use the bound vars to make a weak kvar.
+            Exists(bound_ty) => {
+                for v in &mut self.existential_params {
+                    shift_in_vars(v);
+                }
+                shift_in_vars(&mut self.params);
+                let exist_params = make_vars_and_sorts_from_bound_vars(bound_ty.vars());
+                // Take all of the current existential params + the current params,
+                // AFTER shifting in.
+                let params = self
+                    .existential_params
+                    .iter()
+                    .flatten()
+                    .chain(self.params.iter())
+                    .cloned()
+                    .collect();
+                // We pass the params immediately under this binder as the self args.
+                //
+                // The purpose of self args is to ensure that we don't have duplication
+                // of suggestions.
+                //
+                // Suppose after we add weak kvars we have the type
+                //
+                //     fn ({exists v0. Vec<i32>[v0] | $wk1[v0]()}) requires $wk0[]()
+                //
+                // If we are looking to instantiate a weak kvar to the
+                // expression `2 > 1` (for some reason), we can validly put it
+                // in both $wk0 and $wk1. But the self arg ensures that we don't
+                // put it in $wk1, since it requires the expression contain one
+                // of its self args (in this case, just `v0`).
+                let wkvar = make_weak_kvar(
+                    &mut self.wkvar_map,
+                    self.def_id,
+                    &mut self.kvid,
+                    exist_params.clone(),
+                    params,
+                );
+                // Now we add the params for future weak kvars.
+                self.existential_params.push(exist_params);
+                let new_ty = bound_ty.skip_binder_ref().super_fold_with(self);
+                self.existential_params.pop();
+                for v in &mut self.existential_params {
+                    shift_out_vars(v);
+                }
+                shift_out_vars(&mut self.params);
+                Ty::exists(rty::Binder::bind_with_vars(
+                    Ty::constr(Expr::wkvar(wkvar), new_ty),
+                    bound_ty.vars().clone(),
+                ))
+            }
+            _ => ty.super_fold_with(self),
+        }
+    }
+
+    fn fold_bty(&mut self, bty: &rty::BaseTy) -> rty::BaseTy {
+        use rty::{BaseTy, Expr, GenericArg};
+        match bty {
+            BaseTy::Adt(adt_def, args) => {
+                let new_args = args
+                    .iter()
+                    .map(|arg| {
+                        match arg {
+                            GenericArg::Base(subset_ty) => {
+                                for v in &mut self.existential_params {
+                                    shift_in_vars(v);
+                                }
+                                shift_in_vars(&mut self.params);
+                                let exist_params =
+                                    make_vars_and_sorts_from_bound_vars(subset_ty.vars());
+                                // Take all of the current existential params + the current params,
+                                // AFTER shifting in.
+                                let params = self
+                                    .existential_params
+                                    .iter()
+                                    .flatten()
+                                    .chain(self.params.iter())
+                                    .cloned()
+                                    .collect();
+                                // We pass the params immediately under this binder as the self args.
+                                // see the TyKind::Exists case.
+                                let wkvar = make_weak_kvar(
+                                    &mut self.wkvar_map,
+                                    self.def_id,
+                                    &mut self.kvid,
+                                    exist_params.clone(),
+                                    params,
+                                );
+                                // Now we add the params for future weak kvars.
+                                self.existential_params.push(exist_params);
+                                let new_ty = subset_ty.skip_binder_ref().super_fold_with(self);
+                                let new_ty_with_wkvar = new_ty.strengthen(Expr::wkvar(wkvar));
+                                self.existential_params.pop();
+                                for v in &mut self.existential_params {
+                                    shift_out_vars(v);
+                                }
+                                shift_out_vars(&mut self.params);
+                                GenericArg::Base(rty::Binder::bind_with_vars(
+                                    new_ty_with_wkvar,
+                                    subset_ty.vars().clone(),
+                                ))
+                            }
+                            _ => arg.fold_with(self),
+                        }
+                    })
+                    .collect();
+                BaseTy::Adt(adt_def.clone(), new_args)
+            }
+            BaseTy::Alias(_, _) => {bty.clone()},
+            _ => bty.super_fold_with(self),
+        }
+    }
+
+    fn fold_expr(&mut self, expr: &Expr) -> Expr {
+        expr.clone()
+    }
+
+    fn fold_sort(&mut self, sort: &rty::Sort) -> rty::Sort {
+        sort.clone()
+    }
+}
+
+/// NOTE(CK):
+///   * Skips params (we don't presently handle polymorphism, though even if we did,
+///     I'm not sure that we need to pass params to the weak kvars).
+///   * Skips locs because we can't encode those.
+///   * Skips unit + unit adts because they otherwise get encoded as a 0 tuple
+///     to fixpoint because we use them in the args to a weak kvar, which
+///     we don't want to do.
+fn make_vars_and_sorts_from_bound_vars<'a, I, II>(vars: I) -> Vec<(rty::Var, rty::Sort)>
+where
+    I: IntoIterator<IntoIter = II>,
+    II: DoubleEndedIterator<Item = &'a rty::BoundVariableKind>,
+{
+    vars.into_iter()
+        .enumerate()
+        .filter_map(|(i, var_kind)| {
+            if let rty::BoundVariableKind::Refine(sort, _, reft_kind) = var_kind
+                && !sort.is_param()
+                && !sort.is_loc()
+                && !sort.is_unit()
+                && sort.is_unit_adt().is_none()
+            {
+                let bound_reft = rty::BoundReft { var: rty::BoundVar::from(i), kind: *reft_kind };
+                Some((rty::Var::Bound(INNERMOST, bound_reft), sort.clone()))
+            } else {
+                None
+            }
+        })
+        .collect_vec()
+}
+
+// FIXME: Use a Vec<Vec<_>> solution, per Nico.
+// This is a sort of annoying rearchitecture, but nothing impossible.
+fn shift_in_vars(vars: &mut [(rty::Var, rty::Sort)]) {
+    for (var, _) in vars.iter_mut() {
+        *var = var.shift_in(1);
+    }
+}
+
+fn shift_out_vars(vars: &mut [(rty::Var, rty::Sort)]) {
+    for (var, _) in vars.iter_mut() {
+        *var = var.shift_out(1);
+    }
+}
+
+// FIXME: Don't make a weak kvar if the self_args is empty if there's a weak kvar
+//        that's been created before it with a superset of its params.
+fn make_weak_kvar(
+    wkvar_map: &mut WeakKvarMap,
+    def_id: DefId,
+    kvid: &mut rty::KVid,
+    self_args: Vec<(rty::Var, rty::Sort)>,
+    params: Vec<(rty::Var, rty::Sort)>,
+) -> rty::WKVar {
+    let num_self_args = self_args.len();
+    let (args, sorts): (Vec<rty::Var>, Vec<rty::Sort>) =
+        self_args.into_iter().chain(params).unzip();
+    let arg_exprs = args.into_iter().map(rty::Expr::var).collect();
+    // We don't have any solutions because these weak kvars are being generated
+    // (solutions only come from user annotations).
+    wkvar_map.insert(kvid.as_u32(), WeakKvarInfo { solutions: vec![], sorts });
+    let ret = rty::WKVar {
+        wkvid: rty::WKVid::new(def_id, *kvid),
+        self_args: num_self_args,
+        args: arg_exprs,
+    };
+    *kvid += 1;
+    ret
 }

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -718,8 +718,12 @@ impl TypeFolder for WeakKVarInserter {
                     .collect();
                 BaseTy::Adt(adt_def.clone(), new_args)
             }
-            BaseTy::Alias(_, _) => {bty.clone()},
-            _ => bty.super_fold_with(self),
+            // For these specific btys, we will recur and add wkvars
+            BaseTy::Ref(..) | BaseTy::Tuple(..) | BaseTy::Array(..) | BaseTy::Slice(..) => {
+                bty.super_fold_with(self)
+            }
+            // By default we will not recur on the bty to add wkvars
+            _ => bty.clone(),
         }
     }
 

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -762,7 +762,7 @@ where
         .collect_vec()
 }
 
-// FIXME: Use a Vec<Vec<_>> solution, per Nico.
+// TODO: Use a Vec<Vec<_>> solution, per Nico.
 // This is a sort of annoying rearchitecture, but nothing impossible.
 fn shift_in_vars(vars: &mut [(rty::Var, rty::Sort)]) {
     for (var, _) in vars.iter_mut() {
@@ -776,7 +776,7 @@ fn shift_out_vars(vars: &mut [(rty::Var, rty::Sort)]) {
     }
 }
 
-// FIXME: Don't make a weak kvar if the self_args is empty if there's a weak kvar
+// TODO: Don't make a weak kvar if the self_args is empty if there's a weak kvar
 //        that's been created before it with a superset of its params.
 fn make_weak_kvar(
     wkvar_map: &mut WeakKvarMap,

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -317,12 +317,7 @@ fn add_fn_fix_diagnostic<'a>(
     wkvid: rty::WKVid,
     solution: &rty::Binder<rty::Expr>,
 ) {
-    let pretty_solution = solution.map_ref(|e| e.simplify(&Default::default()));
-    let fn_name = genv.tcx().def_path_str(wkvid.0);
-    let fn_span = genv
-        .tcx()
-        .def_ident_span(wkvid.parent_fn)
-        .unwrap_or_else(|| genv.tcx().def_span(wkvid.parent_fn));
+    let pretty_solution = solution.map_ref(|e| e.simplify(&Default::default()).prettify());
     let fn_sig = genv.fn_sig(wkvid.parent_fn).unwrap();
     let mut wkvar_subst = WKVarSubst::new([(wkvid.clone(), pretty_solution)].into(), false);
     let solved_fn_sig = EarlyBinder(fn_sig.skip_binder_ref().fold_with(&mut wkvar_subst));

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -33,7 +33,7 @@ use checker::{Checker, trait_impl_subtyping};
 use flux_common::{dbg, dbg::SpanTrace, result::ResultExt as _};
 use flux_config as config;
 use flux_infer::{
-    fixpoint_encoding::{FixQueryCache, SolutionTrace},
+    fixpoint_encoding::{FixQueryCache, FixpointCheckError, SolutionTrace},
     infer::{ConstrReason, SubtypeReason, Tag},
 };
 use flux_macros::fluent_messages;
@@ -53,10 +53,10 @@ use crate::{checker::errors::ResultExt as _, ghost_statements::compute_ghost_sta
 
 fluent_messages! { "../locales/en-US.ftl" }
 
-fn report_fixpoint_errors(
+pub fn report_fixpoint_errors(
     genv: GlobalEnv,
     local_id: LocalDefId,
-    errors: Vec<Tag>,
+    errors: Vec<FixpointCheckError<Tag>>,
 ) -> Result<(), ErrorGuaranteed> {
     #[expect(clippy::collapsible_else_if, reason = "it looks better")]
     if genv.should_fail(local_id) {
@@ -205,19 +205,22 @@ fn ret_error(genv: GlobalEnv, span: Span, dst_span: Option<ESpan>) -> ErrorGuara
         .emit_err(errors::RefineError::ret(span, dst_span))
 }
 
-fn report_errors(genv: GlobalEnv, errors: Vec<Tag>) -> Result<(), ErrorGuaranteed> {
+fn report_errors(
+    genv: GlobalEnv,
+    errors: Vec<FixpointCheckError<Tag>>,
+) -> Result<(), ErrorGuaranteed> {
     let mut e = None;
     for err in errors {
-        let span = err.src_span;
-        e = Some(match err.reason {
+        let span = err.tag.src_span;
+        e = Some(match err.tag.reason {
             ConstrReason::Call
             | ConstrReason::Subtype(SubtypeReason::Input)
             | ConstrReason::Subtype(SubtypeReason::Requires)
-            | ConstrReason::Predicate => call_error(genv, span, err.dst_span),
+            | ConstrReason::Predicate => call_error(genv, span, err.tag.dst_span),
             ConstrReason::Assign => genv.sess().emit_err(errors::AssignError { span }),
             ConstrReason::Ret
             | ConstrReason::Subtype(SubtypeReason::Output)
-            | ConstrReason::Subtype(SubtypeReason::Ensures) => ret_error(genv, span, err.dst_span),
+            | ConstrReason::Subtype(SubtypeReason::Ensures) => ret_error(genv, span, err.tag.dst_span),
             ConstrReason::Div => genv.sess().emit_err(errors::DivError { span }),
             ConstrReason::Rem => genv.sess().emit_err(errors::RemError { span }),
             ConstrReason::Goto(_) => genv.sess().emit_err(errors::GotoError { span }),

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -33,7 +33,7 @@ use checker::{Checker, trait_impl_subtyping};
 use flux_common::{dbg, dbg::SpanTrace, result::ResultExt as _};
 use flux_config as config;
 use flux_infer::{
-    fixpoint_encoding::{FixQueryCache, FixpointCheckError, SolutionTrace},
+    fixpoint_encoding::{FixQueryCache, FixpointCheckError, PossibleSolutions, SolutionTrace},
     infer::{ConstrReason, SubtypeReason, Tag},
     wkvars::WKVarSubst,
 };
@@ -46,7 +46,7 @@ use flux_middle::{
     pretty,
     rty::{self, ESpan, EarlyBinder, fold::TypeFoldable},
 };
-use rustc_data_structures::unord::UnordMap;
+use rustc_data_structures::{fx::FxHashMap, unord::UnordMap};
 use rustc_errors::{Applicability, Diag, ErrorGuaranteed};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_span::Span;
@@ -215,14 +215,22 @@ fn report_errors(
     genv: GlobalEnv,
     errors: Vec<FixpointCheckError<Tag>>,
 ) -> Result<(), ErrorGuaranteed> {
+    let mut solutions_by_tag: FxHashMap<Tag, PossibleSolutions> = FxHashMap::default();
+    for error in errors {
+        if let Some(val) = solutions_by_tag.get_mut(&error.tag) {
+            val.extend(error.possible_solutions);
+        } else {
+            solutions_by_tag.insert(error.tag, error.possible_solutions);
+        }
+    }
     let mut e = None;
-    for err in errors {
-        let span = err.tag.src_span;
-        let mut err_diag = match err.tag.reason {
+    for (tag, possible_solutions) in solutions_by_tag {
+        let span = tag.src_span;
+        let mut err_diag = match tag.reason {
             ConstrReason::Call
             | ConstrReason::Subtype(SubtypeReason::Input)
             | ConstrReason::Subtype(SubtypeReason::Requires)
-            | ConstrReason::Predicate => call_error(genv, span, err.tag.dst_span),
+            | ConstrReason::Predicate => call_error(genv, span, tag.dst_span),
             ConstrReason::Assign => {
                 genv.sess()
                     .dcx()
@@ -231,9 +239,7 @@ fn report_errors(
             }
             ConstrReason::Ret
             | ConstrReason::Subtype(SubtypeReason::Output)
-            | ConstrReason::Subtype(SubtypeReason::Ensures) => {
-                ret_error(genv, span, err.tag.dst_span)
-            }
+            | ConstrReason::Subtype(SubtypeReason::Ensures) => ret_error(genv, span, tag.dst_span),
             ConstrReason::Div => {
                 genv.sess()
                     .dcx()
@@ -289,8 +295,7 @@ fn report_errors(
                 })
             }
         };
-        let wkvar_solutions = err
-            .possible_solutions
+        let wkvar_solutions = possible_solutions
             .iter()
             .flat_map(|(wkvid, solutions)| solutions.iter().map(move |solution| (wkvid, solution)));
 

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -35,6 +35,7 @@ use flux_config as config;
 use flux_infer::{
     fixpoint_encoding::{FixQueryCache, FixpointCheckError, SolutionTrace},
     infer::{ConstrReason, SubtypeReason, Tag},
+    wkvars::WKVarSubst,
 };
 use flux_macros::fluent_messages;
 use flux_middle::{
@@ -42,11 +43,12 @@ use flux_middle::{
     def_id::MaybeExternId,
     global_env::GlobalEnv,
     metrics::{self, Metric, TimingKind},
-    rty::{self, ESpan},
+    pretty,
+    rty::{self, ESpan, EarlyBinder, fold::TypeFoldable},
 };
 use rustc_data_structures::unord::UnordMap;
-use rustc_errors::ErrorGuaranteed;
-use rustc_hir::def_id::LocalDefId;
+use rustc_errors::{Applicability, Diag, ErrorGuaranteed};
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_span::Span;
 
 use crate::{checker::errors::ResultExt as _, ghost_statements::compute_ghost_statements};
@@ -195,14 +197,18 @@ pub fn check_fn(
     dbg::check_fn_span!(genv.tcx(), def_id).in_scope(|| Ok(()))
 }
 
-fn call_error(genv: GlobalEnv, span: Span, dst_span: Option<ESpan>) -> ErrorGuaranteed {
+fn call_error<'a>(genv: GlobalEnv<'a, '_>, span: Span, dst_span: Option<ESpan>) -> Diag<'a> {
     genv.sess()
-        .emit_err(errors::RefineError::call(span, dst_span))
+        .dcx()
+        .handle()
+        .create_err(errors::RefineError::call(span, dst_span))
 }
 
-fn ret_error(genv: GlobalEnv, span: Span, dst_span: Option<ESpan>) -> ErrorGuaranteed {
+fn ret_error<'a>(genv: GlobalEnv<'a, '_>, span: Span, dst_span: Option<ESpan>) -> Diag<'a> {
     genv.sess()
-        .emit_err(errors::RefineError::ret(span, dst_span))
+        .dcx()
+        .handle()
+        .create_err(errors::RefineError::ret(span, dst_span))
 }
 
 fn report_errors(
@@ -212,32 +218,87 @@ fn report_errors(
     let mut e = None;
     for err in errors {
         let span = err.tag.src_span;
-        e = Some(match err.tag.reason {
+        let mut err_diag = match err.tag.reason {
             ConstrReason::Call
             | ConstrReason::Subtype(SubtypeReason::Input)
             | ConstrReason::Subtype(SubtypeReason::Requires)
             | ConstrReason::Predicate => call_error(genv, span, err.tag.dst_span),
-            ConstrReason::Assign => genv.sess().emit_err(errors::AssignError { span }),
+            ConstrReason::Assign => {
+                genv.sess()
+                    .dcx()
+                    .handle()
+                    .create_err(errors::AssignError { span })
+            }
             ConstrReason::Ret
             | ConstrReason::Subtype(SubtypeReason::Output)
-            | ConstrReason::Subtype(SubtypeReason::Ensures) => ret_error(genv, span, err.tag.dst_span),
-            ConstrReason::Div => genv.sess().emit_err(errors::DivError { span }),
-            ConstrReason::Rem => genv.sess().emit_err(errors::RemError { span }),
-            ConstrReason::Goto(_) => genv.sess().emit_err(errors::GotoError { span }),
-            ConstrReason::Assert(msg) => genv.sess().emit_err(errors::AssertError { span, msg }),
-            ConstrReason::Fold | ConstrReason::FoldLocal => {
-                genv.sess().emit_err(errors::FoldError { span })
+            | ConstrReason::Subtype(SubtypeReason::Ensures) => {
+                ret_error(genv, span, err.tag.dst_span)
             }
-            ConstrReason::Overflow => genv.sess().emit_err(errors::OverflowError { span }),
-            ConstrReason::Underflow => genv.sess().emit_err(errors::UnderflowError { span }),
-            ConstrReason::Other => genv.sess().emit_err(errors::UnknownError { span }),
+            ConstrReason::Div => {
+                genv.sess()
+                    .dcx()
+                    .handle()
+                    .create_err(errors::DivError { span })
+            }
+            ConstrReason::Rem => {
+                genv.sess()
+                    .dcx()
+                    .handle()
+                    .create_err(errors::RemError { span })
+            }
+            ConstrReason::Goto(_) => {
+                genv.sess()
+                    .dcx()
+                    .handle()
+                    .create_err(errors::GotoError { span })
+            }
+            ConstrReason::Assert(msg) => {
+                genv.sess()
+                    .dcx()
+                    .handle()
+                    .create_err(errors::AssertError { span, msg })
+            }
+            ConstrReason::Fold | ConstrReason::FoldLocal => {
+                genv.sess()
+                    .dcx()
+                    .handle()
+                    .create_err(errors::FoldError { span })
+            }
+            ConstrReason::Overflow => {
+                genv.sess()
+                    .dcx()
+                    .handle()
+                    .create_err(errors::OverflowError { span })
+            }
+            ConstrReason::Other => {
+                genv.sess()
+                    .dcx()
+                    .handle()
+                    .create_err(errors::UnknownError { span })
+            }
+            ConstrReason::Underflow => {
+                genv.sess()
+                    .dcx()
+                    .handle()
+                    .create_err(errors::UnderflowError { span })
+            }
             ConstrReason::NoPanic(callee) => {
-                genv.sess().emit_err(errors::PanicError {
+                genv.sess().dcx().handle().create_err(errors::PanicError {
                     span,
                     callee: genv.tcx().def_path_debug_str(callee),
                 })
             }
-        });
+        };
+        let wkvar_solutions = err
+            .possible_solutions
+            .iter()
+            .flat_map(|(wkvid, solutions)| solutions.iter().map(move |solution| (wkvid, solution)));
+
+        for (wkvid, solution) in wkvar_solutions {
+            add_fn_fix_diagnostic(genv, &mut err_diag, wkvid.clone(), solution);
+        }
+
+        e = Some(err_diag.emit());
     }
 
     if let Some(e) = e { Err(e) } else { Ok(()) }
@@ -248,6 +309,57 @@ fn report_expected_neg(genv: GlobalEnv, def_id: LocalDefId) -> Result<(), ErrorG
         span: genv.tcx().def_span(def_id),
         def_descr: genv.tcx().def_descr(def_id.to_def_id()),
     }))
+}
+
+fn add_fn_fix_diagnostic<'a>(
+    genv: GlobalEnv<'a, '_>,
+    diag: &mut Diag<'a>,
+    wkvid: rty::WKVid,
+    solution: &rty::Binder<rty::Expr>,
+) {
+    let pretty_solution = solution.map_ref(|e| e.simplify(&Default::default()));
+    let fn_name = genv.tcx().def_path_str(wkvid.0);
+    let fn_span = genv
+        .tcx()
+        .def_ident_span(wkvid.parent_fn)
+        .unwrap_or_else(|| genv.tcx().def_span(wkvid.parent_fn));
+    let fn_sig = genv.fn_sig(wkvid.parent_fn).unwrap();
+    let mut wkvar_subst = WKVarSubst::new([(wkvid.clone(), pretty_solution)].into(), false);
+    let solved_fn_sig = EarlyBinder(fn_sig.skip_binder_ref().fold_with(&mut wkvar_subst));
+    let fixed_fn_sig_snippet = format!(
+        "{:?}",
+        pretty::with_cx!(&pretty::PrettyCx::default(genv).hide_regions(true), &solved_fn_sig)
+    );
+    let fn_first_line = fn_first_line(genv, wkvid.parent_fn);
+    let fn_first_line_snippet = genv
+        .tcx()
+        .sess
+        .source_map()
+        .span_to_snippet(fn_first_line)
+        .unwrap_or_else(|_| panic!("No snippet for span {:?}", fn_first_line));
+    let prefix_spaces = &fn_first_line_snippet[..fn_first_line_snippet
+        .find(|c: char| !c.is_whitespace())
+        .unwrap_or(fn_first_line_snippet.len())];
+    let subst_solutions = &wkvar_subst.subst_instantiations[&wkvid];
+    assert!(subst_solutions.len() == 1);
+    diag.span_suggestion(
+        fn_first_line,
+        "try adding the refinement",
+        format!("{}#[sig({})]\n{}", prefix_spaces, fixed_fn_sig_snippet, fn_first_line_snippet),
+        Applicability::MaybeIncorrect,
+    );
+}
+
+fn fn_first_line<'a>(genv: GlobalEnv<'a, '_>, def_id: DefId) -> Span {
+    let span = genv.tcx().def_span(def_id);
+    let first_line = genv
+        .tcx()
+        .sess
+        .source_map()
+        .lookup_line(span.lo())
+        .unwrap_or_else(|_| panic!("span for {:?} doesn't have a first line", def_id));
+    let first_line_range = first_line.sf.line_bounds(first_line.line);
+    Span::new(first_line_range.start, first_line_range.end, span.ctxt(), None)
 }
 
 mod errors {

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -640,6 +640,8 @@ pub enum Attr {
     InferOpts(PartialInferOpts),
     /// A `#[no_panic]` attribute
     NoPanic,
+    /// A `#[no_suggestions]` attribute
+    NoSuggestions,
 }
 
 #[derive(Debug)]

--- a/lib/flux-alloc/flux.toml
+++ b/lib/flux-alloc/flux.toml
@@ -1,0 +1,1 @@
+no_suggestions = true

--- a/lib/flux-alloc/src/lib.rs
+++ b/lib/flux-alloc/src/lib.rs
@@ -1,5 +1,6 @@
 // #![no_std]
 #![cfg_attr(flux, feature(allocator_api))]
+#![cfg_attr(flux, flux::no_suggestions)]
 
 #[cfg(flux)]
 pub mod slice;

--- a/lib/flux-attrs-impl/src/lib.rs
+++ b/lib/flux-attrs-impl/src/lib.rs
@@ -25,6 +25,7 @@ pub const FLUX_ATTRS: &[&str] = &[
     "opts",
     "reft",
     "no_panic",
+    "no_suggestions",
 ];
 
 pub fn extern_spec(attr: TokenStream, tokens: TokenStream) -> TokenStream {

--- a/lib/flux-attrs/src/lib.rs
+++ b/lib/flux-attrs/src/lib.rs
@@ -125,6 +125,11 @@ pub fn no_panic_if(attrs: TokenStream, tokens: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn no_suggestions(attrs: TokenStream, tokens: TokenStream) -> TokenStream {
+    attr_impl::no_suggestions(attrs, tokens)
+}
+
+#[proc_macro_attribute]
 pub fn reft(attrs: TokenStream, tokens: TokenStream) -> TokenStream {
     attr_impl::reft(attrs, tokens)
 }
@@ -177,6 +182,7 @@ mod attr_sysroot {
         reft,
         no_panic,
         no_panic_if,
+        no_suggestions,
     );
 }
 
@@ -227,6 +233,7 @@ mod attr_dummy {
         should_fail,
         no_panic,
         no_panic_if,
+        no_suggestions,
         reft,
     );
 }

--- a/lib/flux-core/flux.toml
+++ b/lib/flux-core/flux.toml
@@ -1,0 +1,1 @@
+no_suggestions = true

--- a/lib/flux-core/src/lib.rs
+++ b/lib/flux-core/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![cfg_attr(flux, feature(step_trait))]
 #![cfg_attr(flux, feature(sized_hierarchy))]
+#![cfg_attr(flux, flux::no_suggestions)]
 
 mod iter;
 mod ops;

--- a/lib/flux-rs/flux.toml
+++ b/lib/flux-rs/flux.toml
@@ -1,0 +1,1 @@
+no_suggestions = true

--- a/lib/flux-rs/src/lib.rs
+++ b/lib/flux-rs/src/lib.rs
@@ -1,12 +1,15 @@
 #![no_std]
+#[cfg_attr(flux, flux::no_suggestions)]
 pub mod bitvec;
 
 pub use attrs::*;
 pub use flux_attrs as attrs;
 
+#[no_suggestions]
 #[sig(fn(bool[true]) )]
 pub fn assert(_: bool) {}
 
+#[no_suggestions]
 #[sig (fn() -> _ requires false)]
 pub fn unreachable() -> ! {
     unreachable!("impossible case")

--- a/lib/liquid-fixpoint/Cargo.toml
+++ b/lib/liquid-fixpoint/Cargo.toml
@@ -7,16 +7,16 @@ version = "0.1.0"
 
 [dependencies]
 derive-where = "1.2.7"
-indexmap = "2.12.0"
+# indexmap = "2.12.0"
 itertools = "0.14.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-z3 = { version = "0.18.1", optional = true }
+z3 = { version = "0.18.1" }
 
 [features]
 default = []
 # Enable Z3 SMT solver integration for constraint satisfiability checking (optional)
-rust-fixpoint = ["dep:z3"]
+rust-fixpoint = [] # ["dep:z3"]
 nightly = []
 
 [lints]

--- a/lib/liquid-fixpoint/Cargo.toml
+++ b/lib/liquid-fixpoint/Cargo.toml
@@ -11,12 +11,13 @@ derive-where = "1.2.7"
 itertools = "0.14.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-z3 = { version = "0.18.1" }
+z3 = { version = "0.18.1", optional = true }
 
 [features]
 default = []
 # Enable Z3 SMT solver integration for constraint satisfiability checking (optional)
-rust-fixpoint = [] # ["dep:z3"]
+rust-fixpoint = ["dep:z3"]
+wick = ["dep:z3"]
 nightly = []
 
 [lints]

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -4,9 +4,10 @@ use std::{
 };
 
 use derive_where::derive_where;
-use indexmap::IndexSet;
+use itertools::Itertools;
+use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 
-use crate::{ThyFunc, Types};
+use crate::{ConstDecl, ThyFunc, Types};
 
 #[derive_where(Hash, Clone, Debug)]
 pub struct Bind<T: Types> {
@@ -74,6 +75,251 @@ impl<T: Types> Constraint<T> {
         go(self, &mut count);
         count
     }
+
+    /// Flattens a single constraint into a list of individual constraints which
+    /// may be checked for satisfiability.
+    ///
+    /// NOTE: Assumes and requires that all binder names are unique, i.e.
+    /// there is no shadowing (it is OK to have multiple binders of the same
+    /// name so long as they never are used, e.g. UNDERSCORE).
+    pub fn flatten<F1>(&self, is_underscore: F1) -> Vec<FlatConstraint<T>>
+    where
+        F1: Copy + Fn(&T::Var) -> bool,
+    {
+        match self {
+            Constraint::Pred(pred, tag) => {
+                vec![FlatConstraint {
+                    binders: vec![],
+                    assumptions: Default::default(),
+                    head: pred.clone(),
+                    tag: tag.clone(),
+                }]
+            }
+            Constraint::Conj(constrs) => {
+                constrs
+                    .iter()
+                    .flat_map(|constr| constr.flatten(is_underscore))
+                    .collect_vec()
+            }
+            Constraint::ForAll(bind, constr) => {
+                let mut flat_constrs = constr.flatten(is_underscore);
+                for constr in &mut flat_constrs {
+                    if !is_underscore(&bind.name) {
+                        constr.binders.push((bind.name.clone(), bind.sort.clone()));
+                    }
+                    constr.add_assumption(bind.pred.clone());
+                    // if is_invariant(&bind.name) {
+                    //     constr.add_invariant(bind.pred.clone());
+                    // } else {
+                    //     constr.add_assumption(bind.pred.clone());
+                    // }
+                }
+                flat_constrs
+            }
+        }
+    }
+}
+
+pub type WKVarAndConstrs<T> = (WKVar<T>, FlatConstraint<T>, Vec<FlatConstraint<T>>);
+pub type VarSorts<T> = (<T as Types>::Var, Sort<T>);
+
+#[derive_where(Clone, Debug)]
+pub struct FlatConstraint<T: Types> {
+    /// All of the binders that come before the head.
+    ///
+    /// NOTE: There should be no duplicates among the binders which are used (so
+    /// e.g. UNDERSCORE appearing multiple times is OK).
+    pub binders: Vec<(T::Var, Sort<T>)>,
+    /// All of the assumptions (i.e. a flattened conjunction of predicates from
+    /// all of the binders)
+    pub assumptions: FxIndexSet<Pred<T>>,
+    pub head: Pred<T>,
+    #[derive_where(skip)]
+    pub tag: Option<T::Tag>,
+}
+
+impl<T: Types> FlatConstraint<T> {
+    /// Removes any binder corresponding to a given var. Returns the new
+    /// constraint along with the removed binders and their sorts.
+    ///
+    /// NOTE: Assumes that all binders are unique and therefore there are no
+    /// name clashes.
+    pub fn remove_binders(&self, vars: &HashSet<T::Var>) -> (Vec<ConstDecl<T>>, FlatConstraint<T>) {
+        let mut new_binders = self.binders.clone();
+        let removed_binders = new_binders
+            .extract_if(.., |(var, _sort)| vars.contains(var))
+            .map(|(var, sort)| ConstDecl { name: var, sort, comment: None })
+            .collect_vec();
+        let new_constraint = FlatConstraint {
+            binders: new_binders,
+            assumptions: self.assumptions.clone(),
+            head: self.head.clone(),
+            tag: self.tag.clone(),
+        };
+        (removed_binders, new_constraint)
+    }
+
+    pub fn add_assumption(&mut self, assumption: Pred<T>) {
+        match assumption {
+            Pred::And(conjs) => {
+                self.assumptions
+                    .extend(conjs.iter().flat_map(|conj| conj.as_conjunction()));
+            }
+            a @ Pred::KVar(_, _) => {
+                self.assumptions.insert(a);
+            }
+            Pred::Expr(e) => {
+                self.assumptions
+                    .extend(e.as_conjunction().into_iter().map(|e| Pred::Expr(e)));
+            }
+        }
+    }
+
+    pub fn preconditions(&self) -> FxIndexSet<Pred<T>> {
+        // If we add invariants, this becomes the union of both invariatns and
+        // assumptions
+        self.assumptions.clone()
+    }
+
+    /// Each element of the output is a wkvar, the constraint it corresponds to,
+    /// and the other constraints which must also hold.
+    ///
+    /// We essentially "decompose" each assumption which contains a wkvar in
+    /// order to transform the constraint into one in which that wkvar is
+    /// exposed.
+    ///
+    /// These decompositions are of two forms.
+    /// 1. Hoisting existentials to the top level.
+    /// 2. Splitting disjuncts using the below property. When we split a
+    ///    disjunct, we generate other constraints. A more sophisticated
+    ///    analysis might try and solve multiple constraints simultaneously; if
+    ///    we were to do this, we would probably want to change how this
+    ///    algorithm works to avoid redundancy, e.g. by instead of generating
+    ///    ((wkvar, constr, other_constrs) outputs generating (all_constrs)
+    ///    outputs and letting consumers choose which wkvars to solve in each
+    ///    constr.
+    ///
+    /// ```
+    /// (p || q) => c
+    /// ==
+    /// (p => c) && (q => c)
+    /// ```
+    pub fn wkvars_and_constrs(&self) -> Vec<WKVarAndConstrs<T>>
+where {
+        let mut wkvars_and_constraints = self
+            .assumptions
+            .iter()
+            .flat_map(|assumption| {
+                assumption
+                    .wkvars_in_conj()
+                    .into_iter()
+                    .map(|wkvar| (wkvar, self.clone(), vec![]))
+            })
+            .collect_vec();
+        // Frontier elements:
+        //   (current assumption, current constraint, other constraints)
+        let mut frontier: Vec<_> = self
+            .assumptions
+            .iter()
+            .enumerate()
+            .filter_map(|(i, assumption)| {
+                if let Pred::Expr(assumption_expr) = assumption
+                    && assumption_expr.has_wkvar_reachable_by_split()
+                {
+                    let mut flat_constraint = self.clone();
+                    flat_constraint.assumptions.shift_remove_index(i);
+                    Some((assumption_expr.clone(), flat_constraint, vec![]))
+                } else {
+                    None
+                }
+            })
+            .collect_vec();
+        while let Some((e, mut constr, other_constrs)) = frontier.pop() {
+            match e {
+                // Base case: we reached a wkvar.
+                //   Record it alongside the constraint it is associated with
+                //   and the other constraints.
+                //
+                // NOTE: we don't need wkvars_in_conj because we explicitly
+                //       handle the And.
+                Expr::WKVar(wkvar) => {
+                    // NOTE: Technically this isn't necessary, so we don't add
+                    // the wkvar back to the assumptions. But for completeness
+                    // we might want to.
+                    //
+                    // constr.add_assumption(Pred::Expr(e));
+                    wkvars_and_constraints.push((wkvar, constr, other_constrs));
+                }
+                // In the And case, we add to the frontier each expression that
+                // is a wkvar or can reach a wkvar; whenever we do so, we also
+                // take all of the other expressions in the And and put them
+                // into the current constr's assumptions.
+                //
+                // We do this kind of annoying filter rather than just adding
+                // everything because it prevents us from cloning a bunch.
+                Expr::And(conjs) => {
+                    for (i, new_assumption) in conjs.iter().enumerate() {
+                        if !(matches!(new_assumption, Expr::WKVar(..))
+                            || new_assumption.has_wkvar_reachable_by_split())
+                        {
+                            continue;
+                        }
+                        let mut new_constr = constr.clone();
+                        for (j, other_new_assumption) in conjs.iter().enumerate() {
+                            if i == j {
+                                continue;
+                            }
+                            new_constr.add_assumption(Pred::Expr(other_new_assumption.clone()));
+                        }
+                        frontier.push((new_assumption.clone(), new_constr, other_constrs.clone()));
+                    }
+                }
+                // Hoist the exists and add it to the frontier.
+                //
+                // We assume that there is a wkvar reachable here, so we don't check.
+                Expr::Exists(_, _) => {
+                    let (new_vars, hoisted_e) = e.hoist_exists();
+                    constr.binders.extend(new_vars);
+                    frontier.push((hoisted_e, constr, other_constrs));
+                }
+                // This is where things get kind of complicated.
+                //
+                // Morally speaking what we are doing is translating the constraint
+                //     (disjunct1 || disjunct2 || ...) => constr
+                // into multiple constraints
+                //     disjunct1 => constr
+                //     disjunct2 => constr
+                //     ...
+                // but our frontier looks like
+                //     (current assumption, constr without that assumption, other constrs we're no longer looking at)
+                // So if there are N disjuncts, we'll push N items to the frontier:
+                //     (disjunct1, constr, (disjunct2 => constr) + (disjunct3 => constr) + ... + other_constrs)
+                // Except the same optimization applies where we won't consider a case where the disjunct
+                // has no wkvars in it.
+                Expr::Or(disjuncts) => {
+                    for (i, disjunct) in disjuncts.iter().enumerate() {
+                        if !(matches!(disjunct, Expr::WKVar(..))
+                            || disjunct.has_wkvar_reachable_by_split())
+                        {
+                            continue;
+                        }
+                        let mut new_other_constrs = other_constrs.clone();
+                        for (j, other_disjunct) in disjuncts.iter().enumerate() {
+                            if i == j {
+                                continue;
+                            }
+                            let mut new_other_constr = constr.clone();
+                            new_other_constr.add_assumption(Pred::Expr(other_disjunct.clone()));
+                            new_other_constrs.push(new_other_constr);
+                        }
+                        frontier.push((disjunct.clone(), constr.clone(), new_other_constrs));
+                    }
+                }
+                _ => {}
+            }
+        }
+        wkvars_and_constraints
+    }
 }
 
 #[derive_where(Hash, Clone, Debug)]
@@ -111,7 +357,7 @@ pub struct DataField<T: Types> {
     pub sort: Sort<T>,
 }
 
-#[derive_where(Hash, Clone, Debug)]
+#[derive_where(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum Sort<T: Types> {
     Int,
     Bool,
@@ -229,14 +475,14 @@ impl<T: Types> FunSort<T> {
     }
 }
 
-#[derive_where(Hash, Clone, Debug)]
+#[derive_where(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum SortCtor<T: Types> {
     Set,
     Map,
     Data(T::Sort),
 }
 
-#[derive_where(Hash, Clone, Debug)]
+#[derive_where(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum Pred<T: Types> {
     And(Vec<Self>),
     KVar(T::KVar, Vec<Expr<T>>),
@@ -259,6 +505,7 @@ impl<T: Types> Pred<T> {
     pub fn is_trivially_true(&self) -> bool {
         match self {
             Pred::Expr(Expr::Constant(Constant::Boolean(true))) => true,
+            // FIXME: We do substitue true for wkvars, but is this correct?
             Pred::And(ps) => ps.is_empty(),
             _ => false,
         }
@@ -284,6 +531,54 @@ impl<T: Types> Pred<T> {
             }
         }
     }
+
+    /// Returns a Vec of Preds whose conjunction is equal to the original Pred.
+    ///
+    /// This trusts that Pred::Expr(BinOp(BinOp::And, ...) is not possible ---
+    /// i.e. Preds are always converted to Pred::And if possible.
+    pub fn as_conjunction(&self) -> Vec<Self> {
+        match self {
+            Pred::And(conjs) => {
+                conjs
+                    .iter()
+                    .flat_map(|conj| conj.as_conjunction())
+                    .collect()
+            }
+            _ => vec![self.clone()],
+        }
+    }
+
+    pub fn has_kvar(&self) -> bool {
+        match self {
+            Pred::KVar(..) => true,
+            Pred::And(preds) => preds.iter().any(|pred| pred.has_kvar()),
+            _ => false,
+        }
+    }
+
+    // Give all the weak kvars that appear as part of a top-level conjunction.
+    // This is a syntactic analysis.
+    pub fn wkvars_in_conj(&self) -> Vec<WKVar<T>> {
+        match self {
+            Pred::And(preds) => {
+                preds
+                    .iter()
+                    .flat_map(|pred| pred.wkvars_in_conj())
+                    .collect()
+            }
+            Pred::Expr(e) => e.wkvars_in_conj(),
+            Pred::KVar(..) => vec![],
+        }
+    }
+
+    /// Remove all wkvars, replacing them with true.
+    pub fn strip_wkvars(&self) -> Self {
+        match self {
+            Pred::And(preds) => Pred::And(preds.iter().map(|pred| pred.strip_wkvars()).collect()),
+            Pred::Expr(e) => Pred::Expr(e.strip_wkvars()),
+            Pred::KVar(..) => self.clone(),
+        }
+    }
 }
 
 #[derive(Hash, Debug, Copy, Clone, PartialEq, Eq)]
@@ -300,25 +595,13 @@ impl BinRel {
     pub const INEQUALITIES: [BinRel; 4] = [BinRel::Gt, BinRel::Ge, BinRel::Lt, BinRel::Le];
 }
 
-#[derive(Hash, Debug, Copy, Clone, PartialEq, Eq)]
-pub struct BoundVar {
-    pub level: usize,
-    pub idx: usize,
-}
-
-impl BoundVar {
-    pub fn new(level: usize, idx: usize) -> Self {
-        Self { level, idx }
-    }
-}
-
-#[derive_where(Hash, Debug, Clone)]
+#[derive_where(PartialEq, Eq, Hash, Debug, Clone)]
 pub struct WKVar<T: Types> {
     pub wkvid: T::Var,
     pub args: Vec<Expr<T>>,
 }
 
-#[derive_where(Hash, Clone, Debug)]
+#[derive_where(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum Expr<T: Types> {
     Constant(Constant<T>),
     Var(T::Var),
@@ -351,6 +634,9 @@ impl<T: Types> From<Constant<T>> for Expr<T> {
 }
 
 impl<T: Types> Expr<T> {
+    pub const FALSE: Self = Expr::Constant(Constant::Boolean(false));
+    pub const TRUE: Self = Expr::Constant(Constant::Boolean(true));
+
     pub const fn int(val: u128) -> Expr<T> {
         Expr::Constant(Constant::Numeral(val))
     }
@@ -422,8 +708,8 @@ impl<T: Types> Expr<T> {
         }
     }
 
-    pub fn free_vars(&self) -> IndexSet<T::Var> {
-        let mut vars = IndexSet::new();
+    pub fn free_vars(&self) -> FxIndexSet<T::Var> {
+        let mut vars = FxIndexSet::default();
         match self {
             Expr::Constant(_) | Expr::ThyFunc(_) => {}
             Expr::Var(x) => {
@@ -552,9 +838,213 @@ impl<T: Types> Expr<T> {
             }
         }
     }
+
+    // Give all the weak kvars that appear as part of a top-level conjunction.
+    // This is a syntactic analysis.
+    pub fn wkvars_in_conj(&self) -> Vec<WKVar<T>> {
+        match self {
+            Expr::WKVar(wkvar) => vec![wkvar.clone()],
+            Expr::And(conj) => conj.iter().flat_map(|e| e.wkvars_in_conj()).collect(),
+            _ => vec![],
+        }
+    }
+
+    pub fn uncurry(&self) -> Self {
+        match self {
+            Expr::App(head, sort_args, args, out_sort) => {
+                let uncurried_head = head.uncurry();
+                let uncurried_args = args.iter().map(|arg| arg.uncurry()).collect_vec();
+                match uncurried_head {
+                    Expr::App(head_head, head_sort_args, mut head_args, _) => {
+                        head_args.extend(uncurried_args);
+                        let new_sort_args = match (head_sort_args, sort_args) {
+                            (Some(mut head_sort_args), Some(sort_args)) => {
+                                head_sort_args.extend(sort_args.clone());
+                                Some(head_sort_args)
+                            }
+                            _ => None,
+                        };
+                        Expr::App(head_head, new_sort_args, head_args, out_sort.clone())
+                    }
+                    Expr::WKVar(WKVar { wkvid, args: mut wkvar_args }) => {
+                        wkvar_args.extend(uncurried_args);
+                        Expr::WKVar(WKVar { wkvid, args: wkvar_args })
+                    }
+                    _ => {
+                        Expr::App(
+                            Box::new(uncurried_head),
+                            sort_args.clone(),
+                            uncurried_args,
+                            out_sort.clone(),
+                        )
+                    }
+                }
+            }
+            Expr::Constant(_) | Expr::Var(_) | Expr::ThyFunc(_) => self.clone(),
+            Expr::Neg(expr) => Expr::Neg(Box::new(expr.uncurry())),
+            Expr::BinaryOp(bin_op, args) => {
+                Expr::BinaryOp(*bin_op, Box::new([args[0].uncurry(), args[1].uncurry()]))
+            }
+            Expr::IfThenElse(args) => {
+                Expr::IfThenElse(Box::new([
+                    args[0].uncurry(),
+                    args[1].uncurry(),
+                    args[2].uncurry(),
+                ]))
+            }
+            Expr::And(exprs) => Expr::And(exprs.iter().map(|e| e.uncurry()).collect_vec()),
+            Expr::Or(exprs) => Expr::Or(exprs.iter().map(|e| e.uncurry()).collect_vec()),
+            Expr::Not(expr) => Expr::Not(Box::new(expr.uncurry())),
+            Expr::Imp(args) => Expr::Imp(Box::new([args[0].uncurry(), args[1].uncurry()])),
+            Expr::Iff(args) => Expr::Iff(Box::new([args[0].uncurry(), args[1].uncurry()])),
+            Expr::Atom(bin_rel, args) => {
+                Expr::Atom(*bin_rel, Box::new([args[0].uncurry(), args[1].uncurry()]))
+            }
+            Expr::Let(var, args) => {
+                Expr::Let(var.clone(), Box::new([args[0].uncurry(), args[1].uncurry()]))
+            }
+            Expr::IsCtor(var, expr) => Expr::IsCtor(var.clone(), Box::new(expr.uncurry())),
+            Expr::Exists(sorts, expr) => Expr::Exists(sorts.clone(), Box::new(expr.uncurry())),
+            Expr::WKVar(WKVar { wkvid, args }) => {
+                Expr::WKVar(WKVar {
+                    wkvid: wkvid.clone(),
+                    args: args.iter().map(|e| e.uncurry()).collect_vec(),
+                })
+            }
+        }
+    }
+
+    /// Are there any weak kvars that are
+    ///
+    /// 1. Behind an exists
+    /// 2. In a disjunction
+    ///
+    /// which if we removed either (or both),
+    /// we would be able to access.
+    ///
+    /// Maybe the correct solution is to hoist all exists
+    /// that we can and _then_ check for reachable weak kvars.
+    pub fn has_wkvar_reachable_by_split(&self) -> bool {
+        if !matches!(self, Expr::Exists(..) | Expr::Or(..) | Expr::And(..)) {
+            return false;
+        }
+        match self {
+            Expr::Or(exprs) => {
+                exprs.iter().any(|expr| {
+                    matches!(expr, Expr::WKVar(..)) || expr.has_wkvar_reachable_by_split()
+                })
+            }
+            Expr::Exists(_sorts, expr) => {
+                !expr.wkvars_in_conj().is_empty() || expr.has_wkvar_reachable_by_split()
+            }
+            Expr::And(exprs) => exprs.iter().any(|expr| expr.has_wkvar_reachable_by_split()),
+            _ => false,
+        }
+    }
+
+    pub fn hoist_exists(&self) -> (Vec<VarSorts<T>>, Expr<T>)
+where {
+        match self {
+            Expr::Exists(var_sorts, inner_e) => {
+                let mut vs = var_sorts.clone();
+                let (new_vs, hoisted_inner) = inner_e.hoist_exists();
+                vs.extend(new_vs);
+                (vs, hoisted_inner)
+            }
+            Expr::And(exprs) => {
+                let mut vars = vec![];
+                let hoisted_e = Expr::And(
+                    exprs
+                        .iter()
+                        .flat_map(|expr| {
+                            let (new_vars, hoisted_e) = expr.hoist_exists();
+                            vars.extend(new_vars);
+                            // Flatten any conjunctions
+                            match hoisted_e {
+                                Expr::And(exprs) => exprs,
+                                hoisted_e => vec![hoisted_e],
+                            }
+                        })
+                        .collect(),
+                );
+                (vars, hoisted_e)
+            }
+            _ => (vec![], self.clone()),
+        }
+    }
+
+    pub fn as_conjunction(self) -> Vec<Self> {
+        match self {
+            Expr::And(exprs) => exprs,
+            _ => vec![self],
+        }
+    }
+
+    pub fn strip_wkvars(&self) -> Self {
+        match self {
+            Expr::Constant(_) | Expr::Var(_) | Expr::ThyFunc(_) => self.clone(),
+            Expr::WKVar(..) => Expr::Constant(Constant::Boolean(true)),
+            Expr::App(head, sort_args, args, out_sort) => {
+                Expr::App(
+                    Box::new(head.strip_wkvars()),
+                    sort_args.clone(),
+                    args.iter().map(|arg| arg.strip_wkvars()).collect(),
+                    out_sort.clone(),
+                )
+            }
+            Expr::Neg(expr) => Expr::Neg(Box::new(expr.strip_wkvars())),
+            Expr::BinaryOp(bin_op, args) => {
+                Expr::BinaryOp(*bin_op, Box::new([args[0].strip_wkvars(), args[1].strip_wkvars()]))
+            }
+            Expr::IfThenElse(args) => {
+                Expr::IfThenElse(Box::new([
+                    args[0].strip_wkvars(),
+                    args[1].strip_wkvars(),
+                    args[2].strip_wkvars(),
+                ]))
+            }
+            Expr::And(exprs) => Expr::And(exprs.iter().map(|e| e.strip_wkvars()).collect_vec()),
+            Expr::Or(exprs) => Expr::Or(exprs.iter().map(|e| e.strip_wkvars()).collect_vec()),
+            Expr::Not(expr) => Expr::Not(Box::new(expr.strip_wkvars())),
+            Expr::Imp(args) => {
+                Expr::Imp(Box::new([args[0].strip_wkvars(), args[1].strip_wkvars()]))
+            }
+            Expr::Iff(args) => {
+                Expr::Iff(Box::new([args[0].strip_wkvars(), args[1].strip_wkvars()]))
+            }
+            Expr::Atom(bin_rel, args) => {
+                Expr::Atom(*bin_rel, Box::new([args[0].strip_wkvars(), args[1].strip_wkvars()]))
+            }
+            Expr::Let(var, args) => {
+                Expr::Let(var.clone(), Box::new([args[0].strip_wkvars(), args[1].strip_wkvars()]))
+            }
+            Expr::IsCtor(var, expr) => Expr::IsCtor(var.clone(), Box::new(expr.strip_wkvars())),
+            Expr::Exists(sorts, expr) => Expr::Exists(sorts.clone(), Box::new(expr.strip_wkvars())),
+        }
+    }
+
+    pub fn total_num_disjuncts(&self) -> usize {
+        match self {
+            // Can pick 0 for the default value since there will always be at least one disjunct.
+            Expr::Or(disjuncts) => {
+                disjuncts.len()
+                    + disjuncts
+                        .iter()
+                        .map(|disjunct| disjunct.total_num_disjuncts())
+                        .sum::<usize>()
+            }
+            Expr::And(conjuncts) => {
+                conjuncts
+                    .iter()
+                    .map(|conjunct| conjunct.total_num_disjuncts())
+                    .sum::<usize>()
+            }
+            _ => 0,
+        }
+    }
 }
 
-#[derive_where(Hash, Clone, Debug)]
+#[derive_where(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum Constant<T: Types> {
     Numeral(u128),
     // Currently we only support parsing integers as decimals. We should extend this to allow

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -505,7 +505,6 @@ impl<T: Types> Pred<T> {
     pub fn is_trivially_true(&self) -> bool {
         match self {
             Pred::Expr(Expr::Constant(Constant::Boolean(true))) => true,
-            // FIXME: We do substitue true for wkvars, but is this correct?
             Pred::And(ps) => ps.is_empty(),
             _ => false,
         }

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -312,6 +312,12 @@ impl BoundVar {
     }
 }
 
+#[derive_where(Hash, Debug, Clone)]
+pub struct WKVar<T: Types> {
+    pub wkvid: T::Var,
+    pub args: Vec<Expr<T>>,
+}
+
 #[derive_where(Hash, Clone, Debug)]
 pub enum Expr<T: Types> {
     Constant(Constant<T>),
@@ -330,6 +336,12 @@ pub enum Expr<T: Types> {
     ThyFunc(ThyFunc),
     IsCtor(T::Var, Box<Self>),
     Exists(Vec<(T::Var, Sort<T>)>, Box<Self>),
+    /// NOTE: WKVars are for internal use and we serialize them as UIFs using
+    /// the var argument. We also don't emit WKVars that are in head position
+    /// when translating to fixpoint.
+    ///
+    /// In an ideal world fixpoint would deal with weak kvars itself.
+    WKVar(WKVar<T>),
 }
 
 impl<T: Types> From<Constant<T>> for Expr<T> {
@@ -404,6 +416,9 @@ impl<T: Types> Expr<T> {
                 }
                 expr.var_sorts_to_int();
             }
+            Expr::WKVar(_) => {
+                unimplemented!()
+            }
         }
     }
 
@@ -463,8 +478,79 @@ impl<T: Types> Expr<T> {
                 }
                 vars.extend(inner);
             }
+            Expr::WKVar(WKVar { wkvid: _, args }) => {
+                for e in args {
+                    vars.extend(e.free_vars());
+                }
+            }
         };
         vars
+    }
+
+    pub fn substitute(&self, subst: &FxIndexMap<T::Var, Self>) -> Self {
+        match self {
+            Expr::Var(v) => {
+                if let Some(subst_val) = subst.get(v) {
+                    subst_val.clone()
+                } else {
+                    self.clone()
+                }
+            }
+            Expr::Constant(_) | Expr::ThyFunc(_) => self.clone(),
+            Expr::App(expr, sort_args, exprs, out_sort) => {
+                Expr::App(
+                    Box::new(expr.substitute(subst)),
+                    sort_args.clone(),
+                    exprs.iter().map(|e| e.substitute(subst)).collect_vec(),
+                    out_sort.clone(),
+                )
+            }
+            Expr::Neg(expr) => Expr::Neg(Box::new(expr.substitute(subst))),
+            Expr::BinaryOp(bin_op, args) => {
+                Expr::BinaryOp(
+                    *bin_op,
+                    Box::new([args[0].substitute(subst), args[1].substitute(subst)]),
+                )
+            }
+            Expr::IfThenElse(args) => {
+                Expr::IfThenElse(Box::new([
+                    args[0].substitute(subst),
+                    args[1].substitute(subst),
+                    args[2].substitute(subst),
+                ]))
+            }
+            Expr::And(exprs) => Expr::And(exprs.iter().map(|e| e.substitute(subst)).collect_vec()),
+            Expr::Or(exprs) => Expr::Or(exprs.iter().map(|e| e.substitute(subst)).collect_vec()),
+            Expr::Not(expr) => Expr::Not(Box::new(expr.substitute(subst))),
+            Expr::Imp(args) => {
+                Expr::Imp(Box::new([args[0].substitute(subst), args[1].substitute(subst)]))
+            }
+            Expr::Iff(args) => {
+                Expr::Iff(Box::new([args[0].substitute(subst), args[1].substitute(subst)]))
+            }
+            Expr::Atom(bin_rel, args) => {
+                Expr::Atom(
+                    *bin_rel,
+                    Box::new([args[0].substitute(subst), args[1].substitute(subst)]),
+                )
+            }
+            Expr::Let(var, args) => {
+                Expr::Let(
+                    var.clone(),
+                    Box::new([args[0].substitute(subst), args[1].substitute(subst)]),
+                )
+            }
+            Expr::IsCtor(var, expr) => Expr::IsCtor(var.clone(), Box::new(expr.substitute(subst))),
+            Expr::Exists(sorts, expr) => {
+                Expr::Exists(sorts.clone(), Box::new(expr.substitute(subst)))
+            }
+            Expr::WKVar(WKVar { wkvid, args }) => {
+                Expr::WKVar(WKVar {
+                    wkvid: wkvid.clone(),
+                    args: args.iter().map(|e| e.substitute(subst)).collect_vec(),
+                })
+            }
+        }
     }
 }
 

--- a/lib/liquid-fixpoint/src/constraint_solving.rs
+++ b/lib/liquid-fixpoint/src/constraint_solving.rs
@@ -353,7 +353,7 @@ impl<T: Types> Pred<T> {
                                     .map(|arg| &arg.0)
                                     .zip(qualifier.1.iter().map(|arg_idx| &args[*arg_idx]))
                                     .fold(qualifier.0.body.clone(), |acc, e| {
-                                        acc.substitute(e.0, e.1)
+                                        acc.substitute_var(e.0, e.1)
                                     }),
                             )
                         })
@@ -384,7 +384,7 @@ impl<T: Types> Pred<T> {
                         .iter()
                         .map(|arg| &arg.0)
                         .zip(assignment.1.iter().map(|arg_idx| &args[*arg_idx]))
-                        .fold(assignment.0.body.clone(), |acc, e| acc.substitute(e.0, e.1)),
+                        .fold(assignment.0.body.clone(), |acc, e| acc.substitute_var(e.0, e.1)),
                 )
             }
             _ => panic!("Conjunctions should not occur here"),
@@ -473,7 +473,7 @@ impl<T: Types> Expr<T> {
         }
     }
 
-    pub(crate) fn substitute(&self, v_from: &T::Var, v_to: &Expr<T>) -> Self {
+    pub(crate) fn substitute_var(&self, v_from: &T::Var, v_to: &Expr<T>) -> Self {
         let mut new_expr = self.clone();
         new_expr.substitute_in_place(v_from, v_to);
         new_expr

--- a/lib/liquid-fixpoint/src/constraint_solving.rs
+++ b/lib/liquid-fixpoint/src/constraint_solving.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, iter};
+use std::iter;
 
 use itertools::Itertools;
 use rustc_data_structures::fx::FxIndexMap;
@@ -40,8 +40,8 @@ impl<T: Types> Constraint<T> {
         }
     }
 
-    pub(crate) fn kvar_mappings(&self) -> HashMap<T::KVar, Vec<Constraint<T>>> {
-        let mut kvar_to_fragments: HashMap<T::KVar, Vec<Constraint<T>>> = HashMap::new();
+    pub(crate) fn kvar_mappings(&self) -> FxIndexMap<T::KVar, Vec<Constraint<T>>> {
+        let mut kvar_to_fragments: FxIndexMap<T::KVar, Vec<Constraint<T>>> = FxIndexMap::default();
         for frag in self.depth_first_fragments() {
             if let Some(kvar) = frag.fragment_kvar_head() {
                 kvar_to_fragments
@@ -56,11 +56,11 @@ impl<T: Types> Constraint<T> {
     /// Computes the kvar dependency graph as an adjacency list.
     ///
     /// There's an edge $k0 -> $k1, if $k1 appears as an assumption when $k0 is a head.
-    pub(crate) fn kvar_dep_graph(&self) -> HashMap<T::KVar, Vec<T::KVar>> {
+    pub(crate) fn kvar_dep_graph(&self) -> FxIndexMap<T::KVar, Vec<T::KVar>> {
         fn go<T: Types>(
             cstr: &Constraint<T>,
             deps: &mut Vec<T::KVar>,
-            graph: &mut HashMap<T::KVar, Vec<T::KVar>>,
+            graph: &mut FxIndexMap<T::KVar, Vec<T::KVar>>,
         ) {
             match cstr {
                 Constraint::Pred(pred, _) => {

--- a/lib/liquid-fixpoint/src/constraint_solving.rs
+++ b/lib/liquid-fixpoint/src/constraint_solving.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use crate::{
     Assignments, BinRel, Types,
-    constraint::{Bind, Constant, Constraint, Expr, Pred, Qualifier},
+    constraint::{Bind, Constant, Constraint, Expr, Pred, Qualifier, WKVar},
     constraint_fragments::ConstraintFragments,
     graph::topological_sort_sccs,
 };
@@ -464,6 +464,10 @@ impl<T: Types> Expr<T> {
             Expr::Constant(_) | Expr::ThyFunc(_) => {}
             Expr::Exists(..) => {
                 todo!("unexpected! exists")
+            }
+            Expr::WKVar(WKVar { wkvid: _, args }) => {
+                args.iter_mut()
+                    .for_each(|expr| expr.substitute_in_place(v_from, v_to));
             }
         }
     }

--- a/lib/liquid-fixpoint/src/constraint_solving.rs
+++ b/lib/liquid-fixpoint/src/constraint_solving.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, iter};
 
 use itertools::Itertools;
+use rustc_data_structures::fx::FxIndexMap;
 
 use crate::{
     Assignments, BinRel, Types,
@@ -99,7 +100,7 @@ impl<T: Types> Constraint<T> {
             .into_iter()
             .rev()
             .flatten()
-            .flat_map(|kvid| kvar_to_fragments.remove(&kvid).unwrap())
+            .flat_map(|kvid| kvar_to_fragments.shift_remove(&kvid).unwrap())
             .collect()
     }
 

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -1,17 +1,25 @@
+#[cfg(feature = "rust-fixpoint")]
+use std::collections::HashMap;
+
 use derive_where::derive_where;
+use itertools::Itertools;
+use rustc_data_structures::fx::FxIndexMap;
 #[cfg(feature = "rust-fixpoint")]
 use {
     crate::{
-        FixpointStatus, Sort, SortCtor,
-        cstr2smt2::{Env, is_constraint_satisfiable, new_binding, new_datatype},
-        graph,
+        FixpointStatus, Sort, SortCtor, cstr2smt2::{Env, is_constraint_satisfiable, new_binding, new_datatype}, graph,
     },
     itertools::Itertools,
     std::collections::{HashMap, VecDeque},
     z3::Solver,
 };
 
-#[allow(unused)]
+use crate::{
+    ConstDecl, DataDecl, KVarDecl, Sort, SortCtor, Types,
+    constraint::{Constraint, Qualifier},
+    graph,
+};
+
 #[derive_where(Hash)]
 pub struct ConstraintWithEnv<T: Types> {
     datatype_decls: Vec<DataDecl<T>>,
@@ -22,10 +30,6 @@ pub struct ConstraintWithEnv<T: Types> {
 }
 #[cfg(feature = "rust-fixpoint")]
 use crate::Assignments;
-use crate::{
-    ConstDecl, DataDecl, KVarDecl, Types,
-    constraint::{Constraint, Qualifier},
-};
 
 #[cfg(not(feature = "rust-fixpoint"))]
 impl<T: Types> ConstraintWithEnv<T> {
@@ -50,7 +54,7 @@ impl<T: Types> ConstraintWithEnv<T> {
         constants: Vec<ConstDecl<T>>,
         constraint: Constraint<T>,
     ) -> Self {
-        let datatype_decls = Self::topo_sort_data_declarations(datatype_decls);
+        let datatype_decls = topo_sort_data_declarations(datatype_decls);
         Self { datatype_decls, kvar_decls, qualifiers, constants, constraint }
     }
 
@@ -145,7 +149,7 @@ impl<T: Types> ConstraintWithEnv<T> {
         self.constants.iter().for_each(|const_decl| {
             vars.insert(
                 const_decl.name.clone(),
-                new_binding(&const_decl.name, &const_decl.sort, &vars),
+                new_binding(&const_decl.name.display().to_string(), &const_decl.sort, &vars),
             );
         });
         self.datatype_decls.iter().for_each(|data_decl| {
@@ -156,35 +160,39 @@ impl<T: Types> ConstraintWithEnv<T> {
         self.constraint = self.constraint.sub_all_kvars(&kvar_assignment);
         is_constraint_satisfiable(&self.constraint, &solver, &mut vars)
     }
+}
 
-    fn topo_sort_data_declarations(datatype_decls: Vec<DataDecl<T>>) -> Vec<DataDecl<T>> {
-        let mut datatype_dependencies: HashMap<T::Sort, Vec<T::Sort>> = HashMap::new();
-        for datatype_decl in &datatype_decls {
-            datatype_dependencies.insert(datatype_decl.name.clone(), vec![]);
-        }
-        let mut data_decls_by_name = HashMap::new();
-        for datatype_decl in datatype_decls {
-            for data_constructor in &datatype_decl.ctors {
-                for accessor in &data_constructor.fields {
-                    if let Sort::App(ctor, _) = &accessor.sort
-                        && let SortCtor::Data(data_ctor) = &ctor
-                    {
-                        datatype_dependencies
-                            .get_mut(&datatype_decl.name)
-                            .unwrap()
-                            .push(data_ctor.clone());
-                    }
+pub fn topo_sort_data_declarations<T: Types>(datatype_decls: Vec<DataDecl<T>>) -> Vec<DataDecl<T>> {
+    let mut datatype_dependencies: FxIndexMap<T::Sort, Vec<T::Sort>> = FxIndexMap::default();
+    for datatype_decl in &datatype_decls {
+        datatype_dependencies.insert(datatype_decl.name.clone(), vec![]);
+    }
+    let mut data_decls_by_name = FxIndexMap::default();
+    for datatype_decl in datatype_decls {
+        for data_constructor in &datatype_decl.ctors {
+            for accessor in &data_constructor.fields {
+                if let Sort::App(ctor, _) = &accessor.sort
+                    && let SortCtor::Data(data_ctor) = &ctor
+                {
+                    datatype_dependencies
+                        .get_mut(&datatype_decl.name)
+                        .unwrap()
+                        .push(data_ctor.clone());
                 }
             }
-            data_decls_by_name.insert(datatype_decl.name.clone(), datatype_decl);
         }
-        graph::topological_sort_sccs(&datatype_dependencies)
-            .into_iter()
-            .flatten()
-            .rev()
-            .map(|datatype_decl_name| data_decls_by_name.remove(&datatype_decl_name).unwrap())
-            .collect_vec()
+        data_decls_by_name.insert(datatype_decl.name.clone(), datatype_decl);
     }
+    graph::topological_sort_sccs(&datatype_dependencies)
+        .into_iter()
+        .flatten()
+        .rev()
+        .map(|datatype_decl_name| {
+            data_decls_by_name
+                .shift_remove(&datatype_decl_name)
+                .unwrap()
+        })
+        .collect_vec()
 }
 
 #[cfg(feature = "rust-fixpoint")]

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -7,10 +7,10 @@ use rustc_data_structures::fx::FxIndexMap;
 #[cfg(feature = "rust-fixpoint")]
 use {
     crate::{
-        FixpointStatus, Sort, SortCtor, cstr2smt2::{Env, is_constraint_satisfiable, new_binding, new_datatype}, graph,
+        FixpointStatus, Identifier,
+        cstr2smt2::{Env, is_constraint_satisfiable, new_binding, new_datatype},
     },
-    itertools::Itertools,
-    std::collections::{HashMap, VecDeque},
+    std::collections::VecDeque,
     z3::Solver,
 };
 

--- a/lib/liquid-fixpoint/src/cstr2smt2.rs
+++ b/lib/liquid-fixpoint/src/cstr2smt2.rs
@@ -1,21 +1,39 @@
 use core::panic;
-use std::{collections::HashMap, iter, str::FromStr, vec};
+#[cfg(feature = "wick")]
+use std::collections::HashSet;
+use std::{iter, str::FromStr, vec};
 
-use itertools::Itertools as _;
+use itertools::Itertools;
+use rustc_data_structures::fx::FxIndexMap;
+#[cfg(feature = "wick")]
+use z3::{AstKind, Goal, Tactic};
 use z3::{
     FuncDecl, SatResult, Solver, SortKind,
     ast::{self, Ast},
 };
 
+#[cfg(feature = "wick")]
+use crate::{ConstDecl, FlatConstraint};
+#[cfg(feature = "rust-fixpoint")]
+use crate::{Constraint, Error, FixpointStatus, Stats};
 use crate::{
-    DataDecl, Error, FixpointFmt, FixpointStatus, Identifier, SortCtor, Stats, ThyFunc, Types,
-    constraint::{BinOp, BinRel, Constant, Constraint, Expr, Pred, Sort},
+    DataDecl, FixpointFmt, Identifier, SortCtor, ThyFunc, Types,
+    constraint::{BinOp, BinRel, Constant, Expr, Pred, Sort},
 };
 
 #[derive(Debug)]
 pub(crate) enum Binding {
     Variable(ast::Dynamic),
     Function(FuncDecl, ast::Dynamic),
+}
+
+impl Binding {
+    pub fn to_var(&self) -> &ast::Dynamic {
+        match self {
+            Binding::Variable(var) => var,
+            Binding::Function(_, c) => c,
+        }
+    }
 }
 
 impl From<ast::Dynamic> for Binding {
@@ -25,39 +43,48 @@ impl From<ast::Dynamic> for Binding {
 }
 
 pub(crate) struct Env<T: Types> {
-    bindings: HashMap<T::Var, Vec<Binding>>,
-    data_types: HashMap<T::Sort, z3::Sort>,
+    bindings: FxIndexMap<T::Var, Vec<Binding>>,
+    data_types: FxIndexMap<T::Sort, z3::Sort>,
+    rev_bindings: FxIndexMap<String, T::Var>,
 }
 
 impl<T: Types> Env<T> {
     pub(crate) fn new() -> Self {
-        Self { bindings: HashMap::new(), data_types: HashMap::new() }
+        Self {
+            bindings: FxIndexMap::default(),
+            data_types: FxIndexMap::default(),
+            rev_bindings: FxIndexMap::default(),
+        }
     }
 
     pub(crate) fn insert<B: Into<Binding>>(&mut self, name: T::Var, value: B) {
         self.bindings
-            .entry(name)
+            .entry(name.clone())
             .or_default()
             .push(Into::<Binding>::into(value));
+        self.rev_bindings
+            .insert(name.display().to_string(), name.clone());
     }
 
     pub(crate) fn insert_data_decl(&mut self, name: T::Sort, datatype: z3::Sort) {
         self.data_types.insert(name, datatype);
     }
 
-    fn pop(&mut self, name: &T::Var) {
+    fn pop(&mut self, name: &T::Var) -> Option<Binding> {
         if let Some(stack) = self.bindings.get_mut(name) {
-            stack.pop();
+            let ret = stack.pop();
             if stack.is_empty() {
-                self.bindings.remove(name);
+                self.bindings.shift_remove(name);
             }
+            ret
+        } else {
+            None
         }
     }
 
     fn var_lookup(&self, name: &T::Var) -> Option<&ast::Dynamic> {
         match &self.lookup(name) {
-            Some(Binding::Variable(var)) => Some(var),
-            Some(Binding::Function(_, c)) => Some(c),
+            Some(b) => Some(b.to_var()),
             _ => None,
         }
     }
@@ -71,6 +98,11 @@ impl<T: Types> Env<T> {
 
     fn lookup(&self, name: &T::Var) -> Option<&Binding> {
         self.bindings.get(name).and_then(|stack| stack.last())
+    }
+
+    #[cfg(feature = "wick")]
+    fn rev_lookup(&self, name: &str) -> Option<&T::Var> {
+        self.rev_bindings.get(name)
     }
 
     fn datatype_lookup(&self, name: &T::Sort) -> Option<&z3::Sort> {
@@ -503,29 +535,70 @@ fn expr_to_z3<T: Types>(expr: &Expr<T>, env: &mut Env<T>) -> ast::Dynamic {
                     fun_decl.apply(&arg_refs)
                 }
                 Expr::ThyFunc(func) => thy_func_application_to_z3(*func, args, env),
-                _ => panic!("encountered function application but no function"),
+                Expr::WKVar(_) => ast::Bool::from_bool(true).into(),
+                _ => panic!("encountered function application but no function: {:?}", expr),
             }
         }
         Expr::IsCtor(..) => todo!("testers not yet implemented"),
         Expr::ThyFunc(_) => {
             unreachable!("Should not encounter theory func outside of an application")
         }
-        Expr::Exists(..) => todo!("exists not yet implemented"),
+        Expr::Exists(var_sorts, e) => {
+            for (var, sort) in var_sorts {
+                let binding = new_binding(&format!("{}", var.display()), sort, env);
+                env.insert(var.clone(), binding);
+            }
+            let mut body = expr_to_z3(e, env)
+                .as_bool()
+                .expect("expecting boolean expression");
+            // It shouldn't matter, but the order we expect to see the binders is
+            // actually the reverse order.
+            for (var, _) in var_sorts.iter().rev() {
+                let binding = env.pop(var).unwrap();
+                let v = binding.to_var();
+                body = z3::ast::quantifier_const(
+                    false,
+                    0,
+                    format!("{}_binder", var.display()),
+                    "",
+                    &[v],
+                    &[],
+                    &[],
+                    &body,
+                );
+            }
+            body.into()
+        }
+        // UIFs are hard to deal with in QE and we don't need weak kvars in it
+        // anyway, so we'll just elide them here.
+        Expr::WKVar(_wkvar) => ast::Bool::from_bool(true).into(),
     }
 }
 
-fn pred_to_z3<T: Types>(pred: &Pred<T>, env: &mut Env<T>) -> ast::Bool {
+#[allow(unused)]
+#[derive(Clone, Copy)]
+enum AllowKVars {
+    ReplaceKVarsWithTrue,
+    NoKVars,
+}
+
+fn pred_to_z3<T: Types>(pred: &Pred<T>, env: &mut Env<T>, allow_kvars: AllowKVars) -> ast::Bool {
     match pred {
         Pred::Expr(expr) => expr_to_z3(expr, env).as_bool().expect(" asldfj "),
         Pred::And(conjuncts) => {
             let bools = conjuncts
                 .iter()
-                .map(|conjunct| pred_to_z3(conjunct, env))
+                .map(|conjunct| pred_to_z3(conjunct, env, allow_kvars))
                 .collect_vec();
             let bool_refs = bools.iter().collect_vec();
             ast::Bool::and(&bool_refs)
         }
-        Pred::KVar(_kvar, _vars) => panic!("Kvars not supported yet"),
+        Pred::KVar(_kvar, _vars) => {
+            match allow_kvars {
+                AllowKVars::NoKVars => panic!("Kvars not supported yet"),
+                AllowKVars::ReplaceKVarsWithTrue => ast::Bool::from_bool(true),
+            }
+        }
     }
 }
 
@@ -570,12 +643,12 @@ pub(crate) fn new_datatype<T: Types>(
     sort
 }
 
-pub(crate) fn new_binding<T: Types>(name: &T::Var, sort: &Sort<T>, env: &Env<T>) -> Binding {
+pub(crate) fn new_binding<T: Types>(name: &str, sort: &Sort<T>, env: &Env<T>) -> Binding {
     match &sort {
-        Sort::Int => Binding::Variable(ast::Int::new_const(name.display().to_string()).into()),
-        Sort::Real => Binding::Variable(ast::Real::new_const(name.display().to_string()).into()),
-        Sort::Bool => Binding::Variable(ast::Bool::new_const(name.display().to_string()).into()),
-        Sort::Str => Binding::Variable(ast::String::new_const(name.display().to_string()).into()),
+        Sort::Int => Binding::Variable(ast::Int::new_const(name).into()),
+        Sort::Real => Binding::Variable(ast::Real::new_const(name).into()),
+        Sort::Bool => Binding::Variable(ast::Bool::new_const(name).into()),
+        Sort::Str => Binding::Variable(ast::String::new_const(name).into()),
         Sort::Func(sorts) => {
             let mut domain = vec![z3_sort(&sorts[0], env)];
             let mut current = sorts.as_ref();
@@ -586,30 +659,24 @@ pub(crate) fn new_binding<T: Types>(name: &T::Var, sort: &Sort<T>, env: &Env<T>)
                 current = sorts.as_ref();
             }
             let domain_refs = domain.iter().collect_vec();
-            let fun_decl =
-                FuncDecl::new(name.display().to_string(), &domain_refs, &z3_sort(range, env));
-            Binding::Function(fun_decl, ast::Int::new_const(name.display().to_string()).into())
+            let fun_decl = FuncDecl::new(name, &domain_refs, &z3_sort(range, env));
+            Binding::Function(fun_decl, ast::Int::new_const(name).into())
         }
         Sort::BitVec(bv_size) => {
             match **bv_size {
-                Sort::BvSize(size) => {
-                    Binding::Variable(ast::BV::new_const(name.display().to_string(), size).into())
-                }
+                Sort::BvSize(size) => Binding::Variable(ast::BV::new_const(name, size).into()),
                 _ => panic!("incorrect bitvector size specification"),
             }
         }
         Sort::App(sort_ctor, args) => {
             match sort_ctor {
                 SortCtor::Set => {
-                    Binding::Variable(
-                        ast::Set::new_const(name.display().to_string(), &z3_sort(&args[0], env))
-                            .into(),
-                    )
+                    Binding::Variable(ast::Set::new_const(name, &z3_sort(&args[0], env)).into())
                 }
                 SortCtor::Map => {
                     Binding::Variable(
                         ast::Array::new_const(
-                            name.display().to_string(),
+                            name,
                             &z3_sort(&args[0], env),
                             &z3_sort(&args[1], env),
                         )
@@ -618,11 +685,8 @@ pub(crate) fn new_binding<T: Types>(name: &T::Var, sort: &Sort<T>, env: &Env<T>)
                 }
                 SortCtor::Data(data_ctor) => {
                     Binding::Variable(
-                        ast::Datatype::new_const(
-                            name.display().to_string(),
-                            env.datatype_lookup(data_ctor).unwrap(),
-                        )
-                        .into(),
+                        ast::Datatype::new_const(name, env.datatype_lookup(data_ctor).unwrap())
+                            .into(),
                     )
                 }
             }
@@ -654,6 +718,7 @@ fn z3_sort<T: Types>(s: &Sort<T>, env: &Env<T>) -> z3::Sort {
     }
 }
 
+#[cfg(feature = "rust-fixpoint")]
 pub(crate) fn is_constraint_satisfiable<T: Types>(
     cstr: &Constraint<T>,
     solver: &Solver,
@@ -662,7 +727,7 @@ pub(crate) fn is_constraint_satisfiable<T: Types>(
     solver.push();
     let res = match cstr {
         Constraint::Pred(pred, tag) => {
-            solver.assert(pred_to_z3(pred, env).not());
+            solver.assert(pred_to_z3(pred, env, AllowKVars::NoKVars).not());
             if solver.check() == SatResult::Unsat {
                 FixpointStatus::Safe(Stats { num_cstr: 1, num_iter: 0, num_chck: 0, num_vald: 0 })
             } else {
@@ -683,8 +748,11 @@ pub(crate) fn is_constraint_satisfiable<T: Types>(
         }
 
         Constraint::ForAll(bind, inner) => {
-            env.insert(bind.name.clone(), new_binding(&bind.name, &bind.sort, env));
-            solver.assert(pred_to_z3(&bind.pred, env));
+            env.insert(
+                bind.name.clone(),
+                new_binding(&bind.name.display().to_string(), &bind.sort, env),
+            );
+            solver.assert(pred_to_z3(&bind.pred, env, AllowKVars::NoKVars));
             let inner_soln = is_constraint_satisfiable(inner, solver, env);
             env.pop(&bind.name);
             inner_soln
@@ -692,4 +760,450 @@ pub(crate) fn is_constraint_satisfiable<T: Types>(
     };
     solver.pop(1);
     res
+}
+
+/// Checks if a [`FlatConstraint`] is valid; for any constraints that fixpoint
+/// fails to check this is not necessary (because otherwise fixpoint's check
+/// would have succeeded); however, if we split a constraint because of a
+/// disjunction we will want to prune branches that are already satisfied.
+#[cfg(feature = "wick")]
+pub fn check_validity<T: Types>(
+    cstr: &FlatConstraint<T>,
+    binder_consts: &Vec<ConstDecl<T>>,
+    global_consts: &Vec<ConstDecl<T>>,
+    datatype_decls: &Vec<DataDecl<T>>,
+) -> bool {
+    let solver = Solver::new();
+    let mut vars = Env::new();
+    datatype_decls.iter().for_each(|data_decl| {
+        let datatype_sort = new_datatype(&data_decl.name, &data_decl, &mut vars);
+        vars.insert_data_decl(data_decl.name.clone(), datatype_sort);
+    });
+    binder_consts.iter().for_each(|const_decl| {
+        vars.insert(
+            const_decl.name.clone(),
+            new_binding(&const_decl.name.display().to_string(), &const_decl.sort, &vars),
+        )
+    });
+    global_consts.iter().for_each(|const_decl| {
+        vars.insert(
+            const_decl.name.clone(),
+            new_binding(&const_decl.name.display().to_string(), &const_decl.sort, &vars),
+        )
+    });
+    for (var, sort) in &cstr.binders {
+        vars.insert(var.clone(), new_binding(&var.display().to_string(), sort, &vars));
+    }
+    solver.push();
+    for assumption in &cstr.preconditions() {
+        let pred_ast = pred_to_z3(assumption, &mut vars, AllowKVars::NoKVars);
+        solver.assert(&pred_ast);
+    }
+    let head_ast = pred_to_z3(&cstr.head, &mut vars, AllowKVars::NoKVars);
+    solver.assert(ast::Bool::not(&head_ast));
+    match solver.check() {
+        SatResult::Unsat => true,
+        _ => false,
+    }
+}
+
+#[cfg(feature = "wick")]
+pub fn qe_and_simplify<T: Types>(
+    cstr: &FlatConstraint<T>,
+    binder_consts: &Vec<ConstDecl<T>>,
+    global_consts: &Vec<ConstDecl<T>>,
+    datatype_decls: &Vec<DataDecl<T>>,
+) -> Result<Expr<T>, Z3DecodeError> {
+    let solver = Solver::new();
+    let goal = Goal::new(true, true, false);
+    let mut vars = Env::new();
+    datatype_decls.iter().for_each(|data_decl| {
+        let datatype_sort = new_datatype(&data_decl.name, &data_decl, &mut vars);
+        vars.insert_data_decl(data_decl.name.clone(), datatype_sort);
+    });
+    binder_consts.iter().for_each(|const_decl| {
+        vars.insert(
+            const_decl.name.clone(),
+            new_binding(&const_decl.name.display().to_string(), &const_decl.sort, &vars),
+        );
+    });
+    let mut const_vars: HashSet<T::Var> = HashSet::new();
+    global_consts.iter().for_each(|const_decl| {
+        const_vars.insert(const_decl.name.clone());
+        vars.insert(
+            const_decl.name.clone(),
+            new_binding(&const_decl.name.display().to_string(), &const_decl.sort, &vars),
+        );
+    });
+    // These are going to be the bound vars, so we declare the free vars above them.
+    for (var, sort) in &cstr.binders {
+        // TODO: eliminate binders that are unused.
+        vars.insert(var.clone(), new_binding(&var.display().to_string(), sort, &vars));
+    }
+    solver.push();
+    let lhs = z3::ast::Bool::and(
+        &cstr
+            .preconditions()
+            .into_iter()
+            .filter_map(|pred| {
+                let pred_ast = pred_to_z3(&pred, &mut vars, AllowKVars::NoKVars);
+                // just be asserted.
+                // println!("assumption:\n{:?}", pred_ast);
+                Some(pred_ast)
+            })
+            .collect_vec(),
+    );
+    let rhs = pred_to_z3(&cstr.head, &mut vars, AllowKVars::NoKVars);
+    let mut body = z3::ast::Bool::implies(&lhs, &rhs);
+    for (var, _sort) in &cstr.binders {
+        if let Binding::Variable(z3_var) = vars.lookup(var).unwrap() {
+            body = z3::ast::quantifier_const(
+                true,
+                0,
+                format!("{}_binder", var.display()),
+                format!("{}_skolem", var.display()),
+                &[z3_var],
+                &[],
+                &[],
+                &body,
+            );
+        } else {
+            panic!("function in forall");
+        }
+    }
+    goal.assert(&body);
+    let qe_and_simplify = Tactic::new("qe").and_then(&Tactic::new("nnf"));
+    match qe_and_simplify
+        .try_for(std::time::Duration::from_secs(10))
+        .apply(&goal, None)
+    {
+        Ok(apply_result) => {
+            let new_goals = apply_result.list_subgoals().last();
+            if let Some(new_goal) = new_goals {
+                let new_formulae: Vec<_> = new_goal
+                    .iter_formulas::<ast::Dynamic>()
+                    .map(|f| {
+                        let fixpoint_expr = z3_to_expr(&vars, &f)?;
+                        Ok((fixpoint_expr.total_num_disjuncts(), fixpoint_expr))
+                    })
+                    .try_collect()?;
+                if let Some((_min_size, mut min_size_formula)) = new_formulae
+                    .into_iter()
+                    .min_by_key(|(num_disjuncts, _)| *num_disjuncts)
+                {
+                    solver.pop(1);
+                    solver.push();
+                    for pred in &cstr.preconditions() {
+                        let pred_ast = pred_to_z3(pred, &mut vars, AllowKVars::NoKVars);
+                        solver.assert(&pred_ast);
+                    }
+                    let res = prune_vacuous(&mut min_size_formula, &mut vars, &solver);
+                    return if res {
+                        Ok(Expr::FALSE)
+                    } else {
+                        solver.pop(1);
+                        let pred_ast = expr_to_z3(&min_size_formula, &mut vars);
+                        solver.assert(z3::ast::Bool::not(&z3::ast::Bool::implies(
+                            &pred_ast.as_bool().unwrap(),
+                            z3::ast::Bool::implies(&lhs, &rhs),
+                        )));
+                        match solver.check() {
+                            SatResult::Unsat => Ok(min_size_formula),
+                            _ => Err(Z3DecodeError::FailedSanityCheck),
+                        }
+                    };
+                }
+            }
+            Err(Z3DecodeError::NoResults)
+        }
+        // FIXME: Not a decode error, but now QE can fail due to a timeout and
+        // we don't want to panic because of this.
+        Err(_) => Err(Z3DecodeError::QEFail),
+    }
+}
+
+/// Prunes any parts of the expression that falsify the current assertions
+/// in solver.
+///
+/// Returns whether the current expression is vacuous.
+#[cfg(feature = "wick")]
+fn prune_vacuous<T: Types>(e: &mut Expr<T>, env: &mut Env<T>, solver: &Solver) -> bool {
+    match e {
+        // Prune individual conjuncts with the added constraint that if _any_
+        // are vacuous, we need to remove the whole expr.
+        //
+        // This is just an optimization to avoid checking for unsat all the
+        // time.
+        Expr::And(conjuncts) => {
+            let conjuncts_copy = conjuncts.clone();
+            for (i, conjunct) in conjuncts.iter_mut().enumerate() {
+                solver.push();
+                for (j, other_conjunct) in conjuncts_copy.iter().enumerate() {
+                    // We could do better here by only creating
+                    // backtracking points for asserts of j > i,
+                    // but whatever.
+                    if i != j {
+                        let z3_conjunct = expr_to_z3(other_conjunct, env);
+                        solver.assert(z3_conjunct.as_bool().unwrap());
+                    }
+                }
+                // If anything in this conjunct is to be pruned, then we need to
+                // throw out the whole conjunct:
+                //
+                // The rationale is that we can reach a contradiction with one
+                // element in our conjunction: therefore the whole conjunction
+                // leads to a contradiction.
+                if prune_vacuous(conjunct, env, solver) {
+                    *e = Expr::FALSE;
+                    solver.pop(1);
+                    return true;
+                } else {
+                    solver.pop(1);
+                }
+            }
+            false
+        }
+        Expr::Or(disjuncts) => {
+            // Drop vacuous parts of this disjunction
+            disjuncts.retain_mut(|disjunct| !prune_vacuous(disjunct, env, solver));
+            if disjuncts.is_empty() {
+                *e = Expr::FALSE;
+                true
+            } else if disjuncts.len() == 1 {
+                *e = disjuncts.pop().unwrap();
+                false
+            } else {
+                false
+            }
+        }
+        _ => {
+            solver.push();
+            let z3_e = expr_to_z3(e, env);
+            solver.assert(z3_e.as_bool().unwrap());
+            let res = match solver.check() {
+                SatResult::Unsat => true,
+                _ => false,
+            };
+            solver.pop(1);
+            res
+        }
+    }
+}
+
+#[derive(Debug)]
+#[cfg(feature = "wick")]
+pub enum Z3DecodeError {
+    /// FIXME: (ck) For some reason Z3 dies when doing ast queries on quantifiers (at
+    /// least in testing the formuals we send to it --- it's possible I've done
+    /// something wrong). We don't want quantifiers in our output anyway, so it's fine,
+    /// but we ought to be able to properly deserialize output from Z3.
+    ContainsQuantifier,
+    /// See [`Z3DecodeError::ContainsQuantifier`]. Pretty sure only quantifiers
+    /// introduce Vars.
+    ContainsVar,
+    /// Right now we only expect to see Ints for numerals (can and probably
+    /// should change in the future).
+    UnexpectedSortKindForNumeral(SortKind),
+    UnexpectedAstKind(AstKind),
+    /// We use a string to identify the operator because there are some
+    /// expressions like [`Expr::Neg`] that don't actually identify their
+    /// operator.
+    ArgNumMismatch(&'static str, usize),
+    LetFirstArgumentNotAVar,
+    UnexpectedAppHead(FuncDecl),
+    UnexpectedConstHead(FuncDecl),
+    InvalidIntConstant,
+    NoResults,
+    TriviallyFalse,
+    QEFail,
+    FailedSanityCheck,
+}
+
+#[cfg(feature = "wick")]
+fn z3_to_expr<T: Types>(env: &Env<T>, z3: &ast::Dynamic) -> Result<Expr<T>, Z3DecodeError> {
+    // println!("node: {:?}", z3);
+    // println!("node sort: {:?}", z3.get_sort());
+    // println!("node funcdecl: {:?}", z3.safe_decl());
+    // println!("node is (app, const): ({}, {})", z3.is_app(), z3.is_const());
+    match z3.kind() {
+        AstKind::Numeral => {
+            match z3.sort_kind() {
+                SortKind::Int => {
+                    let z3_int = z3.as_int().unwrap();
+                    if let Some(uint) = z3_int.as_u64() {
+                        Ok(Expr::Constant(Constant::Numeral(uint as u128)))
+                    } else if let Some(int) = z3_int.as_i64() {
+                        if int > 0 {
+                            Ok(Expr::Constant(Constant::Numeral(int as u128)))
+                        } else {
+                            Ok(Expr::Neg(Box::new(Expr::Constant(Constant::Numeral(
+                                (-1 * int) as u128,
+                            )))))
+                        }
+                    } else {
+                        Err(Z3DecodeError::InvalidIntConstant)
+                    }
+                }
+                // TODO: other sorts (it seems we don't send these to Z3 yet...)
+                // SortKind::Real => {
+                //     let real = z3.as_real().unwrap();
+                //     Expr::
+                // }
+                // SortKind::FloatingPoint => {
+                //     let fp = z3.as_float().unwrap();
+                // }
+                _ => Err(Z3DecodeError::UnexpectedSortKindForNumeral(z3.sort_kind())),
+            }
+        }
+        AstKind::App if z3.is_const() => {
+            assert!(z3.num_children() == 0);
+            z3_const_to_expr(env, z3.decl())
+        }
+        AstKind::App if z3.is_app() => z3_app_to_expr(env, z3.decl(), &z3.children()),
+        AstKind::App => {
+            unreachable!()
+        }
+        // NOTE: if we add support for quantifiers, we will want to change the
+        // return type to Pred<T>.
+        AstKind::Quantifier => Err(Z3DecodeError::ContainsQuantifier),
+        AstKind::Var => Err(Z3DecodeError::ContainsVar),
+        AstKind::FuncDecl | AstKind::Unknown | AstKind::Sort => {
+            Err(Z3DecodeError::UnexpectedAstKind(z3.kind()))
+        }
+    }
+}
+
+#[cfg(feature = "wick")]
+fn z3_app_to_expr<T: Types>(
+    env: &Env<T>,
+    head: FuncDecl,
+    args: &Vec<ast::Dynamic>,
+) -> Result<Expr<T>, Z3DecodeError> {
+    // let args: Vec<Expr<T>> = args.iter().map(|arg| z3_to_expr::<T>(arg)).collect::<Result<Vec<_>,_>>()?;
+    let head_name = head.name();
+    if &head_name == "-" {
+        match args.len() {
+            1 => Ok(Expr::Neg(Box::new(z3_to_expr(env, &args[0])?))),
+            2 => {
+                Ok(Expr::BinaryOp(
+                    BinOp::Sub,
+                    Box::new([z3_to_expr(env, &args[0])?, z3_to_expr(env, &args[1])?]),
+                ))
+            }
+            _ => Err(Z3DecodeError::ArgNumMismatch("-", args.len())),
+        }
+    } else if &head_name == "if" {
+        if args.len() == 3 {
+            Ok(Expr::IfThenElse(Box::new([
+                z3_to_expr(env, &args[0])?,
+                z3_to_expr(env, &args[1])?,
+                z3_to_expr(env, &args[2])?,
+            ])))
+        } else {
+            Err(Z3DecodeError::ArgNumMismatch("if", args.len()))
+        }
+    } else if &head_name == "let" {
+        if args.len() == 3 {
+            let var: Expr<T> = z3_to_expr(env, &args[0])?;
+            let e = z3_to_expr(env, &args[1])?;
+            let body = z3_to_expr(env, &args[2])?;
+            if let Expr::Var(v) = var {
+                Ok(Expr::Let(v, Box::new([e, body])))
+            } else {
+                Err(Z3DecodeError::LetFirstArgumentNotAVar)
+            }
+        } else {
+            Err(Z3DecodeError::ArgNumMismatch("let", args.len()))
+        }
+    } else if &head_name == "and" {
+        Ok(Expr::And(
+            args.iter()
+                .map(|arg| z3_to_expr::<T>(env, arg))
+                .collect::<Result<Vec<_>, _>>()?,
+        ))
+    } else if &head_name == "or" {
+        Ok(Expr::Or(
+            args.iter()
+                .map(|arg| z3_to_expr::<T>(env, arg))
+                .collect::<Result<Vec<_>, _>>()?,
+        ))
+    } else if &head_name == "not" {
+        if args.len() == 1 {
+            Ok(Expr::Not(Box::new(z3_to_expr(env, &args[0])?)))
+        } else {
+            Err(Z3DecodeError::ArgNumMismatch("not", args.len()))
+        }
+    } else if &head_name == "=>" {
+        if args.len() == 2 {
+            Ok(Expr::Imp(Box::new([z3_to_expr(env, &args[0])?, z3_to_expr(env, &args[1])?])))
+        } else {
+            Err(Z3DecodeError::ArgNumMismatch("=>", args.len()))
+        }
+    } else if &head_name == "<=>" {
+        if args.len() == 2 {
+            Ok(Expr::Iff(Box::new([z3_to_expr(env, &args[0])?, z3_to_expr(env, &args[1])?])))
+        } else {
+            Err(Z3DecodeError::ArgNumMismatch("<=>", args.len()))
+        }
+    } else if let Ok(binop) = head_name.parse::<BinOp>() {
+        // NOTE: (ck) It seems like we can get back > 2 for addition (+). I'm
+        // assuming it'll only do this with commutative things, but I did try to
+        // ensure left-to-right ordering just in case.
+        if args.len() >= 2 {
+            let mut exprs: Vec<_> = args
+                .iter()
+                .map(|arg| z3_to_expr::<T>(env, arg))
+                .try_collect()?;
+            let e1 = exprs.pop().unwrap();
+            let e2 = exprs.pop().unwrap();
+            let mut bin_op_e = Expr::BinaryOp(binop, Box::new([e1, e2]));
+            for e in exprs.into_iter().rev() {
+                bin_op_e = Expr::BinaryOp(binop, Box::new([e, bin_op_e]));
+            }
+            Ok(bin_op_e)
+        } else {
+            Err(Z3DecodeError::ArgNumMismatch("binop", args.len()))
+        }
+    } else if let Ok(binrel) = head_name.parse::<BinRel>() {
+        if args.len() == 2 {
+            Ok(Expr::Atom(
+                binrel,
+                Box::new([z3_to_expr(env, &args[0])?, z3_to_expr(env, &args[1])?]),
+            ))
+        } else {
+            Err(Z3DecodeError::ArgNumMismatch("binrel", args.len()))
+        }
+    } else if let Ok(thyfunc) = head_name.parse::<ThyFunc>() {
+        let expr_args = args
+            .iter()
+            .map(|arg| z3_to_expr::<T>(env, arg))
+            .collect::<Result<Vec<_>, _>>()?;
+        // TODO: parse sorts
+        Ok(Expr::App(Box::new(Expr::ThyFunc(thyfunc)), None, expr_args, None))
+    } else if let Some(var) = env.rev_lookup(&head_name) {
+        let expr_args = args
+            .iter()
+            .map(|arg| z3_to_expr::<T>(env, arg))
+            .collect::<Result<Vec<_>, _>>()?;
+        // TODO: parse sorts
+        Ok(Expr::App(Box::new(Expr::Var(var.clone())), None, expr_args, None))
+    } else {
+        Err(Z3DecodeError::UnexpectedAppHead(head))
+    }
+}
+
+#[cfg(feature = "wick")]
+fn z3_const_to_expr<T: Types>(env: &Env<T>, head: FuncDecl) -> Result<Expr<T>, Z3DecodeError> {
+    let head_name = head.name();
+    // TODO: we should parse other constants, but I would need to
+    // see how they're being represented first...
+    if let Some(var) = env.rev_lookup(&head_name) {
+        Ok(Expr::Var(var.clone()))
+    } else if head_name == "true" || head_name == "and" {
+        Ok(Expr::Constant(Constant::Boolean(true)))
+    } else if head_name == "false" || head_name == "or" {
+        Ok(Expr::Constant(Constant::Boolean(false)))
+    } else {
+        Err(Z3DecodeError::UnexpectedConstHead(head))
+    }
 }

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{self, Write},
     iter,
+    str::FromStr,
 };
 
 use itertools::Itertools;
@@ -8,7 +9,7 @@ use itertools::Itertools;
 use crate::{
     BinOp, BinRel, ConstDecl, Constant, Constraint, DataCtor, DataDecl, DataField, Expr,
     FixpointFmt, FunDef, FunSort, Identifier, KVarDecl, Pred, Qualifier, Sort, SortCtor, Task,
-    Types,
+    Types, constraint::WKVar,
 };
 
 pub(crate) fn fmt_constraint<T: Types>(
@@ -416,6 +417,20 @@ impl fmt::Display for BinOp {
     }
 }
 
+impl FromStr for BinOp {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "+" => Ok(BinOp::Add),
+            "-" => Ok(BinOp::Sub),
+            "*" => Ok(BinOp::Mul),
+            "/" | "div" => Ok(BinOp::Div),
+            "mod" => Ok(BinOp::Mod),
+            _ => Err(format!("Unexpected BinOp {}", s)),
+        }
+    }
+}
+
 impl fmt::Display for BinRel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -425,6 +440,21 @@ impl fmt::Display for BinRel {
             BinRel::Ge => write!(f, ">="),
             BinRel::Lt => write!(f, "<"),
             BinRel::Le => write!(f, "<="),
+        }
+    }
+}
+
+impl FromStr for BinRel {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "=" => Ok(BinRel::Eq),
+            "!=" => Ok(BinRel::Ne),
+            ">" => Ok(BinRel::Gt),
+            ">=" => Ok(BinRel::Ge),
+            "<" => Ok(BinRel::Lt),
+            "<=" => Ok(BinRel::Le),
+            _ => Err(format!("Unexpected BinRel {}", s)),
         }
     }
 }

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -336,6 +336,9 @@ impl<T: Types> fmt::Display for Expr<T> {
                     body
                 )
             }
+            Expr::WKVar(WKVar { wkvid, args }) => {
+                write!(f, "({} {})", wkvid.display(), args.iter().format(" "))
+            }
         }
     }
 }

--- a/lib/liquid-fixpoint/src/graph.rs
+++ b/lib/liquid-fixpoint/src/graph.rs
@@ -1,12 +1,11 @@
-use std::{
-    collections::{HashMap, HashSet},
-    hash::Hash,
-};
+use std::hash::Hash;
+
+use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 
 fn dfs_finish_order<'a, T: Hash + Eq + Clone>(
     node: &'a T,
-    graph: &'a HashMap<T, Vec<T>>,
-    visited: &mut HashSet<T>,
+    graph: &'a FxIndexMap<T, Vec<T>>,
+    visited: &mut FxIndexSet<T>,
     order: &mut Vec<T>,
 ) {
     if visited.contains(node) {
@@ -24,8 +23,8 @@ fn dfs_finish_order<'a, T: Hash + Eq + Clone>(
     order.push(node.clone());
 }
 
-fn reverse_graph<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -> HashMap<T, Vec<T>> {
-    let mut reversed = HashMap::new();
+fn reverse_graph<T: Hash + Eq + Clone>(graph: &FxIndexMap<T, Vec<T>>) -> FxIndexMap<T, Vec<T>> {
+    let mut reversed = FxIndexMap::default();
 
     for (node, neighbors) in graph {
         for neighbor in neighbors {
@@ -45,8 +44,8 @@ fn reverse_graph<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -> HashMap<T,
 
 fn dfs_collect_scc<'a, T: Hash + Eq + Clone>(
     node: &'a T,
-    graph: &'a HashMap<T, Vec<T>>,
-    visited: &mut HashSet<T>,
+    graph: &'a FxIndexMap<T, Vec<T>>,
+    visited: &mut FxIndexSet<T>,
     scc: &mut Vec<T>,
 ) {
     if visited.contains(node) {
@@ -63,8 +62,8 @@ fn dfs_collect_scc<'a, T: Hash + Eq + Clone>(
     }
 }
 
-fn find_sccs<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -> Vec<Vec<T>> {
-    let mut visited = HashSet::new();
+fn find_sccs<T: Hash + Eq + Clone>(graph: &FxIndexMap<T, Vec<T>>) -> Vec<Vec<T>> {
+    let mut visited = FxIndexSet::default();
     let mut order = Vec::new();
 
     // First pass: original graph
@@ -90,11 +89,11 @@ fn find_sccs<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -> Vec<Vec<T>> {
     sccs
 }
 
-pub fn topological_sort_sccs<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -> Vec<Vec<T>> {
+pub fn topological_sort_sccs<T: Hash + Eq + Clone>(graph: &FxIndexMap<T, Vec<T>>) -> Vec<Vec<T>> {
     let sccs = find_sccs::<T>(graph);
 
     // Map each node to its SCC index
-    let mut node_to_scc = HashMap::new();
+    let mut node_to_scc = FxIndexMap::default();
     for (i, scc) in sccs.iter().enumerate() {
         for node in scc {
             node_to_scc.insert(node.clone(), i);
@@ -102,7 +101,7 @@ pub fn topological_sort_sccs<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -
     }
 
     // Build condensed graph (DAG of SCCs)
-    let mut condensed_graph: HashMap<usize, HashSet<usize>> = HashMap::new();
+    let mut condensed_graph: FxIndexMap<usize, FxIndexSet<usize>> = FxIndexMap::default();
     for (node, neighbors) in graph {
         let &from = node_to_scc.get(node).unwrap();
         for neighbor in neighbors {
@@ -116,8 +115,8 @@ pub fn topological_sort_sccs<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -
     // Perform topological sort on SCC graph using DFS
     fn dfs_topo(
         node: usize,
-        graph: &HashMap<usize, HashSet<usize>>,
-        visited: &mut HashSet<usize>,
+        graph: &FxIndexMap<usize, FxIndexSet<usize>>,
+        visited: &mut FxIndexSet<usize>,
         result: &mut Vec<usize>,
     ) {
         if visited.contains(&node) {
@@ -135,7 +134,7 @@ pub fn topological_sort_sccs<T: Hash + Eq + Clone>(graph: &HashMap<T, Vec<T>>) -
         result.push(node);
     }
 
-    let mut visited = HashSet::new();
+    let mut visited = FxIndexSet::default();
     let mut result = Vec::new();
 
     for i in 0..sccs.len() {

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -53,7 +53,6 @@ use serde::{Deserialize, Serialize, de};
 pub type Assignments<'a, T> = HashMap<<T as Types>::KVar, Vec<(&'a Qualifier<T>, Vec<usize>)>>;
 
 #[cfg(feature = "wick")]
-
 #[cfg(feature = "rust-fixpoint")]
 use crate::constraint_with_env::ConstraintWithEnv;
 #[cfg(feature = "wick")]
@@ -180,7 +179,6 @@ pub fn check_validity<T: Types>(
     let datatype_decls = topo_sort_data_declarations(datatype_decls);
     cstr2smt2::check_validity(constraint, binder_consts, global_consts, &datatype_decls)
 }
-
 
 #[derive_where(Hash, Clone, Debug)]
 pub struct ConstDecl<T: Types> {

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -17,11 +17,12 @@ mod constraint;
 mod constraint_fragments;
 #[cfg(feature = "rust-fixpoint")]
 mod constraint_solving;
+#[cfg(any(feature = "rust-fixpoint", feature = "wick"))]
 mod constraint_with_env;
-// #[cfg(feature = "rust-fixpoint")]
+#[cfg(any(feature = "rust-fixpoint", feature = "wick"))]
 mod cstr2smt2;
 mod format;
-// #[cfg(feature = "rust-fixpoint")]
+#[cfg(any(feature = "rust-fixpoint", feature = "wick"))]
 mod graph;
 pub mod parser;
 pub mod sexp;
@@ -40,11 +41,9 @@ use std::{
 };
 
 pub use constraint::{
-    BinOp, BinRel, Bind, Constant, Constraint, DataCtor, DataDecl, DataField,
-    FunSort, Expr, FlatConstraint, Pred, Qualifier, Sort, SortCtor, SortDecl, WKVar,
+    BinOp, BinRel, Bind, Constant, Constraint, DataCtor, DataDecl, DataField, Expr, FlatConstraint,
+    FunSort, Pred, Qualifier, Sort, SortCtor, SortDecl, WKVar,
 };
-use constraint_with_env::{topo_sort_data_declarations, ConstraintWithEnv};
-use cstr2smt2::Z3DecodeError;
 use derive_where::derive_where;
 #[cfg(feature = "nightly")]
 use rustc_macros::{Decodable, Encodable};
@@ -57,6 +56,8 @@ pub type Assignments<'a, T> = HashMap<<T as Types>::KVar, Vec<(&'a Qualifier<T>,
 
 #[cfg(feature = "rust-fixpoint")]
 use crate::constraint_with_env::ConstraintWithEnv;
+#[cfg(feature = "wick")]
+use crate::constraint_with_env::topo_sort_data_declarations;
 
 pub trait Types {
     type Sort: Identifier + Hash + Clone + Debug + Eq;
@@ -156,14 +157,26 @@ macro_rules! declare_types {
     };
 }
 
-pub fn qe_and_simplify<T: Types>(constraint: &FlatConstraint<T>, binder_consts: &Vec<ConstDecl<T>>, global_consts: &Vec<ConstDecl<T>>, datatype_decls: Vec<DataDecl<T>>) -> Result<Expr<T>, Z3DecodeError> {
+#[cfg(feature = "wick")]
+pub fn qe_and_simplify<T: Types>(
+    constraint: &FlatConstraint<T>,
+    binder_consts: &Vec<ConstDecl<T>>,
+    global_consts: &Vec<ConstDecl<T>>,
+    datatype_decls: Vec<DataDecl<T>>,
+) -> Result<Expr<T>, cstr2smt2::Z3DecodeError> {
     // let mut consts = self.constants.clone();
     // consts.extend(free_vars.clone());
     let datatype_decls = topo_sort_data_declarations(datatype_decls);
     cstr2smt2::qe_and_simplify(constraint, binder_consts, global_consts, &datatype_decls)
 }
 
-pub fn check_validity<T: Types>(constraint: &FlatConstraint<T>, binder_consts: &Vec<ConstDecl<T>>, global_consts: &Vec<ConstDecl<T>>, datatype_decls: Vec<DataDecl<T>>) -> bool {
+#[cfg(feature = "wick")]
+pub fn check_validity<T: Types>(
+    constraint: &FlatConstraint<T>,
+    binder_consts: &Vec<ConstDecl<T>>,
+    global_consts: &Vec<ConstDecl<T>>,
+    datatype_decls: Vec<DataDecl<T>>,
+) -> bool {
     let datatype_decls = topo_sort_data_declarations(datatype_decls);
     cstr2smt2::check_validity(constraint, binder_consts, global_consts, &datatype_decls)
 }

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -52,8 +52,7 @@ use serde::{Deserialize, Serialize, de};
 /// Type alias for qualifier assignments used in constraint solving
 pub type Assignments<'a, T> = HashMap<<T as Types>::KVar, Vec<(&'a Qualifier<T>, Vec<usize>)>>;
 
-#[cfg(feature = "wick")]
-#[cfg(feature = "rust-fixpoint")]
+#[cfg(any(feature = "wick", feature = "rust-fixpoint"))]
 use crate::constraint_with_env::ConstraintWithEnv;
 #[cfg(feature = "wick")]
 use crate::constraint_with_env::topo_sort_data_declarations;

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -39,7 +39,7 @@ use std::{
 
 pub use constraint::{
     BinOp, BinRel, Bind, BoundVar, Constant, Constraint, DataCtor, DataDecl, DataField, Expr,
-    FunSort, Pred, Qualifier, Sort, SortCtor, SortDecl,
+    FunSort, Pred, Qualifier, Sort, SortCtor, SortDecl, WKVar,
 };
 use derive_where::derive_where;
 #[cfg(feature = "nightly")]
@@ -136,7 +136,7 @@ macro_rules! declare_types {
             pub type DataField = $crate::DataField<FixpointTypes>;
             pub type Bind = $crate::Bind<FixpointTypes>;
             pub type Constant = $crate::Constant<FixpointTypes>;
-            pub use $crate::{BinOp, BinRel, BoundVar, ThyFunc};
+            pub use $crate::{BinOp, BinRel, ThyFunc, WKVar};
         }
 
         impl $crate::Types for fixpoint_generated::FixpointTypes {

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -4,6 +4,8 @@
 #![cfg_attr(feature = "nightly", feature(rustc_private))]
 
 #[cfg(feature = "nightly")]
+extern crate rustc_data_structures;
+#[cfg(feature = "nightly")]
 extern crate rustc_macros;
 #[cfg(feature = "nightly")]
 extern crate rustc_serialize;
@@ -16,10 +18,10 @@ mod constraint_fragments;
 #[cfg(feature = "rust-fixpoint")]
 mod constraint_solving;
 mod constraint_with_env;
-#[cfg(feature = "rust-fixpoint")]
+// #[cfg(feature = "rust-fixpoint")]
 mod cstr2smt2;
 mod format;
-#[cfg(feature = "rust-fixpoint")]
+// #[cfg(feature = "rust-fixpoint")]
 mod graph;
 pub mod parser;
 pub mod sexp;
@@ -38,9 +40,11 @@ use std::{
 };
 
 pub use constraint::{
-    BinOp, BinRel, Bind, BoundVar, Constant, Constraint, DataCtor, DataDecl, DataField, Expr,
-    FunSort, Pred, Qualifier, Sort, SortCtor, SortDecl, WKVar,
+    BinOp, BinRel, Bind, Constant, Constraint, DataCtor, DataDecl, DataField,
+    FunSort, Expr, FlatConstraint, Pred, Qualifier, Sort, SortCtor, SortDecl, WKVar,
 };
+use constraint_with_env::{topo_sort_data_declarations, ConstraintWithEnv};
+use cstr2smt2::Z3DecodeError;
 use derive_where::derive_where;
 #[cfg(feature = "nightly")]
 use rustc_macros::{Decodable, Encodable};
@@ -49,6 +53,8 @@ use serde::{Deserialize, Serialize, de};
 /// Type alias for qualifier assignments used in constraint solving
 pub type Assignments<'a, T> = HashMap<<T as Types>::KVar, Vec<(&'a Qualifier<T>, Vec<usize>)>>;
 
+#[cfg(feature = "wick")]
+
 #[cfg(feature = "rust-fixpoint")]
 use crate::constraint_with_env::ConstraintWithEnv;
 
@@ -56,7 +62,7 @@ pub trait Types {
     type Sort: Identifier + Hash + Clone + Debug + Eq;
     type KVar: Identifier + Hash + Clone + Debug + Eq;
     type Var: Identifier + Hash + Clone + Debug + Eq;
-    type String: FixpointFmt + Hash + Clone + Debug;
+    type String: FixpointFmt + Hash + Clone + Debug + Eq;
     type Tag: fmt::Display + FromStr + Hash + Clone + Debug;
 }
 
@@ -121,6 +127,7 @@ macro_rules! declare_types {
             pub type Expr = $crate::Expr<FixpointTypes>;
             pub type Pred = $crate::Pred<FixpointTypes>;
             pub type Constraint = $crate::Constraint<FixpointTypes>;
+            pub type FlatConstraint = $crate::FlatConstraint<FixpointTypes>;
             pub type KVarDecl = $crate::KVarDecl<FixpointTypes>;
             pub type ConstDecl = $crate::ConstDecl<FixpointTypes>;
             pub type FunDef = $crate::FunDef<FixpointTypes>;
@@ -148,6 +155,19 @@ macro_rules! declare_types {
         }
     };
 }
+
+pub fn qe_and_simplify<T: Types>(constraint: &FlatConstraint<T>, binder_consts: &Vec<ConstDecl<T>>, global_consts: &Vec<ConstDecl<T>>, datatype_decls: Vec<DataDecl<T>>) -> Result<Expr<T>, Z3DecodeError> {
+    // let mut consts = self.constants.clone();
+    // consts.extend(free_vars.clone());
+    let datatype_decls = topo_sort_data_declarations(datatype_decls);
+    cstr2smt2::qe_and_simplify(constraint, binder_consts, global_consts, &datatype_decls)
+}
+
+pub fn check_validity<T: Types>(constraint: &FlatConstraint<T>, binder_consts: &Vec<ConstDecl<T>>, global_consts: &Vec<ConstDecl<T>>, datatype_decls: Vec<DataDecl<T>>) -> bool {
+    let datatype_decls = topo_sort_data_declarations(datatype_decls);
+    cstr2smt2::check_validity(constraint, binder_consts, global_consts, &datatype_decls)
+}
+
 
 #[derive_where(Hash, Clone, Debug)]
 pub struct ConstDecl<T: Types> {
@@ -574,6 +594,56 @@ impl fmt::Display for ThyFunc {
             ThyFunc::MapDefault => write!(f, "Map_default"),
             ThyFunc::MapSelect => write!(f, "Map_select"),
             ThyFunc::MapStore => write!(f, "Map_store"),
+        }
+    }
+}
+
+impl FromStr for ThyFunc {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "strLen" => Ok(ThyFunc::StrLen),
+            "int_to_bv32" => Ok(ThyFunc::IntToBv32),
+            "bv32_to_int" => Ok(ThyFunc::Bv32ToInt),
+            "int_to_bv8" => Ok(ThyFunc::IntToBv8),
+            "bv8_to_int" => Ok(ThyFunc::Bv8ToInt),
+            "int_to_bv64" => Ok(ThyFunc::IntToBv64),
+            "bv64_to_int" => Ok(ThyFunc::Bv64ToInt),
+            "bvule" => Ok(ThyFunc::BvUle),
+            "bvsle" => Ok(ThyFunc::BvSle),
+            "bvuge" => Ok(ThyFunc::BvUge),
+            "bvsge" => Ok(ThyFunc::BvSge),
+            "bvudiv" => Ok(ThyFunc::BvUdiv),
+            "bvsdiv" => Ok(ThyFunc::BvSdiv),
+            "bvurem" => Ok(ThyFunc::BvUrem),
+            "bvsrem" => Ok(ThyFunc::BvSrem),
+            "bvlshr" => Ok(ThyFunc::BvLshr),
+            "bvashr" => Ok(ThyFunc::BvAshr),
+            "bvand" => Ok(ThyFunc::BvAnd),
+            "bvor" => Ok(ThyFunc::BvOr),
+            "bvxor" => Ok(ThyFunc::BvXor),
+            "bvnot" => Ok(ThyFunc::BvNot),
+            "bvadd" => Ok(ThyFunc::BvAdd),
+            "bvneg" => Ok(ThyFunc::BvNeg),
+            "bvsub" => Ok(ThyFunc::BvSub),
+            "bvmul" => Ok(ThyFunc::BvMul),
+            "bvshl" => Ok(ThyFunc::BvShl),
+            "bvugt" => Ok(ThyFunc::BvUgt),
+            "bvsgt" => Ok(ThyFunc::BvSgt),
+            "bvult" => Ok(ThyFunc::BvUlt),
+            "bvslt" => Ok(ThyFunc::BvSlt),
+            "Set_empty" => Ok(ThyFunc::SetEmpty),
+            "Set_sng" => Ok(ThyFunc::SetSng),
+            "Set_cup" => Ok(ThyFunc::SetCup),
+            "Set_mem" => Ok(ThyFunc::SetMem),
+            "Map_default" => Ok(ThyFunc::MapDefault),
+            "Map_select" => Ok(ThyFunc::MapSelect),
+            "Map_store" => Ok(ThyFunc::MapStore),
+            // TODO: (ck) Fix this?
+            // NOTE: (ck) There isn't a straightforward way to translate
+            // the name of a Z3 node to the BvZeroExtend and BvSignExtend,
+            // so this is a partial parse.
+            _ => Err(format!("Unexpected ThyFunc {}", s)),
         }
     }
 }

--- a/lib/liquid-fixpoint/src/parser.rs
+++ b/lib/liquid-fixpoint/src/parser.rs
@@ -199,7 +199,13 @@ where
             }
             Sexp::Atom(Atom::Q(s)) => Ok(Expr::Constant(Constant::String(self.parser.string(s)?))),
             Sexp::Atom(Atom::B(b)) => Ok(Expr::Constant(Constant::Boolean(*b))),
-            Sexp::Atom(Atom::I(i)) => Ok(Expr::Constant(Constant::Numeral(*i))),
+            Sexp::Atom(Atom::I(i)) => {
+                if *i >= 0 {
+                    Ok(Expr::Constant(Constant::Numeral(*i as u128)))
+                } else {
+                    Ok(Expr::Neg(Box::new(Expr::Constant(Constant::Numeral(-i as u128)))))
+                }
+            }
             Sexp::Atom(Atom::F(_f)) => {
                 unimplemented!("Float parsing not supported in fixpoint (see Constant::Real)")
             }

--- a/lib/liquid-fixpoint/src/parser.rs
+++ b/lib/liquid-fixpoint/src/parser.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use indexmap::IndexMap;
 use itertools::Itertools;
+use rustc_data_structures::fx::FxIndexMap;
 
 use crate::{
     BinOp, BinRel, Bind, Constant, Expr, Identifier, Pred, Sort, SortCtor, ThyFunc, Types,
@@ -44,7 +44,7 @@ pub trait FromSexp<T: Types> {
 pub struct FromSexpWrapper<T: Types, Parser> {
     pub parser: Parser,
     pub _phantom: std::marker::PhantomData<T>,
-    scopes: Vec<IndexMap<String, T::Var>>,
+    scopes: Vec<FxIndexMap<String, T::Var>>,
 }
 
 type KvarSolution<T> = (Vec<(<T as Types>::Var, Sort<T>)>, Expr<T>);
@@ -153,6 +153,15 @@ where
         Ok(Expr::IsCtor(ctor, Box::new(arg)))
     }
 
+    fn parse_wkvar(&mut self, wkvar_name: &str, args: &[Sexp]) -> Result<Expr<T>, ParseError> {
+        let wkvid = self.parser.var(wkvar_name)?;
+        let args = args
+            .into_iter()
+            .map(|arg| self.parse_expr(arg))
+            .try_collect()?;
+        Ok(Expr::WKVar(WKVar { wkvid, args }))
+    }
+
     pub fn parse_expr(&mut self, sexp: &Sexp) -> Result<Expr<T>, ParseError> {
         match sexp {
             Sexp::List(items) => {
@@ -172,6 +181,7 @@ where
                         "=>" => self.parse_imp(sexp),
                         "cast_as_int" => self.parse_expr(&items[1]), // some odd thing that fixpoint-hs seems to add for sets...
                         _ if s.starts_with("is$") => self.parse_is_ctor(&s[3..], &items[1]),
+                        _ if s.starts_with("wk$") => self.parse_wkvar(s, &items[1..]),
                         _ => self.parse_app(sexp),
                     }
                 } else {
@@ -518,7 +528,7 @@ where
                 .try_collect()?;
             self.push_scope(&kvar_args);
 
-            let expr = self.parse_expr(body)?;
+            let expr = self.parse_expr(body)?.uncurry();
 
             let mut scope = self.pop_scope().unwrap();
             let bound = kvar_args
@@ -542,7 +552,7 @@ where
         );
     }
 
-    fn pop_scope(&mut self) -> Option<IndexMap<String, T::Var>> {
+    fn pop_scope(&mut self) -> Option<FxIndexMap<String, T::Var>> {
         self.scopes.pop()
     }
 

--- a/lib/liquid-fixpoint/src/parser.rs
+++ b/lib/liquid-fixpoint/src/parser.rs
@@ -153,15 +153,6 @@ where
         Ok(Expr::IsCtor(ctor, Box::new(arg)))
     }
 
-    fn parse_wkvar(&mut self, wkvar_name: &str, args: &[Sexp]) -> Result<Expr<T>, ParseError> {
-        let wkvid = self.parser.var(wkvar_name)?;
-        let args = args
-            .into_iter()
-            .map(|arg| self.parse_expr(arg))
-            .try_collect()?;
-        Ok(Expr::WKVar(WKVar { wkvid, args }))
-    }
-
     pub fn parse_expr(&mut self, sexp: &Sexp) -> Result<Expr<T>, ParseError> {
         match sexp {
             Sexp::List(items) => {
@@ -182,7 +173,6 @@ where
                         "cast_as_int" => self.parse_expr(&items[1]), // some odd thing that fixpoint-hs seems to add for sets...
                         "if" => self.parse_ite(&items[1], &items[2], &items[3]),
                         _ if s.starts_with("is$") => self.parse_is_ctor(&s[3..], &items[1]),
-                        _ if s.starts_with("wk$") => self.parse_wkvar(s, &items[1..]),
                         _ => self.parse_app(sexp),
                     }
                 } else {

--- a/lib/liquid-fixpoint/src/parser.rs
+++ b/lib/liquid-fixpoint/src/parser.rs
@@ -180,6 +180,7 @@ where
                         "<=>" => self.parse_iff(sexp),
                         "=>" => self.parse_imp(sexp),
                         "cast_as_int" => self.parse_expr(&items[1]), // some odd thing that fixpoint-hs seems to add for sets...
+                        "if" => self.parse_ite(&items[1], &items[2], &items[3]),
                         _ if s.starts_with("is$") => self.parse_is_ctor(&s[3..], &items[1]),
                         _ if s.starts_with("wk$") => self.parse_wkvar(s, &items[1..]),
                         _ => self.parse_app(sexp),
@@ -426,6 +427,18 @@ where
             }
             _ => Err(ParseError::err("Expected list for let")),
         }
+    }
+
+    fn parse_ite(
+        &mut self,
+        cond_e: &Sexp,
+        then_e: &Sexp,
+        else_e: &Sexp,
+    ) -> Result<Expr<T>, ParseError> {
+        let c = self.parse_expr(cond_e)?;
+        let t = self.parse_expr(then_e)?;
+        let e = self.parse_expr(else_e)?;
+        Ok(Expr::IfThenElse(Box::new([c, t, e])))
     }
 
     fn parse_list_sort(&self, sexp: &Sexp) -> Result<Sort<T>, ParseError> {

--- a/lib/liquid-fixpoint/src/sexp.rs
+++ b/lib/liquid-fixpoint/src/sexp.rs
@@ -4,7 +4,7 @@ use std::str::Chars;
 pub enum Atom {
     S(String),
     Q(String),
-    I(u128),
+    I(i128),
     F(f64),
     B(bool),
 }
@@ -141,7 +141,7 @@ impl<'a> Parser<'a> {
             "true" => Ok(Sexp::Atom(Atom::B(true))),
             "false" => Ok(Sexp::Atom(Atom::B(false))),
             _ => {
-                if let Ok(i) = s.parse::<u128>() {
+                if let Ok(i) = s.parse::<i128>() {
                     Ok(Sexp::Atom(Atom::I(i)))
                 } else if let Ok(f) = s.parse::<f64>() {
                     Ok(Sexp::Atom(Atom::F(f)))

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,6 +21,8 @@ xflags::xflags! {
         optional --offline
         /// If true, run cargo build commands with --features rust-fixpiont
         optional --rust-fixpoint
+        /// If true, run cargo build commands with --features wick
+        optional --wick
 
         /// Run regression tests
         cmd test {
@@ -113,15 +115,16 @@ fn main() -> anyhow::Result<()> {
         extra.push("--offline");
     }
     match cmd.subcommand {
-        XtaskCmd::Test(args) => test(args, cmd.rust_fixpoint),
+        XtaskCmd::Test(args) => test(args, cmd.rust_fixpoint, cmd.wick),
         XtaskCmd::LeanBench(args) => lean_bench(args, cmd.rust_fixpoint),
-        XtaskCmd::Run(args) => run(args, cmd.rust_fixpoint),
-        XtaskCmd::Install(args) => install(&args, &extra, cmd.rust_fixpoint),
+        XtaskCmd::Run(args) => run(args, cmd.rust_fixpoint, cmd.wick),
+        XtaskCmd::Install(args) => install(&args, &extra, cmd.rust_fixpoint, cmd.wick),
         XtaskCmd::Doc(args) => doc(args),
         XtaskCmd::BuildSysroot(_) => {
             let config = SysrootConfig {
                 profile: Profile::Dev,
                 rust_fixpoint: cmd.rust_fixpoint,
+                wick: cmd.wick,
                 dst: local_sysroot_dir()?,
                 build_libs: BuildLibs { force: true, tests: true, libs: FluxLib::ALL },
             };
@@ -133,14 +136,15 @@ fn main() -> anyhow::Result<()> {
     }
 }
 
-fn test(args: Test, rust_fixpoint: bool) -> anyhow::Result<()> {
+fn test(args: Test, rust_fixpoint: bool, wick: bool) -> anyhow::Result<()> {
     let config = SysrootConfig {
         profile: Profile::Dev,
         rust_fixpoint,
+        wick,
         dst: local_sysroot_dir()?,
         build_libs: BuildLibs { force: false, tests: !args.no_lib_tests, libs: FluxLib::ALL },
     };
-    let flux = build_binary("flux", config.profile, false)?;
+    let flux = build_binary("flux", config.profile, false, false)?;
     install_sysroot(&config)?;
 
     Command::new("cargo")
@@ -159,11 +163,12 @@ fn lean_bench(args: LeanBench, rust_fixpoint: bool) -> anyhow::Result<()> {
     let config = SysrootConfig {
         profile: Profile::Dev,
         rust_fixpoint,
+        wick: false,
         dst: local_sysroot_dir()?,
         build_libs: BuildLibs { force: false, tests: false, libs: FluxLib::ALL },
     };
     install_sysroot(&config)?;
-    let flux = build_binary("flux", config.profile, false)?;
+    let flux = build_binary("flux", config.profile, false, false)?;
 
     let pos_path = PathBuf::from("tests/tests/pos");
     let lean_bench_dir = PathBuf::from("tests/lean_bench");
@@ -281,7 +286,7 @@ fn lean_bench(args: LeanBench, rust_fixpoint: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run(args: Run, rust_fixpoint: bool) -> anyhow::Result<()> {
+fn run(args: Run, rust_fixpoint: bool, wick: bool) -> anyhow::Result<()> {
     let libs = if args.no_extern_specs { &[FluxLib::FluxRs] } else { FluxLib::ALL };
     run_inner(
         args.input,
@@ -290,6 +295,7 @@ fn run(args: Run, rust_fixpoint: bool) -> anyhow::Result<()> {
             .into_iter()
             .chain(args.opts),
         rust_fixpoint,
+        wick,
     )?;
     Ok(())
 }
@@ -300,6 +306,7 @@ fn expand(args: Expand) -> Result<(), anyhow::Error> {
         BuildLibs { force: false, tests: false, libs: &[FluxLib::FluxRs] },
         ["-Zunpretty=expanded".to_string()],
         false,
+        false,
     )?;
     Ok(())
 }
@@ -309,16 +316,18 @@ fn run_inner(
     build_libs: BuildLibs,
     flags: impl IntoIterator<Item = String>,
     rust_fixpoint: bool,
+    wick: bool,
 ) -> Result<(), anyhow::Error> {
     let config = SysrootConfig {
         profile: Profile::Dev,
         rust_fixpoint,
+        wick,
         dst: local_sysroot_dir()?,
         build_libs,
     };
 
     install_sysroot(&config)?;
-    let flux = build_binary("flux", config.profile, false)?;
+    let flux = build_binary("flux", config.profile, false, false)?;
 
     let mut rustc_flags = tests::default_flags();
     rustc_flags.extend(flags);
@@ -330,11 +339,12 @@ fn run_inner(
         .run()
 }
 
-fn install(args: &Install, extra: &[&str], rust_fixpoint: bool) -> anyhow::Result<()> {
+fn install(args: &Install, extra: &[&str], rust_fixpoint: bool, wick: bool) -> anyhow::Result<()> {
     let libs = if args.no_extern_specs { &[FluxLib::FluxRs] } else { FluxLib::ALL };
     let config = SysrootConfig {
         profile: args.profile(),
         rust_fixpoint,
+        wick,
         dst: default_sysroot_dir(),
         build_libs: BuildLibs { force: false, tests: false, libs },
     };
@@ -362,10 +372,18 @@ fn doc(_args: Doc) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn build_binary(bin: &str, profile: Profile, rust_fixpoint: bool) -> anyhow::Result<Utf8PathBuf> {
+fn build_binary(
+    bin: &str,
+    profile: Profile,
+    rust_fixpoint: bool,
+    wick: bool,
+) -> anyhow::Result<Utf8PathBuf> {
     let mut args = vec!["build", "--bin", bin, "--profile", profile.as_str()];
     if rust_fixpoint {
         args.extend_from_slice(&["--features", "rust-fixpoint"]);
+    }
+    if wick {
+        args.extend_from_slice(&["--features", "wick"]);
     }
     Command::new("cargo")
         .args(&args)
@@ -381,6 +399,8 @@ struct SysrootConfig {
     profile: Profile,
     /// Whether rust-fixpoint should be enabled to build `flux-driver`
     rust_fixpoint: bool,
+    /// Whether wick should be enabled to build `flux-driver`
+    wick: bool,
     /// Destination path for sysroot artifacts
     dst: PathBuf,
     build_libs: BuildLibs,
@@ -438,9 +458,12 @@ fn install_sysroot(config: &SysrootConfig) -> anyhow::Result<()> {
     remove_path(&config.dst)?;
     create_dir(&config.dst)?;
 
-    copy_file(build_binary("flux-driver", config.profile, config.rust_fixpoint)?, &config.dst)?;
+    copy_file(
+        build_binary("flux-driver", config.profile, config.rust_fixpoint, config.wick)?,
+        &config.dst,
+    )?;
 
-    let cargo_flux = build_binary("cargo-flux", config.profile, config.rust_fixpoint)?;
+    let cargo_flux = build_binary("cargo-flux", config.profile, config.rust_fixpoint, config.wick)?;
 
     if config.build_libs.force {
         Command::new(&cargo_flux)


### PR DESCRIPTION
# Basic usage
Compile with `--wick` for `xtask` (`--features=wick` otherwise). Running flux will now produce suggestions in addition to the error message.

There is now a `no_suggestions` attribute, flux.toml option, and flag to disable suggestions (granularly with the attribute, global for all else). This does nothing if not compiled with the `wick` feature.

Flux is more unstable with this feature. I've noticed crashes resulting from the WKVars auto-generated in types.

However, modulo errors caused by the removal of the 1-tuple optimization, Flux without the feature is the same as before.

# Errors
* RE: vtock, the crash is caused by the 1-tuple optimization being removed. I tested in a branch with the 1-tuple optimization added back in and it gets past the crash. It doesn't finish running though (even on main) on my machine, so I can't say for sure it's OK

# Commits
I've painstakingly separated out my changes into separate commits, the heaviest of which are the ones which add wkvars and then implement solving for them.

I recommend reviewing *everything else* first, because it's even possible for us to merge those changes into flux in separate commits if so desired.

# TODOs
There are a few TODOs in the PR. Not all of them need to be addressed and I'm pretty sure none are critical for flux to work with or without suggestions enabled.

I do need to remove (commented-out) print statements and do some more code tidying. But I'd like this PR to get review on the important parts rather than continuing to wait for me to tidy it up.

# Next steps
Aside from the TODOs, which represent smaller amounts of work, here are a few things I think should be addressed.
* Polymorphism
  - e.g. `Range` `..` doesn't work (cause a crash) because we don't/can't generate polymorphic sorts when querying Z3.
* Z3 dependency
  - In an ideal world we shouldn't need to compile against Z3. Some options include switching to calling out to Z3 like what fixpoint does or rolling our own QE.
* UIFs in QE
  - We have to fall back to a naive form of suggestion when QE fails due to UIFs. We can explore Ackermannization as well as other what other improvements would be necessary for QE to handle other theories/things Z3 doesn't like.
* Only prune invariants
  - I'm pretty sure we can fix some failures (e.g. those discussed in [#reconciliation > Special case solving for functions that return bool?](https://flux-rs.zulipchat.com/#narrow/channel/526882-reconciliation/topic/Special.20case.20solving.20for.20functions.20that.20return.20bool.3F/with/564841045)[#reconciliation > Special case solving for functions that return bool?](https://flux-rs.zulipchat.com/#narrow/channel/526882-reconciliation/topic/Special.20case.20solving.20for.20functions.20that.20return.20bool.3F/with/564841045)) by only pruning invariants, i.e. keeping all other assumptions
* Translate theory improvements
  - In the paper we made a lot of (good) simplifications to the theory. Now that the code is more manageable, I think it's worth trying to clean up what it's doing using these simplifications.