### PR TITLE
Store monomorphized panic spec

### DIFF
--- a/crates/flux-bin/src/lib.rs
+++ b/crates/flux-bin/src/lib.rs
@@ -86,7 +86,7 @@ impl FluxMetadata {
             flags.push(format!("-Fallow-uninterpreted-cast={v}"));
         }
         if let Some(only_check) = only_check {
-            flags.push(format!("-Finclude={only_check}"))
+            flags.push(format!("-Finclude={only_check}"));
         } else if let Some(patterns) = self.include {
             for pat in patterns {
                 if let Some(prefix) = include_pattern_prefix {

--- a/crates/flux-common/src/mir_storage.rs
+++ b/crates/flux-common/src/mir_storage.rs
@@ -10,7 +10,7 @@
 //! that is used to show that the lifetime that the client provided is indeed
 //! `'tcx`.
 
-use std::{cell::RefCell, collections::HashMap, thread_local};
+use std::{cell::RefCell, collections::HashMap, rc::Rc, thread_local};
 
 use rustc_borrowck::consumers::BodyWithBorrowckFacts;
 use rustc_hir::def_id::LocalDefId;
@@ -20,7 +20,7 @@ use crate::bug;
 
 thread_local! {
     pub static SHARED_STATE:
-        RefCell<HashMap<LocalDefId, BodyWithBorrowckFacts<'static>>> =
+        RefCell<HashMap<LocalDefId, Rc<BodyWithBorrowckFacts<'static>>>> =
         RefCell::new(HashMap::new());
 }
 
@@ -37,26 +37,31 @@ pub unsafe fn store_mir_body<'tcx>(
         unsafe { std::mem::transmute(body_with_facts) };
     SHARED_STATE.with(|state| {
         let mut map = state.borrow_mut();
-        assert!(map.insert(def_id, body_with_facts).is_none());
+        assert!(map.insert(def_id, Rc::new(body_with_facts)).is_none());
     });
 }
 
 /// # Safety
 ///
 /// See the module level comment.
+///
+/// Unlike a plain `remove`, this does *not* consume the stored body: it returns a clone of the
+/// shared [`Rc`] and keeps the entry in place, so the body can be retrieved more than once (e.g.
+/// by both the checker and the no-panic call-graph provider).
 pub unsafe fn retrieve_mir_body<'tcx>(
     _tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,
-) -> BodyWithBorrowckFacts<'tcx> {
-    let body_with_facts: BodyWithBorrowckFacts<'static> = SHARED_STATE.with(|state| {
-        let mut map = state.borrow_mut();
-        match map.remove(&def_id) {
-            Some(body) => body,
+) -> Rc<BodyWithBorrowckFacts<'tcx>> {
+    let body_with_facts: Rc<BodyWithBorrowckFacts<'static>> = SHARED_STATE.with(|state| {
+        let map = state.borrow();
+        match map.get(&def_id) {
+            Some(body) => Rc::clone(body),
             None => {
                 bug!("retrieve_mir_body: panic on {def_id:?}")
             }
         }
     });
-    // SAFETY: See the module level comment.
+    // SAFETY: See the module level comment. `Rc<T>` is a thin pointer regardless of `T`, so the
+    // lifetime transmute does not change its layout.
     unsafe { std::mem::transmute(body_with_facts) }
 }

--- a/crates/flux-common/src/mir_storage.rs
+++ b/crates/flux-common/src/mir_storage.rs
@@ -49,19 +49,30 @@ pub unsafe fn store_mir_body<'tcx>(
 /// shared [`Rc`] and keeps the entry in place, so the body can be retrieved more than once (e.g.
 /// by both the checker and the no-panic call-graph provider).
 pub unsafe fn retrieve_mir_body<'tcx>(
-    _tcx: TyCtxt<'tcx>,
+    tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,
 ) -> Rc<BodyWithBorrowckFacts<'tcx>> {
-    let body_with_facts: Rc<BodyWithBorrowckFacts<'static>> = SHARED_STATE.with(|state| {
-        let map = state.borrow();
-        match map.get(&def_id) {
-            Some(body) => Rc::clone(body),
-            None => {
-                bug!("retrieve_mir_body: panic on {def_id:?}")
-            }
-        }
-    });
+    // SAFETY: See the module level comment.
+    match unsafe { try_retrieve_mir_body(tcx, def_id) } {
+        Some(body) => body,
+        None => bug!("retrieve_mir_body: panic on {def_id:?}"),
+    }
+}
+
+/// Like [`retrieve_mir_body`], but returns `None` instead of panicking when no body was stashed
+/// for `def_id` (e.g. a local item rustc never borrowchecks). The no-panic call-graph provider
+/// uses this to degrade such items to leaf nodes.
+///
+/// # Safety
+///
+/// See the module level comment.
+pub unsafe fn try_retrieve_mir_body<'tcx>(
+    _tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+) -> Option<Rc<BodyWithBorrowckFacts<'tcx>>> {
+    let body_with_facts: Rc<BodyWithBorrowckFacts<'static>> =
+        SHARED_STATE.with(|state| state.borrow().get(&def_id).map(Rc::clone))?;
     // SAFETY: See the module level comment. `Rc<T>` is a thin pointer regardless of `T`, so the
     // lifetime transmute does not change its layout.
-    unsafe { std::mem::transmute(body_with_facts) }
+    Some(unsafe { std::mem::transmute(body_with_facts) })
 }

--- a/crates/flux-common/src/mir_storage.rs
+++ b/crates/flux-common/src/mir_storage.rs
@@ -44,10 +44,6 @@ pub unsafe fn store_mir_body<'tcx>(
 /// # Safety
 ///
 /// See the module level comment.
-///
-/// Unlike a plain `remove`, this does *not* consume the stored body: it returns a clone of the
-/// shared [`Rc`] and keeps the entry in place, so the body can be retrieved more than once (e.g.
-/// by both the checker and the no-panic call-graph provider).
 pub unsafe fn retrieve_mir_body<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,
@@ -72,7 +68,10 @@ pub unsafe fn try_retrieve_mir_body<'tcx>(
 ) -> Option<Rc<BodyWithBorrowckFacts<'tcx>>> {
     let body_with_facts: Rc<BodyWithBorrowckFacts<'static>> =
         SHARED_STATE.with(|state| state.borrow().get(&def_id).map(Rc::clone))?;
-    // SAFETY: See the module level comment. `Rc<T>` is a thin pointer regardless of `T`, so the
-    // lifetime transmute does not change its layout.
-    Some(unsafe { std::mem::transmute(body_with_facts) })
+    // SAFETY: See the module level comment.
+    Some(unsafe {
+        std::mem::transmute::<Rc<BodyWithBorrowckFacts<'static>>, Rc<BodyWithBorrowckFacts<'tcx>>>(
+            body_with_facts,
+        )
+    })
 }

--- a/crates/flux-metadata/src/decoder.rs
+++ b/crates/flux-metadata/src/decoder.rs
@@ -61,11 +61,11 @@ impl<'a, 'tcx> DecodeContext<'a, 'tcx> {
     }
 }
 
