### PR TITLE
Use correct `DefId` (sized_id) when building BUILTIN assoc-refts

### DIFF
--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -331,13 +331,11 @@ fn trigger_queries(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult {
             genv.generics_of(def_id)?;
             genv.predicates_of(def_id)?;
             genv.refinement_generics_of(def_id)?;
-            genv.assoc_refinements_of(def_id)?;
         }
         DefKind::Impl { .. } => {
             genv.generics_of(def_id)?;
             genv.predicates_of(def_id)?;
             genv.refinement_generics_of(def_id)?;
-            genv.assoc_refinements_of(def_id)?;
         }
         DefKind::Fn | DefKind::AssocFn => {
             genv.generics_of(def_id)?;

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -265,12 +265,13 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
             metrics::incr_metric_if(is_fn_with_body, Metric::FnIgnored);
             return Ok(());
         }
+
+        trigger_queries(genv, def_id).emit(&genv)?;
+
         if !self.genv.included(def_id) {
             metrics::incr_metric_if(is_fn_with_body, Metric::FnTrusted);
             return Ok(());
         }
-
-        trigger_queries(genv, def_id).emit(&genv)?;
 
         match kind {
             DefKind::Fn | DefKind::AssocFn => {

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -265,7 +265,7 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
             metrics::incr_metric_if(is_fn_with_body, Metric::FnIgnored);
             return Ok(());
         }
-
+        // Make sure to trigger queries for non-ignored items, EVEN those that are NOT included
         trigger_queries(genv, def_id).emit(&genv)?;
 
         if !self.genv.included(def_id) {

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -265,13 +265,13 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
             metrics::incr_metric_if(is_fn_with_body, Metric::FnIgnored);
             return Ok(());
         }
-        // Make sure to trigger queries for non-ignored items, EVEN those that are NOT included
-        trigger_queries(genv, def_id).emit(&genv)?;
 
         if !self.genv.included(def_id) {
             metrics::incr_metric_if(is_fn_with_body, Metric::FnTrusted);
             return Ok(());
         }
+
+        trigger_queries(genv, def_id).emit(&genv)?;
 
         match kind {
             DefKind::Fn | DefKind::AssocFn => {
@@ -331,11 +331,13 @@ fn trigger_queries(genv: GlobalEnv, def_id: MaybeExternId) -> QueryResult {
             genv.generics_of(def_id)?;
             genv.predicates_of(def_id)?;
             genv.refinement_generics_of(def_id)?;
+            genv.assoc_refinements_of(def_id)?;
         }
         DefKind::Impl { .. } => {
             genv.generics_of(def_id)?;
             genv.predicates_of(def_id)?;
             genv.refinement_generics_of(def_id)?;
+            genv.assoc_refinements_of(def_id)?;
         }
         DefKind::Fn | DefKind::AssocFn => {
             genv.generics_of(def_id)?;

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -265,7 +265,6 @@ impl<'genv, 'tcx> CrateChecker<'genv, 'tcx> {
             metrics::incr_metric_if(is_fn_with_body, Metric::FnIgnored);
             return Ok(());
         }
-
         if !self.genv.included(def_id) {
             metrics::incr_metric_if(is_fn_with_body, Metric::FnTrusted);
             return Ok(());

--- a/crates/flux-middle/src/builtin_assoc_refts.rs
+++ b/crates/flux-middle/src/builtin_assoc_refts.rs
@@ -47,12 +47,12 @@ impl<'tcx> GlobalEnv<'_, 'tcx> {
                     AssocRefinements {
                         items: List::from_arr([
                             AssocReft::new(
-                                FluxDefId::new(def_id, sym::size_of),
+                                FluxDefId::new(sized_id, sym::size_of),
                                 false,
                                 tcx.def_span(sized_id),
                             ),
                             AssocReft::new(
-                                FluxDefId::new(def_id, sym::align_of),
+                                FluxDefId::new(sized_id, sym::align_of),
                                 false,
                                 tcx.def_span(sized_id),
                             ),

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -771,7 +771,7 @@ pub struct CoroutineObligPredicate {
     pub args: flux_rustc_bridge::ty::GenericArgs,
 }
 
-#[derive(Copy, Clone, Encodable, Decodable, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Encodable, Decodable, Hash, PartialEq, Debug, Eq)]
 pub struct AssocReft {
     pub def_id: FluxDefId,
     // NOTE: Field is used to denote final associated generic refinements on Traits
@@ -810,7 +810,9 @@ impl AssocRefinements {
             .items
             .into_iter()
             .find(|it| it.def_id == assoc_id)
-            .unwrap_or_else(|| bug!("caller should guarantee existence of associated refinement"))
+            .unwrap_or_else(|| {
+                bug!("caller should guarantee existence of associated refinement {assoc_id:?}")
+            })
     }
 
     pub fn find(&self, name: Symbol) -> Option<AssocReft> {


### PR DESCRIPTION
This fixes a bug where `cargo flux` finishes fine but `cargo flux --only-check <PATH>` was ICE-ing because of missing stuff e.g.

```
error: internal compiler error: crates/flux-middle/src/rty/mod.rs:813:32: caller should guarantee existence of associated refinement
```

The bug was because FLUX could not find the assoc refinement `size_of`.

Per CC

```
 The `def_id` here is the argument to `builtin_assoc_refts(self, def_id: DefId)` — it's whatever `DefId` was passed to look up. But this code is inside a
  `OnceLock::get_or_init` closure, so it only runs once — on the very first call. 
  The `def_id` captured in the closure is the `def_id` from that first call,
  which might not be `sized_id` at all.

  Compare with line 36 for `FnOnce`, which correctly uses `fn_once_id`:
  `FluxDefId::new(fn_once_id, sym::no_panic),  // correct: uses fn_once_id`

  And line 94 in builtin_assoc_reft_sort, which also correctly uses `sized_id`:
  `FluxDefId::new(sized_id, sym::size_of),  // correct: uses sized_id`

  The bug: Lines 50 and 54 use def_id (the function parameter, captured by the OnceLock closure) instead of sized_id. The first time builtin_assoc_refts is
  called, def_id gets baked into the FluxDefId for size_of and align_of. If that first call happens to pass sized_id, it works. If a different def_id is
  passed first, the FluxDefId is wrong, and later lookups by assoc_id won't match.

  With plain cargo flux, the iteration order over defs happens to call this with sized_id first (or the Sized trait is looked up first). With --only-check,
  a different def triggers the first call, so def_id is some unrelated DefId, and the FluxDefId for size_of/align_of is permanently wrong.

  The fix is to replace def_id with sized_id on lines 50 and 54.
```

@nilehmann does this "fix" seem correct to you?
