### PR TITLE
Literals of Real sort

### DIFF
--- a/crates/flux-desugar/locales/en-US.ftl
+++ b/crates/flux-desugar/locales/en-US.ftl
@@ -18,7 +18,7 @@ desugar_invalid_loc =
 
 desugar_invalid_numeric_suffix =
     invalid suffix `{$suffix}` for number literal
-    .label = the suffix must be one of the numeric sorts `int` or `real`
+    .label = the suffix must be the numeric sort `int`; use a float literal (e.g. `1.0`) for `real`
 
 desugar_unresolved_generic_param =
     cannot resolve generic param

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1701,15 +1701,21 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     Err(err) => return fhir::ExprKind::Err(err),
                 };
                 match lit.suffix {
-                    Some(sym::int) => fhir::Lit::Int(n, Some(fhir::NumLitKind::Int)),
-                    Some(sym::real) => fhir::Lit::Int(n, Some(fhir::NumLitKind::Real)),
-                    None => fhir::Lit::Int(n, None),
+                    None => fhir::Lit::Int(n),
                     Some(suffix) => {
                         return fhir::ExprKind::Err(
                             self.emit(errors::InvalidNumericSuffix::new(span, suffix)),
                         );
                     }
                 }
+            }
+            surface::LitKind::Float => {
+                if let Some(suffix) = lit.suffix {
+                    return fhir::ExprKind::Err(
+                        self.emit(errors::InvalidNumericSuffix::new(span, suffix)),
+                    );
+                }
+                fhir::Lit::Real(lit.symbol)
             }
             surface::LitKind::Bool => fhir::Lit::Bool(lit.symbol == kw::True),
             surface::LitKind::Str => fhir::Lit::Str(lit.symbol),

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -275,6 +275,10 @@ fhir_analysis_invalid_bitvector_constant =
     invalid bit vector literal
     .label = not a valid `{$sort}` literal
 
+fhir_analysis_int_literal_in_real_context =
+    integer literal used in real-sorted context
+    .label = use a float literal instead, e.g. `{$n}.0`
+
 fhir_analysis_refine_arg_mismatch =
     {$kind} takes {$expected} generic refinement {$expected ->
         [one] argument

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2077,6 +2077,10 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                     } else {
                         Err(self.emit(errors::InvalidBitVectorConstant::new(span, sort)))?
                     }
+                } else if sort == rty::Sort::Real {
+                    // Sort inference allows Int literals to unify with Real, but we require
+                    // explicit float syntax to avoid silently producing a mistyped constant.
+                    Err(self.emit(errors::IntLiteralInRealContext::new(span, n)))?
                 } else {
                     Ok(rty::Constant::from(n))
                 }
