### PR TITLE
Several needed fixes

### DIFF
--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -1481,6 +1481,7 @@ impl KVarSolutions {
                     )
             });
             let free_var_subs = free_vars
+                .filter(|fvar| !matches!(fvar, fixpoint::Var::Const(..)))
                 .map(|fvar| (*fvar, variable_sorts.get(fvar).unwrap().clone()))
                 .collect();
             solution.1.var_sorts_to_int();

--- a/crates/flux-infer/src/lean_encoding.rs
+++ b/crates/flux-infer/src/lean_encoding.rs
@@ -184,18 +184,23 @@ fn run_proof(genv: GlobalEnv, def_id: DefId) -> io::Result<()> {
         .arg("--log-level=error")
         .arg("lean")
         .arg(proof_path)
+        .arg("--")
+        .arg("--json")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .current_dir(project_path(genv, FileKind::User))
         .spawn()?
         .wait_with_output()?;
-    if out.stderr.is_empty() && out.stdout.is_empty() {
-        Ok(())
-    } else {
+    if !out.stderr.is_empty() {
         let stderr =
             std::str::from_utf8(&out.stderr).unwrap_or("Lean exited with a non-zero return code");
-        Err(io::Error::other(stderr))
+        return Err(io::Error::other(stderr));
     }
+    let stdout = std::str::from_utf8(&out.stdout).unwrap_or("");
+    if stdout.lines().any(|line| line.contains("\"hasSorry\"")) {
+        return Err(io::Error::other("proof uses `sorry`"));
+    }
+    Ok(())
 }
 
 fn run_check(genv: GlobalEnv, def_id: DefId) -> io::Result<()> {
@@ -205,6 +210,8 @@ fn run_check(genv: GlobalEnv, def_id: DefId) -> io::Result<()> {
         .arg("--log-level=error")
         .arg("lean")
         .arg(checking_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .current_dir(project_path(genv, FileKind::User))
         .spawn()?
         .wait()?;

--- a/crates/flux-infer/src/lean_encoding.rs
+++ b/crates/flux-infer/src/lean_encoding.rs
@@ -390,6 +390,7 @@ impl<'genv, 'tcx> LeanEncoder<'genv, 'tcx> {
             opaque_adt_map: &self.sort_deps.opaque_sorts,
             kvar_solutions: &self.kvar_solutions,
             primop_var_map: &self.primop_var_map,
+            hide_sort_vars: false,
         }
     }
 

--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -375,7 +375,11 @@ impl LeanFmt for Sort {
                 )
             }
             Sort::Var(v) => {
-                if cx.hide_sort_vars { write!(f, "_") } else { write!(f, "t{v}") }
+                if cx.hide_sort_vars {
+                    write!(f, "_")
+                } else {
+                    write!(f, "t{v}")
+                }
             }
             Sort::BvSize(size) => {
                 panic!("sort BvSize({size}) should only occur as an argument to BitVec")

--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -32,6 +32,7 @@ pub struct LeanCtxt<'a, 'genv, 'tcx> {
     pub kvar_solutions: &'a KVarSolutions,
     /// Maps the per-run `GlobalVar` index of a primop constant to its stable Lean name.
     pub primop_var_map: &'a FxHashMap<GlobalVar, String>,
+    pub hide_sort_vars: bool,
 }
 
 pub struct WithLeanCtxt<'a, 'b, 'genv, 'tcx, T> {
@@ -374,7 +375,9 @@ impl LeanFmt for Sort {
                     WithLeanCtxt { item: sort.as_ref(), cx }
                 )
             }
-            Sort::Var(v) => write!(f, "t{v}"),
+            Sort::Var(v) => {
+                if cx.hide_sort_vars { write!(f, "_") } else { write!(f, "t{v}") }
+            }
             Sort::BvSize(size) => {
                 panic!("sort BvSize({size}) should only occur as an argument to BitVec")
             }
@@ -431,6 +434,7 @@ impl LeanFmt for Expr {
                 write!(f, "(")?;
                 function.as_ref().lean_fmt(f, cx)?;
                 if let Some(sort_args) = sort_args {
+                    let cx = &LeanCtxt { hide_sort_vars: true, ..*cx };
                     for (i, s_arg) in sort_args.iter().enumerate() {
                         if matches!(s_arg, Sort::BvSize(..)) {
                             continue;

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -343,7 +343,7 @@ impl<T: Types> Task<T> {
         let mut child = Command::new("fixpoint")
             .arg("-q")
             .arg("--stdin")
-            .arg("--sorted-solution")
+            .arg("--sortedsolution")
             .arg("--json")
             .arg("--allowho")
             .arg("--allowhoqs")

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -343,7 +343,7 @@ impl<T: Types> Task<T> {
         let mut child = Command::new("fixpoint")
             .arg("-q")
             .arg("--stdin")
-            .arg("--sortedsolution")
+            .arg("--sorted-solution")
             .arg("--json")
             .arg("--allowho")
             .arg("--allowhoqs")

--- a/lib/liquid-fixpoint/src/parser.rs
+++ b/lib/liquid-fixpoint/src/parser.rs
@@ -153,6 +153,18 @@ where
         Ok(Expr::IsCtor(ctor, Box::new(arg)))
     }
 
+    fn parse_if(&mut self, sexp: &Sexp) -> Result<Expr<T>, ParseError> {
+        match sexp {
+            Sexp::List(items) => {
+                let condition = self.parse_expr_possibly_nested(&items[1])?;
+                let pos_val = self.parse_expr_possibly_nested(&items[2])?;
+                let neg_val = self.parse_expr_possibly_nested(&items[3])?;
+                Ok(Expr::IfThenElse(Box::new([condition, pos_val, neg_val])))
+            }
+            _ => Err(ParseError::err("Expected list for if-else")),
+        }
+    }
+
     pub fn parse_expr(&mut self, sexp: &Sexp) -> Result<Expr<T>, ParseError> {
         match sexp {
             Sexp::List(items) => {
@@ -165,6 +177,7 @@ where
                         "or" => self.parse_or(sexp),
                         "and" => self.parse_and(sexp),
                         "lit" => parse_bitvec(sexp),
+                        "if" => self.parse_if(sexp),
                         "-" if items.len() == 2 => self.parse_neg(sexp),
                         "+" | "-" | "*" | "/" | "mod" => self.parse_binary_op(sexp),
                         "=" | "!=" | "<" | "<=" | ">" | ">=" => self.parse_atom(sexp),


### PR DESCRIPTION
- ~correctly name sortedsolution flag for fixpoint~
- parse conditionals in the k-solutions returned from fixpoint
- hide type variables (and let lean fill them in) when they'd cause trouble in the definition of VCs
- correct the check flux makes to determine a successful lean run (stdout is OK as long as it doesn't include a "sorry" use)