### PR TITLE
Core pointer spec part 3: offset + pointer comparisons

### DIFF
--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -83,6 +83,22 @@ macro_rules! ptr_specs {
                 -> *$mutable[p.base, p.addr + count, p.size - count] T
                     requires count <= p.size && p.addr + count >= p.base)]
             unsafe fn byte_offset(self, count: isize) -> Self;
+
+            // - Both `self` and `origin` must be derived from a pointer to the same allocation,
+            //   and the memory range between them must be in bounds of that allocation.
+            //   (`p.base == op.base` captures same-allocation provenance; `addr >= base` for
+            //   each captures the in-bounds requirement from below.)
+            // - The distance between the pointers in bytes must be an exact multiple of
+            //   `size_of::<T>()`, so that it corresponds to a whole number of elements.
+            // - `T` must not be a ZST; the function panics via `assert!(0 < size_of::<T>())`.
+            // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L614-L628
+            #[spec(fn (me: *$mutable[@p] T, origin: *const[@op] T) -> isize[(p.addr - op.addr) / T::size_of()]
+                requires p.base == op.base &&
+                         p.addr >= p.base && op.addr >= op.base &&
+                         (p.addr - op.addr) % T::size_of() == 0 &&
+                         T::size_of() > 0)]
+            unsafe fn offset_from(self, origin: *const T) -> isize
+            where T: Sized;
         }
     };
 }

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -99,6 +99,18 @@ macro_rules! ptr_specs {
                          T::size_of() > 0)]
             unsafe fn offset_from(self, origin: *const T) -> isize
             where T: Sized;
+
+            // - All safety conditions of `offset_from` apply.
+            // - Additionally, `self` must be greater than or equal to `origin`.
+            // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L770
+            #[spec(fn (me: *$mutable[@p] T, origin: *const[@op] T) -> usize[(p.addr - op.addr) / T::size_of()]
+                requires p.base == op.base &&
+                         p.addr >= p.base && op.addr >= op.base &&
+                         p.addr >= op.addr &&
+                         (p.addr - op.addr) % T::size_of() == 0 &&
+                         T::size_of() > 0)]
+            unsafe fn offset_from_unsigned(self, origin: *const T) -> usize
+            where T: Sized;
         }
     };
 }

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -71,6 +71,12 @@ macro_rules! ptr_specs {
             #[no_panic]
             #[spec(fn (me: *$mutable[@p] T) -> bool[p.addr == 0])]
             fn is_null(self) -> bool;
+
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L349
+            #[spec(fn (me: *$mutable[@p] T, count: isize)
+                -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T
+                    requires count * T::size_of() <= p.size && p.addr + count * T::size_of() >= p.base)]
+            unsafe fn offset(self, count: isize) -> Self;
         }
     };
 }

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -132,7 +132,7 @@ ptr_specs!(
         requires valid(p, T::size_of()) && aligned_to(p, T::align_of()))]
     unsafe fn write(self, val: T)
     where
-        T: Sized;,
+        T: Sized;
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/mut_ptr.rs#L1490
     #[spec(fn (me: *mut[@p] T, src: T) -> T
         requires valid(p, T::size_of()) && aligned_to(p, T::align_of()))]

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -1,44 +1,46 @@
 #![flux::defs {
-    // The provenance of the pointer is used to determine which allocation it
-    // is derived from; a pointer is dereferenceable if the memory range of
-    // the given size starting at the pointer is entirely contained within the
-    // bounds of that allocation.
-    // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L21-L25
+    // The memory range [addr, addr + num_bytes) is entirely contained within
+    // the pointer's allocation. In our model this is: addr >= base (not before
+    // the start) and num_bytes <= size (num_bytes remaining bytes fit before
+    // the end). The `size >= 0` guard rules out pointers already past the end.
+    // See: https://doc.rust-lang.org/std/ptr/index.html#safety
     fn dereferenceable(p: ptr, num_bytes: int) -> bool {
         p.addr >= p.base && num_bytes <= p.size && p.size >= 0
     }
 
