### PR TITLE
Blanket `TryInto` spec

### DIFF
--- a/lib/flux-core/src/convert/mod.rs
+++ b/lib/flux-core/src/convert/mod.rs
@@ -4,27 +4,27 @@ use flux_attrs::*;
 
 /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/convert/mod.rs#L612
 #[extern_spec(core::convert)]
-#[assoc(fn succeeds(x: Self) -> bool { true })]
-#[assoc(fn into_val(x: Self, into: T) -> bool { true })]
+#[assoc(fn succeeds(s: Self, out: Result) -> bool { true })]
+#[assoc(fn into_val(s: Self, into: T) -> bool { true })]
 trait TryInto<T>: Sized {
-    #[spec(fn(Self[@s]) -> Result<T{v: Self::into_val(s, v)}, Self::Error>[Self::succeeds(s)])]
+    #[spec(fn(Self[@s]) -> Result<T{v: Self::into_val(s, v)}, Self::Error>{out: Self::succeeds(s, out)})]
     fn try_into(self) -> Result<T, Self::Error>;
 }
 
 /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/convert/mod.rs#L687
 #[extern_spec(core::convert)]
-#[assoc(fn succeeds(x: T) -> bool { true })]
-#[assoc(fn from_val(x: T, into: Self) -> bool { true })]
+#[assoc(fn succeeds(s: T, out: Result) -> bool { true })]
+#[assoc(fn from_val(s: T, into: Self) -> bool { true })]
 trait TryFrom<T>: Sized {
-    #[spec(fn(T[@x]) -> Result<Self{v: Self::from_val(x, v)}, Self::Error>[Self::succeeds(x)])]
+    #[spec(fn(T[@s]) -> Result<Self{v: Self::from_val(s, v)}, Self::Error>{out: Self::succeeds(s, out)})]
     fn try_from(value: T) -> Result<Self, Self::Error>;
 }
 
 /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/convert/mod.rs#L740
 #[extern_spec(core::convert)]
-#[assoc(fn succeeds(x: T) -> bool { <U as TryFrom<T>>::succeeds(x) })]
-#[assoc(fn into_val(x: T, into: U) -> bool { <U as TryFrom<T>>::from_val(x, into) })]
+#[assoc(fn succeeds(s: T, out: Result) -> bool { <U as TryFrom<T>>::succeeds(s, out) })]
+#[assoc(fn into_val(s: T, into: U) -> bool { <U as TryFrom<T>>::from_val(s, into) })]
 impl<T, U: TryFrom<T>> TryInto<U> for T {
-    #[spec(fn(T[@x]) -> Result<U{v: <U as TryFrom<T>>::from_val(x, v)}, U::Error>[<U as TryFrom<T>>::succeeds(x)])]
+    #[spec(fn(T[@s]) -> Result<U{v: <U as TryFrom<T>>::from_val(s, v)}, U::Error>{out: <U as TryFrom<T>>::succeeds(s, out)})]
     fn try_into(self) -> Result<U, U::Error>;
 }

--- a/lib/flux-core/src/convert/mod.rs
+++ b/lib/flux-core/src/convert/mod.rs
@@ -7,7 +7,7 @@ use flux_attrs::*;
 #[assoc(fn succeeds(x: Self) -> bool { true })]
 #[assoc(fn into_val(x: Self, into: T) -> bool { true })]
 trait TryInto<T>: Sized {
-    #[spec(fn(Self[@s]) -> Result<T{v: Self::into_val(s, v)}, Self::Error>[<Self as TryInto<T>>::succeeds(s)])]
+    #[spec(fn(Self[@s]) -> Result<T{v: Self::into_val(s, v)}, Self::Error>[Self::succeeds(s)])]
     fn try_into(self) -> Result<T, Self::Error>;
 }
 
