### PR TITLE
Core Ptr Specs - part 1

### DIFF
--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -102,7 +102,6 @@ unsafe fn write<T>(dst: *mut T, src: T);
 #[cfg(flux)]
 #[extern_spec(core::ptr)]
 // - `dst` must be valid for writes or `T` must be a ZST.
-// - `dst` must be properly aligned. Use `write_unaligned` if this is not the case.
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1843-L1846
 #[spec(fn (dst: *mut[@p] T, src: T) requires valid(p, T::size_of()))]
 unsafe fn write_unaligned<T>(dst: *mut T, src: T);

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -45,19 +45,19 @@ macro_rules! ptr_specs {
         #[extern_spec(core::ptr)]
         impl<T> *$mutable T {
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T)]
+                -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T requires count * T::size_of() <= p.size)]
             unsafe fn add(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr - count * T::size_of(), p.size + count * T::size_of()] T)]
+                -> *$mutable[p.base, p.addr - count * T::size_of(), p.size + count * T::size_of()] T requires count * T::size_of() <= p.size)]
             unsafe fn sub(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr + count, p.size - count] T)]
+                -> *$mutable[p.base, p.addr + count, p.size - count] T requires count <= p.size)]
             unsafe fn byte_add(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr - count, p.size + count] T)]
+                -> *$mutable[p.base, p.addr - count, p.size + count] T requires count <= p.size)]
             unsafe fn byte_sub(self, count: usize) -> Self;
         }
     };

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -45,22 +45,22 @@ macro_rules! ptr_specs {
         #[extern_spec(core::ptr)]
         impl<T> *$mutable T {
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T 
+                -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T
                     requires count * T::size_of() <= p.size)]
             unsafe fn add(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr - count * T::size_of(), p.size + count * T::size_of()] T 
+                -> *$mutable[p.base, p.addr - count * T::size_of(), p.size + count * T::size_of()] T
                     requires count * T::size_of() <= p.addr - p.base)]
             unsafe fn sub(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr + count, p.size - count] T 
+                -> *$mutable[p.base, p.addr + count, p.size - count] T
                     requires count <= p.size)]
             unsafe fn byte_add(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr - count, p.size + count] T 
+                -> *$mutable[p.base, p.addr - count, p.size + count] T
                     requires count <= p.addr - p.base)]
             unsafe fn byte_sub(self, count: usize) -> Self;
         }

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -1,3 +1,41 @@
+#![flux::defs {
+    // The provenance of the pointer is used to determine which allocation it
+    // is derived from; a pointer is dereferenceable if the memory range of
+    // the given size starting at the pointer is entirely contained within the
+    // bounds of that allocation.
+    // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L21-L25
+    fn dereferenceable(p: ptr, num_bytes: int) -> bool {
+        p.addr >= p.base && num_bytes <= p.size && p.size >= 0
+    }
+
+    // Guarantees (in order of precenence):
+    // - A null pointer is never valid
+    // - For memory accesses of size zero, every non-null pointer is valid for reads/writes.
+    // - Memory accesses of size zero are always valid
+    // - A valid pointer is dereferenceable
+    // See: https://doc.rust-lang.org/std/ptr/index.html#safety
+    fn valid(p: ptr, num_bytes: int) -> bool {
+        p.addr != 0 && dereferenceable(p, num_bytes)
+    }
+
+    // The above is only partially true: for operations that don't convert
+    // pointers into references (such as read and write), zero-sized
+    // reads/writes of null pointers are valid
+    // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L41-L46
+    fn valid_zst(p: ptr, num_bytes: int) -> bool {
+        num_bytes == 0 || valid(p, num_bytes)
+    }
+
+    // Valid raw pointers as defined above are not necessarily properly aligned
+    // (where “proper” alignment is defined by the pointee type, i.e.,
+    // `*const T` must be aligned to `align_of::<T>()`). However, most
+    // functions require their arguments to be properly aligned,
+    // and will explicitly state this requirement in their documentation.
+    // Notable exceptions to this are `read_unaligned` and `write_unaligned.`
+    // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L54-L59
+    fn aligned(p: ptr, alignment: int) -> bool { p.addr % alignment == 0 }
+}]
+
 #[cfg(flux)]
 use flux_attrs::*;
 
