### PR TITLE
Validate self type in extern specs for trait impls

### DIFF
--- a/crates/flux-driver/locales/en-US.ftl
+++ b/crates/flux-driver/locales/en-US.ftl
@@ -89,3 +89,9 @@ driver_mismatched_generics =
     .label = generic parameters don't match the external {$def_descr}
     .extern_def_label = external {$def_descr} found here
     .note = extern specs must exactly match the external definition, including the list of generic parameters and their names
+
+driver_mismatched_impl_self_ty =
+    invalid extern spec for trait impl
+    .label = self type `{$local_self_ty}` doesn't match the external trait impl
+    .extern_impl_label = external trait impl has self type `{$extern_self_ty}`
+    .note = the self type in an extern spec for a trait impl must exactly match the external implementation

--- a/crates/flux-driver/src/collector/extern_specs.rs
+++ b/crates/flux-driver/src/collector/extern_specs.rs
@@ -169,9 +169,12 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
 
         // If this is a trait impl compute the impl_id from the trait_ref
         let mut impl_of_trait = None;
+        let mut local_trait_self_ty = None;
         if let hir::ItemKind::Impl(dummy_impl) = &dummy_item.kind {
-            impl_of_trait =
-                Some(self.extract_extern_id_from_impl(dummy_item.owner_id, dummy_impl)?);
+            let (extern_id, self_ty) =
+                self.extract_extern_id_from_impl(dummy_item.owner_id, dummy_impl)?;
+            impl_of_trait = Some(extern_id);
+            local_trait_self_ty = Some(self_ty);
 
             self.inner
                 .specs
@@ -198,8 +201,11 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
         if let Some(extern_impl_id) = extern_impl_id {
             self.check_generics(impl_id, extern_impl_id)?;
             // For trait impls, check that the self type matches the external definition
-            if let hir::ItemKind::Impl(dummy_impl) = &dummy_item.kind {
-                self.check_extern_impl_self_ty(impl_id, dummy_impl, extern_impl_id)?;
+            if let (Some(dummy_impl), Some(local_self_ty)) = (
+                if let hir::ItemKind::Impl(d) = &dummy_item.kind { Some(d) } else { None },
+                local_trait_self_ty,
+            ) {
+                self.check_extern_impl_self_ty(dummy_impl, local_self_ty, extern_impl_id)?;
             }
             self.insert_extern_id(impl_id.def_id, extern_impl_id)?;
         }
@@ -364,7 +370,11 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
         }
     }
 
