### PR TITLE
Core pointer specs part 2: Copy & Swap

### DIFF
--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -63,6 +63,11 @@ macro_rules! ptr_specs {
                 -> *$mutable[p.base, p.addr - count, p.size + count] T
                     requires count <= p.addr - p.base)]
             unsafe fn byte_sub(self, count: usize) -> Self;
+
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L22
+            #[no_panic]
+            #[spec(fn (me: *$mutable[@p] T) -> bool[p.addr == 0])]
+            fn is_null(self) -> bool;
         }
     };
 }

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -34,6 +34,12 @@
     // Notable exceptions to this are `read_unaligned` and `write_unaligned`.
     // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L54-L59
     fn aligned_to(p: ptr, alignment: int) -> bool { p.addr % alignment == 0 }
+
+    // Two byte ranges of equal length starting at p and q do not overlap.
+    // Trivially true when num_bytes == 0 (empty intervals never intersect).
+    fn nonoverlapping(p: ptr, q: ptr, num_bytes: int) -> bool {
+        p.addr + num_bytes <= q.addr || q.addr + num_bytes <= p.addr
+    }
 }]
 
 use flux_attrs::*;
@@ -110,3 +116,27 @@ unsafe fn write_unaligned<T>(dst: *mut T, src: T);
 #[spec(fn (dst: *mut[@p] T, val: u8, count: usize) requires
     valid(p, count * T::size_of()) && aligned_to(p, T::align_of()))]
 unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
+
+#[extern_spec(core::ptr)]
+// - `src` must be valid for reads of `count * size_of::<T>()` bytes, or that number must be 0.
+// - `dst` must be valid for writes of `count * size_of::<T>()` bytes, or that number must be 0.
+// - Both `src` and `dst` must be properly aligned, even for zero-size copies.
+// Overlap between `src` and `dst` is permitted (memmove semantics).
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L627
+#[spec(fn (src: *const[@src_p] T, dst: *mut[@dst_p] T, count: usize) requires
+    valid(src_p, count * T::size_of()) && aligned_to(src_p, T::align_of()) &&
+    valid(dst_p, count * T::size_of()) && aligned_to(dst_p, T::align_of()))]
+unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
+
+#[extern_spec(core::ptr)]
+// - `src` must be valid for reads of `count * size_of::<T>()` bytes, or that number must be 0.
+// - `dst` must be valid for writes of `count * size_of::<T>()` bytes, or that number must be 0.
+// - Both `src` and `dst` must be properly aligned, even for zero-size copies.
+// - The byte ranges `[src, src + count * size_of::<T>())` and `[dst, dst + count * size_of::<T>())`
+//   must not overlap.
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L530
+#[spec(fn (src: *const[@src_p] T, dst: *mut[@dst_p] T, count: usize) requires
+    valid(src_p, count * T::size_of()) && aligned_to(src_p, T::align_of()) &&
+    valid(dst_p, count * T::size_of()) && aligned_to(dst_p, T::align_of()) &&
+    nonoverlapping(src_p, dst_p, count * T::size_of()))]
+unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -36,10 +36,8 @@
     fn aligned_to(p: ptr, alignment: int) -> bool { p.addr % alignment == 0 }
 }]
 
-#[cfg(flux)]
 use flux_attrs::*;
 
-#[cfg(flux)]
 macro_rules! ptr_specs {
     ($mutable:tt) => {
         #[extern_spec(core::ptr)]
@@ -72,13 +70,10 @@ macro_rules! ptr_specs {
     };
 }
 
-#[cfg(flux)]
 ptr_specs!(const);
 
-#[cfg(flux)]
 ptr_specs!(mut);
 
-#[cfg(flux)]
 #[extern_spec(core::ptr)]
 // - `src` must be valid for reads or `T` must be a ZST.
 // - `src` must be properly aligned. Use `read_unaligned` if this is not the case.
@@ -87,7 +82,6 @@ ptr_specs!(mut);
     valid(p, T::size_of()) && aligned_to(p, T::align_of()))]
 unsafe fn read<T>(src: *const T) -> T;
 
-#[cfg(flux)]
 #[extern_spec(core::ptr)]
 #[spec(fn (src: *const[@p] T) -> T requires valid(p, T::size_of()))]
 // - `src` must be valid for reads.