@@ -6,8 +44,21 @@ macro_rules! ptr_specs {
     ($mutable:tt) => {
         #[extern_spec(core::ptr)]
         impl<T> *$mutable T {
-            #[spec(fn (me: *$mutable[@base, @addr, @size] T, count: usize) -> *$mutable[base, addr + count, size - count] T)]
+            #[spec(fn (me: *$mutable[@p] T, count: usize)
+                -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T)]
             unsafe fn add(self, count: usize) -> Self;
+
+            #[spec(fn (me: *$mutable[@p] T, count: usize)
+                -> *$mutable[p.base, p.addr - count * T::size_of(), p.size + count * T::size_of()] T)]
+            unsafe fn sub(self, count: usize) -> Self;
+
+            #[spec(fn (me: *$mutable[@p] T, count: usize)
+                -> *$mutable[p.base, p.addr + count, p.size - count] T)]
+            unsafe fn byte_add(self, count: usize) -> Self;
+
+            #[spec(fn (me: *$mutable[@p] T, count: usize)
+                -> *$mutable[p.base, p.addr - count, p.size + count] T)]
+            unsafe fn byte_sub(self, count: usize) -> Self;
         }
     };
 }
@@ -20,10 +71,34 @@ ptr_specs!(mut);
 
 #[cfg(flux)]
 #[extern_spec(core::ptr)]
-#[spec(fn (src: *const{p: p.addr >= p.base && p.size > 0} T) -> T)]
+// - `src` must be valid for reads or `T` must be a ZST.
+// - `src` must be properly aligned. Use `read_unaligned` if this is not the case.
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1591-L1596
+#[spec(fn (src: *const[@p] T) -> T requires
+    valid_zst(p, T::size_of()) && aligned(p, T::align_of()))]
 unsafe fn read<T>(src: *const T) -> T;
 
 #[cfg(flux)]
 #[extern_spec(core::ptr)]
-#[spec(fn (dst: *mut{p: p.addr >= p.base && p.size > 0} T, src: T))]
+#[spec(fn (src: *const[@p] T) -> T requires valid_zst(p, T::size_of()))]
+// - `src` must be valid for reads.
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1744-L1748
+// TODO: Why are the rules for ZSTs different here?
+unsafe fn read_unaligned<T>(src: *const T) -> T;
+
+#[cfg(flux)]
+#[extern_spec(core::ptr)]
+// - `dst` must be valid for writes  or `T` must be a ZST.
+// - `dst` must be properly aligned. Use `write_unaligned` if this is not the case.
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1843-L1846
+#[spec(fn (dst: *mut[@p] T, src: T) requires
+    valid_zst(p, T::size_of()) && aligned(p, T::align_of()))]
 unsafe fn write<T>(dst: *mut T, src: T);
+
+#[cfg(flux)]
+#[extern_spec(core::ptr)]
+// - `dst` must be valid for writes  or `T` must be a ZST.
+// - `dst` must be properly aligned. Use `write_unaligned` if this is not the case.
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1843-L1846
+#[spec(fn (dst: *mut[@p] T, src: T) requires valid_zst(p, T::size_of()))]
+unsafe fn write_unaligned<T>(dst: *mut T, src: T);

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -8,7 +8,7 @@
         p.addr >= p.base && num_bytes <= p.size && p.size >= 0
     }
 
-    // Guarantees (in order of precenence):
+    // Guarantees (in order of precedence):
     // - A null pointer is never valid
     // - For memory accesses of size zero, every non-null pointer is valid for reads/writes.
     // - Memory accesses of size zero are always valid