-    // Guarantees (in order of precedence):
-    // - A null pointer is never valid
-    // - For memory accesses of size zero, every non-null pointer is valid for reads/writes.
-    // - Memory accesses of size zero are always valid
-    // - A valid pointer is dereferenceable
-    // See: https://doc.rust-lang.org/std/ptr/index.html#safety
+    // Non-null and dereferenceable for `num_bytes` bytes. This is the strict
+    // validity predicate with no ZST exception: null is never valid, even for
+    // zero-sized accesses. Used as a building block for `valid` below.
     fn valid_no_zst(p: ptr, num_bytes: int) -> bool {
         p.addr != 0 && dereferenceable(p, num_bytes)
     }
 
-    // The above is only partially true: for operations that don't convert
-    // pointers into references (such as read and write), zero-sized
-    // reads/writes of null pointers are valid
-    // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L41-L46
+    // Validity for raw-pointer operations (ptr::read, ptr::write, etc.).
+    // The Rust docs note that read and write allow null pointers when the
+    // total access size is zero (i.e., T is a ZST); for all other accesses
+    // the pointer must be non-null and dereferenceable.
+    // See: https://doc.rust-lang.org/std/ptr/index.html#safety
     fn valid(p: ptr, num_bytes: int) -> bool {
         num_bytes == 0 || valid_no_zst(p, num_bytes)
     }
 
-    // Valid raw pointers as defined above are not necessarily properly aligned
-    // (where “proper” alignment is defined by the pointee type, i.e.,
-    // `*const T` must be aligned to `align_of::<T>()`). However, most
-    // functions require their arguments to be properly aligned,
-    // and will explicitly state this requirement in their documentation.
-    // Notable exceptions to this are `read_unaligned` and `write_unaligned`.
-    // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L54-L59
+    // The pointer's address is a multiple of `alignment`. Most read/write
+    // functions require proper alignment (align_of::<T>()); the notable
+    // exceptions are read_unaligned and write_unaligned.
+    // See: https://doc.rust-lang.org/std/ptr/index.html#alignment
     fn aligned_to(p: ptr, alignment: int) -> bool { p.addr % alignment == 0 }
 
-    // Two byte ranges of equal length starting at p and q do not overlap.
+    // The byte ranges [p.addr, p.addr + num_bytes) and [q.addr, q.addr + num_bytes)
+    // do not overlap.
     fn nonoverlapping(p: ptr, q: ptr, num_bytes: int) -> bool {
         p.addr + num_bytes <= q.addr || q.addr + num_bytes <= p.addr
     }
+
+    // The pointer itself lies within its allocation: addr >= base and size >= 0.
+    // One-past-the-end pointers (size == 0) satisfy this — they are valid
+    // starting points for pointer arithmetic but cannot be dereferenced.
+    // Required as a precondition for all pointer arithmetic methods.
+    fn in_bounds(p: ptr) -> bool { dereferenceable(p, 0) }
 }]
 
 use flux_attrs::*;
@@ -49,22 +51,22 @@ macro_rules! ptr_specs {
         impl<T> *$mutable T {
             #[spec(fn (me: *$mutable[@p] T, count: usize)
                 -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T
-                    requires count * T::size_of() <= p.size)]
+                    requires in_bounds(p) && count * T::size_of() <= p.size)]
             unsafe fn add(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
                 -> *$mutable[p.base, p.addr - count * T::size_of(), p.size + count * T::size_of()] T
-                    requires count * T::size_of() <= p.addr - p.base)]
+                    requires in_bounds(p) && count * T::size_of() <= p.addr - p.base)]
             unsafe fn sub(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
                 -> *$mutable[p.base, p.addr + count, p.size - count] T
-                    requires count <= p.size)]
+                    requires in_bounds(p) && count <= p.size)]
             unsafe fn byte_add(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
                 -> *$mutable[p.base, p.addr - count, p.size + count] T
-                    requires count <= p.addr - p.base)]
+                    requires in_bounds(p) && count <= p.addr - p.base)]
             unsafe fn byte_sub(self, count: usize) -> Self;
 
             /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L22
@@ -75,13 +77,13 @@ macro_rules! ptr_specs {
             /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L349
             #[spec(fn (me: *$mutable[@p] T, count: isize)
                 -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T
-                    requires count * T::size_of() <= p.size && p.addr + count * T::size_of() >= p.base)]
+                    requires in_bounds(p) && count * T::size_of() <= p.size && p.addr + count * T::size_of() >= p.base)]
             unsafe fn offset(self, count: isize) -> Self;
 
             /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L471
             #[spec(fn (me: *$mutable[@p] T, count: isize)
                 -> *$mutable[p.base, p.addr + count, p.size - count] T
