### PR TITLE
Use compact formatting for fixpoint binary communication

### DIFF
--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -15,13 +15,32 @@ pub(crate) fn fmt_constraint<T: Types>(
     cstr: &Constraint<T>,
     f: &mut fmt::Formatter<'_>,
 ) -> fmt::Result {
-    let mut cx = ConstraintFormatter::default();
+    fmt_constraint_impl(cstr, f, true)
+}
+
+pub(crate) fn fmt_constraint_compact<T: Types>(
+    cstr: &Constraint<T>,
+    f: &mut fmt::Formatter<'_>,
+) -> fmt::Result {
+    fmt_constraint_impl(cstr, f, false)
+}
+
+fn fmt_constraint_impl<T: Types>(
+    cstr: &Constraint<T>,
+    f: &mut fmt::Formatter<'_>,
+    pretty: bool,
+) -> fmt::Result {
+    let mut cx = ConstraintFormatter::new(pretty);
     write!(f, "(constraint")?;
     cx.incr();
     cx.newline(f)?;
     cx.fmt_constraint(f, cstr)?;
     cx.decr();
-    writeln!(f, ")")
+    if pretty {
+        writeln!(f, ")")
+    } else {
+        write!(f, ")")
+    }
 }
 
 impl<T: Types> fmt::Display for Constraint<T> {
@@ -93,12 +112,15 @@ impl<T: Types> fmt::Debug for Task<T> {
     }
 }
 
-#[derive(Default)]
 struct ConstraintFormatter {
     level: u32,
+    pretty: bool,
 }
 
 impl ConstraintFormatter {
+    fn new(pretty: bool) -> Self {
+        Self { level: 0, pretty }
+    }
     fn fmt_constraint<T: Types>(
         &mut self,
         f: &mut fmt::Formatter<'_>,
@@ -177,13 +199,19 @@ impl ConstraintFormatter {
     }
 
     fn newline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_char('\n')?;
-        self.padding(f)
+        if self.pretty {
+            f.write_char('\n')?;
+            self.padding(f)
+        } else {
+            f.write_char(' ')
+        }
     }
 
     fn padding(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for _ in 0..self.level {
-            f.write_str(" ")?;
+        if self.pretty {
+            for _ in 0..self.level {
+                f.write_str(" ")?;
+            }
         }
         Ok(())
     }

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -22,11 +22,7 @@ pub(crate) fn fmt_constraint<T: Types>(
     cx.newline(f)?;
     cx.fmt_constraint(f, cstr)?;
     cx.decr();
-    if pretty {
-        writeln!(f, ")")
-    } else {
-        write!(f, ")")
-    }
+    if pretty { writeln!(f, ")") } else { write!(f, ")") }
 }
 
 impl<T: Types> fmt::Display for Constraint<T> {

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -25,7 +25,6 @@ pub(crate) fn fmt_constraint<T: Types>(
     if pretty { writeln!(f, ")") } else { write!(f, ")") }
 }
 
-
 impl<T: Types> fmt::Display for Constraint<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_constraint(self, f, true)

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -14,20 +14,6 @@ use crate::{
 pub(crate) fn fmt_constraint<T: Types>(
     cstr: &Constraint<T>,
     f: &mut fmt::Formatter<'_>,
-) -> fmt::Result {
-    fmt_constraint_impl(cstr, f, true)
-}
-
-pub(crate) fn fmt_constraint_compact<T: Types>(
-    cstr: &Constraint<T>,
-    f: &mut fmt::Formatter<'_>,
-) -> fmt::Result {
-    fmt_constraint_impl(cstr, f, false)
-}
-
-fn fmt_constraint_impl<T: Types>(
-    cstr: &Constraint<T>,
-    f: &mut fmt::Formatter<'_>,
     pretty: bool,
 ) -> fmt::Result {
     let mut cx = ConstraintFormatter::new(pretty);
@@ -45,7 +31,7 @@ fn fmt_constraint_impl<T: Types>(
 
 impl<T: Types> fmt::Display for Constraint<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt_constraint(self, f)
+        fmt_constraint(self, f, true)
     }
 }
 
@@ -80,7 +66,7 @@ impl<T: Types> fmt::Display for Task<T> {
         }
 
         writeln!(f)?;
-        fmt_constraint(&self.constraint, f)
+        fmt_constraint(&self.constraint, f, true)
     }
 }
 

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -25,44 +25,65 @@ pub(crate) fn fmt_constraint<T: Types>(
     if pretty { writeln!(f, ")") } else { write!(f, ")") }
 }
 
+
 impl<T: Types> fmt::Display for Constraint<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_constraint(self, f, true)
     }
 }
 