@@ -31,7 +31,7 @@
     // `*const T` must be aligned to `align_of::<T>()`). However, most
     // functions require their arguments to be properly aligned,
     // and will explicitly state this requirement in their documentation.
-    // Notable exceptions to this are `read_unaligned` and `write_unaligned.`
+    // Notable exceptions to this are `read_unaligned` and `write_unaligned`.
     // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L54-L59
     fn aligned(p: ptr, alignment: int) -> bool { p.addr % alignment == 0 }
 }]
@@ -88,7 +88,7 @@ unsafe fn read_unaligned<T>(src: *const T) -> T;
 
 #[cfg(flux)]
 #[extern_spec(core::ptr)]
-// - `dst` must be valid for writes  or `T` must be a ZST.
+// - `dst` must be valid for writes or `T` must be a ZST.
 // - `dst` must be properly aligned. Use `write_unaligned` if this is not the case.
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1843-L1846
 #[spec(fn (dst: *mut[@p] T, src: T) requires
@@ -97,7 +97,7 @@ unsafe fn write<T>(dst: *mut T, src: T);
 
 #[cfg(flux)]
 #[extern_spec(core::ptr)]
-// - `dst` must be valid for writes  or `T` must be a ZST.
+// - `dst` must be valid for writes or `T` must be a ZST.
 // - `dst` must be properly aligned. Use `write_unaligned` if this is not the case.
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1843-L1846
 #[spec(fn (dst: *mut[@p] T, src: T) requires valid_zst(p, T::size_of()))]

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -14,7 +14,7 @@
     // - Memory accesses of size zero are always valid
     // - A valid pointer is dereferenceable
     // See: https://doc.rust-lang.org/std/ptr/index.html#safety
-    fn valid(p: ptr, num_bytes: int) -> bool {
+    fn valid_no_zst(p: ptr, num_bytes: int) -> bool {
         p.addr != 0 && dereferenceable(p, num_bytes)
     }
 
@@ -22,8 +22,8 @@
     // pointers into references (such as read and write), zero-sized
     // reads/writes of null pointers are valid
     // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L41-L46
-    fn valid_zst(p: ptr, num_bytes: int) -> bool {
-        num_bytes == 0 || valid(p, num_bytes)
+    fn valid(p: ptr, num_bytes: int) -> bool {
+        num_bytes == 0 || valid_no_zst(p, num_bytes)
     }
 
     // Valid raw pointers as defined above are not necessarily properly aligned
@@ -33,7 +33,7 @@
     // and will explicitly state this requirement in their documentation.
     // Notable exceptions to this are `read_unaligned` and `write_unaligned`.
     // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L54-L59
-    fn aligned(p: ptr, alignment: int) -> bool { p.addr % alignment == 0 }
+    fn aligned_to(p: ptr, alignment: int) -> bool { p.addr % alignment == 0 }
 }]
 
 #[cfg(flux)]
@@ -45,19 +45,23 @@ macro_rules! ptr_specs {
         #[extern_spec(core::ptr)]
         impl<T> *$mutable T {
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T requires count * T::size_of() <= p.size)]
+                -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T 
+                    requires count * T::size_of() <= p.size)]
             unsafe fn add(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr - count * T::size_of(), p.size + count * T::size_of()] T requires count * T::size_of() <= p.size)]
+                -> *$mutable[p.base, p.addr - count * T::size_of(), p.size + count * T::size_of()] T 
+                    requires count * T::size_of() <= p.addr - p.base)]
             unsafe fn sub(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr + count, p.size - count] T requires count <= p.size)]
+                -> *$mutable[p.base, p.addr + count, p.size - count] T 
+                    requires count <= p.size)]
             unsafe fn byte_add(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
-                -> *$mutable[p.base, p.addr - count, p.size + count] T requires count <= p.size)]
+                -> *$mutable[p.base, p.addr - count, p.size + count] T 
+                    requires count <= p.addr - p.base)]
             unsafe fn byte_sub(self, count: usize) -> Self;
         }
     };