-                    requires count <= p.size && p.addr + count >= p.base)]
+                    requires in_bounds(p) && count <= p.size && p.addr + count >= p.base)]
             unsafe fn byte_offset(self, count: isize) -> Self;
 
             // - Both `self` and `origin` must be derived from a pointer to the same allocation,
@@ -94,7 +96,7 @@ macro_rules! ptr_specs {
             // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L614-L628
             #[spec(fn (me: *$mutable[@p] T, origin: *const[@op] T) -> isize[(p.addr - op.addr) / T::size_of()]
                 requires p.base == op.base &&
-                         p.addr >= p.base && op.addr >= op.base &&
+                         in_bounds(p) && in_bounds(op) &&
                          (p.addr - op.addr) % T::size_of() == 0 &&
                          T::size_of() > 0)]
             unsafe fn offset_from(self, origin: *const T) -> isize
@@ -105,7 +107,7 @@ macro_rules! ptr_specs {
             // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L770
             #[spec(fn (me: *$mutable[@p] T, origin: *const[@op] T) -> usize[(p.addr - op.addr) / T::size_of()]
                 requires p.base == op.base &&
-                         p.addr >= p.base && op.addr >= op.base &&
+                         in_bounds(p) && in_bounds(op) &&
                          p.addr >= op.addr &&
                          (p.addr - op.addr) % T::size_of() == 0 &&
                          T::size_of() > 0)]

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -108,6 +108,18 @@ ptr_specs!(const);
 ptr_specs!(mut);
 
 #[extern_spec(core::ptr)]
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L828
+#[no_panic]
+#[spec(fn() -> *const[0, 0, 0] T)]
+fn null<T>() -> *const T;
+
+#[extern_spec(core::ptr)]
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L853
+#[no_panic]
+#[spec(fn() -> *mut[0, 0, 0] T)]
+fn null_mut<T>() -> *mut T;
+
+#[extern_spec(core::ptr)]
 // - `src` must be valid for reads or `T` must be a ZST.
 // - `src` must be properly aligned. Use `read_unaligned` if this is not the case.
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1591-L1596

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -42,7 +42,16 @@
     // Required as a precondition for all pointer arithmetic methods.
     fn in_bounds(p: ptr) -> bool { dereferenceable(p, 0) }
 }]
-
+/// These specs on `core::ptr` allow flux to enforce 2 safety properties:
+/// 1. Spatial safety: A pointer may only be read or written if pointer is derived from
+/// a valid allocation and the entire access would fall within the bounds of that allocation.
+/// 2. Per-method UB contract safety: Some methods in `core::ptr` have additional safety
+/// requirements beyond spatial safety, such as alignment or non-overlapping.
+/// These specs allow flux to enforce those requirements as well.
+///
+/// These specs do NOT prove temporal safety.
+/// To prove temporal safety, Flux would need to tie the lifetimes of allocations to the pointers derived from them,
+/// which is currently out of scope.
 use flux_attrs::*;
 
 macro_rules! ptr_specs {

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -77,6 +77,12 @@ macro_rules! ptr_specs {
                 -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T
                     requires count * T::size_of() <= p.size && p.addr + count * T::size_of() >= p.base)]
             unsafe fn offset(self, count: isize) -> Self;
+
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L471
+            #[spec(fn (me: *$mutable[@p] T, count: isize)
+                -> *$mutable[p.base, p.addr + count, p.size - count] T
+                    requires count <= p.size && p.addr + count >= p.base)]
+            unsafe fn byte_offset(self, count: isize) -> Self;
         }
     };
 }

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -125,6 +125,8 @@ macro_rules! ptr_specs {
 
 ptr_specs!(const);
 
+// Rustfmt likes inserting a comma in here that breaks compilation, so we disable it for this macro invocation
+#[rustfmt::skip]
 ptr_specs!(
     mut,
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/mut_ptr.rs#L1413

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -132,6 +132,12 @@ ptr_specs!(
         requires valid(p, T::size_of()) && aligned_to(p, T::align_of()))]
     unsafe fn write(self, val: T)
     where
+        T: Sized;,
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/mut_ptr.rs#L1490
+    #[spec(fn (me: *mut[@p] T, src: T) -> T
+        requires valid(p, T::size_of()) && aligned_to(p, T::align_of()))]
+    unsafe fn replace(self, src: T) -> T
+    where
         T: Sized;
 );
 

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -44,7 +44,7 @@
 use flux_attrs::*;
 
 macro_rules! ptr_specs {
-    ($mutable:tt) => {
+    ($mutable:tt $(, $($extra:tt)*)?) => {
         #[extern_spec(core::ptr)]
         impl<T> *$mutable T {
             #[spec(fn (me: *$mutable[@p] T, count: usize)
@@ -111,13 +111,29 @@ macro_rules! ptr_specs {
                          T::size_of() > 0)]
             unsafe fn offset_from_unsigned(self, origin: *const T) -> usize
             where T: Sized;
+
+            /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/const_ptr.rs#L1166
+            #[spec(fn (me: *$mutable[@p] T) -> T
+                requires valid(p, T::size_of()) && aligned_to(p, T::align_of()))]
+            unsafe fn read(self) -> T
+            where T: Sized;
+
+            $($($extra)*)?
         }
     };
 }
 
 ptr_specs!(const);
 
