### PR TITLE
Add weak kvars

### DIFF
--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -283,14 +283,14 @@ fn trigger_queries(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult {
             genv.generics_of(def_id)?;
             genv.refinement_generics_of(def_id)?;
             genv.predicates_of(def_id)?;
-            genv.fn_sig(def_id)?;
+            genv.fn_sig(def_id, true)?;
         }
         DefKind::Ctor(_, CtorKind::Fn) => {
             genv.generics_of(def_id)?;
             genv.refinement_generics_of(def_id)?;
             // We don't report the error because it can raise a `QueryErr::OpaqueStruct`,  which
             // should be reported at the use site.
-            let _ = genv.fn_sig(def_id);
+            let _ = genv.fn_sig(def_id, true);
         }
         DefKind::Enum | DefKind::Struct => {
             genv.generics_of(def_id)?;

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -679,9 +679,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
 
         let no_panic = if let Some(e) = fn_sig.no_panic_if {
             self.conv_expr(&mut env, &e)?
-        } else {
-            if self.genv().no_panic(fn_id) { Expr::tt() } else { Expr::ff() }
-        };
+        } else if self.genv().no_panic(fn_id) { Expr::tt() } else { Expr::ff() };
 
         let fn_sig =
             self.conv_fn_decl(&mut env, header.safety(), header.abi, decl, body_id, no_panic)?;

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -679,7 +679,11 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
 
         let no_panic = if let Some(e) = fn_sig.no_panic_if {
             self.conv_expr(&mut env, &e)?
-        } else if self.genv().no_panic(fn_id) { Expr::tt() } else { Expr::ff() };
+        } else if self.genv().no_panic(fn_id) {
+            Expr::tt()
+        } else {
+            Expr::ff()
+        };
 
         let fn_sig =
             self.conv_fn_decl(&mut env, header.safety(), header.abi, decl, body_id, no_panic)?;

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -612,12 +612,15 @@ fn fn_sig(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult<rty::EarlyBinde
                 .into_conv_ctxt()
                 .conv_fn_sig(def_id, fhir_fn_sig)?;
             let fn_sig = struct_compat::fn_sig(genv, fhir_fn_sig.decl, &fn_sig, def_id)?;
-            let fn_sig = fn_sig.hoist_input_binders();
+            let mut fn_sig = fn_sig.hoist_input_binders();
             let id = match def_id {
                 MaybeExternId::Extern(_local_id, def_id) => def_id,
                 MaybeExternId::Local(local_id) => local_id.into(),
             };
-            let fn_sig = fn_sig.add_weak_kvars(genv, id)?;
+
+            if genv.weak_kvars_for(def_id.resolved_id()).is_none() {
+                fn_sig = fn_sig.add_weak_kvars(genv, id)?;
+            }
 
             if config::dump_rty() {
                 let generics = genv.generics_of(def_id)?;

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -611,8 +611,16 @@ fn fn_sig(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult<rty::EarlyBinde
             let fn_sig = AfterSortck::new(genv, &wfckresults)
                 .into_conv_ctxt()
                 .conv_fn_sig(def_id, fhir_fn_sig)?;
-            let fn_sig = struct_compat::fn_sig(genv, fhir_fn_sig.decl, &fn_sig, def_id)?;
-            let fn_sig = fn_sig.hoist_input_binders();
+            if fn_sig.vars().is_empty() {
+                fn_sig = fn_sig.hoist_input_binders();
+            }
+            // println!("adding wkvars for {:?}", def_id);
+            fn_sig = fn_sig.hoist_input_binders();
+            let id = match def_id {
+                MaybeExternId::Extern(_local_id, def_id) => def_id,
+                MaybeExternId::Local(local_id) => local_id.into(),
+            };
+            fn_sig = fn_sig.add_weak_kvars(genv, id)?;
 
             if config::dump_rty() {
                 let generics = genv.generics_of(def_id)?;

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -599,7 +599,11 @@ fn variants_of(
     Ok(variants)
 }
 
-fn fn_sig(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
+fn fn_sig(
+    genv: GlobalEnv,
+    def_id: MaybeExternId,
+    add_wkvars: bool,
+) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
     match genv.fhir_node(def_id.local_id())? {
         fhir::Node::Item(Item { kind: ItemKind::Fn(fhir_fn_sig, ..), .. })
         | fhir::Node::TraitItem(TraitItem { kind: TraitItemKind::Fn(fhir_fn_sig), .. })
@@ -618,7 +622,7 @@ fn fn_sig(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult<rty::EarlyBinde
                 MaybeExternId::Local(local_id) => local_id.into(),
             };
 
-            if genv.weak_kvars_for(def_id.resolved_id()).is_none() {
+            if add_wkvars && genv.weak_kvars_for(def_id.resolved_id()).is_none() {
                 fn_sig = fn_sig.add_weak_kvars(genv, id)?;
             }
 

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -604,7 +604,8 @@ fn fn_sig(
     def_id: MaybeExternId,
     add_wkvars: bool,
 ) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
-    match genv.fhir_node(def_id.local_id())? {
+    let fhir_node = genv.fhir_node(def_id.local_id())?;
+    match &fhir_node {
         fhir::Node::Item(Item { kind: ItemKind::Fn(fhir_fn_sig, ..), .. })
         | fhir::Node::TraitItem(TraitItem { kind: TraitItemKind::Fn(fhir_fn_sig), .. })
         | fhir::Node::ImplItem(ImplItem { kind: ImplItemKind::Fn(fhir_fn_sig), .. })
@@ -622,7 +623,12 @@ fn fn_sig(
                 MaybeExternId::Local(local_id) => local_id.into(),
             };
 
-            if add_wkvars && genv.weak_kvars_for(def_id.resolved_id()).is_none() {
+            if add_wkvars
+                // NOTE(ck): We don't support putting wkvars on traits right now; it doesn't
+                // really make sense since they're used for subtyping.
+                && !matches!(fhir_node, fhir::Node::TraitItem(..) | fhir::Node::ForeignItem(..) | fhir::Node::ImplItem(..))
+                && genv.weak_kvars_for(def_id.resolved_id()).is_none()
+            {
                 fn_sig = fn_sig.add_weak_kvars(genv, id)?;
             }
 

--- a/crates/flux-fhir-analysis/src/lib.rs
+++ b/crates/flux-fhir-analysis/src/lib.rs
@@ -611,16 +611,13 @@ fn fn_sig(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult<rty::EarlyBinde
             let fn_sig = AfterSortck::new(genv, &wfckresults)
                 .into_conv_ctxt()
                 .conv_fn_sig(def_id, fhir_fn_sig)?;
-            if fn_sig.vars().is_empty() {
-                fn_sig = fn_sig.hoist_input_binders();
-            }
-            // println!("adding wkvars for {:?}", def_id);
-            fn_sig = fn_sig.hoist_input_binders();
+            let fn_sig = struct_compat::fn_sig(genv, fhir_fn_sig.decl, &fn_sig, def_id)?;
+            let fn_sig = fn_sig.hoist_input_binders();
             let id = match def_id {
                 MaybeExternId::Extern(_local_id, def_id) => def_id,
                 MaybeExternId::Local(local_id) => local_id.into(),
             };
-            fn_sig = fn_sig.add_weak_kvars(genv, id)?;
+            let fn_sig = fn_sig.add_weak_kvars(genv, id)?;
 
             if config::dump_rty() {
                 let generics = genv.generics_of(def_id)?;

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -20,7 +20,7 @@ use flux_errors::Errors;
 use flux_macros::DebugAsJson;
 use flux_middle::{
     FixpointQueryKind,
-    def_id::{FluxDefId, MaybeExternId},
+    def_id::{FluxDefId, MaybeExternId, ResolvedDefId},
     def_id_to_string,
     global_env::GlobalEnv,
     metrics::{self, Metric, TimingKind},
@@ -2292,7 +2292,10 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
         self_args: usize,
         scx: &mut SortEncodingCtxt,
     ) -> Option<fixpoint::Var> {
-        if !wkvid.parent_fn.is_local() {
+        if !matches!(
+            self.genv.resolve_id(wkvid.parent_fn),
+            ResolvedDefId::Local(..) | ResolvedDefId::ExternSpec(..)
+        ) {
             return None;
         }
         let key = ConstKey::WKVar(wkvid.clone(), self_args);

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -573,12 +573,6 @@ pub fn lean_task_key(tcx: rustc_middle::ty::TyCtxt, def_id: DefId) -> String {
     FixpointQueryKind::Body.task_key(tcx, def_id)
 }
 
-pub(crate) struct SuggestionCtxt {
-    pub(crate) flat_constraints: FxIndexMap<TagIdx, fixpoint::FlatConstraint>,
-    pub(crate) const_decls: Vec<fixpoint::ConstDecl>,
-    pub(crate) data_decls: Vec<fixpoint::DataDecl>,
-}
-
 impl<'genv, 'tcx, Tag> FixpointCtxt<'genv, 'tcx, Tag>
 where
     Tag: std::hash::Hash + Eq + Copy,
@@ -607,7 +601,7 @@ where
         constraint: fixpoint::Constraint,
         scrape_quals: bool,
         solver: SmtSolver,
-    ) -> QueryResult<(fixpoint::Task, Option<SuggestionCtxt>)> {
+    ) -> QueryResult<fixpoint::Task> {
         let kvars = self.kcx.encode_kvars(&self.kvars, &mut self.scx);
 
         let qualifiers = self
@@ -2592,18 +2586,6 @@ fn parse_data_ctor(name: &str) -> Option<fixpoint::Var> {
         let adt_id = fixpoint::AdtId::from(adt_id);
         let variant_idx = VariantIdx::from(variant_idx);
         return Some(fixpoint::Var::DataCtor(adt_id, variant_idx));
-    }
-    None
-}
-
-fn parse_weak_kvar(name: &str) -> Option<fixpoint::Var> {
-    if let Some(rest) = name.strip_prefix("wk$")
-        && let parts = rest.split('$').collect::<Vec<_>>()
-        && parts.len() == 2
-        && let Ok(index) = parts[1].parse::<u32>()
-    {
-        let name = Symbol::intern(parts[0]);
-        return Some(fixpoint::Var::WKVar(name, index));
     }
     None
 }

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -105,6 +105,7 @@ pub mod fixpoint {
         Underscore,
         Global(GlobalVar, FluxDefId),
         Const(GlobalVar, Option<DefId>),
+        WKVar(Symbol, u32),
         Local(LocalVar),
         DataCtor(AdtId, VariantIdx),
         TupleCtor { arity: usize },
@@ -132,6 +133,7 @@ pub mod fixpoint {
             match self {
                 Var::Global(v, did) => write!(f, "f${}${}", did.name(), v.as_u32()),
                 Var::Const(v, _) => write!(f, "c{}", v.as_u32()),
+                Var::WKVar(def, idx) => write!(f, "wk${}${}", def, idx),
                 Var::Local(v) => write!(f, "a{}", v.as_u32()),
                 Var::DataCtor(adt_id, variant_idx) => {
                     write!(f, "mkadt{}${}", adt_id.as_u32(), variant_idx.as_u32())
@@ -542,6 +544,7 @@ enum ConstKey<'tcx> {
     PrimOp(rty::BinOp),
     Cast(rty::Sort, rty::Sort),
     PtrSize,
+    WKVar(rty::WKVid, usize),
 }
 
 #[derive(Clone)]
@@ -568,6 +571,12 @@ pub use liquid_fixpoint::LeanStatus;
 /// Returns the cache key used for a function-body lean query.
 pub fn lean_task_key(tcx: rustc_middle::ty::TyCtxt, def_id: DefId) -> String {
     FixpointQueryKind::Body.task_key(tcx, def_id)
+}
+
+pub(crate) struct SuggestionCtxt {
+    pub(crate) flat_constraints: FxIndexMap<TagIdx, fixpoint::FlatConstraint>,
+    pub(crate) const_decls: Vec<fixpoint::ConstDecl>,
+    pub(crate) data_decls: Vec<fixpoint::DataDecl>,
 }
 
 impl<'genv, 'tcx, Tag> FixpointCtxt<'genv, 'tcx, Tag>
@@ -598,7 +607,7 @@ where
         constraint: fixpoint::Constraint,
         scrape_quals: bool,
         solver: SmtSolver,
-    ) -> QueryResult<fixpoint::Task> {
+    ) -> QueryResult<(fixpoint::Task, Option<SuggestionCtxt>)> {
         let kvars = self.kcx.encode_kvars(&self.kvars, &mut self.scx);
 
         let qualifiers = self
@@ -978,6 +987,12 @@ where
                 let pred = self.kvar_to_fixpoint(kvar, &mut bindings)?;
                 Ok(fixpoint::Constraint::foralls(bindings, fixpoint::Constraint::Pred(pred, None)))
             }
+            rty::ExprKind::WKVar(_wkvar) => {
+                // We don't translate the weak kvar here because we don't want to
+                // send it to fixpoint to check (we only care about it appearing
+                // in assumptions)
+                Ok(fixpoint::Constraint::TRUE)
+            }
             rty::ExprKind::ForAll(pred) => {
                 self.ecx
                     .local_var_env
@@ -1034,6 +1049,9 @@ where
             rty::ExprKind::KVar(kvar) => {
                 preds.push(self.kvar_to_fixpoint(kvar, bindings)?);
             }
+            rty::ExprKind::WKVar(wkvar) => {
+                preds.push(self.wkvar_to_fixpoint(wkvar)?);
+            }
             rty::ExprKind::ForAll(_) => {
                 // If a forall appears in assumptive position replace it with true. This is sound
                 // because we are weakening the context, i.e., anything true without the assumption
@@ -1085,6 +1103,23 @@ where
             .collect_vec();
 
         Ok(fixpoint::Pred::And(kvars))
+    }
+
+    fn wkvar_to_fixpoint(&mut self, wkvar: &rty::WKVar) -> QueryResult<fixpoint::Pred> {
+        if let Some(var) =
+            self.ecx
+                .define_const_for_wkvar(&wkvar.wkvid, wkvar.self_args, &mut self.scx)
+        {
+            let args: Vec<fixpoint::Expr> = wkvar
+                .args
+                .iter()
+                .map(|arg| self.ecx.expr_to_fixpoint(arg, &mut self.scx))
+                .collect::<QueryResult<Vec<fixpoint::Expr>>>()?;
+            Ok(fixpoint::Pred::Expr(fixpoint::Expr::WKVar(fixpoint::WKVar { wkvid: var, args })))
+        } else {
+            // println!("WARN: Skipping encoding wkvar {:?} because it isn't in the global map", wkvar.wkvid);
+            Ok(fixpoint::Pred::Expr(fixpoint::Expr::Constant(fixpoint::Constant::Boolean(true))))
+        }
     }
 }
 
@@ -1419,6 +1454,7 @@ impl std::str::FromStr for TagIdx {
 struct ConstEnv<'tcx> {
     const_map: ConstMap<'tcx>,
     const_map_rev: HashMap<fixpoint::GlobalVar, ConstKey<'tcx>>,
+    pub(crate) wkvar_map_rev: HashMap<fixpoint::Var, ConstKey<'tcx>>,
     global_var_gen: IndexGen<fixpoint::GlobalVar>,
     fun_decl_map: FunDeclMap,
 }
@@ -1750,7 +1786,8 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                 let expr = self.body_to_fixpoint(expr, scx)?;
                 fixpoint::Expr::Exists(expr.0, Box::new(expr.1))
             }
-            rty::ExprKind::Hole(..)
+            rty::ExprKind::WKVar(_)
+            | rty::ExprKind::Hole(..)
             | rty::ExprKind::KVar(_)
             | rty::ExprKind::Local(_)
             | rty::ExprKind::PathProj(..)
@@ -2248,6 +2285,54 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
             .name
     }
 
+    /// We encode weak kvars as UIFs when we send them to fixpoint, but
+    /// represent them in fixpoint as their own Expr. This is necessary to add
+    /// the const declaration for the UIF.
+    ///
+    /// Currently returns an Option in case weak kvars generated automatically
+    /// don't track the sorts of their arguments, but there is no reason why
+    /// they shouldn't --- we could probably unwrap the Option.
+    fn define_const_for_wkvar(
+        &mut self,
+        wkvid: &rty::WKVid,
+        self_args: usize,
+        scx: &mut SortEncodingCtxt,
+    ) -> Option<fixpoint::Var> {
+        if !wkvid.parent_fn.is_local() {
+            return None;
+        }
+        let key = ConstKey::WKVar(wkvid.clone(), self_args);
+        let arg_sorts = self
+            .genv
+            .weak_kvars_for(wkvid.parent_fn)
+            .and_then(|wkvars_map| {
+                wkvars_map
+                    .get(&wkvid.id.as_u32())
+                    .map(|wkvars| wkvars.sorts.clone())
+            });
+        arg_sorts.map(|arg_sorts| {
+            self.const_env
+                .const_map
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    let comment = Some(format!("weak kvar: {:?}", wkvid));
+                    let def_name = self.genv.tcx().def_path_str(wkvid.parent_fn);
+                    let sanitized_name: String = def_name
+                        .chars()
+                        .map(|c| if !c.is_alphanumeric() { '_' } else { c })
+                        .collect();
+                    let name =
+                        fixpoint::Var::WKVar(Symbol::intern(&sanitized_name), wkvid.id.as_u32());
+                    let func_sort =
+                        rty::FuncSort::new(arg_sorts.clone(), rty::Sort::Bool).to_poly();
+                    let sort = scx.func_sort_to_fixpoint(&func_sort).into_sort();
+                    self.const_env.wkvar_map_rev.insert(name, key);
+                    fixpoint::ConstDecl { name, comment, sort }
+                })
+                .name
+        })
+    }
+
     fn assume_const_values(
         &mut self,
         mut constraint: fixpoint::Constraint,
@@ -2302,7 +2387,8 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
                 | ConstKey::Cast(..)
                 | ConstKey::Lambda(..)
                 | ConstKey::PrimOp(..)
-                | ConstKey::PtrSize => {}
+                | ConstKey::PtrSize
+                | ConstKey::WKVar(..) => {}
             }
         }
         Ok(constraint)
@@ -2506,6 +2592,18 @@ fn parse_data_ctor(name: &str) -> Option<fixpoint::Var> {
         let adt_id = fixpoint::AdtId::from(adt_id);
         let variant_idx = VariantIdx::from(variant_idx);
         return Some(fixpoint::Var::DataCtor(adt_id, variant_idx));
+    }
+    None
+}
+
+fn parse_weak_kvar(name: &str) -> Option<fixpoint::Var> {
+    if let Some(rest) = name.strip_prefix("wk$")
+        && let parts = rest.split('$').collect::<Vec<_>>()
+        && parts.len() == 2
+        && let Ok(index) = parts[1].parse::<u32>()
+    {
+        let name = Symbol::intern(parts[0]);
+        return Some(fixpoint::Var::WKVar(name, index));
     }
     None
 }

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -622,11 +622,7 @@ where
             .iter()
             .filter_map(|(k, v)| {
                 // NOTE(ck): Don't send wkvars to fixpoint
-                if let ConstKey::WKVar(..) = k {
-                    None
-                } else {
-                    Some(v)
-                }
+                if let ConstKey::WKVar(..) = k { None } else { Some(v) }
             })
             .cloned()
             .collect_vec();

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -615,7 +615,21 @@ where
         // all constants.
         let constraint = self.ecx.assume_const_values(constraint, &mut self.scx)?;
 
-        let constants = self.ecx.const_env.const_map.values().cloned().collect_vec();
+        let constants = self
+            .ecx
+            .const_env
+            .const_map
+            .iter()
+            .filter_map(|(k, v)| {
+                // NOTE(ck): Don't send wkvars to fixpoint
+                if let ConstKey::WKVar(..) = k {
+                    None
+                } else {
+                    Some(v)
+                }
+            })
+            .cloned()
+            .collect_vec();
 
         // Encode function bodies after qualifiers/assumptions so any functions referenced there
         // are picked up as dependencies.

--- a/crates/flux-infer/src/fixpoint_encoding/decoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding/decoding.rs
@@ -136,6 +136,9 @@ where
                                 ConstKey::PtrSize => {
                                     Ok(rty::Expr::internal_func(InternalFuncKind::PtrSize))
                                 }
+                                ConstKey::WKVar(_, _) => {
+                                    unreachable!("Weak kvars are not global vars");
+                                }
                             }
                         } else {
                             Err(FixpointParseError::NoGlobalVar(*global_var))
@@ -178,6 +181,11 @@ where
                     }
                     fixpoint::Var::ConstGeneric(const_generic) => {
                         Ok(rty::Expr::const_generic(*const_generic))
+                    }
+                    fixpoint::Var::WKVar(..) => {
+                        unreachable!(
+                            "Weak kvar ids should be converted as part of fixpoint::Expr::WKVar"
+                        );
                     }
                 }
             }
@@ -288,6 +296,9 @@ where
                                         .map(|farg| self.fixpoint_to_expr(farg))
                                         .try_collect()?;
                                     Ok(rty::Expr::alias(alias_reft, args))
+                                }
+                                ConstKey::WKVar(..) => {
+                                    unreachable!("WKVars should not appear in global vars");
                                 }
                                 ConstKey::RustConst(..)
                                 | ConstKey::Lambda(..)
@@ -417,6 +428,28 @@ where
                 let body = self.fixpoint_to_expr(body)?;
                 self.ecx.local_var_env.pop_layer();
                 Ok(rty::Expr::exists(Binder::bind_with_sorts(body, &sorts)))
+            }
+            fixpoint::Expr::WKVar(fixpoint::WKVar { wkvid, args }) => {
+                let e_args: Vec<rty::Expr> = args
+                    .iter()
+                    .map(|fexpr| self.fixpoint_to_expr(fexpr))
+                    .try_collect()?;
+                if let Some(const_key) = self.ecx.const_env.wkvar_map_rev.get(wkvid) {
+                    match const_key {
+                        ConstKey::WKVar(wkvid, self_args) => {
+                            Ok(rty::Expr::wkvar(rty::WKVar {
+                                wkvid: wkvid.clone(),
+                                self_args: *self_args,
+                                args: List::from_vec(e_args),
+                            }))
+                        }
+                        _ => {
+                            unreachable!("Weak KVar has a const_key that is not a wkvid");
+                        }
+                    }
+                } else {
+                    unreachable!("missing weak kvar {:?} in const_env", wkvid);
+                }
             }
         }
     }

--- a/crates/flux-infer/src/lean_encoding.rs
+++ b/crates/flux-infer/src/lean_encoding.rs
@@ -155,6 +155,7 @@ fn constant_deps(expr: &fixpoint::Expr, acc: &mut FxIndexSet<fixpoint::Var>) {
             constant_deps(inner, acc);
         }
         fixpoint::Expr::Var(..) | fixpoint::Expr::Constant(..) | fixpoint::Expr::ThyFunc(..) => {}
+        fixpoint::Expr::WKVar(..) => unimplemented!(),
     }
 }
 