@@ -75,12 +79,12 @@ ptr_specs!(mut);
 // - `src` must be properly aligned. Use `read_unaligned` if this is not the case.
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1591-L1596
 #[spec(fn (src: *const[@p] T) -> T requires
-    valid_zst(p, T::size_of()) && aligned(p, T::align_of()))]
+    valid(p, T::size_of()) && aligned_to(p, T::align_of()))]
 unsafe fn read<T>(src: *const T) -> T;
 
 #[cfg(flux)]
 #[extern_spec(core::ptr)]
-#[spec(fn (src: *const[@p] T) -> T requires valid_zst(p, T::size_of()))]
+#[spec(fn (src: *const[@p] T) -> T requires valid(p, T::size_of()))]
 // - `src` must be valid for reads.
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1744-L1748
 // TODO: Why are the rules for ZSTs different here?
@@ -92,7 +96,7 @@ unsafe fn read_unaligned<T>(src: *const T) -> T;
 // - `dst` must be properly aligned. Use `write_unaligned` if this is not the case.
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1843-L1846
 #[spec(fn (dst: *mut[@p] T, src: T) requires
-    valid_zst(p, T::size_of()) && aligned(p, T::align_of()))]
+    valid(p, T::size_of()) && aligned_to(p, T::align_of()))]
 unsafe fn write<T>(dst: *mut T, src: T);
 
 #[cfg(flux)]
@@ -100,5 +104,5 @@ unsafe fn write<T>(dst: *mut T, src: T);
 // - `dst` must be valid for writes or `T` must be a ZST.
 // - `dst` must be properly aligned. Use `write_unaligned` if this is not the case.
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1843-L1846
-#[spec(fn (dst: *mut[@p] T, src: T) requires valid_zst(p, T::size_of()))]
+#[spec(fn (dst: *mut[@p] T, src: T) requires valid(p, T::size_of()))]
 unsafe fn write_unaligned<T>(dst: *mut T, src: T);

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -101,10 +101,12 @@ impl<T> [T] {
     fn split_at_mut_checked(&mut self, mid: usize) -> Option<(&mut [T], &mut [T])>;
 
     #[no_panic]
-    #[spec(fn(&Self[@n]) -> {base:int, addr:int. *const[base, addr, n] T | addr >= base})]
+    #[spec(fn(&Self[@n]) -> {base:int, addr:int. *const[base, addr, n * T::size_of()] T
+        | base >= 0 && base % T::align_of() == 0 && base == addr && addr != 0})]
     fn as_ptr(&self) -> *const T;
 
     #[no_panic]
-    #[spec(fn(&mut Self[@n]) -> {base:int, addr:int. *mut[base, addr, n] T | addr >= base})]
+    #[spec(fn(&mut Self[@n]) -> {base:int, addr:int. *mut[base, addr, n * T::size_of()] T
+        | base >= 0 && base % T::align_of() == 0 && base == addr && addr != 0})]
     fn as_mut_ptr(&mut self) -> *mut T;
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
@@ -1,37 +1,37 @@
 extern crate flux_core;
 
-#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size > 1}))]
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size > 8 && addr != 0 && addr % 4 == 0}))]
 pub fn test_add_ex(ptr: *const i32) {
     unsafe {
         let _val0 = std::ptr::read(ptr.add(0));
-        let _val1 = std::ptr::read(ptr.add(1));
+        let _val1 = std::ptr::read(ptr.add(1)); //~ ERROR: refinement type error
         let _val2 = std::ptr::read(ptr.add(2)); //~ ERROR: refinement type error
     }
 }
 
-#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 2}))]
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8 && addr != 0 && addr % 4 == 0}))]
 pub fn test_add_ix(ptr: *const i32) {
     unsafe {
         let _val0 = std::ptr::read(ptr.add(0));
-        let _val1 = std::ptr::read(ptr.add(1));
+        let _val1 = std::ptr::read(ptr.add(1)); //~ ERROR: refinement type error
         let _val2 = std::ptr::read(ptr.add(2)); //~ ERROR: refinement type error
     }
 }
 