-ptr_specs!(mut);
+ptr_specs!(
+    mut,
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/mut_ptr.rs#L1413
+    #[spec(fn (me: *mut[@p] T, val: T)
+        requires valid(p, T::size_of()) && aligned_to(p, T::align_of()))]
+    unsafe fn write(self, val: T)
+    where
+        T: Sized;
+);
 
 #[extern_spec(core::ptr)]
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L828

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr00.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr00.rs
@@ -20,3 +20,17 @@ fn test_write_i32(ptr: *mut i32, value: i32) {
                                      //~| ERROR refinement type error
     }
 }
+
+// --- method forms ---
+
+fn test_read_method(x: *const i32) -> i32 {
+    unsafe { x.read() } //~ ERROR refinement type error
+                        //~| ERROR refinement type error
+}
+
+fn test_write_method(ptr: *mut i32, value: i32) {
+    unsafe {
+        ptr.write(value); //~ ERROR refinement type error
+                          //~| ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr00.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr00.rs
@@ -34,3 +34,8 @@ fn test_write_method(ptr: *mut i32, value: i32) {
                           //~| ERROR refinement type error
     }
 }
+
+fn test_replace_method(ptr: *mut i32, value: i32) -> i32 {
+    unsafe { ptr.replace(value) } //~ ERROR refinement type error
+                                  //~| ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
@@ -37,3 +37,21 @@ pub fn test_add_mut_ix(ptr: *mut i32) {
         std::ptr::write(ptr.add(2), 30); //~ ERROR refinement type error
     }
 }
+
+// --- offset (signed count) ---
+
+// forward offset past end: size == 4 holds only one i32; offset(2) needs 8 bytes
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size == 4 && addr % 4 == 0}))]
+pub fn test_offset_forward_too_far(ptr: *const i32) {
+    unsafe {
+        let _ = ptr.offset(2); //~ ERROR refinement type error
+    }
+}
+
+// backward offset before base: addr == base means no room behind the pointer
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr == base && size >= 4 && addr % 4 == 0}))]
+pub fn test_offset_backward_past_base(ptr: *const i32) {
+    unsafe {
+        let _ = ptr.offset(-1); //~ ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
@@ -86,3 +86,15 @@ pub fn test_offset_from_zst(p: *const (), q: *const ()) {
         let _ = p.offset_from(q); //~ ERROR refinement type error
     }
 }
+
+// --- offset_from_unsigned ---
+
+// origin is ahead of self: violates p.addr >= op.addr (all other preconditions are satisfied).
+// aq = ap + 4 ensures (ap - aq) % 4 = (-4) % 4 = 0 in SMT-lib.
+#[flux::spec(fn (p: {*const[@bp, @ap, @sp] i32 | ap >= bp && sp >= 0},
+                  q: {*const[@bq, @aq, @sq] i32 | bq == bp && aq == ap + 4 && sq >= 0}))]
+pub fn test_offset_from_unsigned_reversed(p: *const i32, q: *const i32) {
+    unsafe {
+        let _ = p.offset_from_unsigned(q); //~ ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
@@ -55,3 +55,34 @@ pub fn test_offset_backward_past_base(ptr: *const i32) {
         let _ = ptr.offset(-1); //~ ERROR refinement type error
     }
 }
+
+// --- offset_from ---
+
+// different allocations: p.base != q.base violates the same-allocation requirement.
+// Alignment is constrained so that only the base check fails.
+#[flux::spec(fn (p: {*const[@bp, @ap, @sp] i32 | ap >= bp && sp >= 0},
+                  q: {*const[@bq, @aq, @sq] i32 | aq >= bq && sq >= 0 && bq != bp && (ap - aq) % 4 == 0}))]
+pub fn test_offset_from_diff_base(p: *const i32, q: *const i32) {
+    unsafe {
+        let _ = p.offset_from(q); //~ ERROR refinement type error
+    }
+}
+
+// non-element-aligned distance: q is 1 byte ahead of p, but T = i32 requires a multiple of 4
+#[flux::spec(fn (p: {*const[@bp, @ap, @sp] i32 | ap >= bp && sp >= 0},
+                  q: {*const[@bq, @aq, @sq] i32 | bq == bp && aq == ap + 1}))]
+pub fn test_offset_from_unaligned(p: *const i32, q: *const i32) {
+    unsafe {
+        let _ = q.offset_from(p); //~ ERROR refinement type error
+    }
+}
+
+// ZST: size_of::<()>() == 0, violating T::size_of() > 0. Other preconditions are all satisfied
+// (same base, same address, so the distance is 0, which is a multiple of anything).
+#[flux::spec(fn (p: {*const[@bp, @ap, @sp] () | ap >= bp && sp >= 0},
+                  q: {*const[@bq, @aq, @sq] () | bq == bp && aq == ap && sq == sp}))]
+pub fn test_offset_from_zst(p: *const (), q: *const ()) {
+    unsafe {
+        let _ = p.offset_from(q); //~ ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
@@ -70,7 +70,7 @@ pub fn test_offset_from_diff_base(p: *const i32, q: *const i32) {
 
 // non-element-aligned distance: q is 1 byte ahead of p, but T = i32 requires a multiple of 4
 #[flux::spec(fn (p: {*const[@bp, @ap, @sp] i32 | ap >= bp && sp >= 0},
-                  q: {*const[@bq, @aq, @sq] i32 | bq == bp && aq == ap + 1}))]
+                  q: {*const[@bq, @aq, @sq] i32 | bq == bp && aq == ap + 1 && sq >= 0}))]
 pub fn test_offset_from_unaligned(p: *const i32, q: *const i32) {
     unsafe {
         let _ = q.offset_from(p); //~ ERROR refinement type error

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr03.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr03.rs
@@ -32,3 +32,21 @@ pub fn test_byte_sub_oob(buf: &mut [i32; 2]) {
                                                //~| ERROR refinement type error
     }
 }
+
+// --- byte_offset ---
+
+// forward too far: count(9) > size(8)
+pub fn test_byte_offset_forward_oob(buf: &mut [i32; 2]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        let _ = ptr.byte_offset(9); //~ ERROR refinement type error
+    }
+}
+
+// backward before base: fresh ptr has addr == base, so addr + (-1) < base
+pub fn test_byte_offset_backward_oob(buf: &mut [i32; 2]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        let _ = ptr.byte_offset(-1); //~ ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr05.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr05.rs
@@ -1,5 +1,7 @@
+#![allow(invalid_null_arguments)]
 extern crate flux_core;
 use flux_rs::assert;
+use std::ptr;
 
 pub fn test_unknown_not_null_const(p: *const i32) {
     assert(!p.is_null()); //~ ERROR refinement type error
@@ -15,4 +17,29 @@ pub fn test_unknown_not_null_mut(p: *mut i32) {
 
 pub fn test_unknown_is_null_mut(p: *mut i32) {
     assert(p.is_null()); //~ ERROR refinement type error
+}
+
+// --- ptr::null / ptr::null_mut ---
+
+// null() is null, so asserting !is_null() fails
+pub fn test_null_not_null() {
+    let p: *const i32 = ptr::null();
+    assert(!p.is_null()); //~ ERROR refinement type error
+}
+
+pub fn test_null_mut_not_null() {
+    let p: *mut i32 = ptr::null_mut();
+    assert(!p.is_null()); //~ ERROR refinement type error
+}
+
+// null pointer is not valid for reads
+pub fn test_null_read() {
+    let p: *const i32 = ptr::null();
+    unsafe { let _ = std::ptr::read(p); } //~ ERROR refinement type error
+}
+
+// null pointer is not valid for writes
+pub fn test_null_mut_write() {
+    let p: *mut i32 = ptr::null_mut();
+    unsafe { std::ptr::write(p, 42); } //~ ERROR refinement type error
 }

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr00.rs
@@ -51,3 +51,8 @@ fn read_method(ptr: *const i32) -> i32 {
 fn write_method(ptr: *mut i32, value: i32) {
     unsafe { ptr.write(value) }
 }
+
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}, value: i32) -> i32)]
+fn replace_method(ptr: *mut i32, value: i32) -> i32 {
+    unsafe { ptr.replace(value) }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr00.rs
@@ -39,3 +39,15 @@ fn write_ix<T>(ptr: *mut T, value: T) {
         std::ptr::write(ptr, value);
     }
 }
