### PR TITLE
Display log location per failing item (as diag) #1641

### DIFF
--- a/crates/flux-common/src/dbg.rs
+++ b/crates/flux-common/src/dbg.rs
@@ -2,7 +2,7 @@
 use std::{
     fmt, fs,
     io::{self, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use flux_config as config;
@@ -199,6 +199,10 @@ fn dump_base_name(tcx: TyCtxt, def_id: DefId, ext: impl AsRef<str>) -> String {
     let crate_name = tcx.crate_name(def_id.krate);
     let item_name = tcx.def_path(def_id).to_filename_friendly_no_crate();
     format!("{crate_name}.{item_name}.{}", ext.as_ref())
+}
+
+pub fn item_dump_path(tcx: TyCtxt, def_id: DefId, ext: impl AsRef<str>) -> PathBuf {
+    config::log_dir().join(dump_base_name(tcx, def_id, ext))
 }
 
 #[macro_export]

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -1,4 +1,4 @@
-use flux_common::{bug, cache::QueryCache, dbg, iter::IterExt, result::ResultExt};
+use flux_common::{bug, cache::QueryCache, iter::IterExt, result::ResultExt};
 use flux_config::{self as config};
 use flux_errors::FluxSession;
 use flux_infer::{
@@ -148,20 +148,7 @@ fn check_crate(genv: GlobalEnv) -> Result<(), ErrorGuaranteed> {
         let result = genv
             .tcx()
             .iter_local_def_id()
-            .try_for_each_exhaust(|def_id| {
-                let result = ck.check_def_catching_bugs(def_id);
-                // On error, point at the constraint dump for this item
-                if result.is_err() && config::dump_constraint() {
-                    let path = dbg::item_dump_path(genv.tcx(), def_id.to_def_id(), "smt2");
-                    if path.exists() {
-                        genv.sess()
-                            .dcx()
-                            .handle()
-                            .note(format!("log file saved to {}", path.display()));
-                    }
-                }
-                result
-            });
+            .try_for_each_exhaust(|def_id| ck.check_def_catching_bugs(def_id));
 
         if config::lean().is_check() || config::lean().is_emit() {
             lean_encoding::finalize(genv)

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -145,20 +145,23 @@ fn check_crate(genv: GlobalEnv) -> Result<(), ErrorGuaranteed> {
         let mut ck = CrateChecker::new(genv);
 
         // Iterate over all def ids including dummy items for extern specs
-        let result = genv.tcx().iter_local_def_id().try_for_each_exhaust(|def_id| {
-            let result = ck.check_def_catching_bugs(def_id);
-            // On error, point at the constraint dump for this item
-            if result.is_err() && config::dump_constraint() {
-                let path = dbg::item_dump_path(genv.tcx(), def_id.to_def_id(), "smt2");
-                if path.exists() {
-                    genv.sess()
-                        .dcx()
-                        .handle()
-                        .note(format!("log file saved to {}", path.display()));
+        let result = genv
+            .tcx()
+            .iter_local_def_id()
+            .try_for_each_exhaust(|def_id| {
+                let result = ck.check_def_catching_bugs(def_id);
+                // On error, point at the constraint dump for this item
+                if result.is_err() && config::dump_constraint() {
+                    let path = dbg::item_dump_path(genv.tcx(), def_id.to_def_id(), "smt2");
+                    if path.exists() {
+                        genv.sess()
+                            .dcx()
+                            .handle()
+                            .note(format!("log file saved to {}", path.display()));
+                    }
                 }
-            }
-            result
-        });
+                result
+            });
 
         if config::lean().is_check() || config::lean().is_emit() {
             lean_encoding::finalize(genv)

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -1,4 +1,4 @@
-use flux_common::{bug, cache::QueryCache, iter::IterExt, result::ResultExt};
+use flux_common::{bug, cache::QueryCache, dbg, iter::IterExt, result::ResultExt};
 use flux_config::{self as config};
 use flux_errors::FluxSession;
 use flux_infer::{
@@ -145,10 +145,20 @@ fn check_crate(genv: GlobalEnv) -> Result<(), ErrorGuaranteed> {
         let mut ck = CrateChecker::new(genv);
 
         // Iterate over all def ids including dummy items for extern specs
-        let result = genv
-            .tcx()
-            .iter_local_def_id()
-            .try_for_each_exhaust(|def_id| ck.check_def_catching_bugs(def_id));
+        let result = genv.tcx().iter_local_def_id().try_for_each_exhaust(|def_id| {
+            let result = ck.check_def_catching_bugs(def_id);
+            // On error, point at the constraint dump for this item
+            if result.is_err() && config::dump_constraint() {
+                let path = dbg::item_dump_path(genv.tcx(), def_id.to_def_id(), "smt2");
+                if path.exists() {
+                    genv.sess()
+                        .dcx()
+                        .handle()
+                        .note(format!("log file saved to {}", path.display()));
+                }
+            }
+            result
+        });
 
         if config::lean().is_check() || config::lean().is_emit() {
             lean_encoding::finalize(genv)

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -261,7 +261,7 @@ pub struct ParsedResult {
 
 #[derive(Debug, Clone, Default)]
 pub struct Answer<Tag> {
-    pub errors: Vec<Tag>,
+    pub errors: Vec<(Tag, TagIdx)>,
     pub cut_solution: Solution,
     pub non_cut_solution: Solution,
 }
@@ -704,8 +704,8 @@ where
                 metrics::incr_metric(Metric::CsError, errors.len() as u32);
                 errors
                     .into_iter()
-                    .map(|err| self.tags[err.tag])
-                    .unique()
+                    .map(|err| (self.tags[err.tag], err.tag))
+                    .unique_by(|(tag, _)| *tag)
                     .collect_vec()
             }
             FixpointStatus::Crash(err) => span_bug!(def_span, "fixpoint crash: {err:?}"),

--- a/crates/flux-refineck/locales/en-US.ftl
+++ b/crates/flux-refineck/locales/en-US.ftl
@@ -68,3 +68,6 @@ refineck_missing_assoc_reft =
 
 refineck_impl_assoc_reft_final =
     associated refinement `{$name}` is final and should not be implemented anywhere other than the trait definition
+
+refineck_constraint_log_note =
+    log file saved to {$path} (tag: {$tag})

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -33,7 +33,7 @@ use checker::{Checker, trait_impl_subtyping};
 use flux_common::{dbg, dbg::SpanTrace, result::ResultExt as _};
 use flux_config as config;
 use flux_infer::{
-    fixpoint_encoding::{FixQueryCache, SolutionTrace},
+    fixpoint_encoding::{FixQueryCache, SolutionTrace, TagIdx},
     infer::{ConstrReason, SubtypeReason, Tag},
 };
 use flux_macros::fluent_messages;
@@ -42,12 +42,11 @@ use flux_middle::{
     def_id::MaybeExternId,
     global_env::GlobalEnv,
     metrics::{self, Metric, TimingKind},
-    rty::{self, ESpan},
+    rty::{self},
 };
 use rustc_data_structures::unord::UnordMap;
-use rustc_errors::ErrorGuaranteed;
+use rustc_errors::{Diagnostic as _, ErrorGuaranteed};
 use rustc_hir::def_id::LocalDefId;
-use rustc_span::Span;
 
 use crate::{checker::errors::ResultExt as _, ghost_statements::compute_ghost_statements};
 
@@ -56,13 +55,13 @@ fluent_messages! { "../locales/en-US.ftl" }
 fn report_fixpoint_errors(
     genv: GlobalEnv,
     local_id: LocalDefId,
-    errors: Vec<Tag>,
+    errors: Vec<(Tag, TagIdx)>,
 ) -> Result<(), ErrorGuaranteed> {
     #[expect(clippy::collapsible_else_if, reason = "it looks better")]
     if genv.should_fail(local_id) {
         if errors.is_empty() { report_expected_neg(genv, local_id) } else { Ok(()) }
     } else {
-        if errors.is_empty() { Ok(()) } else { report_errors(genv, errors) }
+        if errors.is_empty() { Ok(()) } else { report_errors(genv, local_id, errors) }
     }
 }
 
@@ -197,46 +196,87 @@ pub fn check_fn(
     dbg::check_fn_span!(genv.tcx(), def_id).in_scope(|| Ok(()))
 }
 
-fn call_error(genv: GlobalEnv, span: Span, dst_span: Option<ESpan>) -> ErrorGuaranteed {
-    genv.sess()
-        .emit_err(errors::RefineError::call(span, dst_span))
-}
+fn report_errors(
+    genv: GlobalEnv,
+    local_id: LocalDefId,
+    errors: Vec<(Tag, TagIdx)>,
+) -> Result<(), ErrorGuaranteed> {
+    let log_path = if config::dump_constraint() {
+        let path = dbg::item_dump_path(genv.tcx(), local_id.to_def_id(), "smt2");
+        if path.exists() { Some(path) } else { None }
+    } else {
+        None
+    };
 
-fn ret_error(genv: GlobalEnv, span: Span, dst_span: Option<ESpan>) -> ErrorGuaranteed {
-    genv.sess()
-        .emit_err(errors::RefineError::ret(span, dst_span))
-}
-
-fn report_errors(genv: GlobalEnv, errors: Vec<Tag>) -> Result<(), ErrorGuaranteed> {
     let mut e = None;
-    for err in errors {
+    for (err, tag_idx) in errors {
         let span = err.src_span;
+        let emit = |mut diag: rustc_errors::Diag<'_, ErrorGuaranteed>| -> ErrorGuaranteed {
+            if let Some(path) = &log_path {
+                diag.arg("path", path.display().to_string());
+                diag.arg("tag", tag_idx.to_string());
+                diag.note(crate::fluent_generated::refineck_constraint_log_note);
+            }
+            diag.emit()
+        };
+        let dcx = genv.sess().dcx().handle();
         e = Some(match err.reason {
             ConstrReason::Call
             | ConstrReason::Subtype(SubtypeReason::Input)
             | ConstrReason::Subtype(SubtypeReason::Requires)
-            | ConstrReason::Predicate => call_error(genv, span, err.dst_span),
-            ConstrReason::Assign => genv.sess().emit_err(errors::AssignError { span }),
+            | ConstrReason::Predicate => {
+                emit(
+                    errors::RefineError::call(span, err.dst_span)
+                        .into_diag(dcx, rustc_errors::Level::Error),
+                )
+            }
+            ConstrReason::Assign => {
+                emit(errors::AssignError { span }.into_diag(dcx, rustc_errors::Level::Error))
+            }
             ConstrReason::Ret
             | ConstrReason::Subtype(SubtypeReason::Output)
-            | ConstrReason::Subtype(SubtypeReason::Ensures) => ret_error(genv, span, err.dst_span),
-            ConstrReason::Div => genv.sess().emit_err(errors::DivError { span }),
-            ConstrReason::Rem => genv.sess().emit_err(errors::RemError { span }),
-            ConstrReason::Goto(_) => genv.sess().emit_err(errors::GotoError { span }),
-            ConstrReason::Assert(msg) => genv.sess().emit_err(errors::AssertError { span, msg }),
-            ConstrReason::Fold | ConstrReason::FoldLocal => {
-                genv.sess()
-                    .emit_err(errors::FoldError::new(span, err.dst_span))
+            | ConstrReason::Subtype(SubtypeReason::Ensures) => {
+                emit(
+                    errors::RefineError::ret(span, err.dst_span)
+                        .into_diag(dcx, rustc_errors::Level::Error),
+                )
             }
-            ConstrReason::Overflow => genv.sess().emit_err(errors::OverflowError { span }),
-            ConstrReason::Underflow => genv.sess().emit_err(errors::UnderflowError { span }),
-            ConstrReason::Other => genv.sess().emit_err(errors::UnknownError { span }),
+            ConstrReason::Div => {
+                emit(errors::DivError { span }.into_diag(dcx, rustc_errors::Level::Error))
+            }
+            ConstrReason::Rem => {
+                emit(errors::RemError { span }.into_diag(dcx, rustc_errors::Level::Error))
+            }
+            ConstrReason::Goto(_) => {
+                emit(errors::GotoError { span }.into_diag(dcx, rustc_errors::Level::Error))
+            }
+            ConstrReason::Assert(msg) => {
+                emit(errors::AssertError { span, msg }.into_diag(dcx, rustc_errors::Level::Error))
+            }
+            ConstrReason::Fold | ConstrReason::FoldLocal => {
+                emit(
+                    errors::FoldError::new(span, err.dst_span)
+                        .into_diag(dcx, rustc_errors::Level::Error),
+                )
+            }
+            ConstrReason::Overflow => {
+                emit(errors::OverflowError { span }.into_diag(dcx, rustc_errors::Level::Error))
+            }
+            ConstrReason::Underflow => {
+                emit(errors::UnderflowError { span }.into_diag(dcx, rustc_errors::Level::Error))
+            }
+            ConstrReason::Other => {
+                emit(errors::UnknownError { span }.into_diag(dcx, rustc_errors::Level::Error))
+            }
             ConstrReason::NoPanic(callee, reason) => {
-                genv.sess().emit_err(errors::PanicError {
-                    span,
-                    callee: genv.tcx().def_path_debug_str(callee),
-                    reason: format!("{:?}", reason),
-                })
+                emit(
+                    errors::PanicError {
+                        span,
+                        callee: genv.tcx().def_path_debug_str(callee),
+                        reason: format!("{:?}", reason),
+                    }
+                    .into_diag(dcx, rustc_errors::Level::Error),
+                )
             }
         });
     }


### PR DESCRIPTION
# From #1641:

When `-Fdump-constraint` is set, flux now emits a `note: log file saved to <…>.smt2`  after each failing item's diagnostics.

Old:
```
error[E0999]: refinement type error
 --> src/foo.rs:3:5
  |
3 |     x - 1
  |     ^^^^^ a postcondition cannot be proved
  |
note: this is the condition that cannot be proved
 --> src/foo.rs:1:35
  |
1 | #[flux::spec(fn(x: i32) -> i32{v: x < v})]
  |                                   ^^^^^
error: aborting due to 1 previous error

warning: 1 warning emitted

Error: process exited unsuccessfully: exit status: 1
```

New:
```
error[E0999]: refinement type error
 --> src/foo.rs:3:5
  |
3 |     x - 1
  |     ^^^^^ a postcondition cannot be proved
  |
note: this is the condition that cannot be proved
 --> src/foo.rs:1:35
  |
1 | #[flux::spec(fn(x: i32) -> i32{v: x < v})]
  |                                   ^^^^^

note: log file saved to ./log/foo1.inc.smt2

error: aborting due to 1 previous error

warning: 1 warning emitted

Error: process exited unsuccessfully: exit status: 1
```

# My changes

I switched to using a diag and outputting the tag of the failing constraint.