-#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && size > 1}))]
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && size > 20 && addr != 0 && addr % 4 == 0}))]
 pub fn test_add_mut_ex(ptr: *mut i32) {
     unsafe {
         std::ptr::write(ptr.add(0), 10);
-        std::ptr::write(ptr.add(1), 20);
+        std::ptr::write(ptr.add(1), 20); //~ ERROR: refinement type error
         std::ptr::write(ptr.add(2), 30); //~ ERROR: refinement type error
     }
 }
 
-#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && size == 2}))]
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && size == 8 && addr != 0 && addr % 4 == 0}))]
 pub fn test_add_mut_ix(ptr: *mut i32) {
     unsafe {
         std::ptr::write(ptr.add(0), 10);
-        std::ptr::write(ptr.add(1), 20);
+        std::ptr::write(ptr.add(1), 20); //~ ERROR: refinement type error
         std::ptr::write(ptr.add(2), 30); //~ ERROR: refinement type error
     }
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
@@ -1,11 +1,13 @@
 extern crate flux_core;
 
+// --- add ---
+
 #[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size > 8 && addr != 0 && addr % 4 == 0}))]
 pub fn test_add_ex(ptr: *const i32) {
     unsafe {
         let _val0 = std::ptr::read(ptr.add(0));
-        let _val1 = std::ptr::read(ptr.add(1)); //~ ERROR: refinement type error
-        let _val2 = std::ptr::read(ptr.add(2)); //~ ERROR: refinement type error
+        let _val1 = std::ptr::read(ptr.add(1)); //~ ERROR refinement type error
+        let _val2 = std::ptr::read(ptr.add(2)); //~ ERROR refinement type error
     }
 }
 
@@ -13,17 +15,17 @@ pub fn test_add_ex(ptr: *const i32) {
 pub fn test_add_ix(ptr: *const i32) {
     unsafe {
         let _val0 = std::ptr::read(ptr.add(0));
-        let _val1 = std::ptr::read(ptr.add(1)); //~ ERROR: refinement type error
-        let _val2 = std::ptr::read(ptr.add(2)); //~ ERROR: refinement type error
+        let _val1 = std::ptr::read(ptr.add(1)); //~ ERROR refinement type error
+        let _val2 = std::ptr::read(ptr.add(2)); //~ ERROR refinement type error
     }
 }
 
-#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && size > 20 && addr != 0 && addr % 4 == 0}))]
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && size > 8 && addr != 0 && addr % 4 == 0}))]
 pub fn test_add_mut_ex(ptr: *mut i32) {
     unsafe {
         std::ptr::write(ptr.add(0), 10);
-        std::ptr::write(ptr.add(1), 20); //~ ERROR: refinement type error
-        std::ptr::write(ptr.add(2), 30); //~ ERROR: refinement type error
+        std::ptr::write(ptr.add(1), 20); //~ ERROR refinement type error
+        std::ptr::write(ptr.add(2), 30); //~ ERROR refinement type error
     }
 }
 