+
+// --- method forms ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}) -> i32)]
+fn read_method(ptr: *const i32) -> i32 {
+    unsafe { ptr.read() }
+}
+
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}, value: i32))]
+fn write_method(ptr: *mut i32, value: i32) {
+    unsafe { ptr.write(value) }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr01.rs
@@ -69,3 +69,49 @@ pub fn test_offset_mut_backward(ptr: *mut i32) {
         std::ptr::write(ptr.offset(-1), 42);
     }
 }
+
+// --- offset_from (returns element-count distance between same-allocation pointers) ---
+use flux_rs::assert;
+
+// forward distance: ptr.add(3) is 2 elements ahead of ptr.add(1)
+pub fn test_offset_from_pos(buf: &[i32; 4]) {
+    let ptr = buf.as_ptr();
+    unsafe {
+        let p1 = ptr.add(1);
+        let p2 = ptr.add(3);
+        let diff = p2.offset_from(p1);
+        assert(diff == 2);
+    }
+}
+
+// negative distance: p1 ahead of p2, result is negative
+pub fn test_offset_from_neg(buf: &[i32; 4]) {
+    let ptr = buf.as_ptr();
+    unsafe {
+        let p1 = ptr.add(3);
+        let p2 = ptr.add(1);
+        let diff = p2.offset_from(p1);
+        assert(diff == -2);
+    }
+}
+
+// self offset_from self == 0
+pub fn test_offset_from_zero(buf: &[i32; 4]) {
+    let ptr = buf.as_ptr();
+    unsafe {
+        let p = ptr.add(2);
+        let diff = p.offset_from(p);
+        assert(diff == 0);
+    }
+}
+
+// *mut T: offset_from takes *const T as origin (implicit *mut → *const coercion)
+pub fn test_offset_from_mut(buf: &mut [i32; 4]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        let p1 = ptr.add(1);
+        let p2 = ptr.add(3);
+        let diff = p2.offset_from(p1);
+        assert(diff == 2);
+    }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr01.rs
@@ -31,3 +31,41 @@ pub fn test_add_mut_ix(ptr: *mut i32) {
         std::ptr::write(ptr.add(1), 20);
     }
 }
