### PR TITLE
flux-config flags now appear in main cli help dialog but setting them does nothing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
 name = "flux-config"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "globset",
  "serde",
  "toml",

--- a/crates/flux-bin/src/cargo_flux_opts.rs
+++ b/crates/flux-bin/src/cargo_flux_opts.rs
@@ -1,6 +1,7 @@
 use std::{path::Path, process::Command};
 
 use cargo_metadata::{MetadataCommand, camino::Utf8PathBuf};
+use flux_config::flags::Flags;
 
 use crate::cargo_style;
 
@@ -86,11 +87,13 @@ pub struct CompileOpts {
     compilation: CompilationOptions,
     #[command(flatten)]
     manifest: ManifestOptions,
+    #[command(flatten)]
+    flux_flags: Flags,
 }
 
 impl CompileOpts {
     fn forward_args(&self, cmd: &mut Command) {
-        let CompileOpts { message_format, workspace, features, compilation, manifest } = self;
+        let CompileOpts { message_format, workspace, features, compilation, manifest, .. } = self;
         if let Some(message_format) = &message_format {
             cmd.args(["--message-format", message_format]);
         }

--- a/crates/flux-config/Cargo.toml
+++ b/crates/flux-config/Cargo.toml
@@ -11,6 +11,7 @@ serde.workspace = true
 toml.workspace = true
 globset.workspace = true
 tracing = "0.1"
+clap.workspace = true
 
 [lints]
 workspace = true

--- a/crates/flux-config/src/flags.rs
+++ b/crates/flux-config/src/flags.rs
@@ -1,86 +1,236 @@
 use std::{env, path::PathBuf, process, str::FromStr, sync::LazyLock};
 
 pub use toml::Value;
+use clap::Args;
 use tracing::Level;
 
 use crate::{IncludePattern, LeanMode, OverflowMode, PointerWidth, RawDerefMode, SmtSolver};
 
 const FLUX_FLAG_PREFIX: &str = "-F";
 
+macro_rules! flux_arg {
+    ($name:literal) => {
+        concat!("F", $name)
+    };
+}
+
 /// Exit status code used for invalid flags.
 pub const EXIT_FAILURE: i32 = 2;
 
+
+#[derive(Args)]
+#[command(next_help_heading = "Flux-Specific Flags (Not Yet Supported)")]
 pub struct Flags {
     /// Sets the directory to dump data. Defaults to `./log/`.
+    #[arg(
+        long = flux_arg!("log-dir"),
+        value_name = "PATH",
+        default_value = "./log/",
+    )]
     pub log_dir: PathBuf,
     /// Sets the directory to put all the emitted lean definitions and verification conditions. Defaults to `./`.
+    #[arg(
+        long = flux_arg!("lean-dir"),
+        value_name = "PATH",
+        default_value = "./"
+    )]
     pub lean_dir: PathBuf,
     /// Name of the lean project. Defaults to `lean_proofs`.
+    #[arg(
+        long = flux_arg!("lean-project"),
+        value_name = "NAME",
+        default_value = "lean_proofs"
+    )]
     pub lean_project: String,
     /// If present, only check files matching the [`IncludePattern`] a glob pattern.
+    #[arg(long = flux_arg!("include"), value_name = "PATTERN", value_parser = panicking_parser)]
     pub include: Option<IncludePattern>,
     /// If present, trust items matching [`IncludePattern`]. This implies `-Finclude`
+    #[arg(long = flux_arg!("include-trusted"), value_name = "PATTERN", value_parser = panicking_parser)]
     pub include_trusted: Option<IncludePattern>,
     /// If present, trust items matching [`IncludePattern`]. This implies `-Finclude`
+    #[arg(
+        long = flux_arg!("include-trusted-impl"),
+        value_name = "PATTERN",
+        value_parser = panicking_parser
+    )]
     pub include_trusted_impl: Option<IncludePattern>,
     /// Set the pointer size (either `32` or `64`), used to determine if an integer cast is lossy
     /// (default `64`).
+    #[arg(
+        long = flux_arg!("pointer-width"),
+        value_name = "WIDTH",
+        default_value = "64",
+        value_parser = default_pointerwidth
+    )]
     pub pointer_width: PointerWidth,
     /// If present switches on query caching and saves the cache in the provided path