--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -535,6 +535,9 @@ impl LeanFmt for Expr {
                 write!(f, ")")?;
                 Ok(())
             }
+            Expr::WKVar(_) => {
+                todo!("not yet implemented")
+            }
         }
     }
 }

--- a/crates/flux-metadata/src/lib.rs
+++ b/crates/flux-metadata/src/lib.rs
@@ -467,9 +467,10 @@ fn encode_def_ids<K: Eq + Hash + Copy>(
                     key,
                     genv.run_query_if_reached(def_id, GlobalEnv::refinement_generics_of),
                 );
-                tables
-                    .fn_sig
-                    .insert(key, genv.run_query_if_reached(def_id, GlobalEnv::fn_sig));
+                tables.fn_sig.insert(
+                    key,
+                    genv.run_query_if_reached(def_id, |s, did| GlobalEnv::fn_sig(s, did, true)),
+                );
                 tables.no_panic.insert(key, genv.no_panic(def_id));
             }
             DefKind::Ctor(_, CtorKind::Fn) => {
@@ -480,9 +481,10 @@ fn encode_def_ids<K: Eq + Hash + Copy>(
                     key,
                     genv.run_query_if_reached(def_id, GlobalEnv::refinement_generics_of),
                 );
-                tables
-                    .fn_sig
-                    .insert(key, genv.run_query_if_reached(def_id, GlobalEnv::fn_sig));
+                tables.fn_sig.insert(
+                    key,
+                    genv.run_query_if_reached(def_id, |s, did| GlobalEnv::fn_sig(s, did, true)),
+                );
             }
             DefKind::Enum | DefKind::Struct => {
                 tables

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -449,11 +449,15 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         self.inner.queries.type_of(self, def_id.into_query_param())
     }
 