-impl<T: Types> fmt::Display for Task<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.scrape_quals {
-            writeln!(f, "(fixpoint \"--scrape=both\")")?;
-        }
-        for line in &self.comments {
+pub(crate) fn fmt_task<T: Types>(
+    task: &Task<T>,
+    f: &mut fmt::Formatter<'_>,
+    pretty: bool,
+) -> fmt::Result {
+    if task.scrape_quals {
+        writeln!(f, "(fixpoint \"--scrape=both\")")?;
+    }
+    if pretty {
+        for line in &task.comments {
             writeln!(f, ";; {line}")?;
         }
         writeln!(f)?;
+    }
 
-        for data_decl in &self.data_decls {
-            writeln!(f, "{data_decl}")?;
-        }
+    for data_decl in &task.data_decls {
+        writeln!(f, "{data_decl}")?;
+    }
 
-        for qualif in &self.qualifiers {
-            writeln!(f, "{qualif}")?;
-        }
+    for qualif in &task.qualifiers {
+        writeln!(f, "{qualif}")?;
+    }
 
-        for cinfo in &self.constants {
-            writeln!(f, "{cinfo}")?;
-        }
+    for cinfo in &task.constants {
+        writeln!(f, "{cinfo}")?;
+    }
 
-        for fun_decl in &self.define_funs {
-            writeln!(f, "{fun_decl}")?;
-        }
+    for fun_decl in &task.define_funs {
+        writeln!(f, "{fun_decl}")?;
+    }
 
-        for kvar in &self.kvars {
-            writeln!(f, "{kvar}")?;
-        }
+    for kvar in &task.kvars {
+        writeln!(f, "{kvar}")?;
+    }
 
+    if pretty {
         writeln!(f)?;
-        fmt_constraint(&self.constraint, f, true)
+    }
+    fmt_constraint(&task.constraint, f, pretty)
+}
+
+impl<T: Types> fmt::Display for Task<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_task(self, f, true)
+    }
+}
+
+pub(crate) struct CompactTask<'a, T: Types>(pub &'a Task<T>);
+
+impl<T: Types> fmt::Display for CompactTask<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_task(self.0, f, false)
     }
 }
 

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -322,34 +322,8 @@ impl<T: Types> Task<T> {
         hasher.finish()
     }
 
-    fn fmt_compact(&self) -> String {
-        struct CompactTask<'a, T: Types>(&'a Task<T>);
-
-        impl<T: Types> fmt::Display for CompactTask<'_, T> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                if self.0.scrape_quals {
-                    writeln!(f, "(fixpoint \"--scrape=both\")")?;
-                }
-                for data_decl in &self.0.data_decls {
-                    writeln!(f, "{data_decl}")?;
-                }
-                for qualif in &self.0.qualifiers {
-                    writeln!(f, "{qualif}")?;
-                }
-                for cinfo in &self.0.constants {
-                    writeln!(f, "{cinfo}")?;
-                }
-                for fun_decl in &self.0.define_funs {
-                    writeln!(f, "{fun_decl}")?;
-                }
-                for kvar in &self.0.kvars {
-                    writeln!(f, "{kvar}")?;
-                }
-                format::fmt_constraint_compact(&self.0.constraint, f)
-            }
-        }
-
-        CompactTask(self).to_string()
+    fn compact_display(&self) -> CompactTask<'_, T> {
+        CompactTask(self)
     }
 
     #[cfg(feature = "rust-fixpoint")]
