### PR TITLE
Add re-run hints to error messages

### DIFF
--- a/crates/flux-config/src/flags.rs
+++ b/crates/flux-config/src/flags.rs
@@ -230,6 +230,14 @@ pub struct Flags {
         default_missing_value = "false"
     )]
     pub flux_verbose: bool,
+    /// If `true` (the default), attach a note to each failing item with a copy-pasteable command to
+    /// re-run the check on just that item. Only applies when running under `cargo flux`.
+    #[arg(
+        long = flux_arg!("rerun-hint"),
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
+    pub rerun_hint: bool,
 }
 
 impl Default for Flags {
@@ -266,6 +274,7 @@ impl Default for Flags {
             no_panic: false,
             std_extern_specs: false,
             flux_verbose: false,
+            rerun_hint: true,
         }
     }
 }
@@ -310,6 +319,7 @@ pub(crate) static FLAGS: LazyLock<Flags> = LazyLock::new(|| {
             "no-panic" => parse_bool(&mut flags.no_panic, value),
             "std-extern-specs" => parse_bool(&mut flags.std_extern_specs, value),
             "flux-verbose" => parse_bool(&mut flags.flux_verbose, value),
+            "rerun-hint" => parse_bool(&mut flags.rerun_hint, value),
             _ => {
                 eprintln!("error: unknown flux option: `{key}`");
                 process::exit(EXIT_FAILURE);

--- a/crates/flux-config/src/lib.rs
+++ b/crates/flux-config/src/lib.rs
@@ -155,6 +155,16 @@ pub fn verbose() -> bool {
     FLAGS.flux_verbose
 }
 
+pub fn rerun_hint() -> bool {
+    FLAGS.rerun_hint
+}
+
+/// Whether the driver is running under `cargo flux` (which sets `FLUX_CARGO=1`), as opposed to a
+/// direct `flux`/`flux-driver` invocation. Used to decide whether to emit the re-run hint.
+pub fn is_cargo() -> bool {
+    std::env::var_os("FLUX_CARGO").is_some()
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(try_from = "String")]
 pub struct Pos {

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -229,9 +229,17 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
     }
 
     fn check_def_catching_bugs(&mut self, def_id: LocalDefId) -> Result<(), ErrorGuaranteed> {
-        let mut this = std::panic::AssertUnwindSafe(self);
-        let msg = format!("def_id: {:?}, span: {:?}", def_id, this.genv.tcx().def_span(def_id));
-        flux_common::bug::catch_bugs(&msg, move || this.check_def(def_id))?
+        let genv = self.genv;
+        // Stage the re-run hint for the scope of the check so it gets attached as a note to the
+        // first error this item emits.
+        let note = config::rerun_hint()
+            .then(|| rerun_hint_note(genv, def_id))
+            .flatten();
+        genv.sess().with_next_err_notes(note, || {
+            let mut this = std::panic::AssertUnwindSafe(self);
+            let msg = format!("def_id: {:?}, span: {:?}", def_id, this.genv.tcx().def_span(def_id));
+            flux_common::bug::catch_bugs(&msg, move || this.check_def(def_id))
+        })?
     }
 
     fn check_def(&mut self, def_id: LocalDefId) -> Result<(), ErrorGuaranteed> {
@@ -316,6 +324,23 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
         }
         Ok(())
     }
+}
+
+/// Build the "re-run this check" note for `def_id`, attached by [`FluxSession::emit_err`] to the
+/// item's first error. Only emitted under `cargo flux`.
+fn rerun_hint_note(genv: GlobalEnv, def_id: LocalDefId) -> Option<String> {
+    if !config::is_cargo() {
+        return None;
+    }
+    let pattern = format!("def:{}", genv.tcx().def_path_str(def_id));
+    let pkg = std::env::var("CARGO_PKG_NAME")
+        .map(|p| format!(" -p {p}"))
+        .unwrap_or_default();
+    Some(format!("to rerun: `cargo flux check{pkg} --only-check {}`", shell_quote_arg(&pattern)))
+}
+
+fn shell_quote_arg(arg: &str) -> String {
+    format!("'{}'", arg.replace('\'', "'\\''"))
 }
 
 /// Triggers queries for the given `def_id` to mark it as "reached" for metadata encoding.

--- a/crates/flux-errors/src/lib.rs
+++ b/crates/flux-errors/src/lib.rs
@@ -11,7 +11,7 @@ use flux_common::result::{ErrorCollector, ErrorEmitter};
 use rustc_data_structures::sync;
 pub use rustc_errors::ErrorGuaranteed;
 use rustc_errors::{
-    Diagnostic, ErrCode, FatalAbort, FatalError, LazyFallbackBundle, TerminalUrl,
+    Diagnostic, ErrCode, FatalAbort, FatalError, LazyFallbackBundle, Level, TerminalUrl,
     annotate_snippet_emitter_writer::AnnotateSnippetEmitter,
     emitter::{Emitter, HumanEmitter, HumanReadableErrorType, OutputTheme, stderr_destination},
     json::JsonEmitter,
@@ -22,6 +22,7 @@ use rustc_span::source_map::SourceMap;
 
 pub struct FluxSession {
     pub parse_sess: ParseSess,
+    next_err_notes: Cell<Vec<String>>,
 }
 
 // FIXME(nilehmann) We probably need to move out of this error reporting
@@ -35,7 +36,22 @@ impl FluxSession {
     ) -> Self {
         let emitter = emitter(opts, source_map.clone(), fallback_bundle);
         let dcx = rustc_errors::DiagCtxt::new(emitter);
-        Self { parse_sess: ParseSess::with_dcx(dcx, source_map) }
+        Self {
+            parse_sess: ParseSess::with_dcx(dcx, source_map),
+            next_err_notes: Cell::new(Vec::new()),
+        }
+    }
+
+    /// Run `f` with `notes` staged for the next error emitted through this session, restoring the
+    /// previous staged notes afterwards. The notes are attached once, to the first error emitted in
+    /// the scope, by [`Self::emit_err`].
+    pub fn with_next_err_notes<R>(
+        &self,
+        notes: impl IntoIterator<Item = String>,
+        f: impl FnOnce() -> R,
+    ) -> R {
+        let _guard = NextErrNotesGuard::new(self, notes.into_iter().collect());
+        f()
     }
 
     pub fn err_count(&self) -> usize {
@@ -44,7 +60,11 @@ impl FluxSession {
 
     #[track_caller]
     pub fn emit_err<'a>(&'a self, err: impl Diagnostic<'a>) -> ErrorGuaranteed {
-        self.parse_sess.dcx().emit_err(err)
+        let mut diag = err.into_diag(self.parse_sess.dcx(), Level::Error);
+        for note in self.next_err_notes.take() {
+            diag.note(note);
+        }
+        diag.emit()
     }
 
     #[track_caller]
@@ -68,6 +88,24 @@ impl FluxSession {
 
     pub fn dcx(&self) -> &rustc_errors::DiagCtxt {
         &self.parse_sess.dcx()
+    }
+}
+
+struct NextErrNotesGuard<'sess> {
+    sess: &'sess FluxSession,
+    prev: Vec<String>,
+}
+
+impl<'sess> NextErrNotesGuard<'sess> {
+    fn new(sess: &'sess FluxSession, notes: Vec<String>) -> Self {
+        let prev = sess.next_err_notes.replace(notes);
+        Self { sess, prev }
+    }
+}
+
+impl Drop for NextErrNotesGuard<'_> {
+    fn drop(&mut self) {
+        self.sess.next_err_notes.set(std::mem::take(&mut self.prev));
     }
 }
 

--- a/tests/tests/neg/error_messages/rerun_hint.rs
+++ b/tests/tests/neg/error_messages/rerun_hint.rs
@@ -1,0 +1,54 @@
+//@rustc-env:FLUX_CARGO=1
+//@rustc-env:CARGO_PKG_NAME=mycrate
+
+// Pins the re-run hint's `cargo flux check --only-check ...` command across def-path shapes
+// (free fn, nested module, inherent method, trait-impl method). The hint is attached as a `note:`
+// to the item's first error, and only emitted under `cargo flux` (`FLUX_CARGO=1`).
+#![allow(unused)]
+
+use flux_attrs::*;
+
+// Free function -> `def:<name>`.
+#[flux::sig(fn() -> i32{v: v > 0})] //~ NOTE this is the condition
+fn foo() -> i32 {
+    0 //~ ERROR refinement type
+      //~| NOTE a postcondition cannot be proved
+      //~| NOTE to rerun: `cargo flux check -p mycrate --only-check 'def:foo'`
+}
+
+// Nested modules -> `def:<a>::<b>::<name>`.
+mod a {
+    pub mod b {
+        #[flux::sig(fn() -> i32{v: v > 0})] //~ NOTE this is the condition
+        pub fn baz() -> i32 {
+            0 //~ ERROR refinement type
+              //~| NOTE a postcondition cannot be proved
+              //~| NOTE to rerun: `cargo flux check -p mycrate --only-check 'def:a::b::baz'`
+        }
+    }
+}
+
+struct S;
+
+// Inherent method -> `def:<Type>::<name>`.
+impl S {
+    #[flux::sig(fn() -> i32{v: v > 0})] //~ NOTE this is the condition
+    fn inherent() -> i32 {
+        0 //~ ERROR refinement type
+          //~| NOTE a postcondition cannot be proved
+          //~| NOTE to rerun: `cargo flux check -p mycrate --only-check 'def:S::inherent'`
+    }
+}
+
+// Trait-impl method -> `def:<S as T>::f` (a def path with spaces, hence the quoting).
+trait T {
+    #[sig(fn() -> i32{v: v > 0})] //~ NOTE this is the condition
+    fn f() -> i32;
+}
+impl T for S {
+    fn f() -> i32 { //~ ERROR refinement type
+        //~| NOTE a postcondition cannot be proved
+        //~| NOTE to rerun: `cargo flux check -p mycrate --only-check 'def:<S as T>::f'`
+        0
+    }
+}


### PR DESCRIPTION
When verification fails, Flux now attaches a `note:` to the item's first error with a copy-pastable command to re-run the check on just that item.

```
error[E0999]: refinement type error
 --> src/lib.rs:7:5
  |
7 |     0
  |     ^ a postcondition cannot be proved
  |
note: this is the condition that cannot be proved
 --> src/lib.rs:5:23
  |
5 | #[spec(fn() -> i32{v: v > 0})]
  |                       ^^^^^
  = note: to rerun: `FLUXFLAGS='-Finclude=def:foo' cargo flux check -p mycrate`
```

When run via the standalone `flux` binary on a single file, the note instead reads:

```
  = note: to rerun pass `'-Finclude=def:foo'`
```

Some notes:

- The hint targets the item with a `def:<path>` include pattern, which is stable across line/column edits. It falls back to a whole-file `glob:<file>` pattern when the def path is empty (or, under `cargo flux`, contains spaces, e.g., trait-impl methods like `<S as T>::f`, since `FLUXFLAGS` is split on spaces).
  - `FLUXFLAGS` can recognize quotes but I didn't do so to minimize the PR. Re-running the file isn't too bad IMO.
- Messages have two forms depending on how Flux was invoked:
  - standalone `flux`: `to rerun pass '-Finclude=def:foo'`
  - `cargo flux` (`FLUX_CARGO=1`): `to rerun: FLUXFLAGS='-Finclude=def:foo' cargo flux check -p <pkg>`
- Enabled by default. Disable with `-Frerun-hint=false`.
- In the implementation, `FluxSession::with_next_err_notes` stages notes for the duration of a closure and `emit_err` attaches them (once) to the first error it emits. I considered threading the note through the `emit_err` call sites and rejected it as too invasive — `next_err_notes` is the staging mechanism I landed on. Open to better ideas.
