### PR TITLE
un/curry parsing of primop-uif-applications

### DIFF
--- a/crates/flux-infer/src/fixpoint_encoding/decoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding/decoding.rs
@@ -287,16 +287,10 @@ where
                                 // NOTE: Only a few of these are meaningfully needed,
                                 // e.g. ConstKey::Alias because the rty Expr has its
                                 // args as a part of it.
-                                ConstKey::PrimOp(bin_op) => {
-                                    if fargs.len() != 2 {
-                                        Err(FixpointParseError::PrimOpArityMismatch(fargs.len()))
-                                    } else {
-                                        Ok(rty::Expr::prim_val(
-                                            bin_op.clone(),
-                                            self.fixpoint_to_expr(&fargs[0])?,
-                                            self.fixpoint_to_expr(&fargs[1])?,
-                                        ))
-                                    }
+                                ConstKey::PrimOp(_) => {
+                                    unreachable!(
+                                        "Should have been handled by is_curried_primop_app"
+                                    )
                                 }
                                 ConstKey::Cast(sort1, sort2) => {
                                     if fargs.len() != 1 {

--- a/crates/flux-infer/src/fixpoint_encoding/decoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding/decoding.rs
@@ -94,6 +94,34 @@ where
         }
     }
 
+    fn is_curried_primop_app(
+        &mut self,
+        fhead: &fixpoint::Expr,
+        fargs: &Vec<fixpoint::Expr>,
+        op_args: &mut Vec<fixpoint::Expr>,
+    ) -> Option<rty::BinOp> {
+        match fhead {
+            fixpoint::Expr::Var(fixpoint::Var::Global(global_var, _))
+            | fixpoint::Expr::Var(fixpoint::Var::Const(global_var, _)) => {
+                if let Some(ConstKey::PrimOp(bin_op)) =
+                    self.ecx.const_env.const_map_rev.get(global_var)
+                {
+                    op_args.reverse();
+                    return Some(bin_op.clone());
+                } else {
+                    None
+                }
+            }
+            fixpoint::Expr::App(fhead_inner, _, fargs_inner, _) => {
+                if fargs.len() == 1 {
+                    op_args.push(fargs[0].clone());
+                }
+                self.is_curried_primop_app(fhead_inner, fargs_inner, op_args)
+            }
+            _ => None,
+        }
+    }
+
     #[allow(dead_code)]
     pub(crate) fn fixpoint_to_expr(
         &mut self,
@@ -182,6 +210,16 @@ where
                 }
             }
             fixpoint::Expr::App(fhead, _sort_args, fargs, _out_sort) => {
+                let mut op_args = vec![];
+                if let Some(bin_op) = self.is_curried_primop_app(fhead, fargs, &mut op_args) {
+                    if op_args.len() != 2 {
+                        return Err(FixpointParseError::PrimOpArityMismatch(fargs.len()));
+                    } else {
+                        let e1 = self.fixpoint_to_expr(&op_args[0])?;
+                        let e2 = self.fixpoint_to_expr(&op_args[1])?;
+                        return Ok(rty::Expr::prim_val(bin_op, e1, e2));
+                    }
+                }
                 match &**fhead {
                     fixpoint::Expr::Var(fixpoint::Var::TupleProj { arity, field }) => {
                         if fargs.len() == 1 {

--- a/tests/tests/pos/surface/primops00.rs
+++ b/tests/tests/pos/surface/primops00.rs
@@ -72,3 +72,10 @@ pub fn test6(c: char) {
     let c = c | 1;
     flux_rs::assert(c <= 0x10FFFF); // (1)
 }
+
+#[spec(fn (b:bool) -> usize{v: v <= 7})]
+pub fn test7(b: bool) -> usize {
+    let n: usize = 10;
+    let m = if b { n & 7 } else { 6 };
+    m
+}


### PR DESCRIPTION
This fixes-ish a bug in the code to convert fixpoint::Expr -> rty::Expr; the UIF for `>>` and such like bin-op expects two arguments, but the fixpoint-uif encoding is curried and so looks like `((c0 arg1) arg2)`. I'm not entirely sure why *this* needs special casing: why isn't it like _other_ UIFs? 
- Is fixpoint not "uncurrying" the solutions? (seems unlikely, what about other UIFs, which are presumably treated identically by fixpoint?)
- Is this primop-uif encoded in some special "curried" manner (unlike other UIFs which are encoded fully applied?) 

At any rate, this patch deals with the current crash... @cole-k do you have any theories? or @petros-marko ?