@@ -3161,6 +3165,21 @@ mod errors {
     pub(super) struct GenericsOnForeignTy {
         #[primary_span]
         pub span: Span,
+    }
+
+    #[derive(Diagnostic)]
+    #[diag(fhir_analysis_int_literal_in_real_context, code = E0999)]
+    pub struct IntLiteralInRealContext {
+        #[primary_span]
+        #[label]
+        span: Span,
+        n: u128,
+    }
+
+    impl IntLiteralInRealContext {
+        pub(crate) fn new(span: Span, n: u128) -> Self {
+            Self { span, n }
+        }
     }
 
     #[derive(Diagnostic)]

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2067,26 +2067,21 @@ fn prim_ty_to_bty(prim_ty: rustc_hir::PrimTy) -> rty::BaseTy {
 impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
     fn conv_lit(&self, lit: fhir::Lit, fhir_id: FhirId, span: Span) -> QueryResult<rty::Constant> {
         match lit {
-            fhir::Lit::Int(n, kind) => {
-                match kind {
-                    Some(fhir::NumLitKind::Int) => Ok(rty::Constant::from(n)),
-                    Some(fhir::NumLitKind::Real) => Ok(rty::Constant::Real(rty::Real(n))),
-                    None => {
-                        let sort = self.results().node_sort(fhir_id);
-                        if let rty::Sort::BitVec(bvsize) = sort {
-                            if let rty::BvSize::Fixed(size) = bvsize
-                                && (n == 0 || n.ilog2() < size)
-                            {
-                                Ok(rty::Constant::BitVec(n, size))
-                            } else {
-                                Err(self.emit(errors::InvalidBitVectorConstant::new(span, sort)))?
-                            }
-                        } else {
-                            Ok(rty::Constant::from(n))
-                        }
+            fhir::Lit::Int(n) => {
+                let sort = self.results().node_sort(fhir_id);
+                if let rty::Sort::BitVec(bvsize) = sort {
+                    if let rty::BvSize::Fixed(size) = bvsize
+                        && (n == 0 || n.ilog2() < size)
+                    {
+                        Ok(rty::Constant::BitVec(n, size))
+                    } else {
+                        Err(self.emit(errors::InvalidBitVectorConstant::new(span, sort)))?
                     }
+                } else {
+                    Ok(rty::Constant::from(n))
                 }
             }
+            fhir::Lit::Real(sym) => Ok(rty::Constant::Real(rty::Real(sym))),
             fhir::Lit::Bool(b) => Ok(rty::Constant::from(b)),
             fhir::Lit::Str(s) => Ok(rty::Constant::from(s)),
             fhir::Lit::Char(c) => Ok(rty::Constant::from(c)),

--- a/crates/flux-fhir-analysis/src/wf/sortck.rs
+++ b/crates/flux-fhir-analysis/src/wf/sortck.rs
@@ -270,13 +270,12 @@ impl<'genv, 'tcx> InferCtxt<'genv, 'tcx> {
 
     fn synth_lit(&mut self, lit: fhir::Lit, expr: &fhir::Expr<'genv>) -> rty::Sort {
         match lit {
-            fhir::Lit::Int(_, Some(fhir::NumLitKind::Int)) => rty::Sort::Int,
-            fhir::Lit::Int(_, Some(fhir::NumLitKind::Real)) => rty::Sort::Real,
-            fhir::Lit::Int(_, None) => {
+            fhir::Lit::Int(_) => {
                 let sort = self.next_sort_var_with_cstr(rty::SortCstr::NUMERIC);
                 self.sort_of_literal.insert(*expr, sort.clone());
                 sort
             }
+            fhir::Lit::Real(_) => rty::Sort::Real,
             fhir::Lit::Bool(_) => rty::Sort::Bool,
             fhir::Lit::Str(_) => rty::Sort::Str,
             fhir::Lit::Char(_) => rty::Sort::Char,

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -197,11 +197,21 @@ pub mod fixpoint {
         }
     }
 
+    #[derive(Hash, Clone, Debug)]
+    pub struct SymReal(pub Symbol);
+
+    impl FixpointFmt for SymReal {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
     liquid_fixpoint::declare_types! {
         type Sort = DataSort;
         type KVar = KVid;
         type Var = Var;
         type String = SymStr;
+        type Real = SymReal;
         type Tag = super::TagIdx;
     }
     pub use fixpoint_generated::*;
@@ -1106,7 +1116,7 @@ fn const_to_fixpoint(cst: rty::Constant) -> fixpoint::Expr {
                 fixpoint::Constant::Numeral(i.abs()).into()
             }
         }
-        rty::Constant::Real(r) => fixpoint::Constant::Real(r.0).into(),
+        rty::Constant::Real(r) => fixpoint::Constant::Real(fixpoint::SymReal(r.0)).into(),
         rty::Constant::Bool(b) => fixpoint::Constant::Boolean(b).into(),
         rty::Constant::Char(c) => fixpoint::Constant::Numeral(u128::from(c)).into(),
         rty::Constant::Str(s) => fixpoint::Constant::String(fixpoint::SymStr(s)).into(),

--- a/crates/flux-infer/src/fixpoint_encoding/decoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding/decoding.rs
@@ -131,7 +131,7 @@ where
             fixpoint::Expr::Constant(constant) => {
                 let c = match constant {
                     fixpoint::Constant::Numeral(num) => rty::Constant::Int(BigInt::from(*num)),
-                    fixpoint::Constant::Real(dec) => rty::Constant::Real(rty::Real(*dec)),
+                    fixpoint::Constant::Real(dec) => rty::Constant::Real(rty::Real(dec.0)),
                     fixpoint::Constant::Boolean(b) => rty::Constant::Bool(*b),
                     fixpoint::Constant::String(s) => rty::Constant::Str(s.0),
                     fixpoint::Constant::BitVec(bv, size) => rty::Constant::BitVec(*bv, *size),

--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -397,7 +397,7 @@ impl LeanFmt for Expr {
                     Constant::Numeral(n) => write!(f, "{n}",),
                     Constant::Boolean(b) => write!(f, "{}", if *b { "True" } else { "False" }),
                     Constant::String(s) => write!(f, "{}", s.display()),
-                    Constant::Real(n) => write!(f, "{n}.0"),
+                    Constant::Real(n) => write!(f, "{}", n.display()),
                     Constant::BitVec(bv, size) => write!(f, "{}#{}", bv, size),
                 }
             }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -1084,14 +1084,9 @@ pub struct LetDecl<'fhir> {
 }
 
 #[derive(Clone, Copy)]
-pub enum NumLitKind {
-    Int,
-    Real,
-}
-
-#[derive(Clone, Copy)]
 pub enum Lit {
-    Int(u128, Option<NumLitKind>),
+    Int(u128),
+    Real(Symbol),
     Bool(bool),
     Str(Symbol),
     Char(char),
@@ -1649,8 +1644,8 @@ impl fmt::Debug for PathExpr<'_> {
 impl fmt::Debug for Lit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Lit::Int(i, Some(NumLitKind::Real)) => write!(f, "{i}real"),
-            Lit::Int(i, _) => write!(f, "{i}"),
+            Lit::Int(i) => write!(f, "{i}"),
+            Lit::Real(s) => write!(f, "{s}"),
             Lit::Bool(b) => write!(f, "{b}"),
             Lit::Str(s) => write!(f, "\"{s:?}\""),
             Lit::Char(c) => write!(f, "\'{c}\'"),

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -1223,7 +1223,7 @@ impl From<Local> for Loc {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
-pub struct Real(pub u128);
+pub struct Real(pub Symbol);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum Constant {
@@ -1700,7 +1700,7 @@ pub(crate) mod pretty {
             match self {
                 Constant::Int(i) => w!(cx, f, "{i}"),
                 Constant::BitVec(i, sz) => w!(cx, f, "bv({i}, {sz})"),
-                Constant::Real(r) => w!(cx, f, "{}.0", ^r.0),
+                Constant::Real(r) => w!(cx, f, "{}", ^r.0),
                 Constant::Bool(b) => w!(cx, f, "{b}"),
                 Constant::Str(sym) => w!(cx, f, "\"{sym}\""),
                 Constant::Char(c) => w!(cx, f, "\'{c}\'"),

--- a/crates/flux-syntax/src/symbols.rs
+++ b/crates/flux-syntax/src/symbols.rs
@@ -25,7 +25,6 @@ symbols! {
         Set,
         addr,
         base,
-        float,
         int,
         no_panic,
         no_panic_if,

--- a/crates/flux-syntax/src/symbols.rs
+++ b/crates/flux-syntax/src/symbols.rs
@@ -25,6 +25,7 @@ symbols! {
         Set,
         addr,
         base,
+        float,
         int,
         no_panic,
         no_panic_if,

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -468,12 +468,7 @@ impl<T: Types> Expr<T> {
 #[derive_where(Hash, Clone, Debug)]
 pub enum Constant<T: Types> {
     Numeral(u128),
-    // Currently we only support parsing integers as decimals. We should extend this to allow
-    // rational numbers as a numer/denom.
-    //
-    // NOTE: If this type is updated, then update parse_expr in the parser
-    // (see the unimplemented!() related to float parsing).
-    Real(u128),
+    Real(T::Real),
     Boolean(bool),
     String(T::String),
     BitVec(u128, u32),

--- a/lib/liquid-fixpoint/src/cstr2smt2.rs
+++ b/lib/liquid-fixpoint/src/cstr2smt2.rs
@@ -84,7 +84,11 @@ fn const_to_z3<T: Types>(cnst: &Constant<T>) -> ast::Dynamic {
         Constant::Boolean(b) => ast::Bool::from_bool(*b).into(),
         Constant::String(strconst) => ast::String::from(strconst.display().to_string()).into(),
         Constant::BitVec(bv, size) => ast::BV::from_u64(*bv as u64, *size).into(),
-        Constant::Real(r) => ast::Real::from_str(&r.display().to_string()).unwrap().into(),
+        Constant::Real(r) => {
+            ast::Real::from_str(&r.display().to_string())
+                .unwrap()
+                .into()
+        }
     }
 }
 

--- a/lib/liquid-fixpoint/src/cstr2smt2.rs
+++ b/lib/liquid-fixpoint/src/cstr2smt2.rs
@@ -84,11 +84,7 @@ fn const_to_z3<T: Types>(cnst: &Constant<T>) -> ast::Dynamic {
         Constant::Boolean(b) => ast::Bool::from_bool(*b).into(),
         Constant::String(strconst) => ast::String::from(strconst.display().to_string()).into(),
         Constant::BitVec(bv, size) => ast::BV::from_u64(*bv as u64, *size).into(),
-        Constant::Real(num) => {
-            ast::Real::from_rational_str(&num.to_string(), "1")
-                .unwrap()
-                .into()
-        }
+        Constant::Real(r) => ast::Real::from_str(&r.display().to_string()).unwrap().into(),
     }
 }
 

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -374,7 +374,7 @@ impl<T: Types> fmt::Display for Constant<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Constant::Numeral(n) => write!(f, "{n}"),
-            Constant::Real(n) => write!(f, "{n}.0"),
+            Constant::Real(n) => write!(f, "{}", n.display()),
             Constant::Boolean(b) => write!(f, "{b}"),
             Constant::String(s) => write!(f, "{}", s.display()),
             Constant::BitVec(i, sz) => {

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -57,6 +57,7 @@ pub trait Types {
     type KVar: Identifier + Hash + Clone + Debug + Eq;
     type Var: Identifier + Hash + Clone + Debug + Eq;
     type String: FixpointFmt + Hash + Clone + Debug;
+    type Real: FixpointFmt + Hash + Clone + Debug;
     type Tag: fmt::Display + FromStr + Hash + Clone + Debug;
 }
 
@@ -114,6 +115,7 @@ macro_rules! declare_types {
         type KVar = $kvar:ty;
         type Var = $var:ty;
         type String = $str:ty;
+        type Real = $real:ty;
         type Tag = $tag:ty;
     ) => {
         pub mod fixpoint_generated {
@@ -144,6 +146,7 @@ macro_rules! declare_types {
             type KVar = $kvar;
             type Var = $var;
             type String = $str;
+            type Real = $real;
             type Tag = $tag;
         }
     };

--- a/lib/liquid-fixpoint/src/parser.rs
+++ b/lib/liquid-fixpoint/src/parser.rs
@@ -706,6 +706,7 @@ impl Types for StringTypes {
     type Var = String;
     type Tag = String;
     type String = String;
+    type Real = String;
 }
 
 impl FromSexp<StringTypes> for StringTypes {

--- a/tests/tests/neg/surface/real00.rs
+++ b/tests/tests/neg/surface/real00.rs
@@ -10,7 +10,7 @@ fn add(x: Real, y: Real) -> Real {
 }
 
 #[flux::trusted]
-#[flux::sig(fn(x: Real) -> Real[x + 1real])]
+#[flux::sig(fn(x: Real) -> Real[x + 1.0])]
 fn add1(x: Real) -> Real {
     Real
 }
@@ -23,7 +23,7 @@ fn test01(x: Real) {
 }
 
 fn test02() {
-    #[flux::sig(fn() requires 1real/2real != 1real/2real)]
+    #[flux::sig(fn() requires 1.0/2.0 != 1.0/2.0)]
     fn assert() {}
     assert() //~ ERROR refinement type
 }

--- a/tests/tests/neg/surface/real01.rs
+++ b/tests/tests/neg/surface/real01.rs
@@ -1,0 +1,11 @@
+#[flux::refined_by(val: real)]
+#[flux::opaque]
+pub struct Num(f32);
+
+#[flux::trusted]
+impl Num {
+    #[flux::sig(fn() -> Num[2])] //~ ERROR integer literal used in real-sorted context
+    pub fn two() -> Self {
+        Num(2.0)
+    }
+}

--- a/tests/tests/neg/surface/real02.rs
+++ b/tests/tests/neg/surface/real02.rs
@@ -1,0 +1,28 @@
+#[flux::refined_by(val: real)]
+#[flux::opaque]
+pub struct Num(f32);
+
+#[flux::trusted]
+impl Num {
+    #[flux::sig(fn(x: &Num[@xx], y: &Num[@yy]) -> Num[xx + yy])]
+    pub fn add(&self, other: &Num) -> Num {
+        Num(self.0 + other.0)
+    }
+
+    #[flux::sig(fn(x: &Num[@xx], y: &Num[@yy]) -> Num[xx - yy])]
+    pub fn subtract(&self, other: &Num) -> Num {
+        Num(self.0 - other.0)
+    }
+}
+
+// wrong: claims x + y = x (only true when y = 0)
+#[flux::sig(fn(x: &Num[@xx], y: &Num[@yy]) -> Num[xx])]
+pub fn wrong_add(x: &Num, y: &Num) -> Num {
+    x.add(y) //~ ERROR refinement type error
+}
+
+// wrong: claims (x + y) - y = x + 1.0
+#[flux::sig(fn(x: &Num[@xx], y: &Num[@yy]) -> Num[xx + 1.0])]
+pub fn wrong_add_sub(x: &Num, y: &Num) -> Num {
+    x.add(y).subtract(y) //~ ERROR refinement type error
+}

--- a/tests/tests/neg/surface/real03.rs
+++ b/tests/tests/neg/surface/real03.rs
@@ -1,0 +1,11 @@
+#[flux::refined_by(val: real)]
+#[flux::opaque]
+pub struct Num(f32);
+
+#[flux::trusted]
+impl Num {
+    #[flux::sig(fn() -> Num[2.0f32])] //~ ERROR invalid suffix `f32` for number literal
+    pub fn two() -> Self {
+        Num(2.0)
+    }
+}

--- a/tests/tests/pos/surface/real00.rs
+++ b/tests/tests/pos/surface/real00.rs
@@ -10,7 +10,7 @@ fn add(x: Real, y: Real) -> Real {
 }
 
 #[flux::trusted]
-#[flux::sig(fn(x: Real) -> Real[x + 1real])]
+#[flux::sig(fn(x: Real) -> Real[x + 1.0])]
 fn add1(x: Real) -> Real {
     Real
 }
@@ -23,7 +23,7 @@ fn test01(x: Real) {
 }
 
 fn test02() {
-    #[flux::sig(fn() requires 1real/2real != 1real/3real)]
+    #[flux::sig(fn() requires 1.0/2.0 != 1.0/3.0)]
     fn assert() {}
     assert()
 }

--- a/tests/tests/pos/surface/real01.rs
+++ b/tests/tests/pos/surface/real01.rs
@@ -1,0 +1,11 @@
+#[flux::refined_by(val: real)]
+#[flux::opaque]
+pub struct Num(f32);
+
+#[flux::trusted]
+impl Num {
+    #[flux::sig(fn() -> Num[2.0])]
+    pub fn two() -> Self {
+        Num(2.0)
+    }
+}

--- a/tests/tests/pos/surface/real02.rs
+++ b/tests/tests/pos/surface/real02.rs
@@ -1,0 +1,36 @@
+#[flux::refined_by(val: real)]
+#[flux::opaque]
+pub struct Num(f32);
+
+#[flux::trusted]
+impl Num {
+    #[flux::sig(fn(x: &Num[@xx], y: &Num[@yy]) -> Num[xx + yy])]
+    pub fn add(&self, other: &Num) -> Num {
+        Num(self.0 + other.0)
+    }
+
+    #[flux::sig(fn(x: &Num[@xx], y: &Num[@yy]) -> Num[xx - yy])]
+    pub fn subtract(&self, other: &Num) -> Num {
+        Num(self.0 - other.0)
+    }
+
+    #[flux::sig(fn(x: &Num[@xx], y: &Num[@yy]) -> Num[xx * yy])]
+    pub fn mult(&self, other: &Num) -> Num {
+        Num(self.0 * other.0)
+    }
+}
+
+#[flux::sig(fn(x: &Num[@xx], y: &Num[@yy], z: &Num[@zz]) -> Num[xx + yy + zz])]
+pub fn add3(x: &Num, y: &Num, z: &Num) -> Num {
+    x.add(&y).add(&z)
+}
+
+#[flux::sig(fn(x: &Num[@xx]) -> Num[2.0 * xx])]
+pub fn add_mult_test(x: &Num) -> Num {
+    x.add(x)
+}
+
+#[flux::sig(fn(x: &Num[@xx], y: &Num[@yy]) -> Num[xx])]
+pub fn add_sub_test(x: &Num, y: &Num) -> Num {
+    x.add(y).subtract(y)
+}


### PR DESCRIPTION
This PR adds support for `real` literals of the form `[3.5]`. In doing so, I also disambiguated some int parsing and generally made it harder to accidentally cause implicit conversions in the SMT solver.
In particular, this PR:
1. Implements Real Literals. The literals are parsed as floats, but are never actually converted to floats (they are kept as strings)
2. Prevents ints from being used as indices for reals `[3]` and only allows decimal indicies `[3.5]`. Previously int literals had a kind of either `Int` or `Real`, which was confusing. 
3. Added a check to prevent float suffixes on real literals `3.5f` in order to prevent confusion (floats are not supported).
4. Added some tests

This should close #1634 and #1635
 