+
+// --- offset (signed count — forward and backward) ---
+
+// forward: like add(1) but with isize
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 8 && addr % 4 == 0}))]
+pub fn test_offset_forward(ptr: *const i32) {
+    unsafe {
+        let _val0 = std::ptr::read(ptr.offset(0));
+        let _val1 = std::ptr::read(ptr.offset(1));
+    }
+}
+
+// backward: ptr is one element into its allocation; offset(-1) steps back to base
+// After offset(-1): new addr = addr - 4, new size = size + 4. Read requires size + 4 >= 4,
+// i.e. size >= 0. Non-null requires addr - 4 > 0, i.e. addr > 4.
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr > 4 && addr >= base + 4 && size >= 0 && addr % 4 == 0}))]
+pub fn test_offset_backward(ptr: *const i32) {
+    unsafe {
+        let _ = std::ptr::read(ptr.offset(-1));
+    }
+}
+
+// *mut T forward: offset + write
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 8 && addr % 4 == 0}))]
+pub fn test_offset_mut_forward(ptr: *mut i32) {
+    unsafe {
+        std::ptr::write(ptr.offset(0), 10);
+        std::ptr::write(ptr.offset(1), 20);
+    }
+}
+
+// *mut T backward
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr > 4 && addr >= base + 4 && size >= 0 && addr % 4 == 0}))]
+pub fn test_offset_mut_backward(ptr: *mut i32) {
+    unsafe {
+        std::ptr::write(ptr.offset(-1), 42);
+    }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr01.rs
@@ -115,3 +115,46 @@ pub fn test_offset_from_mut(buf: &mut [i32; 4]) {
         assert(diff == 2);
     }
 }