@@ -387,7 +361,7 @@ impl<T: Types> Task<T> {
         {
             let mut w = BufWriter::new(stdin.unwrap());
             // Use compact formatting when communicating with fixpoint to reduce overhead
-            writeln!(w, "{}", self.fmt_compact())?;
+            writeln!(w, "{}", self.compact_display())?;
         }
         let out = child.wait_with_output()?;
 
@@ -402,6 +376,32 @@ impl<T: Types> Task<T> {
                 err.into()
             }
         })
+    }
+}
+
+struct CompactTask<'a, T: Types>(&'a Task<T>);
+
+impl<T: Types> fmt::Display for CompactTask<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0.scrape_quals {
+            writeln!(f, "(fixpoint \"--scrape=both\")")?;
+        }
+        for data_decl in &self.0.data_decls {
+            writeln!(f, "{data_decl}")?;
+        }
+        for qualif in &self.0.qualifiers {
+            writeln!(f, "{qualif}")?;
+        }
+        for cinfo in &self.0.constants {
+            writeln!(f, "{cinfo}")?;
+        }
+        for fun_decl in &self.0.define_funs {
+            writeln!(f, "{fun_decl}")?;
+        }
+        for kvar in &self.0.kvars {
+            writeln!(f, "{kvar}")?;
+        }
+        format::fmt_constraint(&self.0.constraint, f, false)
     }
 }
 

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -322,30 +322,28 @@ impl<T: Types> Task<T> {
         hasher.finish()
     }
 
-    /// Format the task compactly without pretty-printing (no newlines/indentation).
-    /// Used when communicating with the fixpoint binary to reduce overhead.
-    pub fn fmt_compact(&self) -> String {
+    fn fmt_compact(&self) -> String {
         struct CompactTask<'a, T: Types>(&'a Task<T>);
 
         impl<T: Types> fmt::Display for CompactTask<'_, T> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 if self.0.scrape_quals {
-                    write!(f, "(fixpoint \"--scrape=both\")")?;
+                    writeln!(f, "(fixpoint \"--scrape=both\")")?;
                 }
                 for data_decl in &self.0.data_decls {
-                    write!(f, "{data_decl}")?;
+                    writeln!(f, "{data_decl}")?;
                 }
                 for qualif in &self.0.qualifiers {
-                    write!(f, "{qualif}")?;
+                    writeln!(f, "{qualif}")?;
                 }
                 for cinfo in &self.0.constants {
-                    write!(f, "{cinfo}")?;
+                    writeln!(f, "{cinfo}")?;
                 }
                 for fun_decl in &self.0.define_funs {
-                    write!(f, "{fun_decl}")?;
+                    writeln!(f, "{fun_decl}")?;
                 }
                 for kvar in &self.0.kvars {
-                    write!(f, "{kvar}")?;
+                    writeln!(f, "{kvar}")?;
                 }
                 format::fmt_constraint_compact(&self.0.constraint, f)
             }

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -322,10 +322,6 @@ impl<T: Types> Task<T> {
         hasher.finish()
     }
 
