### PR TITLE
Derive inhabited and make ext grind-able

### DIFF
--- a/crates/flux-infer/src/lean_format.rs
+++ b/crates/flux-infer/src/lean_format.rs
@@ -140,6 +140,10 @@ impl LeanFmt for DataDecl {
                         WithLeanCtxt { item: &field.sort, cx }
                     )?;
                 }
+                writeln!(f, "  deriving Inhabited")?;
+                write!(f, "attribute [grind .] ")?;
+                self.name.lean_fmt(f, cx)?;
+                writeln!(f, ".ext")?;
             } else {
                 bug!("unexpected ctor {ctor:?} in datadecl");
             };
@@ -171,6 +175,7 @@ impl LeanFmt for DataDecl {
                 }
                 writeln!(f)?;
             }
+            writeln!(f, "deriving Inhabited")?;
         }
         Ok(())
     }


### PR DESCRIPTION
For structures emitted to lean
- derive `Inhabited` (we already require type params to be `Inhabited`)
- add a `grind .` annotation to the struct extensionality theorem