+
+// --- offset_from_unsigned ---
+
+// forward distance: returns usize, same arithmetic as offset_from for self >= origin
+pub fn test_offset_from_unsigned_pos(buf: &[i32; 4]) {
+    let ptr = buf.as_ptr();
+    unsafe {
+        let p1 = ptr.add(1);
+        let p2 = ptr.add(3);
+        let diff = p2.offset_from_unsigned(p1);
+        assert(diff == 2);
+    }
+}
+
+// self == origin: distance is zero
+pub fn test_offset_from_unsigned_zero(buf: &[i32; 4]) {
+    let ptr = buf.as_ptr();
+    unsafe {
+        let p = ptr.add(2);
+        let diff = p.offset_from_unsigned(p);
+        assert(diff == 0);
+    }
+}
+
+// offset_from_unsigned inverts add: p.add(n).offset_from_unsigned(p) == n
+pub fn test_offset_from_unsigned_roundtrip(buf: &[i32; 4]) {
+    let ptr = buf.as_ptr();
+    unsafe {
+        let p2 = ptr.add(2);
+        assert(p2.offset_from_unsigned(ptr) == 2);
+    }
+}
+
+// *mut T case
+pub fn test_offset_from_unsigned_mut(buf: &mut [i32; 4]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        let p1 = ptr.add(1);
+        let p2 = ptr.add(3);
+        let diff = p2.offset_from_unsigned(p1);
+        assert(diff == 2);
+    }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr03.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr03.rs
@@ -41,3 +41,25 @@ pub fn test_byte_sub(buf: &mut [i32; 2]) {
         std::ptr::write(ptr1, 20);
     }
 }
+
+// --- byte_offset (signed count — forward and backward) ---
+
+// forward: byte_offset(4) advances by 4 bytes to the second element
+pub fn test_byte_offset_forward(buf: &mut [i32; 2]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        std::ptr::write(ptr.byte_offset(0), 10);
+        std::ptr::write(ptr.byte_offset(4), 20);
+    }
+}
+
+// backward: advance then step back; reads both elements
+pub fn test_byte_offset_backward(buf: &mut [i32; 2]) {
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        let ptr1 = ptr.byte_add(4);
+        let ptr0 = ptr1.byte_offset(-4);
+        std::ptr::write(ptr0, 10);
+        std::ptr::write(ptr1, 20);
+    }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr05.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr05.rs
@@ -1,5 +1,6 @@
 extern crate flux_core;
 use flux_rs::assert;
+use std::ptr;
 
 // --- *const T::is_null ---
 
@@ -34,5 +35,17 @@ pub fn test_not_null_mut(p: *mut i32) {
 
 #[flux::spec(fn (p: {*mut[@base, @addr, @size] i32 | addr == 0}))]
 pub fn test_null_mut(p: *mut i32) {
+    assert(p.is_null());
+}
+
+// --- ptr::null / ptr::null_mut ---
+
+pub fn test_null_is_null() {
+    let p: *const i32 = ptr::null();
+    assert(p.is_null());
+}
+
+pub fn test_null_mut_is_null() {
+    let p: *mut i32 = ptr::null_mut();
     assert(p.is_null());
 }


### PR DESCRIPTION
This PR adds specifications for the remaining common pointer functions not covered by the core spec.
Specifically, this PR:
1. adds specs for `offset`, `byte_offset`, `offset_from` (comparison), `offset_from_unsigned`, `null`, `null_mut`, the method versions of read and write (`ptr.read(4)` rather than `read(ptr, 4)`), and `replace`.
2. Updated our `ptr_spec` macro to handle functions that exist only for mutable pointers.
3. Made the specs for common arithmetic functions stronger. Previously, we required only the output of `add`,`sub`, and related functions to be in bounds of their allocated buffer. However, after inspecting the safety specs closer, it is also immediate UB if these functions are called on oob pointers. I have therefore added preconditions to enforce this requirement. 
4. Added tests for the above specs

This is the last set of pointer specs that I plan to work on. After this, I will work on `NonNull<T>`