-    fn compact_display(&self) -> CompactTask<'_, T> {
-        CompactTask(self)
-    }
-
     #[cfg(feature = "rust-fixpoint")]
     pub fn run(&self) -> io::Result<VerificationResult<T::Tag>> {
         let mut cstr_with_env = ConstraintWithEnv::new(
@@ -360,8 +356,8 @@ impl<T: Types> Task<T> {
         std::mem::swap(&mut stdin, &mut child.stdin);
         {
             let mut w = BufWriter::new(stdin.unwrap());
-            // Use compact formatting when communicating with fixpoint to reduce overhead
-            writeln!(w, "{}", self.compact_display())?;
+            // Use compact formatting to reduce overhead when communicating with fixpoint
+            write!(w, "{}", format::CompactTask(self))?;
         }
         let out = child.wait_with_output()?;
 
@@ -376,32 +372,6 @@ impl<T: Types> Task<T> {
                 err.into()
             }
         })
-    }
-}
-
-struct CompactTask<'a, T: Types>(&'a Task<T>);
-
-impl<T: Types> fmt::Display for CompactTask<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.0.scrape_quals {
-            writeln!(f, "(fixpoint \"--scrape=both\")")?;
-        }
-        for data_decl in &self.0.data_decls {
-            writeln!(f, "{data_decl}")?;
-        }
-        for qualif in &self.0.qualifiers {
-            writeln!(f, "{qualif}")?;
-        }
-        for cinfo in &self.0.constants {
-            writeln!(f, "{cinfo}")?;
-        }
-        for fun_decl in &self.0.define_funs {
-            writeln!(f, "{fun_decl}")?;
-        }
-        for kvar in &self.0.kvars {
-            writeln!(f, "{kvar}")?;
-        }
-        format::fmt_constraint(&self.0.constraint, f, false)
     }
 }
 

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -357,7 +357,7 @@ impl<T: Types> Task<T> {
         {
             let mut w = BufWriter::new(stdin.unwrap());
             // Use compact formatting to reduce overhead when communicating with fixpoint
-            write!(w, "{}", format::CompactTask(self))?;
+            writeln!(w, "{}", format::CompactTask(self))?;
         }
         let out = child.wait_with_output()?;
 

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -322,6 +322,38 @@ impl<T: Types> Task<T> {
         hasher.finish()
     }
 
+    /// Format the task compactly without pretty-printing (no newlines/indentation).
+    /// Used when communicating with the fixpoint binary to reduce overhead.
+    pub fn fmt_compact(&self) -> String {
+        struct CompactTask<'a, T: Types>(&'a Task<T>);
+
+        impl<T: Types> fmt::Display for CompactTask<'_, T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                if self.0.scrape_quals {
+                    write!(f, "(fixpoint \"--scrape=both\")")?;
+                }
+                for data_decl in &self.0.data_decls {
+                    write!(f, "{data_decl}")?;
+                }
+                for qualif in &self.0.qualifiers {
+                    write!(f, "{qualif}")?;
+                }
+                for cinfo in &self.0.constants {
+                    write!(f, "{cinfo}")?;
+                }
+                for fun_decl in &self.0.define_funs {
+                    write!(f, "{fun_decl}")?;
+                }
+                for kvar in &self.0.kvars {
+                    write!(f, "{kvar}")?;
+                }
+                format::fmt_constraint_compact(&self.0.constraint, f)
+            }
+        }
+
+        CompactTask(self).to_string()
+    }
+
     #[cfg(feature = "rust-fixpoint")]
     pub fn run(&self) -> io::Result<VerificationResult<T::Tag>> {
         let mut cstr_with_env = ConstraintWithEnv::new(
@@ -356,7 +388,8 @@ impl<T: Types> Task<T> {
         std::mem::swap(&mut stdin, &mut child.stdin);
         {
             let mut w = BufWriter::new(stdin.unwrap());
-            writeln!(w, "{self}")?;
+            // Use compact formatting when communicating with fixpoint to reduce overhead
+            writeln!(w, "{}", self.fmt_compact())?;
         }
         let out = child.wait_with_output()?;
 


### PR DESCRIPTION
Addresses #858.

Adds a `pretty` flag to `ConstraintFormatter` so constraints can be formatted compactly (spaces instead of newlines/indentation) when writing to the fixpoint binary via stdin. The `Display` impl remains unchanged for debug output.

- `fmt_constraint_compact` skips newlines and indentation
- `Task::fmt_compact()` uses compact constraint formatting with explicit `writeln!` separators between top-level S-expressions
- `Task::run()` now calls `fmt_compact()` instead of `Display`