+    /// `add_wkvars` should be true unless adding wkvars is wrong or breaks something.
     pub fn fn_sig(
         self,
         def_id: impl IntoQueryParam<DefId>,
+        add_wkvars: bool,
     ) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
-        self.inner.queries.fn_sig(self, def_id.into_query_param())
+        self.inner
+            .queries
+            .fn_sig(self, def_id.into_query_param(), add_wkvars)
     }
 
     pub fn feed_weak_kvars(self, def_id: DefId, wk: WeakKvarMap) {

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -1,5 +1,6 @@
 use std::{
     alloc,
+    cell::RefCell,
     path::{Path, PathBuf},
     ptr,
     rc::Rc,
@@ -12,7 +13,7 @@ use flux_config::{self as config, IncludePattern};
 use flux_errors::FluxSession;
 use flux_rustc_bridge::{self, lowering::Lower, mir, ty};
 use flux_syntax::symbols::sym;
-use rustc_data_structures::unord::UnordSet;
+use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_hir::{
     LangItem,
     def::DefKind,
@@ -43,6 +44,16 @@ pub struct GlobalEnv<'genv, 'tcx> {
     inner: &'genv GlobalEnvInner<'genv, 'tcx>,
 }
 
+pub struct WeakKvarInfo {
+    /// Solutions (if provided as ground truth annotations). Each soution is
+    /// part of a conjunction that constitutes the full ground truth.
+    pub solutions: Vec<rty::Binder<rty::Expr>>,
+    /// The sorts of the weak kvar in the order in which they appear in the
+    /// arguments.
+    pub sorts: Vec<rty::Sort>,
+}
+pub type WeakKvarMap = UnordMap<u32, WeakKvarInfo>;
+
 struct GlobalEnvInner<'genv, 'tcx> {
     tcx: TyCtxt<'tcx>,
     sess: &'genv FluxSession,
@@ -50,6 +61,7 @@ struct GlobalEnvInner<'genv, 'tcx> {
     cstore: Box<CrateStoreDyn>,
     queries: Queries<'genv, 'tcx>,
     tempdir: TempDir,
+    weak_kvars: RefCell<UnordMap<DefId, Rc<WeakKvarMap>>>,
 }
 
 impl<'tcx> GlobalEnv<'_, 'tcx> {
@@ -65,7 +77,15 @@ impl<'tcx> GlobalEnv<'_, 'tcx> {
         // files in it.
         let tempdir = TempDir::new_in(lean_parent_dir(tcx)).unwrap();
         let queries = Queries::new(providers);
-        let inner = GlobalEnvInner { tcx, sess, cstore, arena, queries, tempdir };
+        let inner = GlobalEnvInner {
+            tcx,
+            sess,
+            cstore,
+            arena,
+            queries,
+            tempdir,
+            weak_kvars: Default::default(),
+        };
         f(GlobalEnv { inner: &inner })
     }
 }
@@ -434,6 +454,17 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         def_id: impl IntoQueryParam<DefId>,
     ) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
         self.inner.queries.fn_sig(self, def_id.into_query_param())
+    }
+
+    pub fn feed_weak_kvars(self, def_id: DefId, wk: WeakKvarMap) {
+        self.inner
+            .weak_kvars
+            .borrow_mut()
+            .insert(def_id, Rc::new(wk));
+    }
+
+    pub fn weak_kvars_for(self, def_id: DefId) -> Option<Rc<WeakKvarMap>> {
+        self.inner.weak_kvars.borrow().get(&def_id).cloned()
     }
 
     pub fn variants_of(

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -982,9 +982,13 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                     }
 
                     // We only will add weak kvars if