-    fn extract_extern_id_from_impl(&self, impl_id: OwnerId, impl_: &hir::Impl) -> Result<DefId> {
+    fn extract_extern_id_from_impl(
+        &self,
+        impl_id: OwnerId,
+        impl_: &hir::Impl,
+    ) -> Result<(DefId, ty::Ty<'tcx>)> {
         if let Some(item_id) = impl_.items.first()
             && let hir::ImplItemKind::Fn { .. } = self.tcx().hir_impl_item(*item_id).kind
             && let Some((clause, _)) = self
@@ -376,8 +386,9 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
             && let Some(trait_pred) = poly_trait_pred.no_bound_vars()
         {
             let trait_ref = trait_pred.trait_ref;
+            let local_self_ty = trait_ref.self_ty();
             lowering::resolve_trait_ref_impl_id(self.tcx(), impl_id.to_def_id(), trait_ref)
-                .map(|(impl_id, _)| impl_id)
+                .map(|(impl_id, _)| (impl_id, local_self_ty))
                 .ok_or_else(|| self.cannot_resolve_trait_impl())
         } else {
             Err(self.malformed())
@@ -481,23 +492,20 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
 
     fn check_extern_impl_self_ty(
         &mut self,
-        local_id: OwnerId,
         local_impl: &hir::Impl,
+        local_self_ty: ty::Ty<'tcx>,
         extern_impl_id: DefId,
     ) -> Result {
         let tcx = self.tcx();
 
-        // Get the self type from the local extern spec
-        let local_self_ty = tcx.type_of(local_id).instantiate_identity();
-
         // Get the self type from the external impl
         let extern_self_ty = tcx.type_of(extern_impl_id).instantiate_identity();
 
-        // Compare self types. Note: this uses raw Ty equality which works after check_generics
-        // has verified param names and indices match. For generic impls where params have
-        // different DefIds across crates, this comparison may produce false mismatches —
-        // but check_generics already rejects differing param structures, so the remaining
-        // cases (concrete type mismatches like Range<usize> vs Range<A>) are caught correctly.
+        // Compare self types. `local_self_ty` is the user-written self type from the extern
+        // spec's trait_ref (not the `__FluxExternImplStruct` wrapper that the macro retargets
+        // the impl onto). After `check_generics` has verified param names and indices match,
+        // raw Ty equality is sound for the cases we want to catch (concrete type mismatches
+        // like `Range<usize>` vs `Range<A>`).
         if local_self_ty != extern_self_ty {
             let span = local_impl.self_ty.span;
             Err(self.emit(errors::MismatchedImplSelfTy {

--- a/crates/flux-driver/src/collector/extern_specs.rs
+++ b/crates/flux-driver/src/collector/extern_specs.rs
@@ -493,7 +493,11 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
         // Get the self type from the external impl
         let extern_self_ty = tcx.type_of(extern_impl_id).instantiate_identity();
 
-        // They should match structurally
+        // Compare self types. Note: this uses raw Ty equality which works after check_generics
+        // has verified param names and indices match. For generic impls where params have
+        // different DefIds across crates, this comparison may produce false mismatches —
+        // but check_generics already rejects differing param structures, so the remaining
+        // cases (concrete type mismatches like Range<usize> vs Range<A>) are caught correctly.
         if local_self_ty != extern_self_ty {
             let span = local_impl.self_ty.span;
             Err(self.emit(errors::MismatchedImplSelfTy {

--- a/crates/flux-driver/src/collector/extern_specs.rs
+++ b/crates/flux-driver/src/collector/extern_specs.rs
@@ -201,11 +201,8 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
         if let Some(extern_impl_id) = extern_impl_id {
             self.check_generics(impl_id, extern_impl_id)?;
             // For trait impls, check that the self type matches the external definition
-            if let (Some(dummy_impl), Some(local_self_ty)) = (
-                if let hir::ItemKind::Impl(d) = &dummy_item.kind { Some(d) } else { None },
-                local_trait_self_ty,
-            ) {
-                self.check_extern_impl_self_ty(dummy_impl, local_self_ty, extern_impl_id)?;
+            if let Some(local_self_ty) = local_trait_self_ty {
+                self.check_extern_impl_self_ty(impl_id, local_self_ty, extern_impl_id)?;
             }
             self.insert_extern_id(impl_id.def_id, extern_impl_id)?;
         }
@@ -492,7 +489,7 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
 
     fn check_extern_impl_self_ty(
         &mut self,
-        local_impl: &hir::Impl,
+        local_impl_id: OwnerId,
         local_self_ty: ty::Ty<'tcx>,
         extern_impl_id: DefId,
     ) -> Result {
@@ -507,7 +504,10 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
         // raw Ty equality is sound for the cases we want to catch (concrete type mismatches
         // like `Range<usize>` vs `Range<A>`).
         if local_self_ty != extern_self_ty {
-            let span = local_impl.self_ty.span;
+            // Emit on the user's impl block (compiletest matches `//~ ERROR` against the
+            // primary span line). The dummy `__FluxExternImplStruct` wrapper's self_ty has
+            // a macro-generated span that doesn't land on user source.
+            let span = tcx.def_span(local_impl_id);
             Err(self.emit(errors::MismatchedImplSelfTy {
                 span,
                 local_self_ty: local_self_ty.to_string(),

--- a/crates/flux-driver/src/collector/extern_specs.rs
+++ b/crates/flux-driver/src/collector/extern_specs.rs
@@ -197,6 +197,10 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
 
         if let Some(extern_impl_id) = extern_impl_id {
             self.check_generics(impl_id, extern_impl_id)?;
+            // For trait impls, check that the self type matches the external definition
+            if let hir::ItemKind::Impl(dummy_impl) = &dummy_item.kind {
+                self.check_extern_impl_self_ty(impl_id, dummy_impl, extern_impl_id)?;
+            }
             self.insert_extern_id(impl_id.def_id, extern_impl_id)?;
         }
 
@@ -475,6 +479,34 @@ impl<'a, 'sess, 'tcx> ExternSpecCollector<'a, 'sess, 'tcx> {
         }
     }
 
+    fn check_extern_impl_self_ty(
+        &mut self,
+        local_id: OwnerId,
+        local_impl: &hir::Impl,
+        extern_impl_id: DefId,
+    ) -> Result {
+        let tcx = self.tcx();
+
+        // Get the self type from the local extern spec
+        let local_self_ty = tcx.type_of(local_id).instantiate_identity();
+
+        // Get the self type from the external impl
+        let extern_self_ty = tcx.type_of(extern_impl_id).instantiate_identity();
+
+        // They should match structurally
+        if local_self_ty != extern_self_ty {
+            let span = local_impl.self_ty.span;
+            Err(self.emit(errors::MismatchedImplSelfTy {
+                span,
+                local_self_ty: local_self_ty.to_string(),
+                extern_self_ty: extern_self_ty.to_string(),
+                extern_impl_span: tcx.def_span(extern_impl_id),
+            }))
+        } else {
+            Ok(())
+        }
+    }
+
     #[track_caller]
     fn malformed(&self) -> ErrorGuaranteed {
         self.emit(errors::MalformedExternSpec::new(self.block.span))
@@ -681,5 +713,18 @@ mod errors {
         #[label(driver_extern_def_label)]
         pub extern_def: Span,
         pub def_descr: &'static str,
+    }
+
+    #[derive(Diagnostic)]
+    #[diag(driver_mismatched_impl_self_ty, code = E0999)]
+    #[note]
+    pub(super) struct MismatchedImplSelfTy {
+        #[primary_span]
+        #[label]
+        pub span: Span,
+        pub local_self_ty: String,
+        pub extern_self_ty: String,
+        #[label(driver_extern_impl_label)]
+        pub extern_impl_span: Span,
     }
 }

--- a/tests/tests/neg/extern_specs/mismatched_impl_self_ty.rs
+++ b/tests/tests/neg/extern_specs/mismatched_impl_self_ty.rs
@@ -1,5 +1,11 @@
-// Test that extern spec for trait impl rejects mismatched self types
+// Test that extern spec for trait impl rejects mismatched self types.
+// Generic params match the external impl, but the self type is more specific.
 // Issue: https://github.com/flux-rs/flux/issues/833
 
-#[flux::extern_spec(std::ops)]
-impl Iterator for std::ops::Range<usize> {} //~ ERROR invalid extern spec for trait impl
+#![feature(step_trait)]
+use std::iter::Step;
+
+use flux_attrs::extern_spec;
+
+#[extern_spec(std::ops)]
+impl<A: Step> Iterator for Range<usize> {} //~ ERROR invalid extern spec for trait impl

--- a/tests/tests/neg/extern_specs/mismatched_impl_self_ty.rs
+++ b/tests/tests/neg/extern_specs/mismatched_impl_self_ty.rs
@@ -1,0 +1,5 @@
+// Test that extern spec for trait impl rejects mismatched self types
+// Issue: https://github.com/flux-rs/flux/issues/833
+
+#[flux::extern_spec(std::ops)]
+impl Iterator for std::ops::Range<usize> {} //~ ERROR invalid extern spec for trait impl


### PR DESCRIPTION
## Summary
- Add `check_extern_impl_self_ty` to validate that the self type in an extern spec matches the external trait impl
- Emit a clear diagnostic (`driver_mismatched_impl_self_ty`) when they diverge, instead of silently accepting a wrong spec
- Fixes #833

## Test plan
- Added negative test `mismatched_impl_self_ty.rs` that verifies the error is emitted for `impl Iterator for Range<usize>` (wrong self type)
- Existing test suite passes