### PR TITLE
Propagate callee post-state to field-borrowed places when folding local pointers (#1613)

### DIFF
--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -291,7 +291,9 @@ fn check_fn_subtyping(
         .collect_vec();
 
     let mut env = TypeEnv::empty();
-    let actuals = unfold_local_ptrs(&mut infcx, &mut env, sub_sig.as_ref(), &actuals)?;
+    let borrowed_places = vec![None; actuals.len()];
+    let actuals =
+        unfold_local_ptrs(&mut infcx, &mut env, sub_sig.as_ref(), &actuals, &borrowed_places)?;
     let actuals = infer_under_mut_ref_hack(&mut infcx, &actuals[..], sub_sig.as_ref());
 
     let output = infcx.ensure_resolved_evars(|infcx| {
@@ -437,17 +439,18 @@ fn unfold_local_ptrs(
     env: &mut TypeEnv,
     fn_sig: &PolyFnSig,
     actuals: &[Ty],
+    borrowed_places: &[Option<Place>],
 ) -> InferResult<Vec<Ty>> {
     // We *only* need to know whether each input is a &strg or not
     let fn_sig = fn_sig.skip_binder_ref();
     let mut tys = vec![];
-    for (actual, input) in izip!(actuals, fn_sig.inputs()) {
+    for (actual, input, borrowed_place) in izip!(actuals, fn_sig.inputs(), borrowed_places) {
         let actual = if let (
             TyKind::Indexed(BaseTy::Ref(re, bound, Mutability::Mut), _),
             TyKind::StrgRef(_, _, _),
         ) = (actual.kind(), input.kind())
         {
-            let loc = env.unfold_local_ptr(infcx, bound)?;
+            let loc = env.unfold_local_ptr(infcx, bound, borrowed_place.clone())?;
             let path1 = Path::new(loc, rty::List::empty());
             Ty::ptr(PtrKind::Mut(*re), path1)
         } else {
@@ -704,6 +707,9 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 let ty = self.check_rvalue(infcx, env, stmt_span, rvalue)?;
                 self.check_assign_ty(infcx, env, place, ty, stmt_span)
                     .with_span(stmt_span)?;
+                if let Rvalue::Ref(_, BorrowKind::Mut { .. }, borrowed_place) = rvalue {
+                    env.record_borrow(place, borrowed_place);
+                }
             }
             StatementKind::SetDiscriminant { .. } => {
                 // TODO(nilehmann) double check here that the place is unfolded to
@@ -784,6 +790,10 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 }
             }
             TerminatorKind::Call { kind, args, destination, target, .. } => {
+                let borrowed_places = args
+                    .iter()
+                    .map(|arg| env.borrowed_place_for_operand(arg))
+                    .collect_vec();
                 let actuals = self
                     .check_operands(infcx, env, terminator_span, args)
                     .with_span(terminator_span)?;
@@ -806,6 +816,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                             fn_sig,
                             &generic_args,
                             &actuals,
+                            &borrowed_places,
                         )?
                         .output
                     }
@@ -824,6 +835,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                                 EarlyBinder(fn_sig.clone()),
                                 &[],
                                 &actuals,
+                                &borrowed_places,
                             )?
                             .output
                         } else {
@@ -901,12 +913,14 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         fn_sig: EarlyBinder<PolyFnSig>,
         generic_args: &[GenericArg],
         actuals: &[Ty],
+        borrowed_places: &[Option<Place>],
     ) -> Result<ResolvedCall> {
         let genv = self.genv;
         let tcx = genv.tcx();
 
         let actuals =
-            unfold_local_ptrs(infcx, env, fn_sig.skip_binder_ref(), actuals).with_span(span)?;
+            unfold_local_ptrs(infcx, env, fn_sig.skip_binder_ref(), actuals, borrowed_places)
+                .with_span(span)?;
         let actuals = infer_under_mut_ref_hack(infcx, &actuals, fn_sig.skip_binder_ref());
         infcx.push_evar_scope();
 
@@ -1567,8 +1581,22 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                     args,
                 )
                 .with_span(stmt_span)?;
-                self.check_call(infcx, env, stmt_span, None, Some(*def_id), sig, &args, &actuals)
-                    .map(|resolved_call| resolved_call.output)
+                let borrowed_places = operands
+                    .iter()
+                    .map(|operand| env.borrowed_place_for_operand(operand))
+                    .collect_vec();
+                self.check_call(
+                    infcx,
+                    env,
+                    stmt_span,
+                    None,
+                    Some(*def_id),
+                    sig,
+                    &args,
+                    &actuals,
+                    &borrowed_places,
+                )
+                .map(|resolved_call| resolved_call.output)
             }
             Rvalue::Aggregate(AggregateKind::Array(arr_ty), operands) => {
                 let args = self

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -29,7 +29,7 @@ use flux_middle::{
 };
 use flux_rustc_bridge::{
     self,
-    mir::{BasicBlock, Body, Local, LocalDecl, LocalDecls, Place, PlaceElem},
+    mir::{BasicBlock, Body, Local, LocalDecl, LocalDecls, Operand, Place, PlaceElem},
     ty,
 };
 use itertools::{Itertools, izip};
@@ -47,6 +47,7 @@ use super::rty::Sort;
 pub struct TypeEnv<'a> {
     bindings: PlacesTree,
     local_decls: &'a LocalDecls,
+    borrows: UnordMap<Local, Place>,
 }
 
 pub struct BasicBlockEnvShape {
@@ -67,7 +68,11 @@ struct BasicBlockEnvData {
 
 impl<'a> TypeEnv<'a> {
     pub fn new(infcx: &mut InferCtxt, body: &'a Body, fn_sig: &FnSig) -> TypeEnv<'a> {
-        let mut env = TypeEnv { bindings: PlacesTree::default(), local_decls: &body.local_decls };
+        let mut env = TypeEnv {
+            bindings: PlacesTree::default(),
+            local_decls: &body.local_decls,
+            borrows: UnordMap::default(),
+        };
 
         for requires in fn_sig.requires() {
             infcx.assume_pred(requires);
@@ -88,7 +93,11 @@ impl<'a> TypeEnv<'a> {
     }
 
     pub fn empty() -> TypeEnv<'a> {
-        TypeEnv { bindings: PlacesTree::default(), local_decls: IndexSlice::empty() }
+        TypeEnv {
+            bindings: PlacesTree::default(),
+            local_decls: IndexSlice::empty(),
+            borrows: UnordMap::default(),
+        }
     }
 
     fn alloc_with_ty(&mut self, local: Local, ty: Ty) {
@@ -230,11 +239,29 @@ impl<'a> TypeEnv<'a> {
     }
 
     pub(crate) fn fold_local_ptrs(&mut self, infcx: &mut InferCtxtAt) -> InferResult {
-        for (loc, bound, ty) in self.bindings.local_ptrs() {
-            infcx.subtyping(&ty, &bound, ConstrReason::FoldLocal)?;
+        for (loc, bound, ty, borrowed_place) in self.bindings.local_ptrs() {
+            if let Some(borrowed_place) = borrowed_place.filter(has_field_projection) {
+                self.bindings.lookup(&borrowed_place, infcx.span).update(ty);
+            } else {
+                infcx.subtyping(&ty, &bound, ConstrReason::FoldLocal)?;
+            }
             self.bindings.remove_local(&loc);
         }
         Ok(())
+    }
+
+    pub(crate) fn record_borrow(&mut self, place: &Place, borrowed_place: &Place) {
+        if place.projection.is_empty() {
+            self.borrows.insert(place.local, borrowed_place.clone());
+        }
+    }
+
+    pub(crate) fn borrowed_place_for_operand(&self, operand: &Operand) -> Option<Place> {
+        let place = match operand {
+            Operand::Copy(place) | Operand::Move(place) if place.projection.is_empty() => place,
+            _ => return None,
+        };
+        self.borrows.get(&place.local).cloned()
     }
 
     /// Updates the type of `place` to `new_ty`. This may involve a *strong update* if we have
@@ -324,12 +351,13 @@ impl<'a> TypeEnv<'a> {
         &mut self,
         infcx: &mut InferCtxt,
         bound: &Ty,
+        borrowed_place: Option<Place>,
     ) -> InferResult<Loc> {
         let name = infcx.define_unknown_var(&Sort::Loc);
         let loc = Loc::from(name);
         let ty = infcx.unpack(bound);
         self.bindings
-            .insert(loc, LocKind::LocalPtr(bound.clone()), ty);
+            .insert(loc, LocKind::LocalPtr { bound: bound.clone(), borrowed_place }, ty);
         Ok(loc)
     }
 
@@ -420,6 +448,13 @@ impl<'a> TypeEnv<'a> {
     }
 }
 
+fn has_field_projection(place: &Place) -> bool {
+    place
+        .projection
+        .iter()
+        .any(|elem| matches!(elem, PlaceElem::Field(_)))
+}
+
 pub(crate) enum PtrToRefBound {
     Ty(Ty),
     Infer,
@@ -449,7 +484,7 @@ impl flux_infer::infer::LocEnv for TypeEnv<'_> {
 
 impl BasicBlockEnvShape {
     pub fn enter<'a>(&self, local_decls: &'a LocalDecls) -> TypeEnv<'a> {
-        TypeEnv { bindings: self.bindings.clone(), local_decls }
+        TypeEnv { bindings: self.bindings.clone(), local_decls, borrows: UnordMap::default() }
     }
 
     fn new(scope: Scope, env: TypeEnv) -> BasicBlockEnvShape {
@@ -824,7 +859,7 @@ impl BasicBlockEnv {
         for constr in &data.constrs {
             infcx.assume_pred(constr);
         }
-        TypeEnv { bindings: data.bindings, local_decls }
+        TypeEnv { bindings: data.bindings, local_decls, borrows: UnordMap::default() }
     }
 
     pub(crate) fn scope(&self) -> &Scope {

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -35,7 +35,7 @@ pub(crate) enum LocKind {
     Local,
     Box(GenericArg),
     // An &mut T unfolded "locally" at a call-site; with the super-type T
-    LocalPtr(Ty),
+    LocalPtr { bound: Ty, borrowed_place: Option<Place> },
     Universal,
 }
 
@@ -292,12 +292,12 @@ impl PlacesTree {
         self.map.shift_remove(loc);
     }
 
-    pub(crate) fn local_ptrs(&self) -> Vec<(Loc, Ty, Ty)> {
+    pub(crate) fn local_ptrs(&self) -> Vec<(Loc, Ty, Ty, Option<Place>)> {
         self.map
             .iter()
             .filter_map(|(loc, binding)| {
-                if let LocKind::LocalPtr(bound) = &binding.kind {
-                    Some((*loc, bound.clone(), binding.ty.clone()))
+                if let LocKind::LocalPtr { bound, borrowed_place } = &binding.kind {
+                    Some((*loc, bound.clone(), binding.ty.clone(), borrowed_place.clone()))
                 } else {
                     None
                 }
@@ -961,7 +961,7 @@ mod pretty {
             match self {
                 LocKind::Local | LocKind::Universal => Ok(()),
                 LocKind::Box(_) => w!(cx, f, "[box]"),
-                LocKind::LocalPtr(ty) => w!(cx, f, "[local-ptr({:?})]", ty),
+                LocKind::LocalPtr { bound, .. } => w!(cx, f, "[local-ptr({:?})]", bound),
             }
         }
     }

--- a/tests/tests/neg/abstract_refinements/issue-1613.rs
+++ b/tests/tests/neg/abstract_refinements/issue-1613.rs
@@ -1,0 +1,26 @@
+// https://github.com/flux-rs/flux/issues/1613 (soundness companion to the pos test)
+// Here the setter changes the *preserved* projection: it sets `len` to 0, which violates the
+// field invariant `slot.len > 0`. The post-state must be re-checked at the enclosing fold, so
+// this must still be rejected. (A fix that over-suppressed the fold check would wrongly accept it.)
+#[flux::opaque]
+#[flux::refined_by(len: int, hdl get: int -> bool)]
+struct Slot([bool]);
+
+impl Slot {
+    #[flux::trusted]
+    #[flux::sig(fn(self: &strg Slot[@n, @f]) ensures self: Slot[0, f])]
+    fn clear_len(&mut self) {}
+}
+
+#[flux::refined_by(slot: Slot)]
+struct Container<'a> {
+    #[flux::field({&mut Slot[slot] | slot.len > 0})]
+    slot: &'a mut Slot,
+}
+
+impl<'a> Container<'a> {
+    #[flux::sig(fn(self: &strg Container[@s]) ensures self: Container)]
+    fn update(&mut self) {
+        self.slot.clear_len();
+    } //~ ERROR type invariant may not hold
+}

--- a/tests/tests/pos/abstract_refinements/issue-1613.rs
+++ b/tests/tests/pos/abstract_refinements/issue-1613.rs
@@ -1,0 +1,58 @@
+// https://github.com/flux-rs/flux/issues/1613
+// Updating an abstract refinement on a composite-sort field behind a `&mut`, where the field
+// invariant only mentions a *preserved* projection (`slot.len`). The setter changes the `hdl`
+// refinement but keeps `len`, so re-folding `Container` (which only needs `slot.len > 0`) holds.
+#[flux::opaque]
+#[flux::refined_by(len: int, hdl get: int -> bool)]
+struct Slot([bool]);
+
+impl Slot {
+    #[flux::trusted]
+    #[flux::sig(fn(self: &strg Slot[@n, @f], i: usize{i < n})
+                ensures self: Slot[n, |j| j == i || f(j)])]
+    fn set(&mut self, i: usize) {
+        self.0[i] = true;
+    }
+}
+
+#[flux::refined_by(slot: Slot)]
+struct Container<'a> {
+    #[flux::field({&mut Slot[slot] | slot.len > 0})]
+    slot: &'a mut Slot,
+}
+
+impl<'a> Container<'a> {
+    #[flux::sig(fn(self: &strg Container[@s]) ensures self: Container)]
+    fn update(&mut self) {
+        self.slot.set(0);
+    }
+}
+
+// Same shape with plain integer-sort components instead of a function sort. The fix is keyed to
+// the field-projection borrow, not to the sort, so this must also verify. (Guards against a
+// narrower fix that only special-cases function-sort fields.)
+#[flux::opaque]
+#[flux::refined_by(len: int, val: int)]
+struct IntSlot([bool]);
+
+impl IntSlot {
+    #[flux::trusted]
+    #[flux::sig(fn(self: &strg IntSlot[@n, @v], i: usize{i < n})
+                ensures self: IntSlot[n, v + 1])]
+    fn set(&mut self, i: usize) {
+        let _ = i;
+    }
+}
+
+#[flux::refined_by(slot: IntSlot)]
+struct IntContainer<'a> {
+    #[flux::field({&mut IntSlot[slot] | slot.len > 0})]
+    slot: &'a mut IntSlot,
+}
+
+impl<'a> IntContainer<'a> {
+    #[flux::sig(fn(self: &strg IntContainer[@s]) ensures self: IntContainer)]
+    fn update(&mut self) {
+        self.slot.set(0);
+    }
+}


### PR DESCRIPTION
> *Human here. Full disclosure: I genuinely don't follow the details of the code below; it's agent-produced. What I can vouch for is the approach, a trace-backed agent localizing the fix, the same method that turned up a sharper root-cause on #1666 not long ago. Thanks for the attention.*

---

Re #1613. Rebased onto `main` (`8ada590`); ready for review.

A concrete take on the "something simpler" / origin-tracking direction from the thread.

## The fix

When the `&mut` unfolded at a call comes from a **field projection of an owned place**, record that origin and, on fold, write the callee post-state back into the field instead of re-proving it against the original bound (the failing `FoldLocal` obligation). Plain `&mut` parameters keep the original subtyping check. Three source files (`checker.rs`, `type_env.rs`, `type_env/place_ty.rs`) + a pos/neg `issue-1613` pair.

## Hypothesis graph

```mermaid
flowchart TD
    classDef killed fill:#ffe1e1,stroke:#cc3333,color:#5c0000;
    classDef confirmed fill:#e2f6e6,stroke:#2f9e44,color:#0a3d1a;

    H2["repro: E0999 'place is folded'"]:::confirmed
    H4["refinement-preserving setter verifies"]:::killed
    H5["scalar-sort variant verifies"]:::killed
    H6["direct &strg mutation verifies"]:::killed
    H7["dump: FoldLocal is the live obligation,<br/>Container invariant is already valid"]:::confirmed
    H10["drop FoldLocal -> accepts unsound len-- twin"]:::killed
    H11["write callee post-state back to field origin"]:::confirmed
    H14["propagate-for-all breaks neg/surface/local_ptr00"]:::killed
    H15["gate on field projection"]:::confirmed
    H22["int-sort receipt verifies; unsound twin rejected"]:::confirmed

    H2 --> H4 & H5 & H6 --> H7 --> H10 --> H11 --> H14 --> H15 --> H22
```

Each node is a replayable trial (kill = dead end mined for its edge):

| # | perturbation | observed | verdict |
|---|---|---|---|
| H2 | `flux` on the issue repro | `E0999 … place is folded` at the setter call | red reproduced |
| H4 | setter `ensures Slot[n, f]` (preserves refinement) | verifies | ✗ not mutation-through-a-field |
| H5 | scalar-sort variant (`refined_by(len: int)`) | verifies | ✗ not abstract-refinement fields in general |
| H6 | direct `&strg Slot` setter, no enclosing struct | verifies | ✗ not the call in isolation |
| H7 | `flux -Fdump-constraint` | live obligation is `FoldLocal` (`∀a. (a=0 ∨ f(a)) = f(a)`); `Container` invariant simplifies to valid | root = local-fold |
| H10 | remove the `FoldLocal` subtype check | target passes **but** a `len`-shrinking setter verifies | ✗ unsound suppression |
| H11 | write callee post-state back to the field origin | target verifies; `len`-shrinking twin rejected | ✓ |
| H14 | propagate for every `&mut` | `neg/surface/local_ptr00` regresses (compiles) | ✗ over-broad |
| H15 | gate to borrows with `PlaceElem::Field(_)` | `local_ptr00` rejects, `issue-1613` verifies | ✓ load-bearing |
| H22 | int-sort receipt vs a function-sort-gated fix | this fix verifies it; the narrow fix rejects it | ✓ sort-agnostic |

## Receipts (`cargo xtask test`)

- pos `issue-1613` verifies (function-sort **and** int-sort `IntSlot`, the int-sort case is the discriminating receipt H22); neg `issue-1613` (`clear_len` → `Slot[0, f]`) rejected with `type invariant may not hold`.
- full suite: basic 438/399, with-deps 93/58, **0 failed**.

## Honest residual (for the fold-machinery owners)

H15 gates on `borrowed_place` having a `PlaceElem::Field(_)`, a **syntactic proxy** for "an enclosing fold will re-verify the field invariant." Every escape shape I could construct (no `ensures`; plain `ensures Container`; nested `Outer.inner.slot`; free `fn(&mut Container)`; enum-variant field, inexpressible in surface syntax) rejects the invariant-violating program, because a field-projection borrow always sits under an enclosing owned (`&strg`/local) place that gets folded. Safe in practice; the syntactic→semantic equivalence is **not formally proven**, and you own the fold machinery, so flagging rather than burying it.
