### PR TITLE
tests/todo: refined value lost across fn-pointer / closure call

### DIFF
--- a/tests/tests/todo/closure_refined_call.rs
+++ b/tests/tests/todo/closure_refined_call.rs
@@ -1,0 +1,13 @@
+// A captured refined value's refinement is not propagated through the closure boundary to the
+// call site, so a provable index bound is rejected. The program is Rust-safe (`n < 3`), so it
+// should verify. Companion to `fnptr_refined_call.rs`: both lose a refinement across an
+// indirection (fn pointer / closure) that a direct use would preserve.
+#![allow(unused)]
+
+#[flux::sig(fn(n: usize{n < 3}))]
+fn via_closure(n: usize) {
+    let g = || n; // captures n : usize{n < 3}
+    let i = g();  // refinement not propagated through the closure call
+    let a = [0i32; 3];
+    let _ = a[i]; // flux: "possible out-of-bounds"; actually n < 3, in bounds
+}

--- a/tests/tests/todo/fnptr_refined_call.rs
+++ b/tests/tests/todo/fnptr_refined_call.rs
@@ -1,0 +1,19 @@
+// A refined return type is not used after a call *through a function pointer*, so an
+// otherwise-provable index bound is rejected. The identical program with a DIRECT call to
+// `small` verifies today, which isolates the gap to the fn-pointer coercion/call rather than
+// to the refinement or the indexing. Related to the `#[flux::trusted]` workaround + TODO in
+// `tests/pos/fn_ptrs/fnptr00.rs` ("should actually support the below, not just leave it as
+// `trusted`"), and possibly to the same broad FnPtr-refinement area as #1185 (which is an ICE,
+// not this rejection). This program is Rust-safe (`i == 2`), so it should verify.
+#![allow(unused)]
+
+#[flux::sig(fn() -> usize{v: v < 3})]
+fn small() -> usize { 2 }
+
+// Direct call verifies:  let i = small(); let a = [0i32; 3]; let _ = a[i];
+fn via_fn_ptr() {
+    let p: fn() -> usize = small;
+    let i = p(); // refined return `{v < 3}` is not carried through the call
+    let a = [0i32; 3];
+    let _ = a[i]; // flux: "possible out-of-bounds"; actually i == 2, in bounds
+}


### PR DESCRIPTION
> *Human here. Full disclosure: this is agent-produced and I don't follow the internals. What I can vouch for is the method, the same trace-backed approach as my recent flux work. Cautious by design: these are `todo` tests documenting a gap, not a fix, and I'm not claiming a root cause.*

---

Two Rust-safe programs that flux currently rejects with `assertion might fail: possible out-of-bounds access`, added under `tests/tests/todo/`:

- `fnptr_refined_call.rs`: a refined return type `fn() -> usize{v: v < 3}` is not used after a call **through a function pointer**, so `a[p()]` on a length-3 array is rejected even though the result is `2`.
- `closure_refined_call.rs`: a captured refined value `n: usize{n < 3}` is not propagated through a **closure** call, so `a[g()]` is rejected even though `n < 3`.

Both are sound, so they should verify. This is incompleteness, not unsoundness.

The gap is already known on the fn-pointer side: `tests/pos/fn_ptrs/fnptr00.rs:9` carries a `#[flux::trusted]` workaround with `// TODO: should actually support the below, not just leave it as trusted`. These cases give it a refined, minimal form and a runnable control. Possibly the same broad FnPtr-refinement area as #1185, though that one is an ICE and this is a rejection, so not necessarily the same bug.

## How it was isolated

Found with a differential gate (flux static verdict vs the same program compiled by rustc and run; specs erase to no-ops). Each node is a replayable trial.

```mermaid
flowchart TD
    classDef killed fill:#ffe1e1,stroke:#cc3333,color:#5c0000;
    classDef confirmed fill:#e2f6e6,stroke:#2f9e44,color:#0a3d1a;

    A["direct call: let i = small(); a[i]"]:::confirmed
    B["via fn pointer: let p = small; a[p()]"]:::killed
    C["via closure: let g = || n; a[g()]"]:::killed
    A -->|"only change: the indirection"| B
    A --> C
```

| trial | flux | runtime (rustc) | reading |
|---|---|---|---|
| direct call `small()` | VERIFIED | ok | refinement preserved |
| via fn-ptr `p()` | REJECTED | ok | refinement not used after the call |
| via closure `g()` | REJECTED | ok | refinement not propagated through the closure |

The direct-call control verifies with the identical refinement and index, which isolates the loss to the fn-pointer coercion / closure boundary rather than the refinement or the bounds check. No fix here; filing the cases so the gap is pinned and replayable.