+    #[arg(long = flux_arg!("cache"), value_name = "PATH", value_parser = panicking_parser)]
     pub cache: Option<PathBuf>,
     /// Compute statistics about number and size of annotations. Dumps file to [`Self::log_dir`]
+    #[arg(
+        long = flux_arg!("annots"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub annots: bool,
     /// Print statistics about time taken to analyze each fuction. Also dumps a file with the raw
     /// times for each function.
+    #[arg(
+        long = flux_arg!("timings"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub timings: bool,
     /// Print statistics about number of functions checked, trusted, etc.
+    #[arg(
+        long = flux_arg!("summary"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub summary: bool,
     /// Default solver. Either `z3` or `cvc5`.
+    #[arg(
+        long = flux_arg!("solver"),
+        value_name = "SOLVER",
+        default_value = "z3",
+        value_parser = default_smtsolver
+    )]
     pub solver: SmtSolver,
     /// Enables qualifier scrapping in fixpoint
+    #[arg(
+        long = flux_arg!("scrape-quals"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub scrape_quals: bool,
     /// Enables uninterpreted casts
+    #[arg(
+        long = flux_arg!("allow-uninterpreted-cast"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub allow_uninterpreted_cast: bool,
     /// Translates _monomorphic_ `defs` functions into SMT `define-fun` instead of inlining them
     /// away inside `flux`.
+    #[arg(
+        long = flux_arg!("smt-define-fun"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub smt_define_fun: bool,
     /// If `strict` checks for over and underflow on arithmetic integer operations,
     /// If `lazy` checks for underflow and loses information if possible overflow,
     /// If `none` (default), it still checks for underflow on unsigned integer subtraction.
+    #[arg(
+        long = flux_arg!("check-overflow"),
+        value_name = "MODE",
+        default_value = "none",
+        value_parser = default_overflowmode
+    )]
     pub check_overflow: OverflowMode,
     /// Whether to allow raw pointer dereferences during refinement checking.
+    #[arg(
+        long = flux_arg!("allow-raw-deref"),
+        value_name = "MODE",
+        default_value = "default",
+        value_parser = default_rawderefmode
+    )]
     pub allow_raw_deref: RawDerefMode,
     /// Dump constraints generated for each function (debugging)
+    #[arg(
+        long = flux_arg!("dump-constraint"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub dump_constraint: bool,
     /// Saves the checker's trace (debugging)
+    #[arg(long = flux_arg!("dump-checker-trace"), value_name = "LEVEL", value_parser = panicking_parser)]
     pub dump_checker_trace: Option<tracing::Level>,
     /// Saves the `fhir` for each item (debugging)
+    #[arg(
+        long = flux_arg!("dump-fhir"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub dump_fhir: bool,
     /// Saves the the `fhir` (debugging)
+    #[arg(
+        long = flux_arg!("dump-rty"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub dump_rty: bool,
     /// Optimistically keeps running flux even after errors are found to get as many errors as possible
+    #[arg(
+        long = flux_arg!("catch-bugs"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub catch_bugs: bool,
     /// Whether verification for the current crate is enabled. If false (the default), `flux-driver`
     /// will behave exactly like `rustc`. This flag is managed by the `cargo flux` and `flux` binaries,
     /// so you don't need to mess with it.
+    #[arg(
+        long = flux_arg!("verify"),
+        num_args = 0..=1,
+        default_missing_value = "false"
+    )]
     pub verify: bool,
     /// If `true`, produce artifacts after analysis. This flag is managed by `cargo flux`, so you
     /// don't typically have to set it manually.
+    #[arg(
+        long = flux_arg!("full-compilation"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub full_compilation: bool,
     /// Path to the Flux sysroot directory. If not set, the driver infers it from its own binary location.
+    #[arg(long = flux_arg!("sysroot"), value_name = "PATH", value_parser = panicking_parser)]
     pub sysroot: Option<PathBuf>,
     /// If `true`, all code is trusted by default. You can selectively untrust items by marking them with `#[trusted(no)]`. The default value of this flag is `false`, i.e., all code is untrusted by default.
+    #[arg(
+        long = flux_arg!("trusted"),
+        num_args = 0..=1,
+        default_missing_value = "false"
+    )]
     pub trusted_default: bool,
     /// If `true`, all code will be ignored by default. You can selectively unignore items by marking them with `#[ignore(no)]`. The default value of this flag is `false`, i.e., all code is unignored by default.
+    #[arg(
+        long = flux_arg!("ignore"),
+        num_args = 0..=1,
+        default_missing_value = "false"
+    )]
     pub ignore_default: bool,