-                    //   1. add_wkvars is true, and
-                    //   2. There are no weak kvars already
-                    if add_wkvars && genv.weak_kvars_for(def_id).is_none() {
+                    //   1. add_wkvars is true
+                    //   2. The sig is locally defined (i.e. the user can change it)
+                    //   3. There are no weak kvars already
+                    if add_wkvars
+                        && genv.resolve_id(def_id).as_maybe_extern().is_some()
+                        && genv.weak_kvars_for(def_id).is_none()
+                    {
                         poly_sig = poly_sig.add_weak_kvars(genv, def_id)?;
                     }
                     Ok(rty::EarlyBinder(poly_sig))

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -185,7 +185,7 @@ pub struct Providers {
         GlobalEnv,
         MaybeExternId,
     ) -> QueryResult<rty::Opaqueness<rty::EarlyBinder<rty::PolyVariants>>>,
-    pub fn_sig: fn(GlobalEnv, MaybeExternId) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>>,
+    pub fn_sig: fn(GlobalEnv, MaybeExternId, bool) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>>,
     pub generics_of: fn(GlobalEnv, MaybeExternId) -> QueryResult<rty::Generics>,
     pub refinement_generics_of:
         fn(GlobalEnv, MaybeExternId) -> QueryResult<rty::EarlyBinder<rty::RefinementGenerics>>,
@@ -228,7 +228,7 @@ impl Default for Providers {
             adt_def: |_, _| empty_query!(),
             type_of: |_, _| empty_query!(),
             variants_of: |_, _| empty_query!(),
-            fn_sig: |_, _| empty_query!(),
+            fn_sig: |_, _, _| empty_query!(),
             generics_of: |_, _| empty_query!(),
             refinement_generics_of: |_, _| empty_query!(),
             predicates_of: |_, _| empty_query!(),
@@ -946,12 +946,13 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
         &self,
         genv: GlobalEnv,
         def_id: DefId,
+        add_wkvars: bool,
     ) -> QueryResult<rty::EarlyBinder<rty::PolyFnSig>> {
         run_with_cache(&self.fn_sig, def_id, || {
             def_id.dispatch_query(
                 genv,
                 self,
-                |def_id| (self.providers.fn_sig)(genv, def_id),
+                |def_id| (self.providers.fn_sig)(genv, def_id, add_wkvars),
                 |def_id| genv.cstore().fn_sig(def_id),
                 |def_id| {
                     let tcx = genv.tcx();
@@ -981,8 +982,9 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                     }
 
                     // We only will add weak kvars if
-                    //   1. There are no weak kvars already
-                    if genv.weak_kvars_for(def_id).is_none() {
+                    //   1. add_wkvars is true, and
+                    //   2. There are no weak kvars already
+                    if add_wkvars && genv.weak_kvars_for(def_id).is_none() {
                         poly_sig = poly_sig.add_weak_kvars(genv, def_id)?;
                     }
                     Ok(rty::EarlyBinder(poly_sig))

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -961,7 +961,6 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                         .skip_binder()
                         .refine(&Refiner::default_for_item(genv, def_id)?)?
                         .hoist_input_binders();
-
                     if genv.is_fn_call(def_id) {
                         let fn_once_id = tcx.require_lang_item(LangItem::FnOnce, DUMMY_SP);
 
@@ -981,6 +980,11 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                         });
                     }
 
+                    // We only will add weak kvars if
+                    //   1. There are no weak kvars already
+                    if genv.weak_kvars_for(def_id).is_none() {
+                        fn_sig = fn_sig.add_weak_kvars(genv, def_id)?;
+                    }
                     Ok(rty::EarlyBinder(poly_sig))
                 },
             )

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -983,7 +983,7 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                     // We only will add weak kvars if
                     //   1. There are no weak kvars already
                     if genv.weak_kvars_for(def_id).is_none() {
-                        fn_sig = fn_sig.add_weak_kvars(genv, def_id)?;
+                        poly_sig = poly_sig.add_weak_kvars(genv, def_id)?;
                     }
                     Ok(rty::EarlyBinder(poly_sig))
                 },

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -34,10 +34,10 @@ use crate::{
     pretty::*,
     queries::QueryResult,
     rty::{
-        BoundVariableKind, SortArg, SubsetTyCtor,
+        BoundVariableKind, SortArg, SortCtor, SubsetTyCtor,
         fold::{
-            TypeFoldable, TypeFolder, TypeSuperFoldable, TypeSuperVisitable, TypeVisitable as _,
-            TypeVisitor,
+            FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeSuperVisitable,
+            TypeVisitable, TypeVisitor,
         },
     },
 };
@@ -326,6 +326,10 @@ impl Expr {
 
     pub fn kvar(kvar: KVar) -> Expr {
         ExprKind::KVar(kvar).intern()
+    }
+
+    pub fn wkvar(wkvar: WKVar) -> Expr {
+        ExprKind::WKVar(wkvar).intern()
     }
 
     pub fn alias(alias: AliasReft, args: List<Expr>) -> Expr {
@@ -778,6 +782,7 @@ pub enum ExprKind {
     PathProj(Expr, FieldIdx),
     IfThenElse(Expr, Expr, Expr),
     KVar(KVar),
+    WKVar(WKVar),
     Alias(AliasReft, List<Expr>),
     Let(Expr, Binder<Expr>),
     /// Function application. The syntax allows arbitrary expressions in function position, but in
@@ -890,6 +895,87 @@ pub struct KVar {
     /// The list of *all* arguments with the self arguments at the beginning, i.e., the
     /// list of self arguments followed by the scope.
     pub args: List<Expr>,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable,
+)]
+pub struct WKVid {
+    /// Weak KVars right now are always associated with a function definition.
+    /// Weak KVars can in theory be put wherever we can validly add a refinement
+    pub parent_fn: DefId,
+    /// There's no reason why this has to be KVid, and in principle it may be
+    /// better served as just a number or a new index unto itself.
+    pub id: KVid,
+}
+
+impl WKVid {
+    pub fn new(parent_fn: DefId, id: KVid) -> Self {
+        Self { parent_fn, id }
+    }
+}
+
+/// A weak kvar is like a kvar with the exception that it infers the weakest
+/// condition necessary instead of the strongest condition. Due to the way we
+/// generate these kvars (on fn_sigs, rather than during constraint generation),
+/// they also in theory are global.
+#[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
+pub struct WKVar {
+    pub wkvid: WKVid,
+    /// Analagous to KVar self arguments except we require that instantiations
+    /// use *at least one* of the self_args (unless there are none, in which
+    /// case there is no such requirement).
+    ///
+    /// This is mostly relevant for weak kvars corresponding to function
+    /// *outputs*. Consider the signature
+    ///
+    ///     foo: fn(x: usize) -> bool{b: $wk1(b, x)}
+    ///            requires $wk0(x)
+    ///
+    /// In this case self_args would be 1 (corresponding to the bool `b`).
+    /// Consider now the snippet
+    ///
+    ///     let b = foo(x);
+    ///     assert(x > 0);
+    ///
+    /// Suppose the assertion fails. Without the self_args requirement, we
+    /// could validly instantiate
+    ///
+    ///     $wk1(b, x) := x > 0
+    ///
+    /// But this is somewhat nonsensical because only in exceptional cases
+    /// does it make sense for `foo` to somehow "add" information to its
+    /// **argument** (`x`).
+    ///
+    /// By checking for the presence of **at least one** self arg, we
+    /// ensure that the self argument is "used"; fixpoint does a similar check.
+    ///
+    /// This is a syntactic underapproximation and doesn't preclude things like
+    ///
+    ///     $wk1(b, x) := (b => true) && (x > 0)
+    ///
+    /// But we could conceive of a more sophisticated check using the self_args.
+    pub self_args: usize,
+    /// All arguments with self arguments at the beginning.
+    pub args: List<Expr>,
+}
+
+impl TypeVisitable for WKVar {
+    fn visit_with<V: TypeVisitor>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
+        self.wkvid.visit_with(visitor)?;
+        // NOTE: the params shouldn't need to be visited I think
+        self.args.visit_with(visitor)
+    }
+}
+
+impl TypeFoldable for WKVar {
+    fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
+        Ok(WKVar {
+            wkvid: self.wkvid.try_fold_with(folder)?,
+            self_args: self.self_args,
+            args: self.args.try_fold_with(folder)?,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Encodable, Decodable)]
@@ -1018,6 +1104,16 @@ impl KVar {
         KVar { kvid, self_args, args: List::from_vec(args) }
     }
 
+    fn self_args(&self) -> &[Expr] {
+        &self.args[..self.self_args]
+    }
+
+    fn scope(&self) -> &[Expr] {
+        &self.args[self.self_args..]
+    }
+}
+
+impl WKVar {
     fn self_args(&self) -> &[Expr] {
         &self.args[..self.self_args]
     }
@@ -1538,6 +1634,9 @@ pub(crate) mod pretty {
                 ExprKind::KVar(kvar) => {
                     w!(cx, f, "{:?}", kvar)
                 }
+                ExprKind::WKVar(wkvar) => {
+                    w!(cx, f, "{:?}", wkvar)
+                }
                 ExprKind::Alias(alias, args) => {
                     w!(cx, f, "{:?}({:?})", alias, join!(", ", args))
                 }
@@ -1678,6 +1777,16 @@ pub(crate) mod pretty {
         }
     }
 
+    impl Pretty for WKVar {
+        fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            // Since we reuse KVId, we need to make the serialization custom.
+            // Also we will not serialize the parameters for now.
+            w!(cx, f, "$wk{}_{}", ^self.wkvid.id.index(), ^cx.tcx().def_path_str(self.wkvid.parent_fn))?;
+            w!(cx, f, "({:?})[{:?}]", join!(", ", self.self_args()), join!(", ", self.scope()))?;
+            Ok(())
+        }
+    }
+
     impl Pretty for Path {
         fn fmt(&self, cx: &PrettyCx, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             w!(cx, f, "{:?}", &self.loc)?;
@@ -1733,7 +1842,7 @@ pub(crate) mod pretty {
         }
     }
 
-    impl_debug_with_default_cx!(Expr, Loc, Path, Var, KVar, Lambda, AliasReft);
+    impl_debug_with_default_cx!(Expr, Loc, Path, Var, KVar, WKVar, Lambda, AliasReft);
 
     impl PrettyNested for Lambda {
         fn fmt_nested(&self, cx: &PrettyCx) -> Result<NestedString, fmt::Error> {
@@ -1807,6 +1916,7 @@ pub(crate) mod pretty {
                 | ExprKind::Hole(..)
                 | ExprKind::GlobalFunc(..)
                 | ExprKind::InternalFunc(..) => debug_nested(cx, &e),
+                ExprKind::WKVar(..) => debug_nested(cx, &e),
                 ExprKind::KVar(kvar) => {
                     let kv = format!("{:?}", kvar.kvid);
                     let mut strs = vec![kv];

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -34,7 +34,7 @@ use crate::{
     pretty::*,
     queries::QueryResult,
     rty::{
-        BoundVariableKind, SortArg, SortCtor, SubsetTyCtor,
+        BoundVariableKind, SortArg, SubsetTyCtor,
         fold::{
             FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeSuperVisitable,
             TypeVisitable, TypeVisitor,

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -1127,6 +1127,20 @@ impl Var {
     pub fn to_expr(&self) -> Expr {
         Expr::var(*self)
     }
+
+    pub fn shift_in(&self, amount: u32) -> Self {
+        match self {
+            Var::Bound(idx, breft) => Var::Bound(idx.shifted_in(amount), *breft),
+            _ => *self,
+        }
+    }
+
+    pub fn shift_out(&self, amount: u32) -> Self {
+        match self {
+            Var::Bound(idx, breft) => Var::Bound(idx.shifted_out(amount), *breft),
+            _ => *self,
+        }
+    }
 }
 
 impl Path {

--- a/crates/flux-middle/src/rty/fold.rs
+++ b/crates/flux-middle/src/rty/fold.rs
@@ -1052,6 +1052,7 @@ impl TypeSuperVisitable for Expr {
                 e2.visit_with(visitor)
             }
             ExprKind::KVar(kvar) => kvar.visit_with(visitor),
+            ExprKind::WKVar(wkvar) => wkvar.visit_with(visitor),
             ExprKind::Alias(alias, args) => {
                 alias.visit_with(visitor)?;
                 args.visit_with(visitor)
@@ -1119,6 +1120,7 @@ impl TypeSuperFoldable for Expr {
             }
             ExprKind::Hole(kind) => Expr::hole(kind.try_fold_with(folder)?),
             ExprKind::KVar(kvar) => Expr::kvar(kvar.try_fold_with(folder)?),
+            ExprKind::WKVar(wkvar) => Expr::wkvar(wkvar.try_fold_with(folder)?),
             ExprKind::Abs(lam) => Expr::abs(lam.try_fold_with(folder)?),
             ExprKind::BoundedQuant(kind, rng, body) => {
                 Expr::bounded_quant(*kind, *rng, body.try_fold_with(folder)?)
@@ -1148,6 +1150,17 @@ where
     }
 }
 
+impl<S, T> TypeVisitable for (S, T)
+where
+    S: TypeVisitable,
+    T: TypeVisitable,
+{
+    fn visit_with<V: TypeVisitor>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
+        self.0.visit_with(visitor)?;
+        self.1.visit_with(visitor)
+    }
+}
+
 impl<T> TypeFoldable for List<T>
 where
     T: TypeFoldable,
@@ -1155,6 +1168,16 @@ where
 {
     fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
         self.iter().map(|t| t.try_fold_with(folder)).try_collect()
+    }
+}
+
+impl<S, T> TypeFoldable for (S, T)
+where
+    S: TypeFoldable,
+    T: TypeFoldable,
+{
+    fn try_fold_with<F: FallibleTypeFolder>(&self, folder: &mut F) -> Result<Self, F::Error> {
+        Ok((self.0.try_fold_with(folder)?, self.1.try_fold_with(folder)?))
     }
 }
 

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1148,6 +1148,10 @@ impl Sort {
         }
         go(self, &mut f, &mut vec![]);
     }
+
+    pub fn is_param(&self) -> bool {
+        matches!(self, Self::Param(_))
+    }
 }
 
 /// The size of a [bit-vector]

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -20,7 +20,7 @@ use bitflags::bitflags;
 pub use expr::{
     AggregateKind, AliasReft, BinOp, BoundReft, Constant, Ctor, ESpan, EVid, EarlyReftParam, Expr,
     ExprKind, FieldProj, HoleKind, InternalFuncKind, KVar, KVid, Lambda, Loc, Name, NameProvenance,
-    Path, PrettyMap, PrettyVar, Real, SpecFuncKind, UnOp, Var,
+    Path, PrettyMap, PrettyVar, Real, SpecFuncKind, UnOp, Var, WKVar, WKVid,
 };
 pub use flux_arc_interner::List;
 use flux_arc_interner::{Interned, impl_internable, impl_slice_internable};

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -718,7 +718,7 @@ impl TypeFolder for WeakKVarInserter {
                     .collect();
                 BaseTy::Adt(adt_def.clone(), new_args)
             }
-            BaseTy::Alias(_, _) => {bty.clone()},
+            BaseTy::Alias(_, _) => bty.clone(),
             _ => bty.super_fold_with(self),
         }
     }

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -718,8 +718,12 @@ impl TypeFolder for WeakKVarInserter {
                     .collect();
                 BaseTy::Adt(adt_def.clone(), new_args)
             }
-            BaseTy::Alias(_, _) => bty.clone(),
-            _ => bty.super_fold_with(self),
+            // For these specific btys, we will recur and add wkvars
+            BaseTy::Ref(..) | BaseTy::Tuple(..) | BaseTy::Array(..) | BaseTy::Slice(..) => {
+                bty.super_fold_with(self)
+            }
+            // By default we will not recur on the bty to add wkvars
+            _ => bty.clone(),
         }
     }
 

--- a/crates/flux-middle/src/rty/refining.rs
+++ b/crates/flux-middle/src/rty/refining.rs
@@ -8,15 +8,21 @@ use flux_common::bug;
 use flux_rustc_bridge::{ty, ty::GenericArgsExt as _};
 use itertools::Itertools;
 use rustc_abi::VariantIdx;
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::ParamTy;
+use rustc_span::Symbol;
+use rustc_type_ir::INNERMOST;
 
-use super::{RefineArgsExt, fold::TypeFoldable};
+use super::{
+    RefineArgsExt,
+    fold::{TypeFoldable, TypeFolder, TypeVisitable},
+};
 use crate::{
-    global_env::GlobalEnv,
+    global_env::{GlobalEnv, WeakKvarInfo, WeakKvarMap},
     queries::{QueryErr, QueryResult},
     query_bug,
-    rty::{self, Expr},
+    rty::{self, Expr, fold::TypeSuperFoldable},
 };
 
 pub fn refine_generics(generics: &ty::Generics) -> rty::Generics {
@@ -496,4 +502,301 @@ pub fn refine_bound_variables(vars: &[ty::BoundVariableKind]) -> List<rty::Bound
             }
         })
         .collect()
+}
+
+impl rty::PolyFnSig {
+    pub fn add_weak_kvars(self, genv: GlobalEnv, def_id: DefId) -> QueryResult<Self> {
+        let refinement_generics = genv.refinement_generics_of(def_id)?;
+        let early_param_sorts: FxHashMap<Symbol, rty::Sort> = refinement_generics
+            .0
+            .own_params
+            .iter()
+            .map(|param| (param.name, param.sort.clone()))
+            .collect();
+        let early_vars = self
+            .early_params()
+            .into_iter()
+            .filter_map(|param| {
+                let sort = early_param_sorts.get(&param.name).unwrap().clone();
+                if !sort.is_param() && !sort.is_loc() {
+                    Some((rty::Var::EarlyParam(param), sort))
+                } else {
+                    None
+                }
+            })
+            .collect_vec();
+        let late_vars = make_vars_and_sorts_from_bound_vars(self.vars());
+        Ok(self.map(|fn_sig| {
+            let mut params = late_vars.into_iter().chain(early_vars).collect_vec();
+            let mut wkvar_inserter = WeakKVarInserter {
+                wkvar_map: WeakKvarMap::default(),
+                def_id,
+                kvid: rty::KVid::from(0_usize),
+                existential_params: Vec::new(),
+                params: params.clone(),
+            };
+            let requires_wkvar = make_weak_kvar(
+                &mut wkvar_inserter.wkvar_map,
+                def_id,
+                &mut wkvar_inserter.kvid,
+                Vec::new(),
+                params.clone(),
+            );
+            let inputs = fn_sig
+                .inputs
+                .iter()
+                .map(|input| wkvar_inserter.fold_ty(input))
+                .collect();
+            shift_in_vars(&mut params);
+            let output_binder_params = make_vars_and_sorts_from_bound_vars(fn_sig.output.vars());
+            params.extend(output_binder_params);
+            wkvar_inserter.params = params.clone();
+            let ensures = if !fn_sig.output.vars().is_empty() {
+                let ensures_wkvar = make_weak_kvar(
+                    &mut wkvar_inserter.wkvar_map,
+                    def_id,
+                    &mut wkvar_inserter.kvid,
+                    make_vars_and_sorts_from_bound_vars(fn_sig.output.vars()),
+                    params.clone(),
+                );
+                fn_sig
+                    .output
+                    .skip_binder_ref()
+                    .ensures
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(rty::Ensures::Pred(rty::Expr::wkvar(ensures_wkvar))))
+                    .collect()
+            } else {
+                fn_sig.output.skip_binder_ref().ensures.clone()
+            };
+            let output = fn_sig
+                .output
+                .map(|output| rty::FnOutput { ret: wkvar_inserter.fold_ty(&output.ret), ensures });
+            genv.feed_weak_kvars(def_id, wkvar_inserter.wkvar_map);
+
+            rty::FnSig {
+                abi: fn_sig.abi,
+                safety: fn_sig.safety,
+                inputs,
+                // NOTE(CK): Not sure whether we can avoid the clone.
+                requires: fn_sig
+                    .requires
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(rty::Expr::wkvar(requires_wkvar)))
+                    .collect(),
+                output,
+                lifted: fn_sig.lifted,
+                no_panic: fn_sig.no_panic,
+            }
+        }))
+    }
+}
+
+struct WeakKVarInserter {
+    wkvar_map: WeakKvarMap,
+    def_id: DefId,
+    kvid: rty::KVid,
+    existential_params: Vec<Vec<(rty::Var, rty::Sort)>>,
+    params: Vec<(rty::Var, rty::Sort)>,
+}
+
+impl TypeFolder for WeakKVarInserter {
+    fn fold_ty(&mut self, ty: &rty::Ty) -> rty::Ty {
+        use rty::{Expr, Ty, TyKind::*};
+        match ty.kind() {
+            // This is the only recursive case where we need to update the params
+            // since we're going under a binder.
+            //
+            // We handle the shifting in and out explicitly rather than using
+            // the enter_binder and exit_binder methods because we immediately
+            // use the bound vars to make a weak kvar.
+            Exists(bound_ty) => {
+                for v in &mut self.existential_params {
+                    shift_in_vars(v);
+                }
+                shift_in_vars(&mut self.params);
+                let exist_params = make_vars_and_sorts_from_bound_vars(bound_ty.vars());
+                // Take all of the current existential params + the current params,
+                // AFTER shifting in.
+                let params = self
+                    .existential_params
+                    .iter()
+                    .flatten()
+                    .chain(self.params.iter())
+                    .cloned()
+                    .collect();
+                // We pass the params immediately under this binder as the self args.
+                //
+                // The purpose of self args is to ensure that we don't have duplication
+                // of suggestions.
+                //
+                // Suppose after we add weak kvars we have the type
+                //
+                //     fn ({exists v0. Vec<i32>[v0] | $wk1[v0]()}) requires $wk0[]()
+                //
+                // If we are looking to instantiate a weak kvar to the
+                // expression `2 > 1` (for some reason), we can validly put it
+                // in both $wk0 and $wk1. But the self arg ensures that we don't
+                // put it in $wk1, since it requires the expression contain one
+                // of its self args (in this case, just `v0`).
+                let wkvar = make_weak_kvar(
+                    &mut self.wkvar_map,
+                    self.def_id,
+                    &mut self.kvid,
+                    exist_params.clone(),
+                    params,
+                );
+                // Now we add the params for future weak kvars.
+                self.existential_params.push(exist_params);
+                let new_ty = bound_ty.skip_binder_ref().super_fold_with(self);
+                self.existential_params.pop();
+                for v in &mut self.existential_params {
+                    shift_out_vars(v);
+                }
+                shift_out_vars(&mut self.params);
+                Ty::exists(rty::Binder::bind_with_vars(
+                    Ty::constr(Expr::wkvar(wkvar), new_ty),
+                    bound_ty.vars().clone(),
+                ))
+            }
+            _ => ty.super_fold_with(self),
+        }
+    }
+
+    fn fold_bty(&mut self, bty: &rty::BaseTy) -> rty::BaseTy {
+        use rty::{BaseTy, Expr, GenericArg};
+        match bty {
+            BaseTy::Adt(adt_def, args) => {
+                let new_args = args
+                    .iter()
+                    .map(|arg| {
+                        match arg {
+                            GenericArg::Base(subset_ty) => {
+                                for v in &mut self.existential_params {
+                                    shift_in_vars(v);
+                                }
+                                shift_in_vars(&mut self.params);
+                                let exist_params =
+                                    make_vars_and_sorts_from_bound_vars(subset_ty.vars());
+                                // Take all of the current existential params + the current params,
+                                // AFTER shifting in.
+                                let params = self
+                                    .existential_params
+                                    .iter()
+                                    .flatten()
+                                    .chain(self.params.iter())
+                                    .cloned()
+                                    .collect();
+                                // We pass the params immediately under this binder as the self args.
+                                // see the TyKind::Exists case.
+                                let wkvar = make_weak_kvar(
+                                    &mut self.wkvar_map,
+                                    self.def_id,
+                                    &mut self.kvid,
+                                    exist_params.clone(),
+                                    params,
+                                );
+                                // Now we add the params for future weak kvars.
+                                self.existential_params.push(exist_params);
+                                let new_ty = subset_ty.skip_binder_ref().super_fold_with(self);
+                                let new_ty_with_wkvar = new_ty.strengthen(Expr::wkvar(wkvar));
+                                self.existential_params.pop();
+                                for v in &mut self.existential_params {
+                                    shift_out_vars(v);
+                                }
+                                shift_out_vars(&mut self.params);
+                                GenericArg::Base(rty::Binder::bind_with_vars(
+                                    new_ty_with_wkvar,
+                                    subset_ty.vars().clone(),
+                                ))
+                            }
+                            _ => arg.fold_with(self),
+                        }
+                    })
+                    .collect();
+                BaseTy::Adt(adt_def.clone(), new_args)
+            }
+            BaseTy::Alias(_, _) => {bty.clone()},
+            _ => bty.super_fold_with(self),
+        }
+    }
+
+    fn fold_expr(&mut self, expr: &Expr) -> Expr {
+        expr.clone()
+    }
+
+    fn fold_sort(&mut self, sort: &rty::Sort) -> rty::Sort {
+        sort.clone()
+    }
+}
+
+/// NOTE(CK):
+///   * Skips params (we don't presently handle polymorphism, though even if we did,
+///     I'm not sure that we need to pass params to the weak kvars).
+///   * Skips locs because we can't encode those.
+///   * Skips unit + unit adts because they otherwise get encoded as a 0 tuple
+///     to fixpoint because we use them in the args to a weak kvar, which
+///     we don't want to do.
+fn make_vars_and_sorts_from_bound_vars<'a, I, II>(vars: I) -> Vec<(rty::Var, rty::Sort)>
+where
+    I: IntoIterator<IntoIter = II>,
+    II: DoubleEndedIterator<Item = &'a rty::BoundVariableKind>,
+{
+    vars.into_iter()
+        .enumerate()
+        .filter_map(|(i, var_kind)| {
+            if let rty::BoundVariableKind::Refine(sort, _, reft_kind) = var_kind
+                && !sort.is_param()
+                && !sort.is_loc()
+                && !sort.is_unit()
+                && sort.is_unit_adt().is_none()
+            {
+                let bound_reft = rty::BoundReft { var: rty::BoundVar::from(i), kind: *reft_kind };
+                Some((rty::Var::Bound(INNERMOST, bound_reft), sort.clone()))
+            } else {
+                None
+            }
+        })
+        .collect_vec()
+}
+
+// FIXME: Use a Vec<Vec<_>> solution, per Nico.
+// This is a sort of annoying rearchitecture, but nothing impossible.
+fn shift_in_vars(vars: &mut [(rty::Var, rty::Sort)]) {
+    for (var, _) in vars.iter_mut() {
+        *var = var.shift_in(1);
+    }
+}
+
+fn shift_out_vars(vars: &mut [(rty::Var, rty::Sort)]) {
+    for (var, _) in vars.iter_mut() {
+        *var = var.shift_out(1);
+    }
+}
+
+// FIXME: Don't make a weak kvar if the self_args is empty if there's a weak kvar
+//        that's been created before it with a superset of its params.
+fn make_weak_kvar(
+    wkvar_map: &mut WeakKvarMap,
+    def_id: DefId,
+    kvid: &mut rty::KVid,
+    self_args: Vec<(rty::Var, rty::Sort)>,
+    params: Vec<(rty::Var, rty::Sort)>,
+) -> rty::WKVar {
+    let num_self_args = self_args.len();
+    let (args, sorts): (Vec<rty::Var>, Vec<rty::Sort>) =
+        self_args.into_iter().chain(params).unzip();
+    let arg_exprs = args.into_iter().map(rty::Expr::var).collect();
+    // We don't have any solutions because these weak kvars are being generated
+    // (solutions only come from user annotations).
+    wkvar_map.insert(kvid.as_u32(), WeakKvarInfo { solutions: vec![], sorts });
+    let ret = rty::WKVar {
+        wkvid: rty::WKVid::new(def_id, *kvid),
+        self_args: num_self_args,
+        args: arg_exprs,
+    };
+    *kvid += 1;
+    ret
 }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -394,10 +394,12 @@ pub(crate) fn trait_impl_subtyping<'genv, 'tcx>(
 
     let mut infcx = root_ctxt.infcx(impl_method_id, &rustc_infcx);
 
-    let trait_fn_sig =
-        genv.fn_sig(trait_method_id)?
-            .instantiate(tcx, &trait_method_args, &trait_refine_args);
-    let impl_sig = genv.fn_sig(impl_method_id)?;
+    let trait_fn_sig = genv.fn_sig(trait_method_id, true)?.instantiate(
+        tcx,
+        &trait_method_args,
+        &trait_refine_args,
+    );
+    let impl_sig = genv.fn_sig(impl_method_id, true)?;
     let sub_sig = SubFn::Poly(impl_method_id, impl_sig, impl_method_args);
 
     check_fn_subtyping(&mut infcx, sub_sig, &trait_fn_sig, span)?;
@@ -779,7 +781,10 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                     .with_span(terminator_span)?;
                 let ret = match kind {
                     mir::CallKind::FnDef { resolved_id, resolved_args, .. } => {
-                        let fn_sig = self.genv.fn_sig(*resolved_id).with_span(terminator_span)?;
+                        let fn_sig = self
+                            .genv
+                            .fn_sig(*resolved_id, true)
+                            .with_span(terminator_span)?;
                         let generic_args = instantiate_args_for_fun_call(
                             self.genv,
                             self.checker_id.root_id().to_def_id(),
@@ -1069,7 +1074,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 // Generates "function subtyping" obligations between the (super-type) `oblig_sig` in the `fn_trait_pred`
                 // and the (sub-type) corresponding to the signature of `def_id + args`.
                 // See `tests/neg/surface/fndef00.rs`
-                let sub_sig = self.genv.fn_sig(def_id).with_span(span)?;
+                let sub_sig = self.genv.fn_sig(def_id, true).with_span(span)?;
                 check_fn_subtyping(
                     infcx,
                     SubFn::Poly(*def_id, sub_sig, args.clone()),
@@ -1670,7 +1675,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 {
                     let current_did = infcx.def_id;
                     let sub_sig =
-                        SubFn::Poly(current_did, infcx.genv.fn_sig(*def_id)?, args.clone());
+                        SubFn::Poly(current_did, infcx.genv.fn_sig(*def_id, false)?, args.clone());
                     // TODO:CLOSURE:2 TODO(RJ) dicey maneuver? assumes that sig_b is unrefined?
                     check_fn_subtyping(infcx, sub_sig, super_sig, stmt_span)?;
                     to

--- a/crates/flux-refineck/src/ghost_statements.rs
+++ b/crates/flux-refineck/src/ghost_statements.rs
@@ -107,7 +107,7 @@ impl GhostStatements {
                 {
                     None
                 } else {
-                    Some(genv.fn_sig(def_id)?)
+                    Some(genv.fn_sig(def_id, true)?)
                 };
 
             fold_unfold::add_ghost_statements(&mut stmts, genv, body, fn_sig.as_ref())?;

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -183,7 +183,7 @@ pub fn check_fn(
     metrics::incr_metric(Metric::FnChecked, 1);
     metrics::time_it(TimingKind::CheckBody(def_id), || -> Result<(), ErrorGuaranteed> {
         let poly_sig = genv
-            .fn_sig(def_id)
+            .fn_sig(def_id, true)
             .with_span(span)
             .map_err(|err| err.emit(genv, def_id))?
             .instantiate_identity();

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -2,6 +2,7 @@ use std::{collections::HashSet, hash::Hash};
 
 use derive_where::derive_where;
 use indexmap::{IndexMap, IndexSet};
+use itertools::Itertools;
 
 use crate::{ThyFunc, Types};
 
@@ -484,7 +485,7 @@ impl<T: Types> Expr<T> {
         vars
     }
 
-    pub fn substitute(&self, subst: &FxIndexMap<T::Var, Self>) -> Self {
+    pub fn substitute(&self, subst: &IndexMap<T::Var, Self>) -> Self {
         match self {
             Expr::Var(v) => {
                 if let Some(subst_val) = subst.get(v) {

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -309,6 +309,12 @@ impl BoundVar {
     }
 }
 
+#[derive_where(Hash, Debug, Clone)]
+pub struct WKVar<T: Types> {
+    pub wkvid: T::Var,
+    pub args: Vec<Expr<T>>,
+}
+
 #[derive_where(Hash, Clone, Debug)]
 pub enum Expr<T: Types> {
     Constant(Constant<T>),
@@ -327,6 +333,12 @@ pub enum Expr<T: Types> {
     ThyFunc(ThyFunc),
     IsCtor(T::Var, Box<Self>),
     Exists(Vec<(T::Var, Sort<T>)>, Box<Self>),
+    /// NOTE: WKVars are for internal use and we serialize them as UIFs using
+    /// the var argument. We also don't emit WKVars that are in head position
+    /// when translating to fixpoint.
+    ///
+    /// In an ideal world fixpoint would deal with weak kvars itself.
+    WKVar(WKVar<T>),
 }
 
 impl<T: Types> From<Constant<T>> for Expr<T> {
@@ -401,6 +413,9 @@ impl<T: Types> Expr<T> {
                 }
                 expr.var_sorts_to_int();
             }
+            Expr::WKVar(_) => {
+                unimplemented!()
+            }
         }
     }
 
@@ -460,8 +475,79 @@ impl<T: Types> Expr<T> {
                 }
                 vars.extend(inner);
             }
+            Expr::WKVar(WKVar { wkvid: _, args }) => {
+                for e in args {
+                    vars.extend(e.free_vars());
+                }
+            }
         };
         vars
+    }
+
+    pub fn substitute(&self, subst: &FxIndexMap<T::Var, Self>) -> Self {
+        match self {
+            Expr::Var(v) => {
+                if let Some(subst_val) = subst.get(v) {
+                    subst_val.clone()
+                } else {
+                    self.clone()
+                }
+            }
+            Expr::Constant(_) | Expr::ThyFunc(_) => self.clone(),
+            Expr::App(expr, sort_args, exprs, out_sort) => {
+                Expr::App(
+                    Box::new(expr.substitute(subst)),
+                    sort_args.clone(),
+                    exprs.iter().map(|e| e.substitute(subst)).collect_vec(),
+                    out_sort.clone(),
+                )
+            }
+            Expr::Neg(expr) => Expr::Neg(Box::new(expr.substitute(subst))),
+            Expr::BinaryOp(bin_op, args) => {
+                Expr::BinaryOp(
+                    *bin_op,
+                    Box::new([args[0].substitute(subst), args[1].substitute(subst)]),
+                )
+            }
+            Expr::IfThenElse(args) => {
+                Expr::IfThenElse(Box::new([
+                    args[0].substitute(subst),
+                    args[1].substitute(subst),
+                    args[2].substitute(subst),
+                ]))
+            }
+            Expr::And(exprs) => Expr::And(exprs.iter().map(|e| e.substitute(subst)).collect_vec()),
+            Expr::Or(exprs) => Expr::Or(exprs.iter().map(|e| e.substitute(subst)).collect_vec()),
+            Expr::Not(expr) => Expr::Not(Box::new(expr.substitute(subst))),
+            Expr::Imp(args) => {
+                Expr::Imp(Box::new([args[0].substitute(subst), args[1].substitute(subst)]))
+            }
+            Expr::Iff(args) => {
+                Expr::Iff(Box::new([args[0].substitute(subst), args[1].substitute(subst)]))
+            }
+            Expr::Atom(bin_rel, args) => {
+                Expr::Atom(
+                    *bin_rel,
+                    Box::new([args[0].substitute(subst), args[1].substitute(subst)]),
+                )
+            }
+            Expr::Let(var, args) => {
+                Expr::Let(
+                    var.clone(),
+                    Box::new([args[0].substitute(subst), args[1].substitute(subst)]),
+                )
+            }
+            Expr::IsCtor(var, expr) => Expr::IsCtor(var.clone(), Box::new(expr.substitute(subst))),
+            Expr::Exists(sorts, expr) => {
+                Expr::Exists(sorts.clone(), Box::new(expr.substitute(subst)))
+            }
+            Expr::WKVar(WKVar { wkvid, args }) => {
+                Expr::WKVar(WKVar {
+                    wkvid: wkvid.clone(),
+                    args: args.iter().map(|e| e.substitute(subst)).collect_vec(),
+                })
+            }
+        }
     }
 }
 

--- a/lib/liquid-fixpoint/src/constraint_solving.rs
+++ b/lib/liquid-fixpoint/src/constraint_solving.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use crate::{
     Assignments, BinRel, Types,
-    constraint::{Bind, Constant, Constraint, Expr, Pred, Qualifier},
+    constraint::{Bind, Constant, Constraint, Expr, Pred, Qualifier, WKVar},
     constraint_fragments::ConstraintFragments,
     graph::topological_sort_sccs,
 };
@@ -464,6 +464,10 @@ impl<T: Types> Expr<T> {
             Expr::Constant(_) | Expr::ThyFunc(_) => {}
             Expr::Exists(..) => {
                 todo!("unexpected! exists")
+            }
+            Expr::WKVar(WKVar { wkvid: _, args }) => {
+                args.iter_mut()
+                    .for_each(|expr| expr.substitute_in_place(v_from, v_to));
             }
         }
     }

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use crate::{
     BinOp, BinRel, ConstDecl, Constant, Constraint, DataCtor, DataDecl, DataField, Expr,
     FixpointFmt, FunDef, FunSort, Identifier, KVarDecl, Pred, Qualifier, Sort, SortCtor, Task,
-    Types,
+    Types, WKVar,
 };
 
 pub(crate) fn fmt_constraint<T: Types>(

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -366,8 +366,10 @@ impl<T: Types> fmt::Display for Expr<T> {
                     body
                 )
             }
-            Expr::WKVar(WKVar { wkvid, args }) => {
-                write!(f, "({} {})", wkvid.display(), args.iter().format(" "))
+            Expr::WKVar(WKVar { .. }) => {
+                // NOTE(ck): Don't send wkvars to fixpoint
+                write!(f, "(true)")
+                // write!(f, "({} {})", wkvid.display(), args.iter().format(" "))
             }
         }
     }

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -366,6 +366,9 @@ impl<T: Types> fmt::Display for Expr<T> {
                     body
                 )
             }
+            Expr::WKVar(WKVar { wkvid, args }) => {
+                write!(f, "({} {})", wkvid.display(), args.iter().format(" "))
+            }
         }
     }
 }

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -39,7 +39,7 @@ use std::{
 
 pub use constraint::{
     BinOp, BinRel, Bind, BoundVar, Constant, Constraint, DataCtor, DataDecl, DataField, Expr,
-    FunSort, Pred, Qualifier, Sort, SortCtor, SortDecl,
+    FunSort, Pred, Qualifier, Sort, SortCtor, SortDecl, WKVar,
 };
 use derive_where::derive_where;
 #[cfg(feature = "nightly")]
@@ -136,7 +136,7 @@ macro_rules! declare_types {
             pub type DataField = $crate::DataField<FixpointTypes>;
             pub type Bind = $crate::Bind<FixpointTypes>;
             pub type Constant = $crate::Constant<FixpointTypes>;
-            pub use $crate::{BinOp, BinRel, BoundVar, ThyFunc};
+            pub use $crate::{BinOp, BinRel, ThyFunc, WKVar};
         }
 
         impl $crate::Types for fixpoint_generated::FixpointTypes {


### PR DESCRIPTION
This PR adds support for weak, or external kvars. These are inference variables which fixpoint (usually) can't natively handle because they tend to appear *only* in either head position (meaning they can trivially be solved to true) or body position (meaning they can be trivially solved to false).

We generate weak kvars on function signatures, representing holes that can be filled in with refinements. The intended use for theses is for inferring function signatures to fix type errors.

There are some caveats to the code introduced here.

1. This code should not directly affect constraint generation. It **will** change constraints, because weak kvars are not completely elided when being emitted (they get turned into true). But these constraints should be equivalent to the constraints prior. Previously, we emitted weak kvars as UIFs (which should also not affect constraint generation in theory), but this was causing strange bugs in fixpoint.
2. The UIF generation is available as part of the code, and we do emit UIF definitions to fixpoint --- we just don't use the UIFs.
3. The UIF encoding is probably not necessary. Right now the only interaction fixpoint has with weak kvars is syntactically solving non-cut kvars to solutions which may contain weak kvars via the fusion algorithm. So if we depend upon fixpoint to solve these non-cut kvars, then we need to encode weak kvars as UIFs so that they can be "moved around" into the solutions of non-cut kvars. However, I have some code to implement fusion in Flux directly, which means we can skip this hacky encoding.
4. This is not presently gated behind a feature flag, but follow-up work will gate it as well as add a compilation flag. So if it makes sense, we could just merge one big PR or a stacked PR so we don't get an intermediate state where weak kvars are generated (but unused).