### PR TITLE
Include namespace in UnresolvedPath error

### DIFF
--- a/crates/flux-desugar/locales/en-US.ftl
+++ b/crates/flux-desugar/locales/en-US.ftl
@@ -57,7 +57,8 @@ desugar_unsupported_signature =
     .note = {$note}
 
 desugar_unresolved_path =
-    cannot resolve `{$path}`
+    cannot resolve {$ns} `{$path}` in this scope
+    .label = not found in this scope
 
 desugar_unresolved_var =
     cannot find value `{$var}` in this scope

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -879,16 +879,10 @@ mod errors {
 
     impl UnresolvedPath {
         pub fn new(path: &surface::Path, ns: rustc_hir::def::Namespace) -> Self {
-            use rustc_hir::def::Namespace;
-            let ns = match ns {
-                Namespace::TypeNS => "type",
-                Namespace::ValueNS => "value",
-                Namespace::MacroNS => "macro",
-            };
             Self {
                 span: path.span,
                 path: path.segments.iter().map(|segment| segment.ident).join("::"),
-                ns,
+                ns: ns.descr(),
             }
         }
     }

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -732,7 +732,7 @@ impl<'a, 'genv, 'tcx> ItemResolver<'a, 'genv, 'tcx> {
                 .path_res_map
                 .insert(path.node_id, partial_res);
         } else {
-            self.errors.emit(errors::UnresolvedPath::new(path));
+            self.errors.emit(errors::UnresolvedPath::new(path, ns));
         }
     }
 
@@ -871,15 +871,24 @@ mod errors {
     #[diag(desugar_unresolved_path, code = E0999)]
     pub struct UnresolvedPath {
         #[primary_span]
+        #[label]
         pub span: Span,
         pub path: String,
+        pub ns: &'static str,
     }
 
     impl UnresolvedPath {
-        pub fn new(path: &surface::Path) -> Self {
+        pub fn new(path: &surface::Path, ns: rustc_hir::def::Namespace) -> Self {
+            use rustc_hir::def::Namespace;
+            let ns = match ns {
+                Namespace::TypeNS => "type",
+                Namespace::ValueNS => "value",
+                Namespace::MacroNS => "macro",
+            };
             Self {
                 span: path.span,
                 path: path.segments.iter().map(|segment| segment.ident).join("::"),
+                ns,
             }
         }
     }

--- a/tests/tests/neg/error_messages/resolver/cannot_resolve.rs
+++ b/tests/tests/neg/error_messages/resolver/cannot_resolve.rs
@@ -1,4 +1,4 @@
-#[flux::sig(fn(x: i322) -> bool )] //~ ERROR cannot resolve
+#[flux::sig(fn(x: i322) -> bool )] //~ ERROR cannot resolve type `i322` in this scope
 pub fn boo(x: i32) -> bool {
     x > 0
 }

--- a/tests/tests/neg/error_messages/resolver/glob_import.rs
+++ b/tests/tests/neg/error_messages/resolver/glob_import.rs
@@ -6,5 +6,5 @@ mod a {
 
 use a::*;
 
-#[flux::sig(fn(x: S))] //~ERROR cannot resolve
+#[flux::sig(fn(x: S))] //~ERROR cannot resolve type `S` in this scope
 fn foo(x: i32) {}

--- a/tests/tests/neg/error_messages/resolver/invalid_type.rs
+++ b/tests/tests/neg/error_messages/resolver/invalid_type.rs
@@ -1,5 +1,5 @@
 #[flux::refined_by(a: int)]
 struct S {
-    #[flux::field(i31[a])] //~ ERROR cannot resolve
+    #[flux::field(i31[a])] //~ ERROR cannot resolve type `i31` in this scope
     f: i32,
 }

--- a/tests/tests/neg/error_messages/resolver/variant_sig.rs
+++ b/tests/tests/neg/error_messages/resolver/variant_sig.rs
@@ -1,7 +1,7 @@
 #[flux::refined_by(b:bool)]
 pub enum E1<T> {
-    #[flux::variant(Opt<T>[false])] //~ ERROR cannot resolve
+    #[flux::variant(Opt<T>[false])] //~ ERROR cannot resolve type `Opt` in this scope
     A,
-    #[flux::variant({T} -> Opt<T>[true])] //~ ERROR cannot resolve
+    #[flux::variant({T} -> Opt<T>[true])] //~ ERROR cannot resolve type `Opt` in this scope
     B(T),
 }


### PR DESCRIPTION
Shows "cannot resolve type `X` in this scope" instead of just "cannot resolve `X`". Closes #877.