+    #[arg(
+        long = flux_arg!("lean"),
+        value_name = "MODE",
+        default_value = "default",
+        value_parser = default_leanmode
+    )]
     pub lean: LeanMode,
     /// If `true`, every function is implicitly labeled with a `no_panic` by default.
+    #[arg(
+        long = flux_arg!("no-panic"),
+        num_args = 0..=1,
+        default_missing_value = "false"
+    )]
     pub no_panic: bool,
     /// If `true`, automatically inject `flux_core` and `flux_alloc` as force externs using paths
     /// from `sysroot.toml`. Off by default.
+    #[arg(
+        long = flux_arg!("std-extern-specs"),
+        num_args = 0..=1,
+        default_missing_value = "false"
+    )]
     pub std_extern_specs: bool,
     /// If `true`, produce more detailed error messages (e.g. condition spans for fold errors).
-    pub verbose: bool,
+    #[arg(
+        long = flux_arg!("flux-verbose"),
+        num_args = 0..=1,
+        default_missing_value = "false"
+    )]
+    pub flux_verbose: bool,
 }
 
 impl Default for Flags {
@@ -116,7 +266,7 @@ impl Default for Flags {
             lean: LeanMode::default(),
             no_panic: false,
             std_extern_specs: false,
-            verbose: false,
+            flux_verbose: false,
         }
     }
 }
@@ -160,7 +310,7 @@ pub(crate) static FLAGS: LazyLock<Flags> = LazyLock::new(|| {
             "lean" => parse_lean_mode(&mut flags.lean, value),
             "no-panic" => parse_bool(&mut flags.no_panic, value),
             "std-extern-specs" => parse_bool(&mut flags.std_extern_specs, value),
-            "verbose" => parse_bool(&mut flags.verbose, value),
+            "flux-verbose" => parse_bool(&mut flags.flux_verbose, value),
             _ => {
                 eprintln!("error: unknown flux option: `{key}`");
                 process::exit(EXIT_FAILURE);
@@ -320,4 +470,28 @@ fn parse_opt_include(slot: &mut Vec<String>, v: Option<&str>) -> Result<(), &'st
         slot.push(include.to_string());
     }
     Ok(())
+}
+
+fn panicking_parser(_s: &str) -> Result<(), String> {
+    panic!("Parsing flux args from cli is not yet supported.");
+}
+
+fn default_pointerwidth(_s: &str) -> Result<PointerWidth, String> {
+    return Ok(PointerWidth::default());
+}
+
+fn default_overflowmode(_s: &str) -> Result<OverflowMode, String> {
+    return Ok(OverflowMode::default());
+}
+
+fn default_rawderefmode(_s: &str) -> Result<RawDerefMode, String> {
+    return Ok(RawDerefMode::default());
+}
+
+fn default_smtsolver(_s: &str) -> Result<SmtSolver, String> {
+    return Ok(SmtSolver::default());
+}
+
+fn default_leanmode(_s: &str) -> Result<LeanMode, String> {
+    return Ok(LeanMode::default());
 }

--- a/crates/flux-config/src/flags.rs
+++ b/crates/flux-config/src/flags.rs
@@ -1,7 +1,7 @@
 use std::{env, path::PathBuf, process, str::FromStr, sync::LazyLock};
 
-pub use toml::Value;
 use clap::Args;
+pub use toml::Value;
 use tracing::Level;
 
 use crate::{IncludePattern, LeanMode, OverflowMode, PointerWidth, RawDerefMode, SmtSolver};
@@ -16,7 +16,6 @@ macro_rules! flux_arg {
 
 /// Exit status code used for invalid flags.
 pub const EXIT_FAILURE: i32 = 2;
-
 
 #[derive(Args)]
 #[command(next_help_heading = "Flux-Specific Flags (Not Yet Supported)")]

--- a/crates/flux-config/src/lib.rs
+++ b/crates/flux-config/src/lib.rs
@@ -152,7 +152,7 @@ pub fn std_extern_specs() -> bool {
 }
 
 pub fn verbose() -> bool {
-    FLAGS.verbose
+    FLAGS.flux_verbose
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
Run `cargo flux -h` or `cargo-flux flux -h` to see new output.