### PR TITLE
Higher-order (spec) functions

### DIFF
--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -2255,6 +2255,15 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 let sort = rty::Sort::Int;
                 (rty::Expr::const_generic(def_id_to_param_const(genv, def_id)).at(espan), sort)
             }
+            fhir::Res::GlobalFunc(fhir::SpecFuncKind::Def(did)) => {
+                self.hyperlink(path.span, Some(genv.func_span(did)));
+                let sort = rty::Sort::Func(genv.func_sort(did));
+                (rty::Expr::global_func(rty::SpecFuncKind::Def(did)), sort)
+            }
+            fhir::Res::GlobalFunc(fhir::SpecFuncKind::Thy(itf)) => {
+                let sort = THEORY_FUNCS.get(&itf).unwrap().sort.clone();
+                (rty::Expr::global_func(rty::SpecFuncKind::Thy(itf)), rty::Sort::Func(sort))
+            }
             _ => {
                 Err(self.emit(errors::InvalidRes { span: path.span, res_descr: path.res.descr() }))?
             }

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -1705,7 +1705,13 @@ fn parse_int<T: FromStr>(cx: &mut ParseCtxt) -> ParseResult<T> {
 ///         |  ⟨base_sort⟩ -> ⟨base_sort⟩
 /// ```
 fn parse_sort(cx: &mut ParseCtxt) -> ParseResult<Sort> {
-    if cx.peek(token::OpenParen) {
+    if cx.advance_if(kw::Fn) {
+        // fn ( ⟨base_sort⟩,* ) -> ⟨base_sort⟩
+        let inputs = parens(cx, Comma, parse_base_sort)?;
+        cx.expect(token::RArrow)?;
+        let output = parse_base_sort(cx)?;
+        Ok(Sort::Func { inputs, output })
+    } else if cx.peek(token::OpenParen) {
         // ( ⟨base_sort⟩,* ) -> ⟨base_sort⟩ | ( ⟨base_sort⟩,* )
         let inputs = parens(cx, Comma, parse_base_sort)?;
         if cx.advance_if(token::RArrow) {

--- a/tests/tests/neg/error_messages/conv/invalid_res.rs
+++ b/tests/tests/neg/error_messages/conv/invalid_res.rs
@@ -10,9 +10,6 @@ defs! {
 #[refined_by(p: int -> int)]
 struct S;
 
-#[sig(fn(S[add1]))] //~ ERROR refinement function not allowed in this position
-fn test(x: S) {}
-
 #[spec(fn() requires S(0))] //~ ERROR struct not allowed in this position
 fn foo() {}
 

--- a/tests/tests/neg/surface/hof00.rs
+++ b/tests/tests/neg/surface/hof00.rs
@@ -1,0 +1,19 @@
+#![flux::defs(
+
+    fn lt(x: int, y: int) -> bool {
+        x < y
+    }
+
+    fn cmp0(x:int, cmp: fn(int, int) -> bool) -> bool {
+        cmp(0, x)
+    }
+
+    fn pos(n: int) -> bool {
+        cmp0(n, lt)
+    }
+  )]
+
+#[flux::spec(fn() -> i32{v:pos(v)})]
+fn test_fail() -> i32 {
+    2 - 9 //~ ERROR refinement type
+}

--- a/tests/tests/pos/surface/hof00.rs
+++ b/tests/tests/pos/surface/hof00.rs
@@ -12,18 +12,9 @@
         cmp0(n, lt)
     }
 
-    fn pos_lam(n: int) -> bool {
-        cmp0(n, |x, y| { x < y } )
-    }
-
-  )]
+)]
 
 #[flux::spec(fn() -> i32{v:pos(v)})]
 fn test0() -> i32 {
-    29
-}
-
-#[flux::spec(fn() -> i32{v:pos_lam(v)})]
-fn test1() -> i32 {
     29
 }

--- a/tests/tests/pos/surface/hof00.rs
+++ b/tests/tests/pos/surface/hof00.rs
@@ -1,0 +1,19 @@
+#![flux::defs(
+
+    fn lt(x: int, y: int) -> bool {
+        x < y
+    }
+
+    fn cmp0(x:int, cmp: fn(int, int) -> bool) -> bool {
+        cmp(0, x)
+    }
+
+    fn pos(n: int) -> bool {
+        cmp0(n, lt)
+    }
+  )]
+
+#[flux::spec(fn() -> i32{v:pos(v)})]
+fn test_ok() -> i32 {
+    29
+}

--- a/tests/tests/pos/surface/hof00.rs
+++ b/tests/tests/pos/surface/hof00.rs
@@ -13,7 +13,7 @@
     }
 
     fn pos_lam(n: int) -> bool {
-        cmp0(n, |x, y| x < y)
+        cmp0(n, |x, y| { x < y } )
     }
 
   )]

--- a/tests/tests/pos/surface/hof00.rs
+++ b/tests/tests/pos/surface/hof00.rs
@@ -11,9 +11,19 @@
     fn pos(n: int) -> bool {
         cmp0(n, lt)
     }
+
+    fn pos_lam(n: int) -> bool {
+        cmp0(n, |x, y| x < y)
+    }
+
   )]
 
 #[flux::spec(fn() -> i32{v:pos(v)})]
-fn test_ok() -> i32 {
+fn test0() -> i32 {
+    29
+}
+
+#[flux::spec(fn() -> i32{v:pos_lam(v)})]
+fn test1() -> i32 {
     29
 }


### PR DESCRIPTION
Allow writing stuff like

```rust
#![flux::defs(

    fn lt(x: int, y: int) -> bool {
        x < y
    }

    fn cmp0(x:int, cmp: fn(int, int) -> bool) -> bool {
        cmp(0, x)
    }

    fn pos(n: int) -> bool {
        cmp0(n, lt)
    }

)]

#[flux::spec(fn() -> i32{v:pos(v)})]
fn test0() -> i32 {
    29
}
```