@@ -95,7 +89,6 @@ unsafe fn read<T>(src: *const T) -> T;
 // TODO: Why are the rules for ZSTs different here?
 unsafe fn read_unaligned<T>(src: *const T) -> T;
 
-#[cfg(flux)]
 #[extern_spec(core::ptr)]
 // - `dst` must be valid for writes or `T` must be a ZST.
 // - `dst` must be properly aligned. Use `write_unaligned` if this is not the case.
@@ -104,14 +97,12 @@ unsafe fn read_unaligned<T>(src: *const T) -> T;
     valid(p, T::size_of()) && aligned_to(p, T::align_of()))]
 unsafe fn write<T>(dst: *mut T, src: T);
 
-#[cfg(flux)]
 #[extern_spec(core::ptr)]
 // - `dst` must be valid for writes or `T` must be a ZST.
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1843-L1846
 #[spec(fn (dst: *mut[@p] T, src: T) requires valid(p, T::size_of()))]
 unsafe fn write_unaligned<T>(dst: *mut T, src: T);
 
-#[cfg(flux)]
 #[extern_spec(core::ptr)]
 // - `dst` must be valid for writes of `count * size_of::<T>()` bytes.
 // - `dst` must be properly aligned to `align_of::<T>()`, even for zero-size writes.

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -110,3 +110,12 @@ unsafe fn write<T>(dst: *mut T, src: T);
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1843-L1846
 #[spec(fn (dst: *mut[@p] T, src: T) requires valid(p, T::size_of()))]
 unsafe fn write_unaligned<T>(dst: *mut T, src: T);
+
+#[cfg(flux)]
+#[extern_spec(core::ptr)]
+// - `dst` must be valid for writes of `count * size_of::<T>()` bytes.
+// - `dst` must be properly aligned to `align_of::<T>()`, even for zero-size writes.
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L701
+#[spec(fn (dst: *mut[@p] T, val: u8, count: usize) requires
+    valid(p, count * T::size_of()) && aligned_to(p, T::align_of()))]
+unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize);

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -36,7 +36,6 @@
     fn aligned_to(p: ptr, alignment: int) -> bool { p.addr % alignment == 0 }
 
     // Two byte ranges of equal length starting at p and q do not overlap.
-    // Trivially true when num_bytes == 0 (empty intervals never intersect).
     fn nonoverlapping(p: ptr, q: ptr, num_bytes: int) -> bool {
         p.addr + num_bytes <= q.addr || q.addr + num_bytes <= p.addr
     }
@@ -140,3 +139,25 @@ unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
     valid(dst_p, count * T::size_of()) && aligned_to(dst_p, T::align_of()) &&
     nonoverlapping(src_p, dst_p, count * T::size_of()))]
 unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