@@ -16,7 +16,7 @@ trait TryInto<T>: Sized {
 #[assoc(fn succeeds(x: T) -> bool { true })]
 #[assoc(fn from_val(x: T, into: Self) -> bool { true })]
 trait TryFrom<T>: Sized {
-    #[spec(fn(T[@x]) -> Result<Self{v: Self::from_val(x, v)}, Self::Error>[<Self as TryFrom<T>>::succeeds(x)])]
+    #[spec(fn(T[@x]) -> Result<Self{v: Self::from_val(x, v)}, Self::Error>[Self::succeeds(x)])]
     fn try_from(value: T) -> Result<Self, Self::Error>;
 }
 

--- a/lib/flux-core/src/convert/mod.rs
+++ b/lib/flux-core/src/convert/mod.rs
@@ -2,17 +2,31 @@ mod num;
 
 use flux_attrs::*;
 
+/// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/convert/mod.rs#L612
 #[extern_spec(core::convert)]
+#[assoc(fn succeeds(x: Self) -> bool { true })]
 #[assoc(fn into_val(x: Self, into: T) -> bool { true })]
 trait TryInto<T>: Sized {
-    #[spec(fn(Self[@s]) -> Result<T{v: Self::into_val(s, v)}, Self::Error>)]
+    #[spec(fn(Self[@s]) -> Result<T{v: Self::into_val(s, v)}, Self::Error>[<Self as TryInto<T>>::succeeds(s)])]
     fn try_into(self) -> Result<T, Self::Error>;
 }
 
 /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/convert/mod.rs#L687
 #[extern_spec(core::convert)]
+#[assoc(fn succeeds(x: T) -> bool { true })]
 #[assoc(fn from_val(x: T, into: Self) -> bool { true })]
 trait TryFrom<T>: Sized {
-    #[spec(fn(T[@s]) -> Result<Self{v: Self::from_val(s, v)}, Self::Error>)]
+    #[spec(fn(T[@x]) -> Result<Self{v: Self::from_val(x, v)}, Self::Error>[<Self as TryFrom<T>>::succeeds(x)])]
     fn try_from(value: T) -> Result<Self, Self::Error>;
 }
+
+// /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/convert/mod.rs#L740
+// #[extern_spec(core::convert)]
+// impl<T, U> TryInto<U> for T
+// where
+//     U: TryFrom<T>,
+// {
+//     #[assoc(fn succeeds(x: T) -> bool { <U as TryFrom<T>>::succeeds(x) })]
+//     #[assoc(fn into_val(x: T, into: U) -> bool { <U as TryFrom<T>>::from_val(x, into) })]
+//     fn try_into(self) -> Result<U, U::Error>;
+// }

--- a/lib/flux-core/src/convert/mod.rs
+++ b/lib/flux-core/src/convert/mod.rs
@@ -25,5 +25,6 @@ trait TryFrom<T>: Sized {
 #[assoc(fn succeeds(x: T) -> bool { <U as TryFrom<T>>::succeeds(x) })]
 #[assoc(fn into_val(x: T, into: U) -> bool { <U as TryFrom<T>>::from_val(x, into) })]
 impl<T, U: TryFrom<T>> TryInto<U> for T {
+    #[spec(fn(T[@x]) -> Result<U{v: <U as TryFrom<T>>::from_val(x, v)}, U::Error>[<U as TryFrom<T>>::succeeds(x)])]
     fn try_into(self) -> Result<U, U::Error>;
 }

--- a/lib/flux-core/src/convert/mod.rs
+++ b/lib/flux-core/src/convert/mod.rs
@@ -20,13 +20,10 @@ trait TryFrom<T>: Sized {
     fn try_from(value: T) -> Result<Self, Self::Error>;
 }
 
-// /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/convert/mod.rs#L740
-// #[extern_spec(core::convert)]
-// impl<T, U> TryInto<U> for T
-// where
-//     U: TryFrom<T>,
-// {
-//     #[assoc(fn succeeds(x: T) -> bool { <U as TryFrom<T>>::succeeds(x) })]
-//     #[assoc(fn into_val(x: T, into: U) -> bool { <U as TryFrom<T>>::from_val(x, into) })]
-//     fn try_into(self) -> Result<U, U::Error>;
-// }
+/// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/convert/mod.rs#L740
+#[extern_spec(core::convert)]
+#[assoc(fn succeeds(x: T) -> bool { <U as TryFrom<T>>::succeeds(x) })]
+#[assoc(fn into_val(x: T, into: U) -> bool { <U as TryFrom<T>>::from_val(x, into) })]
+impl<T, U: TryFrom<T>> TryInto<U> for T {
+    fn try_into(self) -> Result<U, U::Error>;
+}

--- a/lib/flux-core/src/convert/num.rs
+++ b/lib/flux-core/src/convert/num.rs
@@ -8,7 +8,7 @@ use flux_attrs::*;
 macro_rules! try_from_unbounded {
     ($Src:ident => $($Dst:ident),+) => {$(
         #[extern_spec(core::convert)]
-        #[assoc(fn succeeds(x: int) -> bool { true })]
+        #[assoc(fn succeeds(x: int, out: Result) -> bool { true })]
         #[assoc(fn from_val(x: int, into: int) -> bool { x == into })]
         impl TryFrom<$Src> for $Dst {
             #[no_panic]
@@ -23,7 +23,7 @@ macro_rules! try_from_unbounded {
 macro_rules! try_from_lower_bounded {
     ($Src:ident => $($Dst:ident),+) => {$(
         #[extern_spec(core::convert)]
-        #[assoc(fn succeeds(x: int) -> bool { x >= 0 })]
+        #[assoc(fn succeeds(x: int, out: Result) -> bool { out.is_ok == (x >= 0) })]
         #[assoc(fn from_val(x: int, into: int) -> bool { x == into })]
         impl TryFrom<$Src> for $Dst {
             #[no_panic]
@@ -38,7 +38,7 @@ macro_rules! try_from_lower_bounded {
 macro_rules! try_from_upper_bounded {
     ($Src:ident => $($Dst:ident),+) => {$(
         #[extern_spec(core::convert)]
-        #[assoc(fn succeeds(x: int) -> bool { x <= $Dst::MAX })]
+        #[assoc(fn succeeds(x: int, out: Result) -> bool { out.is_ok == (x <= $Dst::MAX) })]
         #[assoc(fn from_val(x: int, into: int) -> bool { x == into })]
         impl TryFrom<$Src> for $Dst {
             #[no_panic]
@@ -53,7 +53,7 @@ macro_rules! try_from_upper_bounded {
 macro_rules! try_from_both_bounded {
     ($Src:ident => $($Dst:ident),+) => {$(
         #[extern_spec(core::convert)]
-        #[assoc(fn succeeds(x: int) -> bool { $Dst::MIN <= x && x <= $Dst::MAX })]
+        #[assoc(fn succeeds(x: int, out: Result) -> bool { out.is_ok == ($Dst::MIN <= x && x <= $Dst::MAX) })]
         #[assoc(fn from_val(x: int, into: int) -> bool { x == into })]
         impl TryFrom<$Src> for $Dst {
             #[no_panic]

--- a/lib/flux-core/src/convert/num.rs
+++ b/lib/flux-core/src/convert/num.rs
@@ -8,6 +8,7 @@ use flux_attrs::*;
 macro_rules! try_from_unbounded {
     ($Src:ident => $($Dst:ident),+) => {$(
         #[extern_spec(core::convert)]
+        #[assoc(fn succeeds(x: int) -> bool { true })]
         #[assoc(fn from_val(x: int, into: int) -> bool { x == into })]
         impl TryFrom<$Src> for $Dst {
             #[no_panic]
@@ -22,6 +23,7 @@ macro_rules! try_from_unbounded {
 macro_rules! try_from_lower_bounded {
     ($Src:ident => $($Dst:ident),+) => {$(
         #[extern_spec(core::convert)]
+        #[assoc(fn succeeds(x: int) -> bool { x >= 0 })]
         #[assoc(fn from_val(x: int, into: int) -> bool { x == into })]
         impl TryFrom<$Src> for $Dst {
             #[no_panic]
@@ -36,6 +38,7 @@ macro_rules! try_from_lower_bounded {
 macro_rules! try_from_upper_bounded {
     ($Src:ident => $($Dst:ident),+) => {$(
         #[extern_spec(core::convert)]
+        #[assoc(fn succeeds(x: int) -> bool { x <= $Dst::MAX })]
         #[assoc(fn from_val(x: int, into: int) -> bool { x == into })]
         impl TryFrom<$Src> for $Dst {
             #[no_panic]
@@ -50,6 +53,7 @@ macro_rules! try_from_upper_bounded {
 macro_rules! try_from_both_bounded {
     ($Src:ident => $($Dst:ident),+) => {$(
         #[extern_spec(core::convert)]
+        #[assoc(fn succeeds(x: int) -> bool { $Dst::MIN <= x && x <= $Dst::MAX })]
         #[assoc(fn from_val(x: int, into: int) -> bool { x == into })]
         impl TryFrom<$Src> for $Dst {
             #[no_panic]

--- a/tests/tests/neg/extern_specs/flux_core_num01.rs
+++ b/tests/tests/neg/extern_specs/flux_core_num01.rs
@@ -36,3 +36,34 @@ pub fn test_lower_bounded_no_check(x: i64) {
 pub fn test_both_bounded_err_no_check(x: i64) {
     assert(i32::try_from(x).is_err()); //~ ERROR refinement type error
 }
+
+// --- try_into: same checks required ---
+
+pub fn test_into_both_bounded_no_check(x: i64) {
+    let r: Result<i32, _> = x.try_into();
+    assert(r.is_ok()); //~ ERROR refinement type error
+}
+
+pub fn test_into_both_bounded_only_lower(x: i64) {
+    if x >= i32::MIN as i64 {
+        let r: Result<i32, _> = x.try_into();
+        assert(r.is_ok()); //~ ERROR refinement type error
+    }
+}
+
+pub fn test_into_both_bounded_only_upper(x: i64) {
+    if x <= i32::MAX as i64 {
+        let r: Result<i32, _> = x.try_into();
+        assert(r.is_ok()); //~ ERROR refinement type error
+    }
+}
+
+pub fn test_into_upper_bounded_no_check(x: u64) {
+    let r: Result<u32, _> = x.try_into();
+    assert(r.is_ok()); //~ ERROR refinement type error
+}
+
+pub fn test_into_lower_bounded_no_check(x: i64) {
+    let r: Result<u64, _> = x.try_into();
+    assert(r.is_ok()); //~ ERROR refinement type error
+}

--- a/tests/tests/pos/extern_specs/flux_core_num01.rs
+++ b/tests/tests/pos/extern_specs/flux_core_num01.rs
@@ -104,3 +104,69 @@ pub fn test_lower_bounded_concrete() {
     assert(u64::try_from(100i64).unwrap() == 100u64);
     assert(u64::try_from(-1i64).is_err());
 }
+
+// --- try_into mirrors ---
+
+// both bounded: i64 → i32
+pub fn test_into_both_bounded_ok(x: i64) {
+    if x >= i32::MIN as i64 && x <= i32::MAX as i64 {
+        let r: Result<i32, _> = x.try_into();
+        assert(r.is_ok());
+    }
+}
+
+pub fn test_into_both_bounded_err_low(x: i64) {
+    if x < i32::MIN as i64 {
+        let r: Result<i32, _> = x.try_into();
+        assert(r.is_err());
+    }
+}
+
+pub fn test_into_both_bounded_err_high(x: i64) {
+    if x > i32::MAX as i64 {
+        let r: Result<i32, _> = x.try_into();
+        assert(r.is_err());
+    }
+}
+
+pub fn test_into_both_bounded_concrete() {
+    let r: Result<i32, _> = 42i64.try_into();
+    assert(r.is_ok());
+    assert(r.unwrap() == 42);
+    let r: Result<i32, _> = (-42i64).try_into();
+    assert(r.unwrap() == -42);
+    let r: Result<i32, _> = ((i32::MAX as i64) + 1).try_into();
+    assert(r.is_err());
+    let r: Result<i32, _> = ((i32::MIN as i64) - 1).try_into();
+    assert(r.is_err());
+}
+
+// upper bounded: u64 → u32
+pub fn test_into_upper_bounded_ok(x: u64) {
+    if x <= u32::MAX as u64 {
+        let r: Result<u32, _> = x.try_into();
+        assert(r.is_ok());
+    }
+}
+
+pub fn test_into_upper_bounded_err(x: u64) {
+    if x > u32::MAX as u64 {
+        let r: Result<u32, _> = x.try_into();
+        assert(r.is_err());
+    }
+}
+
+// lower bounded: i64 → u64
+pub fn test_into_lower_bounded_ok(x: i64) {
+    if x >= 0 {
+        let r: Result<u64, _> = x.try_into();
+        assert(r.is_ok());
+    }
+}
+
+pub fn test_into_lower_bounded_err(x: i64) {
+    if x < 0 {
+        let r: Result<u64, _> = x.try_into();
+        assert(r.is_err());
+    }
+}


### PR DESCRIPTION
This PR adds a `TryInto` spec for everything that implements `TryFrom`, mirroring `TryInto`'s blanket impl in core. Specifically this PR:
1. adds a `succeeds` assoc to `TryFrom` and `TryInto`  that describes the discriminant on the `Result` type returned from `TryFrom` and `TryInto`
2. Added a blanket spec for `TryInto` that inherits from `TryFrom`, like in core.
3. added tests for the above