@@ -31,7 +33,7 @@ pub fn test_add_mut_ex(ptr: *mut i32) {
 pub fn test_add_mut_ix(ptr: *mut i32) {
     unsafe {
         std::ptr::write(ptr.add(0), 10);
-        std::ptr::write(ptr.add(1), 20); //~ ERROR: refinement type error
-        std::ptr::write(ptr.add(2), 30); //~ ERROR: refinement type error
+        std::ptr::write(ptr.add(1), 20); //~ ERROR refinement type error
+        std::ptr::write(ptr.add(2), 30); //~ ERROR refinement type error
     }
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr02.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr02.rs
@@ -8,6 +8,6 @@ pub fn test(buf: &mut [u32; 2]) {
     unsafe {
         std::ptr::write(ptr.add(0), 10);
         std::ptr::write(ptr.add(1), 20);
-        std::ptr::write(ptr.add(2), 30); //~ ERROR: refinement type error
+        std::ptr::write(ptr.add(2), 30); //~ ERROR refinement type error
     }
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr03.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr03.rs
@@ -1,0 +1,32 @@
+extern crate flux_core;
+
+// --- sub ---
+
+// sub(1) moves addr before base, making the pointer invalid for reads/writes
+pub fn test_sub_oob(buf: &mut [i32; 2]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        std::ptr::write(ptr.sub(1), 10); //~ ERROR refinement type error
+    }
+}
+
+// --- byte_add ---
+
+// byte_add(8) exhausts the 8-byte buffer, leaving size == 0
+pub fn test_byte_add_oob(buf: &mut [i32; 2]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        std::ptr::write(ptr.byte_add(8), 10); //~ ERROR refinement type error
+    }
+}
+
+// --- byte_sub ---
+
+// byte_sub(8) moves addr before base
+pub fn test_byte_sub_oob(buf: &mut [i32; 2]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        let ptr1 = ptr.byte_add(4);
+        std::ptr::write(ptr1.byte_sub(8), 10); //~ ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr03.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr03.rs
@@ -28,5 +28,6 @@ pub fn test_byte_sub_oob(buf: &mut [i32; 2]) {
     unsafe {
         let ptr1 = ptr.byte_add(4);
         std::ptr::write(ptr1.byte_sub(8), 10); //~ ERROR refinement type error
+                                               //~| ERROR refinement type error
     }
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr03.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr03.rs
@@ -7,6 +7,7 @@ pub fn test_sub_oob(buf: &mut [i32; 2]) {
     let ptr = buf.as_mut_ptr();
     unsafe {
         std::ptr::write(ptr.sub(1), 10); //~ ERROR refinement type error
+                                        //~| ERROR refinement type error
     }
 }
 

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr04.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr04.rs
@@ -1,0 +1,14 @@
+extern crate flux_core;
+
+// --- read_unaligned ---
+
+// No preconditions on the pointer — validity cannot be verified
+pub fn test_read_unaligned_invalid(ptr: *const i32) -> i32 {
+    unsafe { std::ptr::read_unaligned(ptr) } //~ ERROR refinement type error
+}
+
+// --- write_unaligned ---
+
+pub fn test_write_unaligned_invalid(ptr: *mut i32, val: i32) {
+    unsafe { std::ptr::write_unaligned(ptr, val) } //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr00.rs
@@ -1,5 +1,3 @@
-use flux_attrs::*;
-
 extern crate flux_core;
 
 #[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}) -> i32)]

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr00.rs
@@ -2,38 +2,40 @@ use flux_attrs::*;
 
 extern crate flux_core;
 
-#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size > 0}) -> i32)]
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}) -> i32)]
 fn read(ptr: *const i32) -> i32 {
     unsafe { std::ptr::read(ptr) }
 }
 
-#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 10}) -> i32)]
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size == 10 && addr % 4 == 0}) -> i32)]
 fn read_ix(ptr: *const i32) -> i32 {
     unsafe { std::ptr::read(ptr) }
 }
 
-#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && size > 0}, value: i32))]
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}, value: i32))]
 fn write_i32(ptr: *mut i32, value: i32) {
     unsafe {
         std::ptr::write(ptr, value);
     }
 }
 
-#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && size == 99}, value: i32))]
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size == 99 && addr % 4 == 0}, value: i32))]
 fn write_ix_i32(ptr: *mut i32, value: i32) {
     unsafe {
         std::ptr::write(ptr, value);
     }
 }
 
-#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] T | addr >= base && size > 0}, value: T))]
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] T | addr >= base && addr > 0 && size >= T::size_of() && addr % T::align_of() == 0}, value: T)
+    requires T::size_of() > 0)]
 fn write<T>(ptr: *mut T, value: T) {
     unsafe {
         std::ptr::write(ptr, value);
     }
 }
 