-pub(super) fn decode_crate_metadata(
-    tcx: TyCtxt,
+pub(super) fn decode_crate_metadata<'tcx>(
+    tcx: TyCtxt<'tcx>,
     sess: &FluxSession,
     path: &Path,
-) -> Option<CrateMetadata> {
+) -> Option<CrateMetadata<'tcx>> {
     let mut file = match fs::File::open(path) {
         Ok(file) => file,
         Err(err) if let io::ErrorKind::NotFound = err.kind() => return None,

--- a/crates/flux-metadata/src/lib.rs
+++ b/crates/flux-metadata/src/lib.rs
@@ -27,6 +27,7 @@ use flux_errors::FluxSession;
 use flux_macros::fluent_messages;
 use flux_middle::{
     PanicSpec,
+    call_graph::NodeKey,
     cstore::{CrateStore, OptResult},
     def_id::{FluxDefId, FluxId},
     fhir,
@@ -43,7 +44,7 @@ use rustc_hir::{
     def_id::{LOCAL_CRATE, LocalDefId},
 };
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
-use rustc_middle::ty::{Instance, InstanceKind, TyCtxt};
+use rustc_middle::ty::{InstanceKind, TyCtxt};
 use rustc_session::config::OutFileName;
 use rustc_span::{
     SourceFile, Span, StableSourceFileId,
@@ -180,7 +181,7 @@ pub struct Tables<'tcx, K: Eq + Hash> {
     sort_decl_param_count: UnordMap<FluxId<K>, usize>,
     no_panic: UnordMap<K, bool>,
     assume_parametric_params: UnordMap<K, UnordSet<u32>>,
-    no_panic_specs: UnordMap<Instance<'tcx>, PanicSpec>,
+    no_panic_specs: UnordMap<NodeKey<'tcx>, PanicSpec>,
 }
 
 impl<'tcx> CStore<'tcx> {
@@ -329,7 +330,7 @@ impl<'tcx> CrateStore<'tcx> for CStore<'tcx> {
         self.local_tables[&krate].normalized_defns.clone()
     }
 
-    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<Instance<'tcx>, PanicSpec>> {
+    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec>> {
         // TODO: Some transitive deps (e.g. `hashbrown`) have no flux metadata. Return
         // an empty map (conservative: MightPanic) until the proper fix is in place.
         // See notes/hashbrown-inferred-no-panic.txt.
@@ -369,17 +370,23 @@ impl<'tcx> CrateMetadata<'tcx> {
             FluxDefId::to_index,
         );
         encode_flux_defs(genv, &mut local_tables);
-        // Serialize the instance-keyed map filtered to instances of locally-defined functions
-        // (identity + monomorphizations). Only `Item` instances carry a meaningful spec; shims and
+        // Serialize the `NodeKey`-keyed map filtered to nodes of locally-defined functions (source
+        // items + monomorphizations). Only `Item`-kind instances carry a meaningful spec; shims and
         // other non-`Item` instances are `Leaf`/`MightPanic` and not worth storing. Downstream
-        // crates reconstruct these `Instance`s for exact/identity lookups (`external_spec`).
+        // crates reconstruct these keys for exact/identity lookups (`inferred_no_panic_external`).
         local_tables.no_panic_specs = genv
             .inferred_no_panic_local()
             .items()
-            .filter(|(instance, _)| {
-                instance.def_id().is_local() && matches!(instance.def, InstanceKind::Item(_))
+            .filter(|(key, _)| {
+                key.def_id().is_local()
+                    && match key {
+                        NodeKey::Item(_) => true,
+                        NodeKey::Mono(instance) => {
+                            matches!(instance.def, InstanceKind::Item(_))
+                        }
+                    }
             })
-            .map(|(instance, spec)| (*instance, *spec))
+            .map(|(key, spec)| (*key, *spec))
             .collect();
 
         let mut extern_tables = Tables::default();

--- a/crates/flux-metadata/src/lib.rs
+++ b/crates/flux-metadata/src/lib.rs
@@ -44,7 +44,7 @@ use rustc_hir::{
     def_id::{LOCAL_CRATE, LocalDefId},
 };
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
-use rustc_middle::ty::{InstanceKind, TyCtxt};
+use rustc_middle::ty::TyCtxt;
 use rustc_session::config::OutFileName;
 use rustc_span::{
     SourceFile, Span, StableSourceFileId,
@@ -360,6 +360,10 @@ impl<'tcx> CrateStore<'tcx> for CStore<'tcx> {
 }
 
 impl<'tcx> CrateMetadata<'tcx> {
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "we seed the call graph with non-dummy local def ids, so the traversal should never reach dummy extern spec items."
+    )]
     fn new(genv: GlobalEnv<'_, 'tcx>) -> Self {
         let mut local_tables = Tables::default();
         encode_def_ids(
@@ -377,15 +381,7 @@ impl<'tcx> CrateMetadata<'tcx> {
         local_tables.no_panic_specs = genv
             .inferred_no_panic_local()
             .items()
-            .filter(|(key, _)| {
-                key.def_id().is_local()
-                    && match key {
-                        NodeKey::Item(_) => true,
-                        NodeKey::Mono(instance) => {
-                            matches!(instance.def, InstanceKind::Item(_))
-                        }
-                    }
-            })
+            .filter(|(key, _)| key.is_local_item())
             .map(|(key, spec)| (*key, *spec))
             .collect();
 

--- a/crates/flux-metadata/src/lib.rs
+++ b/crates/flux-metadata/src/lib.rs
@@ -54,7 +54,7 @@ pub use crate::encoder::encode_metadata;
 
 fluent_messages! { "../locales/en-US.ftl" }
 
-const METADATA_VERSION: u8 = 1;
+const METADATA_VERSION: u8 = 0;
 const METADATA_HEADER: &[u8] = &[b'f', b'l', b'u', b'x', 0, 0, 0, METADATA_VERSION];
 
 #[derive(Default)]

--- a/crates/flux-metadata/src/lib.rs
+++ b/crates/flux-metadata/src/lib.rs
@@ -43,7 +43,7 @@ use rustc_hir::{
     def_id::{LOCAL_CRATE, LocalDefId},
 };
 use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{Instance, InstanceKind, TyCtxt};
 use rustc_session::config::OutFileName;
 use rustc_span::{
     SourceFile, Span, StableSourceFileId,
@@ -54,13 +54,13 @@ pub use crate::encoder::encode_metadata;
 
 fluent_messages! { "../locales/en-US.ftl" }
 
-const METADATA_VERSION: u8 = 0;
+const METADATA_VERSION: u8 = 1;
 const METADATA_HEADER: &[u8] = &[b'f', b'l', b'u', b'x', 0, 0, 0, METADATA_VERSION];
 
 #[derive(Default)]
-pub struct CStore {
-    local_tables: UnordMap<CrateNum, Tables<DefIndex>>,
-    extern_tables: Tables<DefId>,
+pub struct CStore<'tcx> {
+    local_tables: UnordMap<CrateNum, Tables<'tcx, DefIndex>>,
+    extern_tables: Tables<'tcx, DefId>,
 }
 
 /// From CREUSOT: used to store the info about source files
@@ -109,9 +109,9 @@ impl AbsoluteBytePos {
 }
 
 #[derive(Default, TyEncodable, TyDecodable)]
-pub struct CrateMetadata {
-    local_tables: Tables<DefIndex>,
-    extern_tables: Tables<DefId>,
+pub struct CrateMetadata<'tcx> {
+    local_tables: Tables<'tcx, DefIndex>,
+    extern_tables: Tables<'tcx, DefId>,
 }
 
 /// Trait to deal with the fact that `assoc_refinmenents_of` and `assoc_refinements_def` use
@@ -157,7 +157,7 @@ impl Key for FluxDefId {
 
 #[derive_where(Default)]
 #[derive(TyEncodable, TyDecodable)]
-pub struct Tables<K: Eq + Hash> {
+pub struct Tables<'tcx, K: Eq + Hash> {
     generics_of: UnordMap<K, QueryResult<rty::Generics>>,
     refinement_generics_of: UnordMap<K, QueryResult<rty::EarlyBinder<rty::RefinementGenerics>>>,
     predicates_of: UnordMap<K, QueryResult<rty::EarlyBinder<rty::GenericPredicates>>>,
@@ -180,11 +180,11 @@ pub struct Tables<K: Eq + Hash> {
     sort_decl_param_count: UnordMap<FluxId<K>, usize>,
     no_panic: UnordMap<K, bool>,
     assume_parametric_params: UnordMap<K, UnordSet<u32>>,
-    no_panic_specs: UnordMap<DefId, PanicSpec>,
+    no_panic_specs: UnordMap<Instance<'tcx>, PanicSpec>,
 }
 
-impl CStore {
-    pub fn load(tcx: TyCtxt, sess: &FluxSession) -> Self {
+impl<'tcx> CStore<'tcx> {
+    pub fn load(tcx: TyCtxt<'tcx>, sess: &FluxSession) -> Self {
         let mut cstore = CStore::default();
         for crate_num in tcx.used_crates(()) {
             let Some(path) = flux_metadata_extern_location(tcx, *crate_num) else { continue };
@@ -199,7 +199,7 @@ impl CStore {
         &mut self,
         tcx: TyCtxt,
         sess: &FluxSession,
-        extern_tables: Tables<DefId>,
+        extern_tables: Tables<'tcx, DefId>,
     ) {
         macro_rules! merge_extern_table {
             ($self:expr, $tcx:expr, $table:ident, $extern_tables:expr) => {{
@@ -247,7 +247,7 @@ macro_rules! get {
     }};
 }
 
-impl CrateStore for CStore {
+impl<'tcx> CrateStore<'tcx> for CStore<'tcx> {
     fn fn_sig(&self, def_id: DefId) -> OptResult<rty::EarlyBinder<rty::PolyFnSig>> {
         get!(self, fn_sig, def_id)
     }
@@ -329,7 +329,7 @@ impl CrateStore for CStore {
         self.local_tables[&krate].normalized_defns.clone()
     }
 
-    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<DefId, PanicSpec>> {
+    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<Instance<'tcx>, PanicSpec>> {
         // TODO: Some transitive deps (e.g. `hashbrown`) have no flux metadata. Return
         // an empty map (conservative: MightPanic) until the proper fix is in place.
         // See notes/hashbrown-inferred-no-panic.txt.
@@ -358,8 +358,8 @@ impl CrateStore for CStore {
     }
 }
 
-impl CrateMetadata {
-    fn new(genv: GlobalEnv) -> Self {
+impl<'tcx> CrateMetadata<'tcx> {
+    fn new(genv: GlobalEnv<'_, 'tcx>) -> Self {
         let mut local_tables = Tables::default();
         encode_def_ids(
             genv,
@@ -369,7 +369,18 @@ impl CrateMetadata {
             FluxDefId::to_index,
         );
         encode_flux_defs(genv, &mut local_tables);
-        local_tables.no_panic_specs = (*genv.inferred_no_panic_crate(LOCAL_CRATE)).clone();
+        // Serialize the instance-keyed map filtered to instances of locally-defined functions
+        // (identity + monomorphizations). Only `Item` instances carry a meaningful spec; shims and
+        // other non-`Item` instances are `Leaf`/`MightPanic` and not worth storing. Downstream
+        // crates reconstruct these `Instance`s for exact/identity lookups (`external_spec`).
+        local_tables.no_panic_specs = genv
+            .inferred_no_panic_local()
+            .items()
+            .filter(|(instance, _)| {
+                instance.def_id().is_local() && matches!(instance.def, InstanceKind::Item(_))
+            })
+            .map(|(instance, spec)| (*instance, *spec))
+            .collect();
 
         let mut extern_tables = Tables::default();
         encode_def_ids(
@@ -384,7 +395,7 @@ impl CrateMetadata {
     }
 }
 
-fn encode_flux_defs(genv: GlobalEnv, tables: &mut Tables<DefIndex>) {
+fn encode_flux_defs<'tcx>(genv: GlobalEnv<'_, 'tcx>, tables: &mut Tables<'tcx, DefIndex>) {
     tables.normalized_defns = genv.normalized_defns(LOCAL_CRATE);
 
     for (def_id, item) in genv.fhir_iter_flux_items() {
@@ -407,10 +418,10 @@ fn encode_flux_defs(genv: GlobalEnv, tables: &mut Tables<DefIndex>) {
     }
 }
 
-fn encode_def_ids<K: Eq + Hash + Copy>(
-    genv: GlobalEnv,
+fn encode_def_ids<'tcx, K: Eq + Hash + Copy>(
+    genv: GlobalEnv<'_, 'tcx>,
     def_ids: impl IntoIterator<Item = DefId>,
-    tables: &mut Tables<K>,
+    tables: &mut Tables<'tcx, K>,
     did_to_key: fn(DefId) -> K,
     assoc_id_to_key: fn(FluxDefId) -> FluxId<K>,
 ) {

--- a/crates/flux-middle/src/call_graph.rs
+++ b/crates/flux-middle/src/call_graph.rs
@@ -19,12 +19,13 @@ use rustc_middle::{
 /// *monomorphization* synthesized while building the graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum NodeKey<'tcx> {
-    /// An item as written in source (generic or not), identified by its `DefId`. Its `Instance`
-    /// is the identity instance `new_raw(def_id, identity_for_item(def_id))`.
+    /// An item as written in source (generic or not), identified by its `DefId`.
     Item(DefId),
-    /// A generic item monomorphized at concrete (non-identity) type/const args while walking the
-    /// call graph (e.g. `Vec::<i32>::push`). We guarantee that the instance is fully monomorphic, i.e.,
-    /// the Instance's args are all concrete types.
+    /// A generic item monomorphized at concrete type/const args while building the
+    /// call graph (e.g. `Vec::<i32>::push`). We must guarantee that the instance is fully
+    /// monomorphic, i.e., the `Instance`'s args are all concrete types/consts.
+    ///
+    /// Use `NodeKey::from_instance` to classify an `Instance` into a `NodeKey`.
     Mono(Instance<'tcx>),
 }
 
@@ -32,6 +33,8 @@ impl<'tcx> NodeKey<'tcx> {
     /// Classifies an `Instance` into a `NodeKey`.
     pub fn from_instance(instance: Instance<'tcx>) -> Self {
         if let InstanceKind::Item(def_id) = instance.def
+            // - If `has_param()` is true then the instance is not fully monomorphic
+            // - If args is empty then is a non-generic item
             && (instance.args.has_param() || instance.args.is_empty())
         {
             NodeKey::Item(def_id)
@@ -97,11 +100,21 @@ pub enum Node<'tcx> {
 
 impl<'tcx> Node<'tcx> {
     /// Call sites observed in this node's body. Empty for non-`Analyzed` nodes.
-    pub fn call_sites(&self) -> &[CallSite<'tcx>] {
+    fn call_sites(&self) -> &[CallSite<'tcx>] {
         match self {
             Node::Analyzed { call_sites } => call_sites,
             Node::ExternalCrate | Node::Leaf(_) => &[],
         }
+    }
+
+    /// The callee nodes of this node's resolved call sites (skipping unresolved/dynamic ones).
+    pub fn resolved_callees(&self) -> impl Iterator<Item = NodeKey<'tcx>> {
+        self.call_sites().iter().filter_map(|site| {
+            match site.kind {
+                CallSiteKind::Resolved { callee } => Some(callee),
+                _ => None,
+            }
+        })
     }
 }
 
@@ -114,7 +127,7 @@ impl<'tcx> CallGraph<'tcx> {
     pub fn new(nodes: FxIndexMap<NodeKey<'tcx>, Node<'tcx>>) -> Self {
         let mut callers: UnordMap<_, Vec<_>> = UnordMap::default();
         for (&caller, node) in &nodes {
-            for callee in resolved_callees(node.call_sites()) {
+            for callee in node.resolved_callees() {
                 callers.entry(callee).or_default().push(caller);
             }
         }
@@ -133,17 +146,6 @@ impl<'tcx> CallGraph<'tcx> {
             }
         })
     }
-}
-
-pub fn resolved_callees<'tcx>(
-    call_sites: &[CallSite<'tcx>],
-) -> impl Iterator<Item = NodeKey<'tcx>> {
-    call_sites.iter().filter_map(|site| {
-        match site.kind {
-            CallSiteKind::Resolved { callee } => Some(callee),
-            _ => None,
-        }
-    })
 }
 
 impl<'tcx> fmt::Display for NodeKey<'tcx> {

--- a/crates/flux-middle/src/call_graph.rs
+++ b/crates/flux-middle/src/call_graph.rs
@@ -60,6 +60,22 @@ impl<'tcx> NodeKey<'tcx> {
             NodeKey::Mono(instance) => instance,
         }
     }
+
+    /// Whether this key denotes a locally-defined function item — the source item itself or a
+    /// monomorphization of it. Excludes foreign defs and non-`Item` instances (drop glue, fn-ptr
+    /// shims, etc.), which never carry a meaningful spec. Used to decide which specs a crate owns
+    /// and serializes into its own metadata.
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "is responsibility of who builds the graph to filter out dummy extern spec items."
+    )]
+    pub fn is_local_item(self) -> bool {
+        self.def_id().is_local()
+            && match self {
+                NodeKey::Item(_) => true,
+                NodeKey::Mono(instance) => matches!(instance.def, InstanceKind::Item(_)),
+            }
+    }
 }
 
 /// A single call site observed in a function's MIR body.

--- a/crates/flux-middle/src/call_graph.rs
+++ b/crates/flux-middle/src/call_graph.rs
@@ -1,0 +1,155 @@
+//! Data types for the no-panic call graph.
+//!
+//! The graph is *constructed* by the `flux-opt` crate (the `call_graph` query provider) but the
+//! types live here so they can be cached in `flux-middle` and consumed by both `flux-opt`
+//! (no-panic inference) and `flux-refineck` (the checker, which recovers the resolved callee at a
+//! call site by location).
+
+use std::fmt;
+
+use rustc_data_structures::{fx::FxIndexMap, unord::UnordMap};
+use rustc_hir::{def::DefKind, def_id::DefId};
+use rustc_middle::{
+    mir::Location,
+    ty::{GenericArgs, Instance, TyCtxt},
+};
+
+/// A single call site observed in a function's MIR body.
+#[derive(Debug, Clone)]
+pub struct CallSite<'tcx> {
+    pub location: Location,
+    pub kind: CallSiteKind<'tcx>,
+}
+
+#[derive(Debug, Clone)]
+pub enum CallSiteKind<'tcx> {
+    /// `Call` terminator that resolved to a concrete `Instance`
+    /// (potentionally monomorphized)
+    Resolved { callee: Instance<'tcx> },
+    /// Synthetic edge from an `Assert` terminator with a reachable unwind path —
+    /// represents the implicit call to `core::panicking::panic`.
+    SynthesizedPanic,
+    /// `Call` terminator on a `FnDef` where `Instance::try_resolve` failed.
+    Unresolved { def_id: DefId },
+    /// `Call` terminator on a non-`FnDef` type (function pointer, closure).
+    DynamicDispatch,
+}
+
+/// Classification of a node in the call graph.
+#[derive(Debug, Clone)]
+pub enum NodeKind {
+    /// MIR was available and walked.
+    /// `is_mono` is true when the instance is a concrete monomorphization
+    /// (args differ from the identity args). False for the source-level item.
+    Analyzed { is_mono: bool },
+    /// External crate function — panic spec looked up from crate metadata.
+    ExternalCrate,
+    /// Function with no analyzable body (no Rust body by design, MIR unavailable,
+    /// or a non-`Item` instance such as a shim or virtual dispatch stub).
+    /// Conservatively treated as `MightPanic`.
+    Leaf(DefKind),
+}
+
+#[derive(Debug, Clone)]
+pub struct NodeInfo<'tcx> {
+    pub kind: NodeKind,
+    /// Call sites observed in this function's MIR body. Non-empty only for
+    /// `NodeKind::Analyzed` nodes.
+    pub call_sites: Vec<CallSite<'tcx>>,
+}
+
+pub struct CallGraph<'tcx> {
+    pub nodes: FxIndexMap<Instance<'tcx>, NodeInfo<'tcx>>,
+    pub callers: UnordMap<Instance<'tcx>, Vec<Instance<'tcx>>>,
+}
+
+impl<'tcx> CallGraph<'tcx> {
+    /// Builds a `CallGraph` from its nodes, deriving the `callers` map.
+    pub fn new(nodes: FxIndexMap<Instance<'tcx>, NodeInfo<'tcx>>) -> Self {
+        let mut graph = CallGraph { nodes, callers: UnordMap::default() };
+        graph.build_callers();
+        graph
+    }
+
+    fn build_callers(&mut self) {
+        for (&caller, info) in &self.nodes {
+            for callee in resolved_callees(&info.call_sites) {
+                self.callers.entry(callee).or_default().push(caller);
+            }
+        }
+    }
+
+    /// The callee `Instance` resolved for the `Call` terminator at `location` in the body of
+    /// `def_id`. The checker only ever checks identity bodies (mono instances of a local generic
+    /// share the same `def_id` and body), so we look up the identity instance's node and scan its
+    /// call sites. Returns `None` for call sites that did not resolve to a concrete instance
+    /// (unresolved trait calls, dynamic dispatch) or whose body is not in the graph.
+    pub fn resolved_callee(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        def_id: DefId,
+        location: Location,
+    ) -> Option<Instance<'tcx>> {
+        let instance = Instance::new_raw(def_id, GenericArgs::identity_for_item(tcx, def_id));
+        let info = self.nodes.get(&instance)?;
+        info.call_sites.iter().find_map(|site| {
+            match site.kind {
+                CallSiteKind::Resolved { callee } if site.location == location => Some(callee),
+                _ => None,
+            }
+        })
+    }
+}
+
+pub fn resolved_callees<'tcx>(
+    call_sites: &[CallSite<'tcx>],
+) -> impl Iterator<Item = Instance<'tcx>> {
+    call_sites.iter().filter_map(|site| {
+        match site.kind {
+            CallSiteKind::Resolved { callee } => Some(callee),
+            _ => None,
+        }
+    })
+}
+
+impl fmt::Display for NodeKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NodeKind::Analyzed { is_mono } => {
+                if *is_mono {
+                    write!(f, "Analyzed(mono)")
+                } else {
+                    write!(f, "Analyzed")
+                }
+            }
+            NodeKind::ExternalCrate => write!(f, "ExternalCrate"),
+            NodeKind::Leaf(kind) => write!(f, "Leaf({kind:?})"),
+        }
+    }
+}
+
+impl<'tcx> fmt::Display for CallSiteKind<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CallSiteKind::Resolved { callee } => write!(f, "-> {callee}"),
+            CallSiteKind::SynthesizedPanic => write!(f, "-> panic"),
+            CallSiteKind::Unresolved { def_id: method } => write!(f, "-> trait {method:?}"),
+            CallSiteKind::DynamicDispatch => write!(f, "-> <dynamic>"),
+        }
+    }
+}
+
+impl<'tcx> fmt::Display for CallGraph<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "call graph ({} nodes):", self.nodes.len())?;
+        let mut nodes: Vec<_> = self.nodes.iter().collect();
+        nodes.sort_by_key(|(inst, _)| format!("{inst}"));
+        for (instance, info) in nodes {
+            writeln!(f, "  {instance} [{}]:", info.kind)?;
+            for site in &info.call_sites {
+                writeln!(f, "    {} at {:?}", site.kind, site.location)?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/flux-middle/src/call_graph.rs
+++ b/crates/flux-middle/src/call_graph.rs
@@ -83,9 +83,7 @@ impl<'tcx> CallGraph<'tcx> {
     }
 
     /// The callee `Instance` resolved for the `Call` terminator at `location` in the body of
-    /// `def_id`. The checker only ever checks identity bodies (mono instances of a local generic
-    /// share the same `def_id` and body), so we look up the identity instance's node and scan its
-    /// call sites. Returns `None` for call sites that did not resolve to a concrete instance
+    /// `def_id`. Returns `None` for call sites that did not resolve to a concrete instance
     /// (unresolved trait calls, dynamic dispatch) or whose body is not in the graph.
     pub fn resolved_callee(
         &self,

--- a/crates/flux-middle/src/call_graph.rs
+++ b/crates/flux-middle/src/call_graph.rs
@@ -35,13 +35,14 @@ pub enum CallSiteKind<'tcx> {
     DynamicDispatch,
 }
 
-/// Classification of a node in the call graph.
+/// A node in the call graph: an `Instance` together with its classification and, when it has an
+/// analyzable body, the call sites observed in it.
 #[derive(Debug, Clone)]
-pub enum NodeKind {
-    /// MIR was available and walked.
-    /// `is_mono` is true when the instance is a concrete monomorphization
-    /// (args differ from the identity args). False for the source-level item.
-    Analyzed { is_mono: bool },
+pub enum Node<'tcx> {
+    /// MIR was available and walked. `is_mono` is true when the instance is a concrete
+    /// monomorphization (args differ from the identity args), false for the source-level item.
+    /// `call_sites` are the Call/Assert terminators observed in the body.
+    Analyzed { is_mono: bool, call_sites: Vec<CallSite<'tcx>> },
     /// External crate function — panic spec looked up from crate metadata.
     ExternalCrate,
     /// Function with no analyzable body (no Rust body by design, MIR unavailable,
@@ -50,30 +51,32 @@ pub enum NodeKind {
     Leaf(DefKind),
 }
 
-#[derive(Debug, Clone)]
-pub struct NodeInfo<'tcx> {
-    pub kind: NodeKind,
-    /// Call sites observed in this function's MIR body. Non-empty only for
-    /// `NodeKind::Analyzed` nodes.
-    pub call_sites: Vec<CallSite<'tcx>>,
+impl<'tcx> Node<'tcx> {
+    /// Call sites observed in this node's body. Empty for non-`Analyzed` nodes.
+    pub fn call_sites(&self) -> &[CallSite<'tcx>] {
+        match self {
+            Node::Analyzed { call_sites, .. } => call_sites,
+            Node::ExternalCrate | Node::Leaf(_) => &[],
+        }
+    }
 }
 
 pub struct CallGraph<'tcx> {
-    pub nodes: FxIndexMap<Instance<'tcx>, NodeInfo<'tcx>>,
+    pub nodes: FxIndexMap<Instance<'tcx>, Node<'tcx>>,
     pub callers: UnordMap<Instance<'tcx>, Vec<Instance<'tcx>>>,
 }
 
 impl<'tcx> CallGraph<'tcx> {
     /// Builds a `CallGraph` from its nodes, deriving the `callers` map.
-    pub fn new(nodes: FxIndexMap<Instance<'tcx>, NodeInfo<'tcx>>) -> Self {
+    pub fn new(nodes: FxIndexMap<Instance<'tcx>, Node<'tcx>>) -> Self {
         let mut graph = CallGraph { nodes, callers: UnordMap::default() };
         graph.build_callers();
         graph
     }
 
     fn build_callers(&mut self) {
-        for (&caller, info) in &self.nodes {
-            for callee in resolved_callees(&info.call_sites) {
+        for (&caller, node) in &self.nodes {
+            for callee in resolved_callees(node.call_sites()) {
                 self.callers.entry(callee).or_default().push(caller);
             }
         }
@@ -91,8 +94,8 @@ impl<'tcx> CallGraph<'tcx> {
         location: Location,
     ) -> Option<Instance<'tcx>> {
         let instance = Instance::new_raw(def_id, GenericArgs::identity_for_item(tcx, def_id));
-        let info = self.nodes.get(&instance)?;
-        info.call_sites.iter().find_map(|site| {
+        let node = self.nodes.get(&instance)?;
+        node.call_sites().iter().find_map(|site| {
             match site.kind {
                 CallSiteKind::Resolved { callee } if site.location == location => Some(callee),
                 _ => None,
@@ -112,18 +115,18 @@ pub fn resolved_callees<'tcx>(
     })
 }
 
-impl fmt::Display for NodeKind {
+impl<'tcx> fmt::Display for Node<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            NodeKind::Analyzed { is_mono } => {
+            Node::Analyzed { is_mono, .. } => {
                 if *is_mono {
                     write!(f, "Analyzed(mono)")
                 } else {
                     write!(f, "Analyzed")
                 }
             }
-            NodeKind::ExternalCrate => write!(f, "ExternalCrate"),
-            NodeKind::Leaf(kind) => write!(f, "Leaf({kind:?})"),
+            Node::ExternalCrate => write!(f, "ExternalCrate"),
+            Node::Leaf(kind) => write!(f, "Leaf({kind:?})"),
         }
     }
 }
@@ -144,9 +147,9 @@ impl<'tcx> fmt::Display for CallGraph<'tcx> {
         writeln!(f, "call graph ({} nodes):", self.nodes.len())?;
         let mut nodes: Vec<_> = self.nodes.iter().collect();
         nodes.sort_by_key(|(inst, _)| format!("{inst}"));
-        for (instance, info) in nodes {
-            writeln!(f, "  {instance} [{}]:", info.kind)?;
-            for site in &info.call_sites {
+        for (instance, node) in nodes {
+            writeln!(f, "  {instance} [{node}]:")?;
+            for site in node.call_sites() {
                 writeln!(f, "    {} at {:?}", site.kind, site.location)?;
             }
         }

--- a/crates/flux-middle/src/call_graph.rs
+++ b/crates/flux-middle/src/call_graph.rs
@@ -9,10 +9,55 @@ use std::fmt;
 
 use rustc_data_structures::{fx::FxIndexMap, unord::UnordMap};
 use rustc_hir::{def::DefKind, def_id::DefId};
+use rustc_macros::{TyDecodable, TyEncodable};
 use rustc_middle::{
     mir::Location,
-    ty::{GenericArgs, Instance, TyCtxt},
+    ty::{GenericArgs, Instance, InstanceKind, TyCtxt, TypeVisitableExt},
 };
+
+/// Identity of a call-graph node. Distinguishes an item *as defined in source* from a
+/// *monomorphization* synthesized while building the graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
+pub enum NodeKey<'tcx> {
+    /// An item as written in source (generic or not), identified by its `DefId`. Its `Instance`
+    /// is the identity instance `new_raw(def_id, identity_for_item(def_id))`.
+    Item(DefId),
+    /// A generic item monomorphized at concrete (non-identity) type/const args while walking the
+    /// call graph (e.g. `Vec::<i32>::push`). We guarantee that the instance is fully monomorphic, i.e.,
+    /// the Instance's args are all concrete types.
+    Mono(Instance<'tcx>),
+}
+
+impl<'tcx> NodeKey<'tcx> {
+    /// Classifies an `Instance` into a `NodeKey`.
+    pub fn from_instance(instance: Instance<'tcx>) -> Self {
+        if let InstanceKind::Item(def_id) = instance.def
+            && (instance.args.has_param() || instance.args.is_empty())
+        {
+            NodeKey::Item(def_id)
+        } else {
+            NodeKey::Mono(instance)
+        }
+    }
+
+    pub fn def_id(self) -> DefId {
+        match self {
+            NodeKey::Item(def_id) => def_id,
+            NodeKey::Mono(instance) => instance.def_id(),
+        }
+    }
+
+    /// The `Instance` this key denotes. For an [`Item`](NodeKey::Item) this rebuilds the identity
+    /// instance; for a [`Mono`](NodeKey::Mono) it is the stored instance.
+    pub fn instance(self, tcx: TyCtxt<'tcx>) -> Instance<'tcx> {
+        match self {
+            NodeKey::Item(def_id) => {
+                Instance::new_raw(def_id, GenericArgs::identity_for_item(tcx, def_id))
+            }
+            NodeKey::Mono(instance) => instance,
+        }
+    }
+}
 
 /// A single call site observed in a function's MIR body.
 #[derive(Debug, Clone)]
@@ -23,9 +68,9 @@ pub struct CallSite<'tcx> {
 
 #[derive(Debug, Clone)]
 pub enum CallSiteKind<'tcx> {
-    /// `Call` terminator that resolved to a concrete `Instance`
-    /// (potentionally monomorphized)
-    Resolved { callee: Instance<'tcx> },
+    /// `Call` terminator that resolved to a concrete callee node (a source item or a
+    /// monomorphization).
+    Resolved { callee: NodeKey<'tcx> },
     /// Synthetic edge from an `Assert` terminator with a reachable unwind path —
     /// represents the implicit call to `core::panicking::panic`.
     SynthesizedPanic,
@@ -35,14 +80,13 @@ pub enum CallSiteKind<'tcx> {
     DynamicDispatch,
 }
 
-/// A node in the call graph: an `Instance` together with its classification and, when it has an
-/// analyzable body, the call sites observed in it.
+/// A node in the call graph. The node's provenance (source item vs monomorphization) is carried by
+/// its [`NodeKey`]; the node itself only records, when it has an analyzable body, the call sites
+/// observed in it.
 #[derive(Debug, Clone)]
 pub enum Node<'tcx> {
-    /// MIR was available and walked. `is_mono` is true when the instance is a concrete
-    /// monomorphization (args differ from the identity args), false for the source-level item.
-    /// `call_sites` are the Call/Assert terminators observed in the body.
-    Analyzed { is_mono: bool, call_sites: Vec<CallSite<'tcx>> },
+    /// MIR was available and walked. `call_sites` are the Call/Assert terminators observed.
+    Analyzed { call_sites: Vec<CallSite<'tcx>> },
     /// External crate function — panic spec looked up from crate metadata.
     ExternalCrate,
     /// Function with no analyzable body (no Rust body by design, MIR unavailable,
@@ -55,44 +99,33 @@ impl<'tcx> Node<'tcx> {
     /// Call sites observed in this node's body. Empty for non-`Analyzed` nodes.
     pub fn call_sites(&self) -> &[CallSite<'tcx>] {
         match self {
-            Node::Analyzed { call_sites, .. } => call_sites,
+            Node::Analyzed { call_sites } => call_sites,
             Node::ExternalCrate | Node::Leaf(_) => &[],
         }
     }
 }
 
 pub struct CallGraph<'tcx> {
-    pub nodes: FxIndexMap<Instance<'tcx>, Node<'tcx>>,
-    pub callers: UnordMap<Instance<'tcx>, Vec<Instance<'tcx>>>,
+    pub nodes: FxIndexMap<NodeKey<'tcx>, Node<'tcx>>,
+    pub callers: UnordMap<NodeKey<'tcx>, Vec<NodeKey<'tcx>>>,
 }
 
 impl<'tcx> CallGraph<'tcx> {
-    /// Builds a `CallGraph` from its nodes, deriving the `callers` map.
-    pub fn new(nodes: FxIndexMap<Instance<'tcx>, Node<'tcx>>) -> Self {
-        let mut graph = CallGraph { nodes, callers: UnordMap::default() };
-        graph.build_callers();
-        graph
-    }
-
-    fn build_callers(&mut self) {
-        for (&caller, node) in &self.nodes {
+    pub fn new(nodes: FxIndexMap<NodeKey<'tcx>, Node<'tcx>>) -> Self {
+        let mut callers: UnordMap<_, Vec<_>> = UnordMap::default();
+        for (&caller, node) in &nodes {
             for callee in resolved_callees(node.call_sites()) {
-                self.callers.entry(callee).or_default().push(caller);
+                callers.entry(callee).or_default().push(caller);
             }
         }
+        CallGraph { nodes, callers }
     }
 
-    /// The callee `Instance` resolved for the `Call` terminator at `location` in the body of
-    /// `def_id`. Returns `None` for call sites that did not resolve to a concrete instance
-    /// (unresolved trait calls, dynamic dispatch) or whose body is not in the graph.
-    pub fn resolved_callee(
-        &self,
-        tcx: TyCtxt<'tcx>,
-        def_id: DefId,
-        location: Location,
-    ) -> Option<Instance<'tcx>> {
-        let instance = Instance::new_raw(def_id, GenericArgs::identity_for_item(tcx, def_id));
-        let node = self.nodes.get(&instance)?;
+    /// The callee node resolved for the `Call` terminator at `location` in the body of `caller`.
+    /// Returns `None` for call sites that did not resolve to a concrete node (unresolved trait
+    /// calls, dynamic dispatch) or whose body is not in the graph.
+    pub fn resolved_callee(&self, caller: DefId, location: Location) -> Option<NodeKey<'tcx>> {
+        let node = self.nodes.get(&NodeKey::Item(caller))?;
         node.call_sites().iter().find_map(|site| {
             match site.kind {
                 CallSiteKind::Resolved { callee } if site.location == location => Some(callee),
@@ -104,7 +137,7 @@ impl<'tcx> CallGraph<'tcx> {
 
 pub fn resolved_callees<'tcx>(
     call_sites: &[CallSite<'tcx>],
-) -> impl Iterator<Item = Instance<'tcx>> {
+) -> impl Iterator<Item = NodeKey<'tcx>> {
     call_sites.iter().filter_map(|site| {
         match site.kind {
             CallSiteKind::Resolved { callee } => Some(callee),
@@ -113,16 +146,19 @@ pub fn resolved_callees<'tcx>(
     })
 }
 
+impl<'tcx> fmt::Display for NodeKey<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NodeKey::Item(def_id) => write!(f, "{def_id:?}"),
+            NodeKey::Mono(instance) => write!(f, "{instance}"),
+        }
+    }
+}
+
 impl<'tcx> fmt::Display for Node<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Node::Analyzed { is_mono, .. } => {
-                if *is_mono {
-                    write!(f, "Analyzed(mono)")
-                } else {
-                    write!(f, "Analyzed")
-                }
-            }
+            Node::Analyzed { .. } => write!(f, "Analyzed"),
             Node::ExternalCrate => write!(f, "ExternalCrate"),
             Node::Leaf(kind) => write!(f, "Leaf({kind:?})"),
         }
@@ -144,9 +180,9 @@ impl<'tcx> fmt::Display for CallGraph<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "call graph ({} nodes):", self.nodes.len())?;
         let mut nodes: Vec<_> = self.nodes.iter().collect();
-        nodes.sort_by_key(|(inst, _)| format!("{inst}"));
-        for (instance, node) in nodes {
-            writeln!(f, "  {instance} [{node}]:")?;
+        nodes.sort_by_key(|(key, _)| format!("{key}"));
+        for (key, node) in nodes {
+            writeln!(f, "  {key} [{node}]:")?;
             for site in node.call_sites() {
                 writeln!(f, "    {} at {:?}", site.kind, site.location)?;
             }

--- a/crates/flux-middle/src/cstore.rs
+++ b/crates/flux-middle/src/cstore.rs
@@ -2,10 +2,9 @@ use std::rc::Rc;
 
 use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_hir::def_id::CrateNum;
-use rustc_middle::ty::Instance;
 use rustc_span::def_id::DefId;
 
-use crate::{PanicSpec, def_id::FluxDefId, queries::QueryResult, rty};
+use crate::{PanicSpec, call_graph::NodeKey, def_id::FluxDefId, queries::QueryResult, rty};
 
 pub type OptResult<T> = Option<QueryResult<T>>;
 
@@ -40,7 +39,7 @@ pub trait CrateStore<'tcx> {
     fn sort_decl_param_count(&self, def_id: FluxDefId) -> Option<usize>;
     fn no_panic(&self, def_id: DefId) -> Option<bool>;
     fn assume_parametric_params(&self, def_id: DefId) -> Option<UnordSet<u32>>;
-    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<Instance<'tcx>, PanicSpec>>;
+    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec>>;
     fn has_crate(&self, krate: CrateNum) -> bool;
 }
 

--- a/crates/flux-middle/src/cstore.rs
+++ b/crates/flux-middle/src/cstore.rs
@@ -2,13 +2,14 @@ use std::rc::Rc;
 
 use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_hir::def_id::CrateNum;
+use rustc_middle::ty::Instance;
 use rustc_span::def_id::DefId;
 
 use crate::{PanicSpec, def_id::FluxDefId, queries::QueryResult, rty};
 
 pub type OptResult<T> = Option<QueryResult<T>>;
 
-pub trait CrateStore {
+pub trait CrateStore<'tcx> {
     fn fn_sig(&self, def_id: DefId) -> OptResult<rty::EarlyBinder<rty::PolyFnSig>>;
     fn adt_def(&self, def_id: DefId) -> OptResult<rty::AdtDef>;
     fn adt_sort_def(&self, def_id: DefId) -> OptResult<rty::AdtSortDef>;
@@ -39,8 +40,8 @@ pub trait CrateStore {
     fn sort_decl_param_count(&self, def_id: FluxDefId) -> Option<usize>;
     fn no_panic(&self, def_id: DefId) -> Option<bool>;
     fn assume_parametric_params(&self, def_id: DefId) -> Option<UnordSet<u32>>;
-    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<DefId, PanicSpec>>;
+    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<Instance<'tcx>, PanicSpec>>;
     fn has_crate(&self, krate: CrateNum) -> bool;
 }
 
-pub type CrateStoreDyn = dyn CrateStore;
+pub type CrateStoreDyn<'tcx> = dyn CrateStore<'tcx> + 'tcx;

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -180,10 +180,6 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         self.inner.queries.call_graph(self)
     }
 
-    pub fn inferred_no_panic_crate(self, krate: CrateNum) -> Rc<UnordMap<DefId, PanicSpec>> {
-        self.inner.queries.inferred_no_panic_crate(self, krate)
-    }
-
     /// The inferred [`PanicSpec`] for a concrete `instance`, looked up in the local crate's
     /// instance-keyed map. Missing entries default to `MightPanic(NotInCallGraph)`.
     pub fn inferred_no_panic_instance(self, instance: Instance<'tcx>) -> PanicSpec {
@@ -498,14 +494,6 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             .map(|variants| variants.map(|variants| variants[variant_idx.as_usize()].clone())))
     }
 
-    /// Whether we have inferred that the function cannot panic.
-    pub fn inferred_no_panic(self, def_id: impl IntoQueryParam<DefId>) -> PanicSpec {
-        let def_id = def_id.into_query_param();
-        let map = self.inferred_no_panic_crate(def_id.krate);
-        map.get(&def_id)
-            .copied()
-            .unwrap_or(PanicSpec::MightPanic(PanicReason::NotInCallGraph))
-    }
 
     /// Whether the crate has Flux metadata in the cratestore.
     pub fn cstore_has_crate(self, krate: CrateNum) -> bool {

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -20,7 +20,7 @@ use rustc_hir::{
 };
 use rustc_middle::{
     query::IntoQueryParam,
-    ty::{Instance, TyCtxt, Variance},
+    ty::{TyCtxt, Variance},
 };
 use rustc_span::{FileName, Span};
 pub use rustc_span::{Symbol, symbol::Ident};
@@ -28,6 +28,7 @@ use tempfile::TempDir;
 
 use crate::{
     PanicReason, PanicSpec,
+    call_graph::NodeKey,
     cstore::CrateStoreDyn,
     def_id::{FluxDefId, FluxLocalDefId, MaybeExternId, ResolvedDefId},
     fhir::{self, VariantIdx},
@@ -180,35 +181,33 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         self.inner.queries.call_graph(self)
     }
 
-    /// The inferred [`PanicSpec`] for a concrete `instance`, looked up in the local crate's
-    /// instance-keyed map. Missing entries default to `MightPanic(NotInCallGraph)`.
-    pub fn inferred_no_panic_instance(self, instance: Instance<'tcx>) -> PanicSpec {
+    /// The inferred [`PanicSpec`] for the node `key`, looked up in the local crate's
+    /// `NodeKey`-keyed map. Missing entries default to `MightPanic(NotInCallGraph)`.
+    pub fn inferred_no_panic_key(self, key: NodeKey<'tcx>) -> PanicSpec {
         self.inferred_no_panic_local()
-            .get(&instance)
+            .get(&key)
             .copied()
             .unwrap_or(PanicSpec::MightPanic(PanicReason::NotInCallGraph))
     }
 
-    /// The local crate's full instance-keyed no-panic map (used by metadata encoding).
-    pub fn inferred_no_panic_local(self) -> Rc<UnordMap<Instance<'tcx>, PanicSpec>> {
+    /// The local crate's full `NodeKey`-keyed no-panic map (used by metadata encoding).
+    pub fn inferred_no_panic_local(self) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec>> {
         self.inner.queries.inferred_no_panic(self)
     }
 
-    /// Looks up the inferred [`PanicSpec`] for an `instance` defined in an *external* crate, from
-    /// that crate's serialized metadata table. Tries the exact (monomorphized) instance first, then
-    /// falls back to the identity instance (covering instantiations the external crate could never
-    /// have analyzed, e.g. at a local type), then to `MightPanic`.
-    pub fn inferred_no_panic_external(self, instance: Instance<'tcx>) -> PanicSpec {
-        let def_id = instance.def_id();
-        let table = self.cstore().inferred_no_panic(def_id.krate);
-        if let Some(&spec) = table.get(&instance) {
+    /// Looks up the inferred [`PanicSpec`] for a node `key` defined in an *external* crate, from
+    /// that crate's serialized metadata table. Tries the exact key first (so a serialized
+    /// [`Mono`](NodeKey::Mono) is used when present), then for a monomorphization falls back to the
+    /// source [`Item`](NodeKey::Item) (covering instantiations the external crate could never have
+    /// analyzed, e.g. at a local type), then to `MightPanic`.
+    pub fn inferred_no_panic_external(self, key: NodeKey<'tcx>) -> PanicSpec {
+        let table = self.cstore().inferred_no_panic(key.def_id().krate);
+        if let Some(&spec) = table.get(&key) {
             return spec;
         }
-        let identity = Instance::new_raw(
-            def_id,
-            rustc_middle::ty::GenericArgs::identity_for_item(self.tcx(), def_id),
-        );
-        if let Some(&spec) = table.get(&identity) {
+        if let NodeKey::Mono(instance) = key
+            && let Some(&spec) = table.get(&NodeKey::Item(instance.def_id()))
+        {
             return spec;
         }
         PanicSpec::MightPanic(PanicReason::NotInCallGraph)

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -48,7 +48,7 @@ struct GlobalEnvInner<'genv, 'tcx> {
     tcx: TyCtxt<'tcx>,
     sess: &'genv FluxSession,
     arena: &'genv fhir::Arena,
-    cstore: Box<CrateStoreDyn>,
+    cstore: Box<CrateStoreDyn<'tcx>>,
     queries: Queries<'genv, 'tcx>,
     tempdir: TempDir,
 }
@@ -57,7 +57,7 @@ impl<'tcx> GlobalEnv<'_, 'tcx> {
     pub fn enter<'a, R>(
         tcx: TyCtxt<'tcx>,
         sess: &'a FluxSession,
-        cstore: Box<CrateStoreDyn>,
+        cstore: Box<CrateStoreDyn<'tcx>>,
         arena: &'a fhir::Arena,
         providers: Providers,
         f: impl for<'genv> FnOnce(GlobalEnv<'genv, 'tcx>) -> R,
@@ -187,12 +187,35 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
     /// The inferred [`PanicSpec`] for a concrete `instance`, looked up in the local crate's
     /// instance-keyed map. Missing entries default to `MightPanic(NotInCallGraph)`.
     pub fn inferred_no_panic_instance(self, instance: Instance<'tcx>) -> PanicSpec {
-        self.inner
-            .queries
-            .inferred_no_panic(self)
+        self.inferred_no_panic_local()
             .get(&instance)
             .copied()
             .unwrap_or(PanicSpec::MightPanic(PanicReason::NotInCallGraph))
+    }
+
+    /// The local crate's full instance-keyed no-panic map (used by metadata encoding).
+    pub fn inferred_no_panic_local(self) -> Rc<UnordMap<Instance<'tcx>, PanicSpec>> {
+        self.inner.queries.inferred_no_panic(self)
+    }
+
+    /// Looks up the inferred [`PanicSpec`] for an `instance` defined in an *external* crate, from
+    /// that crate's serialized metadata table. Tries the exact (monomorphized) instance first, then
+    /// falls back to the identity instance (covering instantiations the external crate could never
+    /// have analyzed, e.g. at a local type), then to `MightPanic`.
+    pub fn inferred_no_panic_external(self, instance: Instance<'tcx>) -> PanicSpec {
+        let def_id = instance.def_id();
+        let table = self.cstore().inferred_no_panic(def_id.krate);
+        if let Some(&spec) = table.get(&instance) {
+            return spec;
+        }
+        let identity = Instance::new_raw(
+            def_id,
+            rustc_middle::ty::GenericArgs::identity_for_item(self.tcx(), def_id),
+        );
+        if let Some(&spec) = table.get(&identity) {
+            return spec;
+        }
+        PanicSpec::MightPanic(PanicReason::NotInCallGraph)
     }
 
     pub fn inlined_body(self, did: FluxDefId) -> rty::Binder<rty::Expr> {
@@ -510,7 +533,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         generics.param_def_id_to_index(self.tcx(), def_id).unwrap()
     }
 
-    pub(crate) fn cstore(self) -> &'genv CrateStoreDyn {
+    pub(crate) fn cstore(self) -> &'genv CrateStoreDyn<'tcx> {
         &*self.inner.cstore
     }
 

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -20,7 +20,7 @@ use rustc_hir::{
 };
 use rustc_middle::{
     query::IntoQueryParam,
-    ty::{TyCtxt, Variance},
+    ty::{Instance, TyCtxt, Variance},
 };
 use rustc_span::{FileName, Span};
 pub use rustc_span::{Symbol, symbol::Ident};
@@ -182,6 +182,17 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
 
     pub fn inferred_no_panic_crate(self, krate: CrateNum) -> Rc<UnordMap<DefId, PanicSpec>> {
         self.inner.queries.inferred_no_panic_crate(self, krate)
+    }
+
+    /// The inferred [`PanicSpec`] for a concrete `instance`, looked up in the local crate's
+    /// instance-keyed map. Missing entries default to `MightPanic(NotInCallGraph)`.
+    pub fn inferred_no_panic_instance(self, instance: Instance<'tcx>) -> PanicSpec {
+        self.inner
+            .queries
+            .inferred_no_panic(self)
+            .get(&instance)
+            .copied()
+            .unwrap_or(PanicSpec::MightPanic(PanicReason::NotInCallGraph))
     }
 
     pub fn inlined_body(self, did: FluxDefId) -> rty::Binder<rty::Expr> {

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -176,6 +176,10 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         }
     }
 
+    pub fn call_graph(self) -> &'genv crate::call_graph::CallGraph<'tcx> {
+        self.inner.queries.call_graph(self)
+    }
+
     pub fn inferred_no_panic_crate(self, krate: CrateNum) -> Rc<UnordMap<DefId, PanicSpec>> {
         self.inner.queries.inferred_no_panic_crate(self, krate)
     }

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -493,7 +493,6 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             .map(|variants| variants.map(|variants| variants[variant_idx.as_usize()].clone())))
     }
 
-
     /// Whether the crate has Flux metadata in the cratestore.
     pub fn cstore_has_crate(self, krate: CrateNum) -> bool {
         self.cstore().has_crate(krate)
@@ -564,7 +563,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
         })
     }
 
-    /// Iterator over all local def ids that are not a extern spec
+    /// Iterator over all local def ids that are not an extern spec
     pub fn iter_local_def_id(self) -> impl Iterator<Item = LocalDefId> + use<'tcx, 'genv> {
         self.tcx().iter_local_def_id().filter(move |&local_def_id| {
             self.maybe_extern_id(local_def_id).is_local() && !self.is_dummy(local_def_id)

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -28,6 +28,7 @@ extern crate self as flux_middle;
 
 pub mod big_int;
 mod builtin_assoc_refts;
+pub mod call_graph;
 pub mod cstore;
 pub mod def_id;
 pub mod fhir;

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -612,7 +612,8 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
     }
 
     pub fn call_graph(&'genv self, genv: GlobalEnv<'genv, 'tcx>) -> &'genv CallGraph<'tcx> {
-        self.call_graph.get_or_init(|| (self.providers.call_graph)(genv))
+        self.call_graph
+            .get_or_init(|| (self.providers.call_graph)(genv))
     }
 
     /// The no-panic inference result for the local crate, keyed by `NodeKey`.

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -24,11 +24,12 @@ use rustc_hir::{
 };
 use rustc_index::IndexVec;
 use rustc_macros::{Decodable, Encodable};
+use rustc_middle::ty::Instance;
 use rustc_span::{DUMMY_SP, Span, Symbol};
 
 use crate::{
     PanicSpec,
-    call_graph::CallGraph,
+    call_graph::{CallGraph, Node},
     def_id::{FluxDefId, FluxId, MaybeExternId, ResolvedDefId},
     fhir,
     global_env::GlobalEnv,
@@ -205,7 +206,8 @@ pub struct Providers {
         fn(GlobalEnv, MaybeExternId) -> QueryResult<rty::EarlyBinder<List<rty::Clause>>>,
     pub sort_decl_param_count: fn(GlobalEnv, FluxId<MaybeExternId>) -> usize,
     pub call_graph: for<'genv, 'tcx> fn(GlobalEnv<'genv, 'tcx>) -> CallGraph<'tcx>,
-    pub inferred_no_panic: fn(GlobalEnv) -> UnordMap<DefId, PanicSpec>,
+    pub inferred_no_panic:
+        for<'genv, 'tcx> fn(GlobalEnv<'genv, 'tcx>) -> UnordMap<Instance<'tcx>, PanicSpec>,
 }
 
 macro_rules! empty_query {
@@ -294,7 +296,12 @@ pub struct Queries<'genv, 'tcx> {
     no_panic: Cache<DefId, bool>,
     assume_parametric_params: Cache<DefId, UnordSet<u32>>,
     call_graph: OnceCell<CallGraph<'tcx>>,
-    inferred_no_panic: Cache<CrateNum, Rc<UnordMap<DefId, PanicSpec>>>,
+    /// The no-panic inference result for the local crate, keyed by `Instance`.
+    inferred_no_panic: OnceCell<Rc<UnordMap<Instance<'tcx>, PanicSpec>>>,
+    /// `DefId`-keyed projection (identity instances) consulted by the metadata/checker path. Fed
+    /// from `inferred_no_panic` for the local crate and from the cstore for external crates.
+    /// Temporary: removed once the checker queries the instance-keyed map directly (Step 6/7).
+    inferred_no_panic_crate: Cache<CrateNum, Rc<UnordMap<DefId, PanicSpec>>>,
 }
 
 impl<'genv, 'tcx> Queries<'genv, 'tcx> {
@@ -338,6 +345,7 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
             assume_parametric_params: Default::default(),
             call_graph: Default::default(),
             inferred_no_panic: Default::default(),
+            inferred_no_panic_crate: Default::default(),
         }
     }
 
@@ -613,9 +621,19 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
         self.call_graph.get_or_init(|| (self.providers.call_graph)(genv))
     }
 
+    /// The no-panic inference result for the local crate, keyed by `Instance`.
+    pub fn inferred_no_panic(
+        &'genv self,
+        genv: GlobalEnv<'genv, 'tcx>,
+    ) -> Rc<UnordMap<Instance<'tcx>, PanicSpec>> {
+        self.inferred_no_panic
+            .get_or_init(|| Rc::new((self.providers.inferred_no_panic)(genv)))
+            .clone()
+    }
+
     pub fn inferred_no_panic_crate(
-        &self,
-        genv: GlobalEnv,
+        &'genv self,
+        genv: GlobalEnv<'genv, 'tcx>,
         krate: CrateNum,
     ) -> Rc<UnordMap<DefId, PanicSpec>> {
         // We can just make this `core` if we only care about that.
@@ -623,12 +641,25 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
             matches!(tcx.crate_name(krate).as_str(), "core" | "alloc" | "std")
         }
 
-        run_with_cache(&self.inferred_no_panic, krate, || {
+        run_with_cache(&self.inferred_no_panic_crate, krate, || {
             if krate == LOCAL_CRATE
                 || is_stdlib_crate(genv.tcx(), krate)
                 || !genv.cstore_has_crate(krate)
             {
-                Rc::new((self.providers.inferred_no_panic)(genv))
+                // Project the instance-keyed local map down to identity instances, reproducing the
+                // pre-Step-4 `DefId`-keyed result. The checker (until Step 6) and metadata (until
+                // Step 5) still consume this; it disappears once they query by `Instance`.
+                let instance_map = self.inferred_no_panic(genv);
+                let def_map = genv
+                    .call_graph()
+                    .nodes
+                    .iter()
+                    .filter(|(_, node)| matches!(node, Node::Analyzed { is_mono: false, .. }))
+                    .filter_map(|(&instance, _)| {
+                        instance_map.get(&instance).map(|&spec| (instance.def_id(), spec))
+                    })
+                    .collect();
+                Rc::new(def_map)
             } else {
                 genv.cstore().inferred_no_panic(krate)
             }

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -28,6 +28,7 @@ use rustc_span::{DUMMY_SP, Span, Symbol};
 
 use crate::{
     PanicSpec,
+    call_graph::CallGraph,
     def_id::{FluxDefId, FluxId, MaybeExternId, ResolvedDefId},
     fhir,
     global_env::GlobalEnv,
@@ -203,6 +204,7 @@ pub struct Providers {
     pub item_bounds:
         fn(GlobalEnv, MaybeExternId) -> QueryResult<rty::EarlyBinder<List<rty::Clause>>>,
     pub sort_decl_param_count: fn(GlobalEnv, FluxId<MaybeExternId>) -> usize,
+    pub call_graph: for<'genv, 'tcx> fn(GlobalEnv<'genv, 'tcx>) -> CallGraph<'tcx>,
     pub inferred_no_panic: fn(GlobalEnv) -> UnordMap<DefId, PanicSpec>,
 }
 
@@ -242,6 +244,7 @@ impl Default for Providers {
             constant_info: |_, _| empty_query!(),
             static_info: |_, _| empty_query!(),
             sort_decl_param_count: |_, _| empty_query!(),
+            call_graph: |_| empty_query!(),
             inferred_no_panic: |_| empty_query!(),
         }
     }
@@ -290,6 +293,7 @@ pub struct Queries<'genv, 'tcx> {
     sort_decl_param_count: Cache<FluxDefId, usize>,
     no_panic: Cache<DefId, bool>,
     assume_parametric_params: Cache<DefId, UnordSet<u32>>,
+    call_graph: OnceCell<CallGraph<'tcx>>,
     inferred_no_panic: Cache<CrateNum, Rc<UnordMap<DefId, PanicSpec>>>,
 }
 
@@ -332,6 +336,7 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
             sort_decl_param_count: Default::default(),
             no_panic: Default::default(),
             assume_parametric_params: Default::default(),
+            call_graph: Default::default(),
             inferred_no_panic: Default::default(),
         }
     }
@@ -602,6 +607,10 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                 },
             )
         })
+    }
+
+    pub fn call_graph(&'genv self, genv: GlobalEnv<'genv, 'tcx>) -> &'genv CallGraph<'tcx> {
+        self.call_graph.get_or_init(|| (self.providers.call_graph)(genv))
     }
 
     pub fn inferred_no_panic_crate(

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -24,12 +24,11 @@ use rustc_hir::{
 };
 use rustc_index::IndexVec;
 use rustc_macros::{Decodable, Encodable};
-use rustc_middle::ty::Instance;
 use rustc_span::{DUMMY_SP, Span, Symbol};
 
 use crate::{
     PanicSpec,
-    call_graph::CallGraph,
+    call_graph::{CallGraph, NodeKey},
     def_id::{FluxDefId, FluxId, MaybeExternId, ResolvedDefId},
     fhir,
     global_env::GlobalEnv,
@@ -207,7 +206,7 @@ pub struct Providers {
     pub sort_decl_param_count: fn(GlobalEnv, FluxId<MaybeExternId>) -> usize,
     pub call_graph: for<'genv, 'tcx> fn(GlobalEnv<'genv, 'tcx>) -> CallGraph<'tcx>,
     pub inferred_no_panic:
-        for<'genv, 'tcx> fn(GlobalEnv<'genv, 'tcx>) -> UnordMap<Instance<'tcx>, PanicSpec>,
+        for<'genv, 'tcx> fn(GlobalEnv<'genv, 'tcx>) -> UnordMap<NodeKey<'tcx>, PanicSpec>,
 }
 
 macro_rules! empty_query {
@@ -296,8 +295,8 @@ pub struct Queries<'genv, 'tcx> {
     no_panic: Cache<DefId, bool>,
     assume_parametric_params: Cache<DefId, UnordSet<u32>>,
     call_graph: OnceCell<CallGraph<'tcx>>,
-    /// The no-panic inference result for the local crate, keyed by `Instance`.
-    inferred_no_panic: OnceCell<Rc<UnordMap<Instance<'tcx>, PanicSpec>>>,
+    /// The no-panic inference result for the local crate, keyed by `NodeKey`.
+    inferred_no_panic: OnceCell<Rc<UnordMap<NodeKey<'tcx>, PanicSpec>>>,
 }
 
 impl<'genv, 'tcx> Queries<'genv, 'tcx> {
@@ -616,11 +615,11 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
         self.call_graph.get_or_init(|| (self.providers.call_graph)(genv))
     }
 
-    /// The no-panic inference result for the local crate, keyed by `Instance`.
+    /// The no-panic inference result for the local crate, keyed by `NodeKey`.
     pub fn inferred_no_panic(
         &'genv self,
         genv: GlobalEnv<'genv, 'tcx>,
-    ) -> Rc<UnordMap<Instance<'tcx>, PanicSpec>> {
+    ) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec>> {
         self.inferred_no_panic
             .get_or_init(|| Rc::new((self.providers.inferred_no_panic)(genv)))
             .clone()

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -24,12 +24,12 @@ use rustc_hir::{
 };
 use rustc_index::IndexVec;
 use rustc_macros::{Decodable, Encodable};
-use rustc_middle::ty::{GenericArgs, Instance};
+use rustc_middle::ty::Instance;
 use rustc_span::{DUMMY_SP, Span, Symbol};
 
 use crate::{
     PanicSpec,
-    call_graph::{CallGraph, Node},
+    call_graph::CallGraph,
     def_id::{FluxDefId, FluxId, MaybeExternId, ResolvedDefId},
     fhir,
     global_env::GlobalEnv,
@@ -298,10 +298,6 @@ pub struct Queries<'genv, 'tcx> {
     call_graph: OnceCell<CallGraph<'tcx>>,
     /// The no-panic inference result for the local crate, keyed by `Instance`.
     inferred_no_panic: OnceCell<Rc<UnordMap<Instance<'tcx>, PanicSpec>>>,
-    /// `DefId`-keyed projection (identity instances) consulted by the metadata/checker path. Fed
-    /// from `inferred_no_panic` for the local crate and from the cstore for external crates.
-    /// Temporary: removed once the checker queries the instance-keyed map directly (Step 6/7).
-    inferred_no_panic_crate: Cache<CrateNum, Rc<UnordMap<DefId, PanicSpec>>>,
 }
 
 impl<'genv, 'tcx> Queries<'genv, 'tcx> {
@@ -345,7 +341,6 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
             assume_parametric_params: Default::default(),
             call_graph: Default::default(),
             inferred_no_panic: Default::default(),
-            inferred_no_panic_crate: Default::default(),
         }
     }
 
@@ -629,55 +624,6 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
         self.inferred_no_panic
             .get_or_init(|| Rc::new((self.providers.inferred_no_panic)(genv)))
             .clone()
-    }
-
-    pub fn inferred_no_panic_crate(
-        &'genv self,
-        genv: GlobalEnv<'genv, 'tcx>,
-        krate: CrateNum,
-    ) -> Rc<UnordMap<DefId, PanicSpec>> {
-        // We can just make this `core` if we only care about that.
-        fn is_stdlib_crate(tcx: rustc_middle::ty::TyCtxt<'_>, krate: CrateNum) -> bool {
-            matches!(tcx.crate_name(krate).as_str(), "core" | "alloc" | "std")
-        }
-
-        run_with_cache(&self.inferred_no_panic_crate, krate, || {
-            if krate == LOCAL_CRATE
-                || is_stdlib_crate(genv.tcx(), krate)
-                || !genv.cstore_has_crate(krate)
-            {
-                // Project the instance-keyed local map down to identity instances, reproducing the
-                // pre-Step-4 `DefId`-keyed result. The checker (until Step 6) and metadata (until
-                // Step 5) still consume this; it disappears once they query by `Instance`.
-                let instance_map = self.inferred_no_panic(genv);
-                let def_map = genv
-                    .call_graph()
-                    .nodes
-                    .iter()
-                    .filter(|(_, node)| matches!(node, Node::Analyzed { is_mono: false, .. }))
-                    .filter_map(|(&instance, _)| {
-                        instance_map.get(&instance).map(|&spec| (instance.def_id(), spec))
-                    })
-                    .collect();
-                Rc::new(def_map)
-            } else {
-                // The cstore table is instance-keyed (Step 5). Project it down to identity
-                // instances to reproduce the `DefId`-keyed result the checker still expects (until
-                // Step 6). The exact-instance precision is consumed only inside the inference via
-                // `inferred_no_panic_external`, not on this path.
-                let tcx = genv.tcx();
-                let def_map = genv
-                    .cstore()
-                    .inferred_no_panic(krate)
-                    .items()
-                    .filter(|(instance, _)| {
-                        instance.args == GenericArgs::identity_for_item(tcx, instance.def_id())
-                    })
-                    .map(|(instance, spec)| (instance.def_id(), *spec))
-                    .collect();
-                Rc::new(def_map)
-            }
-        })
     }
 
     pub(crate) fn static_info(

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -24,7 +24,7 @@ use rustc_hir::{
 };
 use rustc_index::IndexVec;
 use rustc_macros::{Decodable, Encodable};
-use rustc_middle::ty::Instance;
+use rustc_middle::ty::{GenericArgs, Instance};
 use rustc_span::{DUMMY_SP, Span, Symbol};
 
 use crate::{
@@ -661,7 +661,21 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
                     .collect();
                 Rc::new(def_map)
             } else {
-                genv.cstore().inferred_no_panic(krate)
+                // The cstore table is instance-keyed (Step 5). Project it down to identity
+                // instances to reproduce the `DefId`-keyed result the checker still expects (until
+                // Step 6). The exact-instance precision is consumed only inside the inference via
+                // `inferred_no_panic_external`, not on this path.
+                let tcx = genv.tcx();
+                let def_map = genv
+                    .cstore()
+                    .inferred_no_panic(krate)
+                    .items()
+                    .filter(|(instance, _)| {
+                        instance.args == GenericArgs::identity_for_item(tcx, instance.def_id())
+                    })
+                    .map(|(instance, spec)| (instance.def_id(), *spec))
+                    .collect();
+                Rc::new(def_map)
             }
         })
     }

--- a/crates/flux-opt/src/call_graph.rs
+++ b/crates/flux-opt/src/call_graph.rs
@@ -1,9 +1,8 @@
 use flux_middle::{
-    call_graph::{CallGraph, CallSite, CallSiteKind, Node, NodeKey, resolved_callees},
+    call_graph::{CallGraph, CallSite, CallSiteKind, Node, NodeKey},
     global_env::GlobalEnv,
 };
-use rustc_data_structures::fx::FxIndexMap;
-use rustc_hash::FxHashSet;
+use rustc_data_structures::{fx::FxIndexMap, unord::UnordSet};
 use rustc_hir::{
     def::DefKind,
     def_id::{CrateNum, DefId, LOCAL_CRATE},
@@ -21,7 +20,7 @@ pub fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tcx> {
     // Node-level worklist and visited set: the same DefId can appear both as a source item and as
     // distinct monomorphizations, each a separate [`NodeKey`].
     let mut worklist: Vec<NodeKey<'_>> = Vec::new();
-    let mut explored: FxHashSet<NodeKey<'_>> = FxHashSet::default();
+    let mut explored: UnordSet<NodeKey<'_>> = UnordSet::default();
 
     for root_local in tcx.iter_local_def_id() {
         let def_id = root_local.to_def_id();
@@ -37,7 +36,7 @@ pub fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tcx> {
             continue;
         }
         let node = analyze_node(genv, key);
-        worklist.extend(resolved_callees(node.call_sites()));
+        worklist.extend(node.resolved_callees());
         nodes.insert(key, node);
     }
 

--- a/crates/flux-opt/src/call_graph.rs
+++ b/crates/flux-opt/src/call_graph.rs
@@ -1,7 +1,8 @@
-use std::fmt;
-
-use flux_middle::global_env::GlobalEnv;
-use rustc_data_structures::{fx::FxIndexMap, unord::UnordMap};
+use flux_middle::{
+    call_graph::{CallGraph, CallSite, CallSiteKind, NodeInfo, NodeKind, resolved_callees},
+    global_env::GlobalEnv,
+};
+use rustc_data_structures::fx::FxIndexMap;
 use rustc_hash::FxHashSet;
 use rustc_hir::{
     def::DefKind,
@@ -12,69 +13,10 @@ use rustc_middle::{
     ty::{EarlyBinder, GenericArgs, Instance, InstanceKind, TyCtxt, TypeVisitableExt, TypingEnv},
 };
 
-/// A single call site observed in a function's MIR body.
-#[derive(Debug, Clone)]
-pub(crate) struct CallSite<'tcx> {
-    pub(crate) location: Location,
-    pub(crate) kind: CallSiteKind<'tcx>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) enum CallSiteKind<'tcx> {
-    /// `Call` terminator that resolved to a concrete `Instance`
-    /// (potentionally monomorphized)
-    Resolved { callee: Instance<'tcx> },
-    /// Synthetic edge from an `Assert` terminator with a reachable unwind path —
-    /// represents the implicit call to `core::panicking::panic`.
-    SynthesizedPanic,
-    /// `Call` terminator on a `FnDef` where `Instance::try_resolve` failed.
-    Unresolved { def_id: DefId },
-    /// `Call` terminator on a non-`FnDef` type (function pointer, closure).
-    DynamicDispatch,
-}
-
-/// Classification of a node in the call graph.
-#[derive(Debug, Clone)]
-pub(crate) enum NodeKind {
-    /// MIR was available and walked.
-    /// `is_mono` is true when the instance is a concrete monomorphization
-    /// (args differ from the identity args). False for the source-level item.
-    Analyzed { is_mono: bool },
-    /// External crate function — panic spec looked up from crate metadata.
-    ExternalCrate,
-    /// Function with no analyzable body (no Rust body by design, MIR unavailable,
-    /// or a non-`Item` instance such as a shim or virtual dispatch stub).
-    /// Conservatively treated as `MightPanic`.
-    Leaf(DefKind),
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct NodeInfo<'tcx> {
-    pub(crate) kind: NodeKind,
-    /// Call sites observed in this function's MIR body. Non-empty only for
-    /// `NodeKind::Analyzed` nodes.
-    pub(crate) call_sites: Vec<CallSite<'tcx>>,
-}
-
-pub(crate) struct CallGraph<'tcx> {
-    pub(crate) nodes: FxIndexMap<Instance<'tcx>, NodeInfo<'tcx>>,
-    pub(crate) callers: UnordMap<Instance<'tcx>, Vec<Instance<'tcx>>>,
-}
-
-impl<'tcx> CallGraph<'tcx> {
-    fn build_callers(&mut self) {
-        for (&caller, info) in &self.nodes {
-            for callee in resolved_callees(&info.call_sites) {
-                self.callers.entry(callee).or_default().push(caller);
-            }
-        }
-    }
-}
-
-pub(crate) fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tcx> {
+pub fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tcx> {
     let tcx = genv.tcx();
 
-    let mut graph = CallGraph { nodes: FxIndexMap::default(), callers: UnordMap::default() };
+    let mut nodes: FxIndexMap<Instance<'_>, NodeInfo<'_>> = FxIndexMap::default();
 
     // Instance-level worklist and visited set to handle the same DefId being
     // called with different concrete type args.
@@ -98,9 +40,7 @@ pub(crate) fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tc
 
         // External non-stdlib callees: treat as a leaf and record for spec lookup.
         if !should_include_in_call_graph(genv, def_id.krate) {
-            graph
-                .nodes
-                .insert(instance, NodeInfo { kind: NodeKind::ExternalCrate, call_sites: vec![] });
+            nodes.insert(instance, NodeInfo { kind: NodeKind::ExternalCrate, call_sites: vec![] });
             continue;
         }
 
@@ -110,19 +50,16 @@ pub(crate) fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tc
             let call_sites = item_callees(tcx, instance);
             worklist.extend(resolved_callees(&call_sites));
             let is_mono = !is_identity_instance(tcx, instance);
-            graph
-                .nodes
-                .insert(instance, NodeInfo { kind: NodeKind::Analyzed { is_mono }, call_sites });
+            nodes.insert(instance, NodeInfo { kind: NodeKind::Analyzed { is_mono }, call_sites });
         } else {
-            graph.nodes.insert(
+            nodes.insert(
                 instance,
                 NodeInfo { kind: NodeKind::Leaf(tcx.def_kind(def_id)), call_sites: vec![] },
             );
         }
     }
 
-    graph.build_callers();
-    graph
+    CallGraph::new(nodes)
 }
 
 fn is_method_in_trait<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
@@ -178,7 +115,7 @@ fn callees_in_body<'tcx>(
         let terminator = bb_data.terminator();
         let location = Location { block: bb, statement_index: bb_data.statements.len() };
 
-        match &terminator.kind {
+        let kind = match &terminator.kind {
             TerminatorKind::Call { func, .. } => {
                 let ty = func.ty(&body.local_decls, tcx);
                 // Apply the caller's concrete type args to get the concrete callee type.
@@ -192,32 +129,24 @@ fn callees_in_body<'tcx>(
                     rustc_middle::ty::TyKind::FnDef(callee_def_id, callee_args) => {
                         match Instance::try_resolve(tcx, typing_env, *callee_def_id, callee_args) {
                             Ok(Some(instance)) => {
-                                let instance = normalize_abstract_args(tcx, instance);
-                                call_sites.push(CallSite {
-                                    location,
-                                    kind: CallSiteKind::Resolved { callee: instance },
-                                });
+                                CallSiteKind::Resolved {
+                                    callee: normalize_abstract_args(tcx, instance),
+                                }
                             }
-                            _ => {
-                                call_sites.push(CallSite {
-                                    location,
-                                    kind: CallSiteKind::Unresolved { def_id: *callee_def_id },
-                                });
-                            }
+                            _ => CallSiteKind::Unresolved { def_id: *callee_def_id },
                         }
                     }
-                    _ => {
-                        call_sites.push(CallSite { location, kind: CallSiteKind::DynamicDispatch });
-                    }
+                    _ => CallSiteKind::DynamicDispatch,
                 }
             }
             TerminatorKind::Assert { unwind, .. }
                 if !matches!(unwind, UnwindAction::Unreachable) =>
             {
-                call_sites.push(CallSite { location, kind: CallSiteKind::SynthesizedPanic });
+                CallSiteKind::SynthesizedPanic
             }
-            _ => {}
-        }
+            _ => continue,
+        };
+        call_sites.push(CallSite { location, kind });
     }
 
     call_sites
@@ -227,57 +156,4 @@ fn callees_in_body<'tcx>(
 /// are identity instances, so `instance_mir` returns the unspecialized body.
 fn item_callees<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> Vec<CallSite<'tcx>> {
     callees_in_body(tcx, instance, tcx.instance_mir(instance.def))
-}
-
-pub(crate) fn resolved_callees<'tcx>(
-    call_sites: &[CallSite<'tcx>],
-) -> impl Iterator<Item = Instance<'tcx>> {
-    call_sites.iter().filter_map(|site| {
-        match site.kind {
-            CallSiteKind::Resolved { callee } => Some(callee),
-            _ => None,
-        }
-    })
-}
-
-impl fmt::Display for NodeKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            NodeKind::Analyzed { is_mono } => {
-                if *is_mono {
-                    write!(f, "Analyzed(mono)")
-                } else {
-                    write!(f, "Analyzed")
-                }
-            }
-            NodeKind::ExternalCrate => write!(f, "ExternalCrate"),
-            NodeKind::Leaf(kind) => write!(f, "Leaf({kind:?})"),
-        }
-    }
-}
-
-impl<'tcx> fmt::Display for CallSiteKind<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CallSiteKind::Resolved { callee } => write!(f, "-> {callee}"),
-            CallSiteKind::SynthesizedPanic => write!(f, "-> panic"),
-            CallSiteKind::Unresolved { def_id: method } => write!(f, "-> trait {method:?}"),
-            CallSiteKind::DynamicDispatch => write!(f, "-> <dynamic>"),
-        }
-    }
-}
-
-impl<'tcx> fmt::Display for CallGraph<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "call graph ({} nodes):", self.nodes.len())?;
-        let mut nodes: Vec<_> = self.nodes.iter().collect();
-        nodes.sort_by_key(|(inst, _)| format!("{inst}"));
-        for (instance, info) in nodes {
-            writeln!(f, "  {instance} [{}]:", info.kind)?;
-            for site in &info.call_sites {
-                writeln!(f, "    {} at {:?}", site.kind, site.location)?;
-            }
-        }
-        Ok(())
-    }
 }

--- a/crates/flux-opt/src/call_graph.rs
+++ b/crates/flux-opt/src/call_graph.rs
@@ -49,7 +49,7 @@ fn analyze_instance<'tcx>(genv: GlobalEnv<'_, 'tcx>, instance: Instance<'tcx>) -
     let tcx = genv.tcx();
     let def_id = instance.def_id();
 
-    // External non-stdlib callees: leaf, panic spec looked up from crate metadata.
+    // External non-stdlib callees looked up from crate metadata.
     if !should_include_in_call_graph(genv, def_id.krate) {
         return Node::ExternalCrate;
     }
@@ -141,7 +141,9 @@ fn callees_in_body<'tcx>(
                 // which `instantiate_mir_and_normalize_erasing_regions` would panic on. Erase
                 // regions up front — we only need the callee's type/const args to resolve it.
                 let ty = tcx.erase_and_anonymize_regions(ty);
-                // Apply the caller's concrete type args to get the concrete callee type.
+                // If we are inside a generic caller that we have monomorphized to a particular `Instance`,
+                // we apply the caller's concrete args to get the concrete callee type. For generic callers
+                // where `Instance` remains polymorphic (i.e., it has identity args) this is a no-op.
                 let ty = caller.instantiate_mir_and_normalize_erasing_regions(
                     tcx,
                     typing_env,

--- a/crates/flux-opt/src/call_graph.rs
+++ b/crates/flux-opt/src/call_graph.rs
@@ -1,5 +1,5 @@
 use flux_middle::{
-    call_graph::{CallGraph, CallSite, CallSiteKind, NodeInfo, NodeKind, resolved_callees},
+    call_graph::{CallGraph, CallSite, CallSiteKind, Node, resolved_callees},
     global_env::GlobalEnv,
 };
 use rustc_data_structures::fx::FxIndexMap;
@@ -16,7 +16,7 @@ use rustc_middle::{
 pub fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tcx> {
     let tcx = genv.tcx();
 
-    let mut nodes: FxIndexMap<Instance<'_>, NodeInfo<'_>> = FxIndexMap::default();
+    let mut nodes: FxIndexMap<Instance<'_>, Node<'_>> = FxIndexMap::default();
 
     // Instance-level worklist and visited set to handle the same DefId being
     // called with different concrete type args.
@@ -35,31 +35,50 @@ pub fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tcx> {
         if !explored.insert(instance) {
             continue;
         }
-
-        let def_id = instance.def_id();
-
-        // External non-stdlib callees: treat as a leaf and record for spec lookup.
-        if !should_include_in_call_graph(genv, def_id.krate) {
-            nodes.insert(instance, NodeInfo { kind: NodeKind::ExternalCrate, call_sites: vec![] });
-            continue;
-        }
-
-        if let InstanceKind::Item(_) = instance.def
-            && tcx.is_mir_available(def_id)
-        {
-            let call_sites = item_callees(tcx, instance);
-            worklist.extend(resolved_callees(&call_sites));
-            let is_mono = !is_identity_instance(tcx, instance);
-            nodes.insert(instance, NodeInfo { kind: NodeKind::Analyzed { is_mono }, call_sites });
-        } else {
-            nodes.insert(
-                instance,
-                NodeInfo { kind: NodeKind::Leaf(tcx.def_kind(def_id)), call_sites: vec![] },
-            );
-        }
+        let node = analyze_instance(genv, instance);
+        worklist.extend(resolved_callees(node.call_sites()));
+        nodes.insert(instance, node);
     }
 
     CallGraph::new(nodes)
+}
+
+/// Classifies `instance` into a call-graph [`Node`], walking its body for call sites when one is
+/// available.
+fn analyze_instance<'tcx>(genv: GlobalEnv<'_, 'tcx>, instance: Instance<'tcx>) -> Node<'tcx> {
+    let tcx = genv.tcx();
+    let def_id = instance.def_id();
+
+    // External non-stdlib callees: leaf, panic spec looked up from crate metadata.
+    if !should_include_in_call_graph(genv, def_id.krate) {
+        return Node::ExternalCrate;
+    }
+
+    // Only `Item` instances have a walkable Rust body; shims / virtual stubs are leaves.
+    //
+    // For **local** functions we walk the unoptimized borrowck body (stashed by the `mir_borrowck`
+    // override) rather than `tcx.instance_mir`, which would give us *optimized* MIR. This matters
+    // because the checker recovers the resolved callee at a call site by `Location`, and those
+    // locations must refer to the same (unoptimized) body the checker checks. See REPORT step 3.
+    if let InstanceKind::Item(_) = instance.def {
+        let call_sites = if let Some(local_def_id) = def_id.as_local() {
+            // SAFETY: the call graph runs after rustc's analysis pass, so every local body has
+            // been borrowchecked and stashed. `try_retrieve_mir_body` degrades to `None` (→ leaf)
+            // for the rare local fn-like item rustc never borrowchecks.
+            unsafe { flux_common::mir_storage::try_retrieve_mir_body(tcx, local_def_id) }
+                .map(|facts| callees_in_body(tcx, instance, &facts.body))
+        } else if tcx.is_mir_available(def_id) {
+            Some(callees_in_body(tcx, instance, tcx.instance_mir(instance.def)))
+        } else {
+            None
+        };
+        if let Some(call_sites) = call_sites {
+            let is_mono = !is_identity_instance(tcx, instance);
+            return Node::Analyzed { is_mono, call_sites };
+        }
+    }
+
+    Node::Leaf(tcx.def_kind(def_id))
 }
 
 fn is_method_in_trait<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
@@ -118,6 +137,10 @@ fn callees_in_body<'tcx>(
         let kind = match &terminator.kind {
             TerminatorKind::Call { func, .. } => {
                 let ty = func.ty(&body.local_decls, tcx);
+                // The unoptimized borrowck body still carries region inference vars (`ReVar`),
+                // which `instantiate_mir_and_normalize_erasing_regions` would panic on. Erase
+                // regions up front — we only need the callee's type/const args to resolve it.
+                let ty = tcx.erase_and_anonymize_regions(ty);
                 // Apply the caller's concrete type args to get the concrete callee type.
                 let ty = caller.instantiate_mir_and_normalize_erasing_regions(
                     tcx,
@@ -150,10 +173,4 @@ fn callees_in_body<'tcx>(
     }
 
     call_sites
-}
-
-/// Call sites of a worklist instance. After normalization all non-mono instances on the worklist
-/// are identity instances, so `instance_mir` returns the unspecialized body.
-fn item_callees<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> Vec<CallSite<'tcx>> {
-    callees_in_body(tcx, instance, tcx.instance_mir(instance.def))
 }

--- a/crates/flux-opt/src/call_graph.rs
+++ b/crates/flux-opt/src/call_graph.rs
@@ -22,6 +22,7 @@ pub fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tcx> {
     let mut worklist: Vec<NodeKey<'_>> = Vec::new();
     let mut explored: UnordSet<NodeKey<'_>> = UnordSet::default();
 
+    // Seed the worklist with non-dummy local def ids.
     for root_local in genv.iter_local_def_id() {
         let def_id = root_local.to_def_id();
         if !tcx.def_kind(root_local).is_fn_like() || is_method_in_trait(tcx, def_id) {
@@ -63,7 +64,13 @@ fn analyze_node<'tcx>(genv: GlobalEnv<'_, 'tcx>, key: NodeKey<'tcx>) -> Node<'tc
     // because the checker recovers the resolved callee at a call site by `Location`, and those
     // locations must refer to the same (unoptimized) body the checker checks. See REPORT step 3.
     if let InstanceKind::Item(_) = instance.def {
+        #[allow(
+            clippy::disallowed_methods,
+            reason = "we seed the call graph with non-dummy local def ids, so the traversal should never reach dummy extern spec items."
+        )]
         let call_sites = if let Some(local_def_id) = def_id.as_local() {
+            debug_assert!(!genv.maybe_extern_id(local_def_id).is_extern());
+
             // SAFETY: the call graph runs after rustc's analysis pass, so every local body has
             // been borrowchecked and stashed. `try_retrieve_mir_body` degrades to `None` (→ leaf)
             // for the rare local fn-like item rustc never borrowchecks.

--- a/crates/flux-opt/src/call_graph.rs
+++ b/crates/flux-opt/src/call_graph.rs
@@ -1,5 +1,5 @@
 use flux_middle::{
-    call_graph::{CallGraph, CallSite, CallSiteKind, Node, resolved_callees},
+    call_graph::{CallGraph, CallSite, CallSiteKind, Node, NodeKey, resolved_callees},
     global_env::GlobalEnv,
 };
 use rustc_data_structures::fx::FxIndexMap;
@@ -10,49 +10,52 @@ use rustc_hir::{
 };
 use rustc_middle::{
     mir::{Location, TerminatorKind, UnwindAction},
-    ty::{EarlyBinder, GenericArgs, Instance, InstanceKind, TyCtxt, TypeVisitableExt, TypingEnv},
+    ty::{EarlyBinder, Instance, InstanceKind, TyCtxt, TypingEnv},
 };
 
 pub fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tcx> {
     let tcx = genv.tcx();
 
-    let mut nodes: FxIndexMap<Instance<'_>, Node<'_>> = FxIndexMap::default();
+    let mut nodes: FxIndexMap<NodeKey<'_>, Node<'_>> = FxIndexMap::default();
 
-    // Instance-level worklist and visited set to handle the same DefId being
-    // called with different concrete type args.
-    let mut worklist: Vec<Instance<'_>> = Vec::new();
-    let mut explored: FxHashSet<Instance<'_>> = FxHashSet::default();
+    // Node-level worklist and visited set: the same DefId can appear both as a source item and as
+    // distinct monomorphizations, each a separate [`NodeKey`].
+    let mut worklist: Vec<NodeKey<'_>> = Vec::new();
+    let mut explored: FxHashSet<NodeKey<'_>> = FxHashSet::default();
 
     for root_local in tcx.iter_local_def_id() {
         let def_id = root_local.to_def_id();
         if !tcx.def_kind(root_local).is_fn_like() || is_method_in_trait(tcx, def_id) {
             continue;
         }
-        worklist.push(Instance::new_raw(def_id, GenericArgs::identity_for_item(tcx, def_id)));
+        // Roots are the items as written in source.
+        worklist.push(NodeKey::Item(def_id));
     }
 
-    while let Some(instance) = worklist.pop() {
-        if !explored.insert(instance) {
+    while let Some(key) = worklist.pop() {
+        if !explored.insert(key) {
             continue;
         }
-        let node = analyze_instance(genv, instance);
+        let node = analyze_node(genv, key);
         worklist.extend(resolved_callees(node.call_sites()));
-        nodes.insert(instance, node);
+        nodes.insert(key, node);
     }
 
     CallGraph::new(nodes)
 }
 
-/// Classifies `instance` into a call-graph [`Node`], walking its body for call sites when one is
-/// available.
-fn analyze_instance<'tcx>(genv: GlobalEnv<'_, 'tcx>, instance: Instance<'tcx>) -> Node<'tcx> {
+/// Classifies the node identified by `key` into a call-graph [`Node`], walking its body for call
+/// sites when one is available.
+fn analyze_node<'tcx>(genv: GlobalEnv<'_, 'tcx>, key: NodeKey<'tcx>) -> Node<'tcx> {
     let tcx = genv.tcx();
-    let def_id = instance.def_id();
+    let def_id = key.def_id();
 
     // External non-stdlib callees looked up from crate metadata.
     if !should_include_in_call_graph(genv, def_id.krate) {
         return Node::ExternalCrate;
     }
+
+    let instance = key.instance(tcx);
 
     // Only `Item` instances have a walkable Rust body; shims / virtual stubs are leaves.
     //
@@ -73,8 +76,7 @@ fn analyze_instance<'tcx>(genv: GlobalEnv<'_, 'tcx>, instance: Instance<'tcx>) -
             None
         };
         if let Some(call_sites) = call_sites {
-            let is_mono = !is_identity_instance(tcx, instance);
-            return Node::Analyzed { is_mono, call_sites };
+            return Node::Analyzed { call_sites };
         }
     }
 
@@ -87,23 +89,6 @@ fn is_method_in_trait<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
         matches!(tcx.associated_item(def_id).container, rustc_middle::ty::AssocContainer::Trait)
     } else {
         false
-    }
-}
-
-fn is_identity_instance<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
-    let identity = GenericArgs::identity_for_item(tcx, instance.def_id());
-    instance.args == identity
-}
-
-/// If `instance` is an `InstanceKind::Item` whose args still contain abstract type/const
-/// parameters (i.e., we are inside a generic caller), normalize it to its identity instance so
-/// all call sites for the same generic function fold into one graph node.
-fn normalize_abstract_args<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> Instance<'tcx> {
-    if matches!(instance.def, InstanceKind::Item(_)) && instance.args.has_param() {
-        let def_id = instance.def_id();
-        Instance::new_raw(def_id, GenericArgs::identity_for_item(tcx, def_id))
-    } else {
-        instance
     }
 }
 
@@ -154,9 +139,7 @@ fn callees_in_body<'tcx>(
                     rustc_middle::ty::TyKind::FnDef(callee_def_id, callee_args) => {
                         match Instance::try_resolve(tcx, typing_env, *callee_def_id, callee_args) {
                             Ok(Some(instance)) => {
-                                CallSiteKind::Resolved {
-                                    callee: normalize_abstract_args(tcx, instance),
-                                }
+                                CallSiteKind::Resolved { callee: NodeKey::from_instance(instance) }
                             }
                             _ => CallSiteKind::Unresolved { def_id: *callee_def_id },
                         }

--- a/crates/flux-opt/src/call_graph.rs
+++ b/crates/flux-opt/src/call_graph.rs
@@ -22,7 +22,7 @@ pub fn build_call_graph<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> CallGraph<'tcx> {
     let mut worklist: Vec<NodeKey<'_>> = Vec::new();
     let mut explored: UnordSet<NodeKey<'_>> = UnordSet::default();
 
-    for root_local in tcx.iter_local_def_id() {
+    for root_local in genv.iter_local_def_id() {
         let def_id = root_local.to_def_id();
         if !tcx.def_kind(root_local).is_fn_like() || is_method_in_trait(tcx, def_id) {
             continue;

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -104,8 +104,8 @@ fn run_fixpoint<'tcx>(
         }
     }
 
-    // Return every analyzed instance's spec, keyed by `Instance`. The `DefId`-keyed projection
-    // (identity instances only) now happens downstream in `Queries::inferred_no_panic_crate` for
-    // the metadata/checker path; it is removed entirely once the checker queries by `Instance`.
+    // Return every analyzed instance's spec, keyed by `Instance`. The checker queries this map
+    // directly by the callee `Instance` recovered from the call graph (see `Checker::check_call`),
+    // and metadata serializes the crate-local entries; there is no `DefId`-keyed projection.
     specs.into_iter().collect()
 }

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -10,12 +10,11 @@ use std::collections::VecDeque;
 
 use flux_middle::{
     PanicReason, PanicSpec,
-    call_graph::{CallGraph, CallSiteKind, Node},
+    call_graph::{CallSiteKind, Node},
     global_env::GlobalEnv,
     queries::Providers,
 };
 use rustc_data_structures::unord::UnordMap;
-use rustc_hash::FxHashMap;
 use rustc_middle::ty::Instance;
 
 pub fn provide(providers: &mut Providers) {
@@ -23,54 +22,6 @@ pub fn provide(providers: &mut Providers) {
     providers.inferred_no_panic = inferred_no_panic;
 }
 
-pub fn inferred_no_panic<'tcx>(
-    genv: GlobalEnv<'_, 'tcx>,
-) -> UnordMap<Instance<'tcx>, PanicSpec> {
-    infer_no_panics(genv, |instance| genv.inferred_no_panic_external(instance))
-}
-
-/// The entry point for no-panic inference. Explores the call graph and returns, for every analyzed
-/// `Instance`, an over-approximation of whether it might panic.
-///
-/// `external_spec` resolves the spec of an `Instance` defined in another crate (a
-/// [`Node::ExternalCrate`]), looking it up in that crate's serialized metadata.
-pub fn infer_no_panics<'tcx>(
-    genv: GlobalEnv<'_, 'tcx>,
-    external_spec: impl Fn(Instance<'tcx>) -> PanicSpec,
-) -> UnordMap<Instance<'tcx>, PanicSpec> {
-    let graph = genv.call_graph();
-    run_fixpoint(graph, external_spec)
-}
-
-/// Computes the initial `PanicSpec` for a node before propagation.
-///
-/// `Analyzed` nodes with only resolved call sites start as `WillNotPanic` (optimistic).
-/// Every other node starts as `MightPanic` with the appropriate reason.
-fn initial_spec<'tcx>(
-    node: &Node<'tcx>,
-    external_spec: &impl Fn(Instance<'tcx>) -> PanicSpec,
-    instance: Instance<'tcx>,
-) -> PanicSpec {
-    match node {
-        Node::ExternalCrate => external_spec(instance),
-        Node::Leaf(_) => PanicSpec::MightPanic(PanicReason::NoMIRAvailable),
-        Node::Analyzed { call_sites, .. } => {
-            for site in call_sites {
-                let reason = match site.kind {
-                    CallSiteKind::SynthesizedPanic => PanicReason::SynthesizedPanic,
-                    CallSiteKind::DynamicDispatch => PanicReason::DynamicDispatch,
-                    CallSiteKind::Unresolved { def_id } => PanicReason::UnresolvedCall(def_id),
-                    CallSiteKind::Resolved { .. } => continue,
-                };
-                return PanicSpec::MightPanic(reason);
-            }
-            PanicSpec::WillNotPanic
-        }
-    }
-}
-
-/// Consumes the labeled call graph and produces a `PanicSpec` for every root node.
-///
 /// Implements a greatest fixpoint on the two-point lattice `WillNotPanic` > `MightPanic(_)`:
 /// 1. Seed every node optimistically (`WillNotPanic` for fully-resolved `Analyzed` nodes).
 /// 2. Add all `MightPanic` seeds to a worklist.
@@ -79,15 +30,17 @@ fn initial_spec<'tcx>(
 ///
 /// Each node flips at most once, so the loop terminates. Cycles with no reachable panic
 /// source correctly remain `WillNotPanic`.
-fn run_fixpoint<'tcx>(
-    graph: &CallGraph<'tcx>,
-    external_spec: impl Fn(Instance<'tcx>) -> PanicSpec,
-) -> UnordMap<Instance<'tcx>, PanicSpec> {
-    let mut specs: FxHashMap<Instance<'tcx>, PanicSpec> = FxHashMap::default();
+///
+/// `external_spec` resolves the spec of an `Instance` defined in another crate (a
+/// [`Node::ExternalCrate`]), looking it up in that crate's serialized metadata.
+pub fn inferred_no_panic<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> UnordMap<Instance<'tcx>, PanicSpec> {
+    let graph = genv.call_graph();
+
+    let mut specs: UnordMap<Instance<'tcx>, PanicSpec> = UnordMap::default();
     let mut queue: VecDeque<Instance<'tcx>> = VecDeque::new();
 
     for (&instance, node) in &graph.nodes {
-        let spec = initial_spec(node, &external_spec, instance);
+        let spec = initial_spec(genv, node, instance);
         if matches!(spec, PanicSpec::MightPanic(_)) {
             queue.push_back(instance);
         }
@@ -103,9 +56,32 @@ fn run_fixpoint<'tcx>(
             }
         }
     }
+    specs
+}
 
-    // Return every analyzed instance's spec, keyed by `Instance`. The checker queries this map
-    // directly by the callee `Instance` recovered from the call graph (see `Checker::check_call`),
-    // and metadata serializes the crate-local entries; there is no `DefId`-keyed projection.
-    specs.into_iter().collect()
+/// Computes the initial `PanicSpec` for a node before propagation.
+///
+/// `Analyzed` nodes with only resolved call sites and no explicit panics start as `WillNotPanic`
+/// (optimistic). Every other node starts as `MightPanic` with the appropriate reason.
+fn initial_spec<'tcx>(
+    genv: GlobalEnv<'_, 'tcx>,
+    node: &Node<'tcx>,
+    instance: Instance<'tcx>,
+) -> PanicSpec {
+    match node {
+        Node::ExternalCrate => genv.inferred_no_panic_external(instance),
+        Node::Leaf(_) => PanicSpec::MightPanic(PanicReason::NoMIRAvailable),
+        Node::Analyzed { call_sites, .. } => {
+            for site in call_sites {
+                let reason = match site.kind {
+                    CallSiteKind::SynthesizedPanic => PanicReason::SynthesizedPanic,
+                    CallSiteKind::DynamicDispatch => PanicReason::DynamicDispatch,
+                    CallSiteKind::Unresolved { def_id } => PanicReason::UnresolvedCall(def_id),
+                    CallSiteKind::Resolved { .. } => continue,
+                };
+                return PanicSpec::MightPanic(reason);
+            }
+            PanicSpec::WillNotPanic
+        }
+    }
 }

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -10,12 +10,11 @@ use std::collections::VecDeque;
 
 use flux_middle::{
     PanicReason, PanicSpec,
-    call_graph::{CallSiteKind, Node},
+    call_graph::{CallSiteKind, Node, NodeKey},
     global_env::GlobalEnv,
     queries::Providers,
 };
 use rustc_data_structures::unord::UnordMap;
-use rustc_middle::ty::Instance;
 
 pub fn provide(providers: &mut Providers) {
     providers.call_graph = call_graph::build_call_graph;
@@ -33,22 +32,22 @@ pub fn provide(providers: &mut Providers) {
 ///
 /// `external_spec` resolves the spec of an `Instance` defined in another crate (a
 /// [`Node::ExternalCrate`]), looking it up in that crate's serialized metadata.
-pub fn inferred_no_panic<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> UnordMap<Instance<'tcx>, PanicSpec> {
+pub fn inferred_no_panic<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> UnordMap<NodeKey<'tcx>, PanicSpec> {
     let graph = genv.call_graph();
 
-    let mut specs: UnordMap<Instance<'tcx>, PanicSpec> = UnordMap::default();
-    let mut queue: VecDeque<Instance<'tcx>> = VecDeque::new();
+    let mut specs: UnordMap<NodeKey<'tcx>, PanicSpec> = UnordMap::default();
+    let mut queue: VecDeque<NodeKey<'tcx>> = VecDeque::new();
 
-    for (&instance, node) in &graph.nodes {
-        let spec = initial_spec(genv, node, instance);
+    for (&key, node) in &graph.nodes {
+        let spec = initial_spec(genv, node, key);
         if matches!(spec, PanicSpec::MightPanic(_)) {
-            queue.push_back(instance);
+            queue.push_back(key);
         }
-        specs.insert(instance, spec);
+        specs.insert(key, spec);
     }
 
-    while let Some(instance) = queue.pop_front() {
-        let Some(callers) = graph.callers.get(&instance) else { continue };
+    while let Some(key) = queue.pop_front() {
+        let Some(callers) = graph.callers.get(&key) else { continue };
         for &caller in callers {
             if specs[&caller] == PanicSpec::WillNotPanic {
                 specs.insert(caller, PanicSpec::MightPanic(PanicReason::Transitive));
@@ -66,12 +65,12 @@ pub fn inferred_no_panic<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> UnordMap<Instance<'
 fn initial_spec<'tcx>(
     genv: GlobalEnv<'_, 'tcx>,
     node: &Node<'tcx>,
-    instance: Instance<'tcx>,
+    key: NodeKey<'tcx>,
 ) -> PanicSpec {
     match node {
-        Node::ExternalCrate => genv.inferred_no_panic_external(instance),
+        Node::ExternalCrate => genv.inferred_no_panic_external(key),
         Node::Leaf(_) => PanicSpec::MightPanic(PanicReason::NoMIRAvailable),
-        Node::Analyzed { call_sites, .. } => {
+        Node::Analyzed { call_sites } => {
             for site in call_sites {
                 let reason = match site.kind {
                     CallSiteKind::SynthesizedPanic => PanicReason::SynthesizedPanic,

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -16,7 +16,6 @@ use flux_middle::{
 };
 use rustc_data_structures::unord::UnordMap;
 use rustc_hash::FxHashMap;
-use rustc_hir::def_id::DefId;
 use rustc_middle::ty::Instance;
 
 pub fn provide(providers: &mut Providers) {
@@ -27,14 +26,17 @@ pub fn provide(providers: &mut Providers) {
 pub fn inferred_no_panic<'tcx>(
     genv: GlobalEnv<'_, 'tcx>,
 ) -> UnordMap<Instance<'tcx>, PanicSpec> {
-    infer_no_panics(genv, |def_id| genv.inferred_no_panic(def_id))
+    infer_no_panics(genv, |instance| genv.inferred_no_panic_external(instance))
 }
 
 /// The entry point for no-panic inference. Explores the call graph and returns, for every analyzed
 /// `Instance`, an over-approximation of whether it might panic.
+///
+/// `external_spec` resolves the spec of an `Instance` defined in another crate (a
+/// [`Node::ExternalCrate`]), looking it up in that crate's serialized metadata.
 pub fn infer_no_panics<'tcx>(
     genv: GlobalEnv<'_, 'tcx>,
-    external_spec: impl Fn(DefId) -> PanicSpec,
+    external_spec: impl Fn(Instance<'tcx>) -> PanicSpec,
 ) -> UnordMap<Instance<'tcx>, PanicSpec> {
     let graph = genv.call_graph();
     run_fixpoint(graph, external_spec)
@@ -44,13 +46,13 @@ pub fn infer_no_panics<'tcx>(
 ///
 /// `Analyzed` nodes with only resolved call sites start as `WillNotPanic` (optimistic).
 /// Every other node starts as `MightPanic` with the appropriate reason.
-fn initial_spec(
-    node: &Node<'_>,
-    external_spec: &impl Fn(DefId) -> PanicSpec,
-    def_id: DefId,
+fn initial_spec<'tcx>(
+    node: &Node<'tcx>,
+    external_spec: &impl Fn(Instance<'tcx>) -> PanicSpec,
+    instance: Instance<'tcx>,
 ) -> PanicSpec {
     match node {
-        Node::ExternalCrate => external_spec(def_id),
+        Node::ExternalCrate => external_spec(instance),
         Node::Leaf(_) => PanicSpec::MightPanic(PanicReason::NoMIRAvailable),
         Node::Analyzed { call_sites, .. } => {
             for site in call_sites {
@@ -79,13 +81,13 @@ fn initial_spec(
 /// source correctly remain `WillNotPanic`.
 fn run_fixpoint<'tcx>(
     graph: &CallGraph<'tcx>,
-    external_spec: impl Fn(DefId) -> PanicSpec,
+    external_spec: impl Fn(Instance<'tcx>) -> PanicSpec,
 ) -> UnordMap<Instance<'tcx>, PanicSpec> {
     let mut specs: FxHashMap<Instance<'tcx>, PanicSpec> = FxHashMap::default();
     let mut queue: VecDeque<Instance<'tcx>> = VecDeque::new();
 
     for (&instance, node) in &graph.nodes {
-        let spec = initial_spec(node, &external_spec, instance.def_id());
+        let spec = initial_spec(node, &external_spec, instance);
         if matches!(spec, PanicSpec::MightPanic(_)) {
             queue.push_back(instance);
         }

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -8,14 +8,19 @@ mod call_graph;
 
 use std::collections::VecDeque;
 
-use call_graph::{CallGraph, CallSiteKind, NodeKind};
-use flux_middle::{PanicReason, PanicSpec, global_env::GlobalEnv, queries::Providers};
+use flux_middle::{
+    PanicReason, PanicSpec,
+    call_graph::{CallGraph, CallSiteKind, NodeInfo, NodeKind},
+    global_env::GlobalEnv,
+    queries::Providers,
+};
 use rustc_data_structures::unord::UnordMap;
 use rustc_hash::FxHashMap;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::Instance;
 
 pub fn provide(providers: &mut Providers) {
+    providers.call_graph = call_graph::build_call_graph;
     providers.inferred_no_panic = inferred_no_panic;
 }
 
@@ -29,8 +34,8 @@ pub fn infer_no_panics(
     genv: GlobalEnv,
     external_spec: impl Fn(DefId) -> PanicSpec,
 ) -> UnordMap<DefId, PanicSpec> {
-    let graph = call_graph::build_call_graph(genv);
-    run_fixpoint(&graph, external_spec)
+    let graph = genv.call_graph();
+    run_fixpoint(graph, external_spec)
 }
 
 /// Computes the initial `PanicSpec` for a node before propagation.
@@ -38,7 +43,7 @@ pub fn infer_no_panics(
 /// `Analyzed` nodes with only resolved call sites start as `WillNotPanic` (optimistic).
 /// Every other node starts as `MightPanic` with the appropriate reason.
 fn initial_spec(
-    node: &call_graph::NodeInfo<'_>,
+    node: &NodeInfo<'_>,
     external_spec: &impl Fn(DefId) -> PanicSpec,
     def_id: DefId,
 ) -> PanicSpec {

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -24,16 +24,18 @@ pub fn provide(providers: &mut Providers) {
     providers.inferred_no_panic = inferred_no_panic;
 }
 
-pub fn inferred_no_panic(genv: GlobalEnv) -> UnordMap<DefId, PanicSpec> {
+pub fn inferred_no_panic<'tcx>(
+    genv: GlobalEnv<'_, 'tcx>,
+) -> UnordMap<Instance<'tcx>, PanicSpec> {
     infer_no_panics(genv, |def_id| genv.inferred_no_panic(def_id))
 }
 
-/// The entry point for no-panic inference. Given a root function, explores its
-/// call graph and returns an over-approximation of whether it might panic.
-pub fn infer_no_panics(
-    genv: GlobalEnv,
+/// The entry point for no-panic inference. Explores the call graph and returns, for every analyzed
+/// `Instance`, an over-approximation of whether it might panic.
+pub fn infer_no_panics<'tcx>(
+    genv: GlobalEnv<'_, 'tcx>,
     external_spec: impl Fn(DefId) -> PanicSpec,
-) -> UnordMap<DefId, PanicSpec> {
+) -> UnordMap<Instance<'tcx>, PanicSpec> {
     let graph = genv.call_graph();
     run_fixpoint(graph, external_spec)
 }
@@ -75,12 +77,12 @@ fn initial_spec(
 ///
 /// Each node flips at most once, so the loop terminates. Cycles with no reachable panic
 /// source correctly remain `WillNotPanic`.
-fn run_fixpoint(
-    graph: &CallGraph<'_>,
+fn run_fixpoint<'tcx>(
+    graph: &CallGraph<'tcx>,
     external_spec: impl Fn(DefId) -> PanicSpec,
-) -> UnordMap<DefId, PanicSpec> {
-    let mut specs: FxHashMap<Instance<'_>, PanicSpec> = FxHashMap::default();
-    let mut queue: VecDeque<Instance<'_>> = VecDeque::new();
+) -> UnordMap<Instance<'tcx>, PanicSpec> {
+    let mut specs: FxHashMap<Instance<'tcx>, PanicSpec> = FxHashMap::default();
+    let mut queue: VecDeque<Instance<'tcx>> = VecDeque::new();
 
     for (&instance, node) in &graph.nodes {
         let spec = initial_spec(node, &external_spec, instance.def_id());
@@ -100,10 +102,8 @@ fn run_fixpoint(
         }
     }
 
-    graph
-        .nodes
-        .iter()
-        .filter(|(_, node)| matches!(node, Node::Analyzed { is_mono: false, .. }))
-        .map(|(&instance, _)| (instance.def_id(), specs[&instance]))
-        .collect()
+    // Return every analyzed instance's spec, keyed by `Instance`. The `DefId`-keyed projection
+    // (identity instances only) now happens downstream in `Queries::inferred_no_panic_crate` for
+    // the metadata/checker path; it is removed entirely once the checker queries by `Instance`.
+    specs.into_iter().collect()
 }

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -10,7 +10,7 @@ use std::collections::VecDeque;
 
 use flux_middle::{
     PanicReason, PanicSpec,
-    call_graph::{CallGraph, CallSiteKind, NodeInfo, NodeKind},
+    call_graph::{CallGraph, CallSiteKind, Node},
     global_env::GlobalEnv,
     queries::Providers,
 };
@@ -43,15 +43,15 @@ pub fn infer_no_panics(
 /// `Analyzed` nodes with only resolved call sites start as `WillNotPanic` (optimistic).
 /// Every other node starts as `MightPanic` with the appropriate reason.
 fn initial_spec(
-    node: &NodeInfo<'_>,
+    node: &Node<'_>,
     external_spec: &impl Fn(DefId) -> PanicSpec,
     def_id: DefId,
 ) -> PanicSpec {
-    match &node.kind {
-        NodeKind::ExternalCrate => external_spec(def_id),
-        NodeKind::Leaf(_) => PanicSpec::MightPanic(PanicReason::NoMIRAvailable),
-        NodeKind::Analyzed { .. } => {
-            for site in &node.call_sites {
+    match node {
+        Node::ExternalCrate => external_spec(def_id),
+        Node::Leaf(_) => PanicSpec::MightPanic(PanicReason::NoMIRAvailable),
+        Node::Analyzed { call_sites, .. } => {
+            for site in call_sites {
                 let reason = match site.kind {
                     CallSiteKind::SynthesizedPanic => PanicReason::SynthesizedPanic,
                     CallSiteKind::DynamicDispatch => PanicReason::DynamicDispatch,
@@ -103,7 +103,7 @@ fn run_fixpoint(
     graph
         .nodes
         .iter()
-        .filter(|(_, node)| matches!(node.kind, NodeKind::Analyzed { is_mono: false }))
+        .filter(|(_, node)| matches!(node, Node::Analyzed { is_mono: false, .. }))
         .map(|(&instance, _)| (instance.def_id(), specs[&instance]))
         .collect()
 }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -975,10 +975,9 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             let callee_inferred_spec = body_def_id
                 .zip(location)
                 .and_then(|(body_def_id, location)| {
-                    genv.call_graph()
-                        .resolved_callee(tcx, body_def_id, location)
+                    genv.call_graph().resolved_callee(body_def_id, location)
                 })
-                .map(|instance| genv.inferred_no_panic_instance(instance))
+                .map(|key| genv.inferred_no_panic_key(key))
                 .unwrap_or(PanicSpec::MightPanic(PanicReason::NotInCallGraph));
 
             let inferred_panic_expr = if callee_inferred_spec == PanicSpec::WillNotPanic {

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -13,7 +13,7 @@ use flux_infer::{
     refine_tree::{Marker, RefineCtxtTrace},
 };
 use flux_middle::{
-    PanicSpec,
+    PanicReason, PanicSpec,
     global_env::GlobalEnv,
     pretty::PrettyCx,
     queries::{QueryResult, try_query},
@@ -664,7 +664,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 dbg::terminator!("start", terminator, infcx, env);
 
                 let successors =
-                    self.check_terminator(&mut infcx, &mut env, terminator, last_stmt_span)?;
+                    self.check_terminator(&mut infcx, &mut env, terminator, location, last_stmt_span)?;
                 dbg::terminator!("end", terminator, infcx, env);
 
                 self.markers[bb] = Some(infcx.marker());
@@ -746,6 +746,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         infcx: &mut InferCtxt<'_, 'genv, 'tcx>,
         env: &mut TypeEnv,
         terminator: &Terminator<'tcx>,
+        location: Location,
         last_stmt_span: Option<Span>,
     ) -> Result<Vec<(BasicBlock, Guard)>> {
         let source_info = terminator.source_info;
@@ -795,6 +796,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                             infcx,
                             env,
                             terminator_span,
+                            Some(location),
                             Some(*resolved_id),
                             fn_sig,
                             &generic_args,
@@ -812,6 +814,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                                 infcx,
                                 env,
                                 terminator_span,
+                                Some(location),
                                 None,
                                 EarlyBinder(fn_sig.clone()),
                                 &[],
@@ -888,6 +891,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         infcx: &mut InferCtxt<'_, 'genv, 'tcx>,
         env: &mut TypeEnv,
         span: Span,
+        location: Option<Location>,
         callee_def_id: Option<DefId>,
         fn_sig: EarlyBinder<PolyFnSig>,
         generic_args: &[GenericArg],
@@ -953,22 +957,25 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             && genv.def_kind(callee_def_id).is_fn_like()
         {
             let callee_no_panic = fn_sig.no_panic();
-            let callee_inferred_spec = genv.inferred_no_panic(callee_def_id);
 
-            // The call-graph and fixpoint iteration are over `Instance`s, but the output map only
-            // retains non-mono (identity) instances (that we can identify with a `DefId`). A concrete
-            // callee (e.g., `Vec::<i32>::push`) is a mono instance whose spec is not directly queryable
-            // via inferred_no_panic. However, if the caller is `WillNotPanic`, the fixpoint already
-            // accounted for all its concrete callees: any `MightPanic` callee would have propagated up
-            // and marked the caller `MightPanic(Transitive)`. So the caller's `WillNotPanic` proves all
-            // its concrete callees are no-panic, even those whose mono spec is absent from the output
-            // map. We could potentially key specs by `Instance`, but we also need to be able to recover
-            // the resolution to a mono-instance here.
-            let inferred_panic_expr = if let CheckerId::DefId(caller_id) = self.checker_id
-                && genv.inferred_no_panic(caller_id) == PanicSpec::WillNotPanic
-            {
-                Expr::tt()
-            } else if callee_inferred_spec == PanicSpec::WillNotPanic {
+            // Recover the resolved callee `Instance` from the call graph by the call-site location,
+            // then query the instance-keyed no-panic map. This lets us use the precise spec of a mono
+            // instance (e.g., `Vec::<i32>::push`) instead of only the identity instance's. A miss
+            // (unresolved trait call, dynamic dispatch, fn-pointer call, or a call site we can't
+            // locate because we are checking a promoted body) conservatively defaults to may-panic.
+            let body_def_id = match self.checker_id {
+                CheckerId::DefId(def_id) => Some(def_id.to_def_id()),
+                CheckerId::Promoted(..) => None,
+            };
+            let callee_inferred_spec = body_def_id
+                .zip(location)
+                .and_then(|(body_def_id, location)| {
+                    genv.call_graph().resolved_callee(tcx, body_def_id, location)
+                })
+                .map(|instance| genv.inferred_no_panic_instance(instance))
+                .unwrap_or(PanicSpec::MightPanic(PanicReason::NotInCallGraph));
+
+            let inferred_panic_expr = if callee_inferred_spec == PanicSpec::WillNotPanic {
                 Expr::tt()
             } else {
                 Expr::ff()
@@ -1558,7 +1565,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                     args,
                 )
                 .with_span(stmt_span)?;
-                self.check_call(infcx, env, stmt_span, Some(*def_id), sig, &args, &actuals)
+                self.check_call(infcx, env, stmt_span, None, Some(*def_id), sig, &args, &actuals)
                     .map(|resolved_call| resolved_call.output)
             }
             Rvalue::Aggregate(AggregateKind::Array(arr_ty), operands) => {

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -963,11 +963,8 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         {
             let callee_no_panic = fn_sig.no_panic();
 
-            // Recover the resolved callee `Instance` from the call graph by the call-site location,
-            // then query the instance-keyed no-panic map. This lets us use the precise spec of a mono
-            // instance (e.g., `Vec::<i32>::push`) instead of only the identity instance's. A miss
-            // (unresolved trait call, dynamic dispatch, fn-pointer call, or a call site we can't
-            // locate because we are checking a promoted body) conservatively defaults to may-panic.
+            // Recover the resolved callee `NodeKey` from the call graph by the call-site location,
+            // then query the no-panic spec map.
             let body_def_id = match self.checker_id {
                 CheckerId::DefId(def_id) => Some(def_id.to_def_id()),
                 CheckerId::Promoted(..) => None,

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -663,8 +663,13 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             bug::track_span(span, || {
                 dbg::terminator!("start", terminator, infcx, env);
 
-                let successors =
-                    self.check_terminator(&mut infcx, &mut env, terminator, location, last_stmt_span)?;
+                let successors = self.check_terminator(
+                    &mut infcx,
+                    &mut env,
+                    terminator,
+                    location,
+                    last_stmt_span,
+                )?;
                 dbg::terminator!("end", terminator, infcx, env);
 
                 self.markers[bb] = Some(infcx.marker());
@@ -970,7 +975,8 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
             let callee_inferred_spec = body_def_id
                 .zip(location)
                 .and_then(|(body_def_id, location)| {
-                    genv.call_graph().resolved_callee(tcx, body_def_id, location)
+                    genv.call_graph()
+                        .resolved_callee(tcx, body_def_id, location)
                 })
                 .map(|instance| genv.inferred_no_panic_instance(instance))
                 .unwrap_or(PanicSpec::MightPanic(PanicReason::NotInCallGraph));

--- a/crates/flux-refineck/src/ghost_statements.rs
+++ b/crates/flux-refineck/src/ghost_statements.rs
@@ -111,7 +111,7 @@ impl GhostStatements {
                 };
 
             fold_unfold::add_ghost_statements(&mut stmts, genv, body, fn_sig.as_ref())?;
-            points_to::add_ghost_statements(&mut stmts, genv, &body.rustc_body, fn_sig.as_ref())?;
+            points_to::add_ghost_statements(&mut stmts, genv, body.rustc_body(), fn_sig.as_ref())?;
             // We only add unblock statements for the main body because borrows in promoted constants
             // have to be live in the main body so they never go out of scope in the promoted body.
             if !checker_id.is_promoted() {
@@ -190,7 +190,7 @@ impl GhostStatements {
 
     pub(crate) fn dump_ghost_mir<'tcx>(&self, tcx: TyCtxt<'tcx>, body: &Body<'tcx>) {
         use rustc_middle::mir::{PassWhere, pretty::MirDumper};
-        if let Some(dumper) = MirDumper::new(tcx, "ghost", &body.rustc_body) {
+        if let Some(dumper) = MirDumper::new(tcx, "ghost", body.rustc_body()) {
             dumper
                 .set_extra_data(&|pass, w| {
                     match pass {
@@ -221,7 +221,7 @@ impl GhostStatements {
                     }
                     Ok(())
                 })
-                .dump_mir(&body.rustc_body);
+                .dump_mir(body.rustc_body());
         }
     }
 }

--- a/crates/flux-rustc-bridge/src/lowering.rs
+++ b/crates/flux-rustc-bridge/src/lowering.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use flux_arc_interner::List;
 use flux_common::result::ResultExt;
 use flux_errors::FluxSession;
@@ -35,7 +37,7 @@ use super::{
     },
 };
 use crate::{
-    mir::{BodyRoot, CallKind, ConstOperand},
+    mir::{BodyKind, BodyRoot, CallKind, ConstOperand},
     ty::{
         AliasTy, ExistentialTraitRef, GenericArgs, ProjectionPredicate, Region,
         RegionOutlivesPredicate,
@@ -144,29 +146,32 @@ impl<'sess, 'tcx> MirLoweringCtxt<'_, 'sess, 'tcx> {
         tcx: TyCtxt<'tcx>,
         sess: &'sess FluxSession,
         def_id: LocalDefId,
-        body_with_facts: BodyWithBorrowckFacts<'tcx>,
+        body_with_facts: Rc<BodyWithBorrowckFacts<'tcx>>,
     ) -> Result<BodyRoot<'tcx>, ErrorGuaranteed> {
         let infcx = tcx
             .infer_ctxt()
             .with_next_trait_solver(true)
             .build(TypingMode::analysis_in_body(tcx, def_id));
-        let rustc_body = body_with_facts.body;
-        let def_id = rustc_body.source.def_id();
+        let def_id = body_with_facts.body.source.def_id();
 
-        let body = Self::lower_rustc_body(tcx, &infcx, sess, def_id, rustc_body)?;
+        let body =
+            Self::lower_rustc_body(tcx, &infcx, sess, def_id, &body_with_facts, BodyKind::Main)?;
         let promoted = body_with_facts
             .promoted
-            .into_iter()
-            .map(|rustc_promoted| Self::lower_rustc_body(tcx, &infcx, sess, def_id, rustc_promoted))
+            .indices()
+            .map(|promoted| {
+                Self::lower_rustc_body(
+                    tcx,
+                    &infcx,
+                    sess,
+                    def_id,
+                    &body_with_facts,
+                    BodyKind::Promoted(promoted),
+                )
+            })
             .try_collect()?;
 
-        let body_root = BodyRoot::new(
-            body_with_facts.borrow_set,
-            body_with_facts.region_inference_context,
-            infcx,
-            body,
-            promoted,
-        );
+        let body_root = BodyRoot::new(body_with_facts, infcx, body, promoted);
         Ok(body_root)
     }
 
@@ -175,11 +180,13 @@ impl<'sess, 'tcx> MirLoweringCtxt<'_, 'sess, 'tcx> {
         infcx: &InferCtxt<'tcx>,
         sess: &'sess FluxSession,
         def_id: DefId,
-        body: rustc_mir::Body<'tcx>,
+        facts: &Rc<BodyWithBorrowckFacts<'tcx>>,
+        kind: BodyKind,
     ) -> Result<Body<'tcx>, ErrorGuaranteed> {
+        let body = kind.select_body(facts);
         let selcx = SelectionContext::new(infcx);
         let param_env = tcx.param_env(def_id);
-        let mut lower = MirLoweringCtxt { tcx, selcx, param_env, sess, rustc_mir: &body };
+        let mut lower = MirLoweringCtxt { tcx, selcx, param_env, sess, rustc_mir: body };
 
         let basic_blocks = body
             .basic_blocks
@@ -193,7 +200,7 @@ impl<'sess, 'tcx> MirLoweringCtxt<'_, 'sess, 'tcx> {
             .map(|local_decl| lower.lower_local_decl(local_decl))
             .try_collect()?;
 
-        Ok(Body::new(basic_blocks, local_decls, body))
+        Ok(Body::new(basic_blocks, local_decls, Rc::clone(facts), kind))
     }
 
     fn lower_basic_block_data(

--- a/crates/flux-rustc-bridge/src/mir.rs
+++ b/crates/flux-rustc-bridge/src/mir.rs
@@ -1,12 +1,12 @@
 //! A simplified version of rust mir.
 
-use std::fmt;
+use std::{fmt, rc::Rc};
 
 use flux_arc_interner::List;
 use flux_common::index::{Idx, IndexVec};
 use itertools::Itertools;
 pub use rustc_abi::{FIRST_VARIANT, FieldIdx, VariantIdx};
-use rustc_borrowck::consumers::{BorrowData, BorrowIndex, BorrowSet, RegionInferenceContext};
+use rustc_borrowck::consumers::{BodyWithBorrowckFacts, BorrowData, BorrowIndex};
 use rustc_data_structures::{
     fx::FxIndexMap,
     graph::{self, DirectedGraph, StartNode, dominators::Dominators},
@@ -66,11 +66,12 @@ pub struct BodyRoot<'tcx> {
     /// [region variable ids]: super::ty::RegionVid
     /// [`InferCtxt`]: rustc_infer::infer::InferCtxt
     pub infcx: rustc_infer::infer::InferCtxt<'tcx>,
-    /// The set of borrows occurring in `body` with data about them.
-    pub borrow_set: rustc_borrowck::consumers::BorrowSet<'tcx>,
-    /// Context generated during borrowck, intended to be passed to
-    /// [`calculate_borrows_out_of_scope_at_location`].
-    pub region_inference_context: rustc_borrowck::consumers::RegionInferenceContext<'tcx>,
+    /// The borrowck facts (`rustc_body`, `borrow_set`, `region_inference_context`, ...) backing
+    /// this body. Shared via [`Rc`] so the same stashed body can be lowered by the checker and
+    /// walked by the no-panic call-graph provider without being cloned or moved out. The lowered
+    /// [`Body`]s in `body`/`promoted` keep their own clone of this `Rc` and recover their
+    /// corresponding [`rustc_middle::mir::Body`] through it.
+    facts: Rc<BodyWithBorrowckFacts<'tcx>>,
 }
 
 impl<'tcx> BodyRoot<'tcx> {
@@ -82,14 +83,15 @@ impl<'tcx> BodyRoot<'tcx> {
         &self,
     ) -> FxIndexMap<Location, Vec<BorrowIndex>> {
         rustc_borrowck::consumers::calculate_borrows_out_of_scope_at_location(
-            &self.body.rustc_body,
-            &self.region_inference_context,
-            &self.borrow_set,
+            self.body.rustc_body(),
+            &self.facts.region_inference_context,
+            &self.facts.borrow_set,
         )
     }
 
     pub fn borrow_data(&self, idx: BorrowIndex) -> &BorrowData<'tcx> {
-        self.borrow_set
+        self.facts
+            .borrow_set
             .location_map()
             .get_index(idx.as_usize())
             .unwrap()
@@ -104,8 +106,34 @@ pub struct Body<'tcx> {
     /// See [`mk_fake_predecessors`]
     fake_predecessors: IndexVec<BasicBlock, usize>,
     pub local_names: UnordMap<Local, Symbol>,
-    /// A mir body that contains region identifiers.
-    pub rustc_body: rustc_middle::mir::Body<'tcx>,
+    /// The borrowck facts backing the whole [`BodyRoot`]. The unrefined [`rustc_middle::mir::Body`]
+    /// for *this* body (which contains region identifiers) lives inside, selected by `kind`. Access
+    /// it through [`Body::rustc_body`].
+    facts: Rc<BodyWithBorrowckFacts<'tcx>>,
+    /// Identifies which [`rustc_middle::mir::Body`] inside `facts` this body corresponds to.
+    kind: BodyKind,
+}
+
+/// Selects a particular [`rustc_middle::mir::Body`] within a [`BodyWithBorrowckFacts`].
+#[derive(Clone, Copy)]
+pub enum BodyKind {
+    /// The main body, i.e. `facts.body`.
+    Main,
+    /// The promoted constant at the given index, i.e. `facts.promoted[_]`.
+    Promoted(Promoted),
+}
+
+impl BodyKind {
+    /// The [`rustc_middle::mir::Body`] this kind selects out of `facts`.
+    pub fn select_body<'a, 'tcx>(
+        self,
+        facts: &'a BodyWithBorrowckFacts<'tcx>,
+    ) -> &'a rustc_middle::mir::Body<'tcx> {
+        match self {
+            BodyKind::Main => &facts.body,
+            BodyKind::Promoted(promoted) => &facts.promoted[promoted],
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -402,13 +430,12 @@ impl Statement<'_> {
 
 impl<'tcx> BodyRoot<'tcx> {
     pub fn new(
-        borrow_set: BorrowSet<'tcx>,
-        region_inference_context: RegionInferenceContext<'tcx>,
+        facts: Rc<BodyWithBorrowckFacts<'tcx>>,
         infcx: rustc_infer::infer::InferCtxt<'tcx>,
         body: Body<'tcx>,
         promoted: IndexVec<Promoted, Body<'tcx>>,
     ) -> Self {
-        Self { body, promoted, infcx, borrow_set, region_inference_context }
+        Self { body, promoted, infcx, facts }
     }
 }
 
@@ -416,8 +443,10 @@ impl<'tcx> Body<'tcx> {
     pub fn new(
         basic_blocks: IndexVec<BasicBlock, BasicBlockData<'tcx>>,
         local_decls: IndexVec<Local, LocalDecl>,
-        rustc_body: rustc_middle::mir::Body<'tcx>,
+        facts: Rc<BodyWithBorrowckFacts<'tcx>>,
+        kind: BodyKind,
     ) -> Self {
+        let rustc_body = kind.select_body(&facts);
         let fake_predecessors = mk_fake_predecessors(&basic_blocks);
 
         // The dominator rank of each node is just its index in a reverse-postorder traversal.
@@ -446,8 +475,15 @@ impl<'tcx> Body<'tcx> {
             fake_predecessors,
             dominator_order_rank,
             local_names,
-            rustc_body,
+            facts,
+            kind,
         }
+    }
+
+    /// The unrefined [`rustc_middle::mir::Body`] backing this body. It still contains region
+    /// identifiers.
+    pub fn rustc_body(&self) -> &rustc_middle::mir::Body<'tcx> {
+        self.kind.select_body(&self.facts)
     }
 
     pub fn terminator_loc(&self, bb: BasicBlock) -> Location {
@@ -456,7 +492,7 @@ impl<'tcx> Body<'tcx> {
 
     #[inline]
     pub fn is_join_point(&self, bb: BasicBlock) -> bool {
-        let total_preds = self.rustc_body.basic_blocks.predecessors()[bb].len();
+        let total_preds = self.rustc_body().basic_blocks.predecessors()[bb].len();
         let real_preds = total_preds - self.fake_predecessors[bb];
         // The entry block is a joint point if it has at least one predecessor because there's
         // an implicit goto from the environment at the beginning of the function.
@@ -465,21 +501,21 @@ impl<'tcx> Body<'tcx> {
 
     #[inline]
     pub fn dominators(&self) -> &Dominators<BasicBlock> {
-        self.rustc_body.basic_blocks.dominators()
+        self.rustc_body().basic_blocks.dominators()
     }
 
     #[inline]
     pub fn args_iter(&self) -> impl ExactSizeIterator<Item = Local> {
-        (1..self.rustc_body.arg_count + 1).map(Local::new)
+        (1..self.rustc_body().arg_count + 1).map(Local::new)
     }
 
     #[inline]
     pub fn vars_and_temps_iter(&self) -> impl ExactSizeIterator<Item = Local> {
-        (self.rustc_body.arg_count + 1..self.local_decls.len()).map(Local::new)
+        (self.rustc_body().arg_count + 1..self.local_decls.len()).map(Local::new)
     }
 
     pub fn span(&self) -> Span {
-        self.rustc_body.span
+        self.rustc_body().span
     }
 
     #[inline]

--- a/tests/tests/neg/surface/no_panic07.rs
+++ b/tests/tests/neg/surface/no_panic07.rs
@@ -1,0 +1,51 @@
+// Regression (negative): instance-keying must not over-approve. The generic `dispatch<S: Shape>`
+// is resolved per mono instance, so two instantiations in the *same* `#[flux::no_panic]` caller are
+// classified independently: `dispatch::<Square>` is `WillNotPanic` (accepted), but
+// `dispatch::<Spiky>` resolves `s.area()` to a method that may panic (unguarded array index), so it
+// is `MightPanic` and the call must be rejected. A bug that keyed only by `DefId`, or that trusted
+// the identity instance, would either reject both or accept both.
+//
+// `Spiky::area` is made may-panic by calling into a helper that may panic (the `println!` path),
+// *not* by an array index: an unguarded index would additionally raise an unrelated Flux
+// bounds-check refinement error, which would mask the no-panic diagnostic under test.
+
+trait Shape {
+    fn area(&self) -> usize;
+}
+
+struct Square {
+    side: usize,
+}
+
+impl Shape for Square {
+    fn area(&self) -> usize {
+        self.side
+    }
+}
+
+struct Spiky {
+    n: usize,
+}
+
+impl Shape for Spiky {
+    fn area(&self) -> usize {
+        noisy(); // calls into a may-panic helper
+        self.n
+    }
+}
+
+// Not `no_panic`: reaches `println!`, which the no-panic inference classifies as `MightPanic`.
+fn noisy() {
+    println!("spiky");
+}
+
+fn dispatch<S: Shape>(s: &S) -> usize {
+    s.area()
+}
+
+#[flux::no_panic]
+fn caller() -> usize {
+    let ok = dispatch(&Square { side: 3 });
+    let bad = dispatch(&Spiky { n: 5 }); //~ ERROR may panic
+    ok + bad
+}

--- a/tests/tests/pos/surface/no_panic07.rs
+++ b/tests/tests/pos/surface/no_panic07.rs
@@ -1,0 +1,35 @@
+// Regression: the no-panic call graph must substitute a generic function's concrete type args
+// before resolving the callees in its body (the `instantiate_mir_and_normalize_erasing_regions`
+// call in `flux-opt`'s `callees_in_body`), and the inferred specs must be keyed by `Instance` so
+// the checker can recover the *mono* spec at the call site.
+//
+// As the identity instance `dispatch::<S>`, the call `s.area()` is an unresolved trait call, so its
+// inferred spec is `MightPanic`. Only the mono instance `dispatch::<Square>` resolves it to the
+// concrete, non-panicking `<Square as Shape>::area`. The `#[flux::no_panic]` caller below is
+// accepted only because the checker queries that mono instance (location -> instance -> spec),
+// rather than the pessimistic identity instance.
+
+trait Shape {
+    fn area(&self) -> usize;
+}
+
+struct Square {
+    side: usize,
+}
+
+impl Shape for Square {
+    fn area(&self) -> usize {
+        self.side
+    }
+}
+
+// Not marked `no_panic`: the identity instance is `MightPanic` (unresolved trait call). Only the
+// mono instance `dispatch::<Square>` is `WillNotPanic`.
+fn dispatch<S: Shape>(s: &S) -> usize {
+    s.area()
+}
+
+#[flux::no_panic]
+fn caller() -> usize {
+    dispatch(&Square { side: 3 })
+}

--- a/tests/tests/pos/surface/no_panic08.rs
+++ b/tests/tests/pos/surface/no_panic08.rs
@@ -1,0 +1,47 @@
+// Regression: the *same* generic function instantiated at two different impls must be resolved
+// independently per mono instance. `dispatch::<S>` (identity) is `MightPanic` (unresolved trait
+// call), but both `dispatch::<Square>` and `dispatch::<Circle>` resolve to non-panicking methods,
+// so a single `#[flux::no_panic]` caller that uses both instantiations is accepted. This exercises
+// the instance-keyed spec map distinguishing two monos that share one `DefId`.
+
+trait Shape {
+    fn area(&self) -> usize;
+}
+
+struct Square {
+    side: usize,
+}
+
+impl Shape for Square {
+    fn area(&self) -> usize {
+        self.side
+    }
+}
+
+struct Circle {
+    r: usize,
+}
+
+impl Shape for Circle {
+    fn area(&self) -> usize {
+        3 * self.r * self.r
+    }
+}
+
+fn dispatch<S: Shape>(s: &S) -> usize {
+    s.area()
+}
+
+// A second layer of generality: `dispatch_twice::<S>` is itself only `MightPanic` as the identity
+// instance, but each mono instance is `WillNotPanic` once `dispatch::<S>` resolves.
+fn dispatch_twice<S: Shape>(a: &S, b: &S) -> usize {
+    dispatch(a) + dispatch(b)
+}
+
+#[flux::no_panic]
+fn caller() -> usize {
+    let sq = dispatch(&Square { side: 3 });
+    let ci = dispatch(&Circle { r: 2 });
+    let tw = dispatch_twice(&Square { side: 1 }, &Square { side: 2 });
+    sq + ci + tw
+}

--- a/tests/tests/pos/surface/no_panic09.rs
+++ b/tests/tests/pos/surface/no_panic09.rs
@@ -1,0 +1,29 @@
+// Regression: the instance-keying win, exercised purely by the no-panic *inference* (no flux specs,
+// no deps, no refinements) on a generic function that calls into the standard library through an
+// iterator.
+//
+// `drain<I: Iterator>` calls `it.next()`. As the *identity* instance `drain::<I>` this is an
+// unresolved `<I as Iterator>::next` trait call, so its inferred spec is `MightPanic` — a `DefId`-
+// keyed spec map (the pre-change behavior) would stop here and reject the caller. Only the *mono*
+// instance `drain::<Empty<i32>>` resolves the call to the concrete standard-library instance
+// `<core::iter::Empty<i32> as Iterator>::next`, whose monomorphized MIR returns `None` with no
+// panic edges and is `WillNotPanic`. The `#[flux::no_panic]` caller is accepted only because the
+// checker queries that mono std instance at the call site.
+
+fn drain<I: Iterator<Item = i32>>(mut it: I) -> Option<i32> {
+    it.next()
+}
+
+#[flux::no_panic]
+fn drain_empty() -> Option<i32> {
+    drain(core::iter::empty::<i32>())
+}
+
+// A direct call into a generic standard-library function: `core::iter::empty::<i32>` and the
+// monomorphized `Empty::<i32>::next` are both panic-free, so the inference proves this no-panic
+// without any instantiation in our own code.
+#[flux::no_panic]
+fn empty_next() -> Option<i32> {
+    let mut it = core::iter::empty::<i32>();
+    it.next()
+}


### PR DESCRIPTION
* Make a query for the call graph
* Add NodeKey to distinguish between source items and monomorphized items
* Key PanicSpec by NodeKey
* Recover resolved PanicSpec for callee based on the call graph in checker.rs