+
+#[extern_spec(core::ptr)]
+// - Both `x` and `y` must be valid for both reads and writes of `size_of::<T>()` bytes.
+// - Both `x` and `y` must be properly aligned, even if `T` has size 0.
+// Overlap between `x` and `y` is permitted.
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1316
+#[spec(fn (x: *mut[@xp] T, y: *mut[@yp] T) requires
+    valid(xp, T::size_of()) && aligned_to(xp, T::align_of()) &&
+    valid(yp, T::size_of()) && aligned_to(yp, T::align_of()))]
+unsafe fn swap<T>(x: *mut T, y: *mut T);
+
+#[extern_spec(core::ptr)]
+// - Both `x` and `y` must be valid for both reads and writes of `count * size_of::<T>()` bytes.
+// - Both `x` and `y` must be properly aligned, even for zero-size swaps.
+// - The byte ranges `[x, x + count * size_of::<T>())` and `[y, y + count * size_of::<T>())`
+//   must not overlap.
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1380
+#[spec(fn (x: *mut[@xp] T, y: *mut[@yp] T, count: usize) requires
+    valid(xp, count * T::size_of()) && aligned_to(xp, T::align_of()) &&
+    valid(yp, count * T::size_of()) && aligned_to(yp, T::align_of()) &&
+    nonoverlapping(xp, yp, count * T::size_of()))]
+unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize);

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr05.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr05.rs
@@ -1,0 +1,18 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+pub fn test_unknown_not_null_const(p: *const i32) {
+    assert(!p.is_null()); //~ ERROR refinement type error
+}
+
+pub fn test_unknown_is_null_const(p: *const i32) {
+    assert(p.is_null()); //~ ERROR refinement type error
+}
+
+pub fn test_unknown_not_null_mut(p: *mut i32) {
+    assert(!p.is_null()); //~ ERROR refinement type error
+}
+
+pub fn test_unknown_is_null_mut(p: *mut i32) {
+    assert(p.is_null()); //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr06.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr06.rs
@@ -1,0 +1,19 @@
+extern crate flux_core;
+
+// missing alignment
+#[flux::spec(fn (p: {*mut[@base, @addr, @size] u32 | addr > 0 && addr >= base && size >= 4}))]
+pub fn test_write_bytes_unaligned(p: *mut u32) {
+    unsafe { std::ptr::write_bytes(p, 0, 1) } //~ ERROR refinement type error
+}
+
+// insufficient space (only 3 bytes for a 4-byte write)
+#[flux::spec(fn (p: {*mut[@base, @addr, @size] u32 | addr > 0 && addr >= base && size == 3 && addr % 4 == 0}))]
+pub fn test_write_bytes_too_small(p: *mut u32) {
+    unsafe { std::ptr::write_bytes(p, 0, 1) } //~ ERROR refinement type error
+}
+
+// null pointer with nonzero count
+#[flux::spec(fn (p: {*mut[@base, @addr, @size] u32 | addr == 0 && addr % 4 == 0}))]
+pub fn test_write_bytes_null(p: *mut u32) {
+    unsafe { std::ptr::write_bytes(p, 0, 1) } //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr07.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr07.rs
@@ -1,0 +1,76 @@
+#![flux::defs {
+    fn ptr_ok(p: ptr, num_bytes: int, align: int) -> bool {
+        p.addr > 0 && p.addr >= p.base && num_bytes <= p.size && p.addr % align == 0
+    }
+}]
+
+extern crate flux_core;
+
+// --- copy ---
+
+// src unaligned: ptr_ok requires alignment, but src is missing it
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    sp.addr > 0 && sp.addr >= sp.base && sp.size >= 4 &&
+    ptr_ok(dp, 4, 4))]
+pub fn test_copy_src_unaligned(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy(src, dst, 1) } //~ ERROR refinement type error
+}
+
+// dst unaligned
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    ptr_ok(sp, 4, 4) &&
+    dp.addr > 0 && dp.addr >= dp.base && dp.size >= 4)]
+pub fn test_copy_dst_unaligned(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy(src, dst, 1) } //~ ERROR refinement type error
+}
+
+// src too small: only 3 bytes available, but 4 needed
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    sp.addr > 0 && sp.addr >= sp.base && sp.size == 3 && sp.addr % 4 == 0 &&
+    ptr_ok(dp, 4, 4))]
+pub fn test_copy_src_too_small(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy(src, dst, 1) } //~ ERROR refinement type error
+}
+
+// dst too small
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    ptr_ok(sp, 4, 4) &&
+    dp.addr > 0 && dp.addr >= dp.base && dp.size == 3 && dp.addr % 4 == 0)]
+pub fn test_copy_dst_too_small(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy(src, dst, 1) } //~ ERROR refinement type error
+}
+
+// src null with nonzero count
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    sp.addr == 0 && ptr_ok(dp, 4, 4))]
+pub fn test_copy_src_null(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy(src, dst, 1) } //~ ERROR refinement type error
+}
+
+// --- copy_nonoverlapping ---
+
+// overlapping ranges: negation of nonoverlapping is provably true
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32, count: usize) requires
+    ptr_ok(sp, count * 4, 4) && ptr_ok(dp, count * 4, 4) &&
+    sp.addr < dp.addr + count * 4 && dp.addr < sp.addr + count * 4)]
+pub fn test_copy_nonoverlapping_overlapping(src: *const u32, dst: *mut u32, count: usize) {
+    unsafe { std::ptr::copy_nonoverlapping(src, dst, count) } //~ ERROR refinement type error
+}
+
+// src unaligned
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    sp.addr > 0 && sp.addr >= sp.base && sp.size >= 4 &&
+    ptr_ok(dp, 4, 4) &&
+    sp.addr + 4 <= dp.addr)]
+pub fn test_copy_nonoverlapping_src_unaligned(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy_nonoverlapping(src, dst, 1) } //~ ERROR refinement type error
+}
+
+// dst too small
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    ptr_ok(sp, 4, 4) &&
+    dp.addr > 0 && dp.addr >= dp.base && dp.size == 3 && dp.addr % 4 == 0 &&
+    sp.addr + 4 <= dp.addr)]
+pub fn test_copy_nonoverlapping_dst_too_small(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy_nonoverlapping(src, dst, 1) } //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr08.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr08.rs
@@ -1,0 +1,60 @@
+#![flux::defs {
+    fn ptr_ok(p: ptr, num_bytes: int, align: int) -> bool {
+        p.addr > 0 && p.addr >= p.base && num_bytes <= p.size && p.addr % align == 0
+    }
+}]
+
+extern crate flux_core;
+
+// --- swap ---
+
+// x unaligned
+#[flux::spec(fn (x: *mut[@xp] u32, y: *mut[@yp] u32) requires
+    xp.addr > 0 && xp.addr >= xp.base && xp.size >= 4 &&
+    ptr_ok(yp, 4, 4))]
+pub fn test_swap_x_unaligned(x: *mut u32, y: *mut u32) {
+    unsafe { std::ptr::swap(x, y) } //~ ERROR refinement type error
+}
+
+// y too small: only 3 bytes available, but 4 needed
+#[flux::spec(fn (x: *mut[@xp] u32, y: *mut[@yp] u32) requires
+    ptr_ok(xp, 4, 4) &&
+    yp.addr > 0 && yp.addr >= yp.base && yp.size == 3 && yp.addr % 4 == 0)]
+pub fn test_swap_y_too_small(x: *mut u32, y: *mut u32) {
+    unsafe { std::ptr::swap(x, y) } //~ ERROR refinement type error
+}
+
+// x null with non-zero size type
+#[flux::spec(fn (x: *mut[@xp] u32, y: *mut[@yp] u32) requires
+    xp.addr == 0 && ptr_ok(yp, 4, 4))]
+pub fn test_swap_x_null(x: *mut u32, y: *mut u32) {
+    unsafe { std::ptr::swap(x, y) } //~ ERROR refinement type error
+}
+
+// --- swap_nonoverlapping ---
+
+// overlapping ranges
+#[flux::spec(fn (x: *mut[@xp] u32, y: *mut[@yp] u32, count: usize) requires
+    ptr_ok(xp, count * 4, 4) && ptr_ok(yp, count * 4, 4) &&
+    xp.addr < yp.addr + count * 4 && yp.addr < xp.addr + count * 4)]
+pub fn test_swap_nonoverlapping_overlapping(x: *mut u32, y: *mut u32, count: usize) {
+    unsafe { std::ptr::swap_nonoverlapping(x, y, count) } //~ ERROR refinement type error
+}
+
+// x unaligned
+#[flux::spec(fn (x: *mut[@xp] u32, y: *mut[@yp] u32) requires
+    xp.addr > 0 && xp.addr >= xp.base && xp.size >= 4 &&
+    ptr_ok(yp, 4, 4) &&
+    xp.addr + 4 <= yp.addr)]
+pub fn test_swap_nonoverlapping_x_unaligned(x: *mut u32, y: *mut u32) {
+    unsafe { std::ptr::swap_nonoverlapping(x, y, 1) } //~ ERROR refinement type error
+}
+
+// y too small
+#[flux::spec(fn (x: *mut[@xp] u32, y: *mut[@yp] u32) requires
+    ptr_ok(xp, 4, 4) &&
+    yp.addr > 0 && yp.addr >= yp.base && yp.size == 3 && yp.addr % 4 == 0 &&
+    xp.addr + 4 <= yp.addr)]
+pub fn test_swap_nonoverlapping_y_too_small(x: *mut u32, y: *mut u32) {
+    unsafe { std::ptr::swap_nonoverlapping(x, y, 1) } //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr05.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr05.rs
@@ -1,0 +1,38 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- *const T::is_null ---
+
+pub fn test_is_null_branch_const(p: *const i32) {
+    if p.is_null() {
+        assert(p.is_null());
+    }
+}
+
+#[flux::spec(fn (p: {*const[@base, @addr, @size] i32 | addr > 0}))]
+pub fn test_not_null_const(p: *const i32) {
+    assert(!p.is_null());
+}
+
+#[flux::spec(fn (p: {*const[@base, @addr, @size] i32 | addr == 0}))]
+pub fn test_null_const(p: *const i32) {
+    assert(p.is_null());
+}
+
+// --- *mut T::is_null ---
+
+pub fn test_is_null_branch_mut(p: *mut i32) {
+    if p.is_null() {
+        assert(p.is_null());
+    }
+}
+
+#[flux::spec(fn (p: {*mut[@base, @addr, @size] i32 | addr > 0}))]
+pub fn test_not_null_mut(p: *mut i32) {
+    assert(!p.is_null());
+}
+
+#[flux::spec(fn (p: {*mut[@base, @addr, @size] i32 | addr == 0}))]
+pub fn test_null_mut(p: *mut i32) {
+    assert(p.is_null());
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr06.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr06.rs
@@ -1,0 +1,22 @@
+extern crate flux_core;
+
+// write_bytes: valid for `count * size_of::<T>()` bytes, aligned to `align_of::<T>()`
+
+// concrete: aligned, non-null, sufficient room for 4 u32s
+#[flux::spec(fn (p: {*mut[@base, @addr, @size] u32 | addr > 0 && addr >= base && size >= 16 && addr % 4 == 0}))]
+pub fn test_write_bytes_concrete(p: *mut u32) {
+    unsafe { std::ptr::write_bytes(p, 0xfe, 4) }
+}
+
+// zero count: alignment is still required, but validity is trivially satisfied
+#[flux::spec(fn (p: {*mut[@base, @addr, @size] u32 | addr % 4 == 0}))]
+pub fn test_write_bytes_zero_count(p: *mut u32) {
+    unsafe { std::ptr::write_bytes(p, 0, 0) }
+}
+
+// generic T: count * T::size_of() bytes must fit in the allocation
+#[flux::spec(fn (p: {*mut[@base, @addr, @size] T | addr > 0 && addr >= base && size >= T::size_of() && addr % T::align_of() == 0})
+    requires T::size_of() > 0)]
+pub fn test_write_bytes_one<T>(p: *mut T) {
+    unsafe { std::ptr::write_bytes(p, 0, 1) }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr07.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr07.rs
@@ -1,0 +1,62 @@
+#![flux::defs {
+    fn ptr_ok(p: ptr, num_bytes: int, align: int) -> bool {
+        p.addr > 0 && p.addr >= p.base && num_bytes <= p.size && p.addr % align == 0
+    }
+}]
+
+extern crate flux_core;
+
+// --- copy ---
+
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    ptr_ok(sp, 8, 4) && ptr_ok(dp, 8, 4))]
+pub fn test_copy_concrete(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy(src, dst, 2) }
+}
+
+// zero count: only alignment required; null is fine for validity
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    sp.addr % 4 == 0 && dp.addr % 4 == 0)]
+pub fn test_copy_zero_count(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy(src, dst, 0) }
+}
+
+#[flux::spec(fn (src: *const[@sp] T, dst: *mut[@dp] T) requires
+    T::size_of() > 0 &&
+    ptr_ok(sp, T::size_of(), T::align_of()) &&
+    ptr_ok(dp, T::size_of(), T::align_of()))]
+pub fn test_copy_one<T>(src: *const T, dst: *mut T) {
+    unsafe { std::ptr::copy(src, dst, 1) }
+}
+
+// --- copy_nonoverlapping ---
+
+// dst starts after src ends
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    ptr_ok(sp, 8, 4) && ptr_ok(dp, 8, 4) && sp.addr + 8 <= dp.addr)]
+pub fn test_copy_nonoverlapping_after(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy_nonoverlapping(src, dst, 2) }
+}
+
+// src starts after dst ends
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    ptr_ok(sp, 8, 4) && ptr_ok(dp, 8, 4) && dp.addr + 8 <= sp.addr)]
+pub fn test_copy_nonoverlapping_before(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy_nonoverlapping(src, dst, 2) }
+}
+
+// zero count: nonoverlapping is trivially true; only alignment required
+#[flux::spec(fn (src: *const[@sp] u32, dst: *mut[@dp] u32) requires
+    sp.addr % 4 == 0 && dp.addr % 4 == 0)]
+pub fn test_copy_nonoverlapping_zero_count(src: *const u32, dst: *mut u32) {
+    unsafe { std::ptr::copy_nonoverlapping(src, dst, 0) }
+}
+
+#[flux::spec(fn (src: *const[@sp] T, dst: *mut[@dp] T) requires
+    T::size_of() > 0 &&
+    ptr_ok(sp, T::size_of(), T::align_of()) &&
+    ptr_ok(dp, T::size_of(), T::align_of()) &&
+    sp.addr + T::size_of() <= dp.addr)]
+pub fn test_copy_nonoverlapping_one<T>(src: *const T, dst: *mut T) {
+    unsafe { std::ptr::copy_nonoverlapping(src, dst, 1) }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr08.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr08.rs
@@ -1,0 +1,55 @@
+#![flux::defs {
+    fn ptr_ok(p: ptr, num_bytes: int, align: int) -> bool {
+        p.addr > 0 && p.addr >= p.base && num_bytes <= p.size && p.addr % align == 0
+    }
+}]
+
+extern crate flux_core;
+
+// --- swap ---
+
+#[flux::spec(fn (x: *mut[@xp] u32, y: *mut[@yp] u32) requires
+    ptr_ok(xp, 4, 4) && ptr_ok(yp, 4, 4))]
+pub fn test_swap_concrete(x: *mut u32, y: *mut u32) {
+    unsafe { std::ptr::swap(x, y) }
+}
+
+#[flux::spec(fn (x: *mut[@xp] T, y: *mut[@yp] T) requires
+    T::size_of() > 0 &&
+    ptr_ok(xp, T::size_of(), T::align_of()) &&
+    ptr_ok(yp, T::size_of(), T::align_of()))]
+pub fn test_swap_generic<T>(x: *mut T, y: *mut T) {
+    unsafe { std::ptr::swap(x, y) }
+}
+
+// --- swap_nonoverlapping ---
+
+// x ends before y starts
+#[flux::spec(fn (x: *mut[@xp] u32, y: *mut[@yp] u32) requires
+    ptr_ok(xp, 8, 4) && ptr_ok(yp, 8, 4) && xp.addr + 8 <= yp.addr)]
+pub fn test_swap_nonoverlapping_after(x: *mut u32, y: *mut u32) {
+    unsafe { std::ptr::swap_nonoverlapping(x, y, 2) }
+}
+
+// y ends before x starts
+#[flux::spec(fn (x: *mut[@xp] u32, y: *mut[@yp] u32) requires
+    ptr_ok(xp, 8, 4) && ptr_ok(yp, 8, 4) && yp.addr + 8 <= xp.addr)]
+pub fn test_swap_nonoverlapping_before(x: *mut u32, y: *mut u32) {
+    unsafe { std::ptr::swap_nonoverlapping(x, y, 2) }
+}
+
+// zero count: nonoverlapping trivially true; only alignment required
+#[flux::spec(fn (x: *mut[@xp] u32, y: *mut[@yp] u32) requires
+    xp.addr % 4 == 0 && yp.addr % 4 == 0)]
+pub fn test_swap_nonoverlapping_zero_count(x: *mut u32, y: *mut u32) {
+    unsafe { std::ptr::swap_nonoverlapping(x, y, 0) }
+}
+
+#[flux::spec(fn (x: *mut[@xp] T, y: *mut[@yp] T) requires
+    T::size_of() > 0 &&
+    ptr_ok(xp, T::size_of(), T::align_of()) &&
+    ptr_ok(yp, T::size_of(), T::align_of()) &&
+    xp.addr + T::size_of() <= yp.addr)]
+pub fn test_swap_nonoverlapping_generic<T>(x: *mut T, y: *mut T) {
+    unsafe { std::ptr::swap_nonoverlapping(x, y, 1) }
+}


### PR DESCRIPTION
This PR adds specs for some common core functions that copy data to/from pointers.
Specifically, this PR:
1. Adds specs for `copy`, `copy_nonoverlapping`, `swap`, `swap_nonoverlapping`, `write_bytes`, and `is_null`.
2. Adds a new helper flux_def `nonoverlapping` to help write the above specs in a clean way
3. Adds positive and negative tests for the above specs.