-#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] T | addr >= base && size == 99}, value: T))]
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] T | addr >= base && addr > 0 && size == 99 && addr % T::align_of() == 0}, value: T)
+    requires T::size_of() > 0 && T::size_of() <= 99)]
 fn write_ix<T>(ptr: *mut T, value: T) {
     unsafe {
         std::ptr::write(ptr, value);

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr01.rs
@@ -1,6 +1,6 @@
 extern crate flux_core;
 
-#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size > 1}))]
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 8 && addr % 4 == 0}))]
 pub fn test_add_ex(ptr: *const i32) {
     unsafe {
         let _val0 = std::ptr::read(ptr.add(0));
@@ -8,7 +8,7 @@ pub fn test_add_ex(ptr: *const i32) {
     }
 }
 
-#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 2}))]
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size == 8 && addr % 4 == 0}))]
 pub fn test_add_ix(ptr: *const i32) {
     unsafe {
         let _val0 = std::ptr::read(ptr.add(0));
@@ -16,7 +16,7 @@ pub fn test_add_ix(ptr: *const i32) {
     }
 }
 
-#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && size > 1}))]
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 8 && addr % 4 == 0}))]
 pub fn test_add_mut_ex(ptr: *mut i32) {
     unsafe {
         std::ptr::write(ptr.add(0), 10);
@@ -24,7 +24,7 @@ pub fn test_add_mut_ex(ptr: *mut i32) {
     }
 }
 
-#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && size == 2}))]
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size == 8 && addr % 4 == 0}))]
 pub fn test_add_mut_ix(ptr: *mut i32) {
     unsafe {
         std::ptr::write(ptr.add(0), 10);

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr03.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr03.rs
@@ -1,0 +1,43 @@
+extern crate flux_core;
+
+// --- sub ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 8 && addr % 4 == 0}))]
+pub fn test_sub_ex(ptr: *const i32) {
+    unsafe {
+        let ptr1 = ptr.add(1);
+        let ptr0 = ptr1.sub(1);
+        let _val = std::ptr::read(ptr0);
+    }
+}
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size == 8 && addr % 4 == 0}))]
+pub fn test_sub_ix(ptr: *const i32) {
+    unsafe {
+        let ptr1 = ptr.add(1);
+        let ptr0 = ptr1.sub(1);
+        let _val = std::ptr::read(ptr0);
+    }
+}
+
+// --- byte_add ---
+
+pub fn test_byte_add(buf: &mut [i32; 2]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        std::ptr::write(ptr.byte_add(0), 10);
+        std::ptr::write(ptr.byte_add(4), 20);
+    }
+}
+
+// --- byte_sub ---
+
+pub fn test_byte_sub(buf: &mut [i32; 2]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        let ptr1 = ptr.byte_add(4);
+        let ptr0 = ptr1.byte_sub(4);
+        std::ptr::write(ptr0, 10);
+        std::ptr::write(ptr1, 20);
+    }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr04.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr04.rs
@@ -1,0 +1,16 @@
+extern crate flux_core;
+
+// --- read_unaligned ---
+
+// Only validity is required, not alignment
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4}) -> i32)]
+pub fn test_read_unaligned(ptr: *const i32) -> i32 {
+    unsafe { std::ptr::read_unaligned(ptr) }
+}
+
+// --- write_unaligned ---
+
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4}, val: i32))]
+pub fn test_write_unaligned(ptr: *mut i32, val: i32) {
+    unsafe { std::ptr::write_unaligned(ptr, val) }
+}


### PR DESCRIPTION
This will be the first of a set of 3-4 PRs merging core library ptr specs.
In particular, this PR adds:
1. `add`, `sub`, `byte_add`, `byte_sub`, `read`, `read_unaligned`, `write`, `write_unaligned`, `Slice::as_ptr`, and `Slice::as_mut_ptr`.
2. flux_defs like `dereferencable`, `valid`, `aligned` and `valid_zst` to help us write clean specs for pointer functions in the future.
3. Tests for the above specs