### PR TITLE
Track and report root cause for panics

### DIFF
--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -4,7 +4,7 @@ use flux_common::{bug, dbg, tracked_span_assert_eq, tracked_span_bug, tracked_sp
 use flux_config::{self as config, InferOpts, OverflowMode, RawDerefMode};
 use flux_macros::{TypeFoldable, TypeVisitable};
 use flux_middle::{
-    FixpointQueryKind, PanicSpec,
+    FixpointQueryKind,
     def_id::MaybeExternId,
     global_env::GlobalEnv,
     metrics::{self, Metric},
@@ -23,7 +23,7 @@ use itertools::{Itertools, izip};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_macros::extension;
 use rustc_middle::{
-    mir::BasicBlock,
+    mir::{BasicBlock, Location},
     ty::{TyCtxt, Variance},
 };
 use rustc_span::{Span, Symbol};
@@ -81,7 +81,7 @@ pub enum ConstrReason {
     Overflow,
     Underflow,
     Subtype(SubtypeReason),
-    NoPanic(DefId, PanicSpec),
+    NoPanic { callee: DefId, caller: Option<DefId>, location: Option<Location> },
     Other,
 }
 

--- a/crates/flux-metadata/src/lib.rs
+++ b/crates/flux-metadata/src/lib.rs
@@ -181,7 +181,7 @@ pub struct Tables<'tcx, K: Eq + Hash> {
     sort_decl_param_count: UnordMap<FluxId<K>, usize>,
     no_panic: UnordMap<K, bool>,
     assume_parametric_params: UnordMap<K, UnordSet<u32>>,
-    no_panic_specs: UnordMap<NodeKey<'tcx>, PanicSpec>,
+    no_panic_specs: UnordMap<NodeKey<'tcx>, PanicSpec<'tcx>>,
 }
 
 impl<'tcx> CStore<'tcx> {
@@ -330,7 +330,7 @@ impl<'tcx> CrateStore<'tcx> for CStore<'tcx> {
         self.local_tables[&krate].normalized_defns.clone()
     }
 
-    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec>> {
+    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec<'tcx>>> {
         // TODO: Some transitive deps (e.g. `hashbrown`) have no flux metadata. Return
         // an empty map (conservative: MightPanic) until the proper fix is in place.
         // See notes/hashbrown-inferred-no-panic.txt.

--- a/crates/flux-middle/src/call_graph.rs
+++ b/crates/flux-middle/src/call_graph.rs
@@ -14,6 +14,7 @@ use rustc_middle::{
     mir::Location,
     ty::{GenericArgs, Instance, InstanceKind, TyCtxt, TypeVisitableExt},
 };
+use rustc_span::Span;
 
 /// Identity of a call-graph node. Distinguishes an item *as defined in source* from a
 /// *monomorphization* synthesized while building the graph.
@@ -82,6 +83,7 @@ impl<'tcx> NodeKey<'tcx> {
 #[derive(Debug, Clone)]
 pub struct CallSite<'tcx> {
     pub location: Location,
+    pub span: Span,
     pub kind: CallSiteKind<'tcx>,
 }
 
@@ -116,7 +118,7 @@ pub enum Node<'tcx> {
 
 impl<'tcx> Node<'tcx> {
     /// Call sites observed in this node's body. Empty for non-`Analyzed` nodes.
-    fn call_sites(&self) -> &[CallSite<'tcx>] {
+    pub fn call_sites(&self) -> &[CallSite<'tcx>] {
         match self {
             Node::Analyzed { call_sites } => call_sites,
             Node::ExternalCrate | Node::Leaf(_) => &[],

--- a/crates/flux-middle/src/cstore.rs
+++ b/crates/flux-middle/src/cstore.rs
@@ -39,7 +39,7 @@ pub trait CrateStore<'tcx> {
     fn sort_decl_param_count(&self, def_id: FluxDefId) -> Option<usize>;
     fn no_panic(&self, def_id: DefId) -> Option<bool>;
     fn assume_parametric_params(&self, def_id: DefId) -> Option<UnordSet<u32>>;
-    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec>>;
+    fn inferred_no_panic(&self, krate: CrateNum) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec<'tcx>>>;
     fn has_crate(&self, krate: CrateNum) -> bool;
 }
 

--- a/crates/flux-middle/src/global_env.rs
+++ b/crates/flux-middle/src/global_env.rs
@@ -19,6 +19,7 @@ use rustc_hir::{
     def_id::{CrateNum, DefId, LocalDefId},
 };
 use rustc_middle::{
+    mir::Location,
     query::IntoQueryParam,
     ty::{TyCtxt, Variance},
 };
@@ -183,7 +184,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
 
     /// The inferred [`PanicSpec`] for the node `key`, looked up in the local crate's
     /// `NodeKey`-keyed map. Missing entries default to `MightPanic(NotInCallGraph)`.
-    pub fn inferred_no_panic_key(self, key: NodeKey<'tcx>) -> PanicSpec {
+    pub fn inferred_no_panic_key(self, key: NodeKey<'tcx>) -> PanicSpec<'tcx> {
         self.inferred_no_panic_local()
             .get(&key)
             .copied()
@@ -191,7 +192,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
     }
 
     /// The local crate's full `NodeKey`-keyed no-panic map (used by metadata encoding).
-    pub fn inferred_no_panic_local(self) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec>> {
+    pub fn inferred_no_panic_local(self) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec<'tcx>>> {
         self.inner.queries.inferred_no_panic(self)
     }
 
@@ -200,7 +201,7 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
     /// [`Mono`](NodeKey::Mono) is used when present), then for a monomorphization falls back to the
     /// source [`Item`](NodeKey::Item) (covering instantiations the external crate could never have
     /// analyzed, e.g. at a local type), then to `MightPanic`.
-    pub fn inferred_no_panic_external(self, key: NodeKey<'tcx>) -> PanicSpec {
+    pub fn inferred_no_panic_external(self, key: NodeKey<'tcx>) -> PanicSpec<'tcx> {
         let table = self.cstore().inferred_no_panic(key.def_id().krate);
         if let Some(&spec) = table.get(&key) {
             return spec;
@@ -211,6 +212,21 @@ impl<'genv, 'tcx> GlobalEnv<'genv, 'tcx> {
             return spec;
         }
         PanicSpec::MightPanic(PanicReason::NotInCallGraph)
+    }
+
+    /// The inferred [`PanicSpec`] for the call site at `location` in `caller`'s body.
+    /// Falls back to `MightPanic(NotInCallGraph)` when either argument is `None` or the
+    /// call site did not resolve to a concrete callee in the call graph.
+    pub fn inferred_no_panic_at(
+        self,
+        caller: Option<DefId>,
+        location: Option<Location>,
+    ) -> PanicSpec<'tcx> {
+        caller
+            .zip(location)
+            .and_then(|(caller, loc)| self.call_graph().resolved_callee(caller, loc))
+            .map(|key| self.inferred_no_panic_key(key))
+            .unwrap_or(PanicSpec::MightPanic(PanicReason::NotInCallGraph))
     }
 
     pub fn inlined_body(self, did: FluxDefId) -> rty::Binder<rty::Expr> {

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -59,28 +59,28 @@ use rustc_data_structures::{
     unord::{UnordMap, UnordSet},
 };
 use rustc_hir::OwnerId;
-use rustc_macros::{Decodable, Encodable, extension};
+use rustc_macros::{TyDecodable, TyEncodable, extension};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{
-    Symbol,
+    Span, Symbol,
     def_id::{DefId, LocalDefId},
     symbol::Ident,
 };
 
 fluent_messages! { "../locales/en-US.ftl" }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Encodable, Decodable)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, TyEncodable, TyDecodable)]
 pub enum PanicSpec {
     WillNotPanic,
     MightPanic(PanicReason),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum PanicReason {
-    Transitive,
-    UnresolvedCall(DefId),
-    DynamicDispatch,
-    SynthesizedPanic,
+    Transitive { call_site: Span },
+    UnresolvedCall { def_id: DefId, call_site: Span },
+    DynamicDispatch { call_site: Span },
+    SynthesizedPanic { call_site: Span },
     NotInCallGraph,
     NoMIRAvailable,
 }

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -41,6 +41,7 @@ mod sort_of;
 
 use std::sync::LazyLock;
 
+use call_graph::NodeKey;
 use flux_arc_interner::List;
 use flux_macros::fluent_messages;
 pub use flux_rustc_bridge::def_id_to_string;
@@ -70,14 +71,14 @@ use rustc_span::{
 fluent_messages! { "../locales/en-US.ftl" }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, TyEncodable, TyDecodable)]
-pub enum PanicSpec {
+pub enum PanicSpec<'tcx> {
     WillNotPanic,
-    MightPanic(PanicReason),
+    MightPanic(PanicReason<'tcx>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
-pub enum PanicReason {
-    Transitive { call_site: Span },
+pub enum PanicReason<'tcx> {
+    Transitive { callee: NodeKey<'tcx>, call_site: Span },
     UnresolvedCall { def_id: DefId, call_site: Span },
     DynamicDispatch { call_site: Span },
     SynthesizedPanic { call_site: Span },

--- a/crates/flux-middle/src/queries.rs
+++ b/crates/flux-middle/src/queries.rs
@@ -205,7 +205,7 @@ pub struct Providers {
     pub sort_decl_param_count: fn(GlobalEnv, FluxId<MaybeExternId>) -> usize,
     pub call_graph: for<'genv, 'tcx> fn(GlobalEnv<'genv, 'tcx>) -> CallGraph<'tcx>,
     pub inferred_no_panic:
-        for<'genv, 'tcx> fn(GlobalEnv<'genv, 'tcx>) -> UnordMap<NodeKey<'tcx>, PanicSpec>,
+        for<'genv, 'tcx> fn(GlobalEnv<'genv, 'tcx>) -> UnordMap<NodeKey<'tcx>, PanicSpec<'tcx>>,
 }
 
 macro_rules! empty_query {
@@ -295,7 +295,7 @@ pub struct Queries<'genv, 'tcx> {
     assume_parametric_params: Cache<DefId, UnordSet<u32>>,
     call_graph: OnceCell<CallGraph<'tcx>>,
     /// The no-panic inference result for the local crate, keyed by `NodeKey`.
-    inferred_no_panic: OnceCell<Rc<UnordMap<NodeKey<'tcx>, PanicSpec>>>,
+    inferred_no_panic: OnceCell<Rc<UnordMap<NodeKey<'tcx>, PanicSpec<'tcx>>>>,
 }
 
 impl<'genv, 'tcx> Queries<'genv, 'tcx> {
@@ -619,7 +619,7 @@ impl<'genv, 'tcx> Queries<'genv, 'tcx> {
     pub fn inferred_no_panic(
         &'genv self,
         genv: GlobalEnv<'genv, 'tcx>,
-    ) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec>> {
+    ) -> Rc<UnordMap<NodeKey<'tcx>, PanicSpec<'tcx>>> {
         self.inferred_no_panic
             .get_or_init(|| Rc::new((self.providers.inferred_no_panic)(genv)))
             .clone()

--- a/crates/flux-opt/src/call_graph.rs
+++ b/crates/flux-opt/src/call_graph.rs
@@ -160,7 +160,7 @@ fn callees_in_body<'tcx>(
             }
             _ => continue,
         };
-        call_sites.push(CallSite { location, kind });
+        call_sites.push(CallSite { location, span: terminator.source_info.span, kind });
     }
 
     call_sites

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -34,10 +34,12 @@ pub fn provide(providers: &mut Providers) {
 ///
 /// `external_spec` resolves the spec of an `Instance` defined in another crate (a
 /// [`Node::ExternalCrate`]), looking it up in that crate's serialized metadata.
-pub fn inferred_no_panic<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> UnordMap<NodeKey<'tcx>, PanicSpec> {
+pub fn inferred_no_panic<'tcx>(
+    genv: GlobalEnv<'_, 'tcx>,
+) -> UnordMap<NodeKey<'tcx>, PanicSpec<'tcx>> {
     let graph = genv.call_graph();
 
-    let mut specs: UnordMap<NodeKey<'tcx>, PanicSpec> = UnordMap::default();
+    let mut specs: UnordMap<NodeKey<'tcx>, PanicSpec<'tcx>> = UnordMap::default();
     let mut queue: VecDeque<NodeKey<'tcx>> = VecDeque::new();
 
     for (&key, node) in &graph.nodes {
@@ -53,7 +55,10 @@ pub fn inferred_no_panic<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> UnordMap<NodeKey<'t
         for &caller in callers {
             if specs[&caller] == PanicSpec::WillNotPanic {
                 let call_site = call_site_span_to(&graph, caller, key);
-                specs.insert(caller, PanicSpec::MightPanic(PanicReason::Transitive { call_site }));
+                specs.insert(
+                    caller,
+                    PanicSpec::MightPanic(PanicReason::Transitive { callee: key, call_site }),
+                );
                 queue.push_back(caller);
             }
         }
@@ -69,7 +74,7 @@ fn initial_spec<'tcx>(
     genv: GlobalEnv<'_, 'tcx>,
     node: &Node<'tcx>,
     key: NodeKey<'tcx>,
-) -> PanicSpec {
+) -> PanicSpec<'tcx> {
     match node {
         Node::ExternalCrate => genv.inferred_no_panic_external(key),
         Node::Leaf(_) => PanicSpec::MightPanic(PanicReason::NoMIRAvailable),

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate rustc_data_structures;
 extern crate rustc_hir;
 extern crate rustc_middle;
+extern crate rustc_span;
 
 mod call_graph;
 
@@ -10,11 +11,12 @@ use std::collections::VecDeque;
 
 use flux_middle::{
     PanicReason, PanicSpec,
-    call_graph::{CallSiteKind, Node, NodeKey},
+    call_graph::{CallGraph, CallSite, CallSiteKind, Node, NodeKey},
     global_env::GlobalEnv,
     queries::Providers,
 };
 use rustc_data_structures::unord::UnordMap;
+use rustc_span::Span;
 
 pub fn provide(providers: &mut Providers) {
     providers.call_graph = call_graph::build_call_graph;
@@ -50,7 +52,8 @@ pub fn inferred_no_panic<'tcx>(genv: GlobalEnv<'_, 'tcx>) -> UnordMap<NodeKey<'t
         let Some(callers) = graph.callers.get(&key) else { continue };
         for &caller in callers {
             if specs[&caller] == PanicSpec::WillNotPanic {
-                specs.insert(caller, PanicSpec::MightPanic(PanicReason::Transitive));
+                let call_site = call_site_span_to(&graph, caller, key);
+                specs.insert(caller, PanicSpec::MightPanic(PanicReason::Transitive { call_site }));
                 queue.push_back(caller);
             }
         }
@@ -73,9 +76,15 @@ fn initial_spec<'tcx>(
         Node::Analyzed { call_sites } => {
             for site in call_sites {
                 let reason = match site.kind {
-                    CallSiteKind::SynthesizedPanic => PanicReason::SynthesizedPanic,
-                    CallSiteKind::DynamicDispatch => PanicReason::DynamicDispatch,
-                    CallSiteKind::Unresolved { def_id } => PanicReason::UnresolvedCall(def_id),
+                    CallSiteKind::SynthesizedPanic => {
+                        PanicReason::SynthesizedPanic { call_site: site.span }
+                    }
+                    CallSiteKind::DynamicDispatch => {
+                        PanicReason::DynamicDispatch { call_site: site.span }
+                    }
+                    CallSiteKind::Unresolved { def_id } => {
+                        PanicReason::UnresolvedCall { def_id, call_site: site.span }
+                    }
                     CallSiteKind::Resolved { .. } => continue,
                 };
                 return PanicSpec::MightPanic(reason);
@@ -83,4 +92,25 @@ fn initial_spec<'tcx>(
             PanicSpec::WillNotPanic
         }
     }
+}
+
+/// Returns the span of the first call site in `caller`'s body that resolves to `callee`.
+///
+/// By graph construction, if `caller` appears in `graph.callers[callee]`, a matching resolved
+/// site must exist. Falls back to `DUMMY_SP` only if the graph is somehow inconsistent.
+fn call_site_span_to<'tcx>(
+    graph: &CallGraph<'tcx>,
+    caller: NodeKey<'tcx>,
+    callee: NodeKey<'tcx>,
+) -> Span {
+    graph
+        .nodes
+        .get(&caller)
+        .and_then(|n| {
+            n.call_sites().iter().find_map(|s: &CallSite<'tcx>| {
+                matches!(s.kind, CallSiteKind::Resolved { callee: c } if c == callee)
+                    .then_some(s.span)
+            })
+        })
+        .unwrap_or(rustc_span::DUMMY_SP)
 }

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -988,7 +988,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                     self.fn_sig.no_panic(),
                     Expr::or(callee_no_panic, inferred_panic_expr),
                 ),
-                ConstrReason::NoPanic(callee_def_id, callee_inferred_spec),
+                ConstrReason::NoPanic { callee: callee_def_id, caller: body_def_id, location },
             );
         }
 

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -295,12 +295,9 @@ fn emit_panic_error(
 ) -> ErrorGuaranteed {
     let spec = genv.inferred_no_panic_at(caller, location);
     let (hops, reason) = collect_panic_chain(genv, spec);
-    let mut diag = errors::PanicError {
-        span,
-        callee: genv.tcx().def_path_debug_str(callee),
-        reason,
-    }
-    .into_diag(dcx, rustc_errors::Level::Error);
+    let mut diag =
+        errors::PanicError { span, callee: genv.tcx().def_path_debug_str(callee), reason }
+            .into_diag(dcx, rustc_errors::Level::Error);
     for (hop_span, msg) in hops {
         diag.span_note(hop_span, msg);
     }
@@ -323,33 +320,38 @@ fn collect_panic_chain<'tcx>(
     for _ in 0..MAX_DEPTH {
         match spec {
             PanicSpec::WillNotPanic => break,
-            PanicSpec::MightPanic(reason) => match reason {
-                PanicReason::Transitive { callee, call_site } => {
-                    let name = genv.tcx().def_path_debug_str(callee.def_id());
-                    hops.push((call_site, format!("which calls `{name}` here")));
-                    spec = genv.inferred_no_panic_key(callee);
-                    transitive = true;
+            PanicSpec::MightPanic(reason) => {
+                match reason {
+                    PanicReason::Transitive { callee, call_site } => {
+                        let name = genv.tcx().def_path_debug_str(callee.def_id());
+                        hops.push((call_site, format!("which calls `{name}` here")));
+                        spec = genv.inferred_no_panic_key(callee);
+                        transitive = true;
+                    }
+                    PanicReason::UnresolvedCall { def_id, call_site } => {
+                        let name = genv.tcx().def_path_debug_str(def_id);
+                        hops.push((
+                            call_site,
+                            format!("cannot resolve `{name}` to a concrete implementation"),
+                        ));
+                        return (hops, root_cause(transitive, format!("UnresolvedCall(`{name}`)")));
+                    }
+                    PanicReason::DynamicDispatch { call_site } => {
+                        hops.push((call_site, "calls a function pointer or closure".into()));
+                        return (hops, root_cause(transitive, "DynamicDispatch".into()));
+                    }
+                    PanicReason::SynthesizedPanic { call_site } => {
+                        hops.push((call_site, "Rustc-synthesized panic here (likely arithmetic overflow, bounds check, div-by-zero, or assert! macro)".into()));
+                        return (hops, root_cause(transitive, "SynthesizedPanic".into()));
+                    }
+                    PanicReason::NotInCallGraph => {
+                        return (hops, root_cause(transitive, "NotInCallGraph".into()));
+                    }
+                    PanicReason::NoMIRAvailable => {
+                        return (hops, root_cause(transitive, "NoMIRAvailable".into()));
+                    }
                 }
-                PanicReason::UnresolvedCall { def_id, call_site } => {
-                    let name = genv.tcx().def_path_debug_str(def_id);
-                    hops.push((call_site, format!("cannot resolve `{name}` to a concrete implementation")));
-                    return (hops, root_cause(transitive, format!("UnresolvedCall(`{name}`)")));
-                }
-                PanicReason::DynamicDispatch { call_site } => {
-                    hops.push((call_site, "calls a function pointer or closure".into()));
-                    return (hops, root_cause(transitive, "DynamicDispatch".into()));
-                }
-                PanicReason::SynthesizedPanic { call_site } => {
-                    hops.push((call_site, "Rustc-synthesized panic here (likely arithmetic overflow, bounds check, div-by-zero, or assert! macro)".into()));
-                    return (hops, root_cause(transitive, "SynthesizedPanic".into()));
-                }
-                PanicReason::NotInCallGraph => {
-                    return (hops, root_cause(transitive, "NotInCallGraph".into()));
-                }
-                PanicReason::NoMIRAvailable => {
-                    return (hops, root_cause(transitive, "NoMIRAvailable".into()));
-                }
-            },
+            }
         }
     }
     (hops, "unknown".into())

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -340,7 +340,7 @@ fn collect_panic_chain<'tcx>(
                     return (hops, root_cause(transitive, "DynamicDispatch".into()));
                 }
                 PanicReason::SynthesizedPanic { call_site } => {
-                    hops.push((call_site, "arithmetic operation that may panic".into()));
+                    hops.push((call_site, "Rustc-synthesized panic here (likely arithmetic overflow, bounds check, div-by-zero, or assert! macro)".into()));
                     return (hops, root_cause(transitive, "SynthesizedPanic".into()));
                 }
                 PanicReason::NotInCallGraph => {

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -38,7 +38,7 @@ use flux_infer::{
 };
 use flux_macros::fluent_messages;
 use flux_middle::{
-    FixpointQueryKind,
+    FixpointQueryKind, PanicReason, PanicSpec,
     def_id::MaybeExternId,
     global_env::GlobalEnv,
     metrics::{self, Metric, TimingKind},
@@ -269,15 +269,7 @@ fn report_errors(
                 emit(errors::UnknownError { span }.into_diag(dcx, rustc_errors::Level::Error))
             }
             ConstrReason::NoPanic { callee, caller, location } => {
-                let spec = genv.inferred_no_panic_at(caller, location);
-                emit(
-                    errors::PanicError {
-                        span,
-                        callee: genv.tcx().def_path_debug_str(callee),
-                        reason: format!("{spec:?}"),
-                    }
-                    .into_diag(dcx, rustc_errors::Level::Error),
-                )
+                emit_panic_error(genv, dcx, span, callee, caller, location, emit)
             }
         });
     }
@@ -290,6 +282,81 @@ fn report_expected_neg(genv: GlobalEnv, def_id: LocalDefId) -> Result<(), ErrorG
         span: genv.tcx().def_span(def_id),
         def_descr: genv.tcx().def_descr(def_id.to_def_id()),
     }))
+}
+
+fn emit_panic_error(
+    genv: GlobalEnv,
+    dcx: rustc_errors::DiagCtxtHandle<'_>,
+    span: rustc_span::Span,
+    callee: rustc_span::def_id::DefId,
+    caller: Option<rustc_span::def_id::DefId>,
+    location: Option<rustc_middle::mir::Location>,
+    emit: impl FnOnce(rustc_errors::Diag<'_, ErrorGuaranteed>) -> ErrorGuaranteed,
+) -> ErrorGuaranteed {
+    let spec = genv.inferred_no_panic_at(caller, location);
+    let (hops, reason) = collect_panic_chain(genv, spec);
+    let mut diag = errors::PanicError {
+        span,
+        callee: genv.tcx().def_path_debug_str(callee),
+        reason,
+    }
+    .into_diag(dcx, rustc_errors::Level::Error);
+    for (hop_span, msg) in hops {
+        diag.span_note(hop_span, msg);
+    }
+    emit(diag)
+}
+
+/// Walks the `Transitive` blame chain in `spec`, collecting a `span_note` per hop and
+/// producing a short root-cause label for the primary error message.
+///
+/// Returns `(hops, reason)` where each hop is `(call_site_span, note_text)` and `reason`
+/// names the terminal variant, prefixed with `"Transitive -> "` if any hops were traversed
+/// (e.g. `"Transitive -> SynthesizedPanic"`, `"UnresolvedCall(\`foo\`)"`)
+fn collect_panic_chain<'tcx>(
+    genv: GlobalEnv<'_, 'tcx>,
+    mut spec: PanicSpec<'tcx>,
+) -> (Vec<(rustc_span::Span, String)>, String) {
+    let mut hops = Vec::new();
+    let mut transitive = false;
+    const MAX_DEPTH: usize = 20;
+    for _ in 0..MAX_DEPTH {
+        match spec {
+            PanicSpec::WillNotPanic => break,
+            PanicSpec::MightPanic(reason) => match reason {
+                PanicReason::Transitive { callee, call_site } => {
+                    let name = genv.tcx().def_path_debug_str(callee.def_id());
+                    hops.push((call_site, format!("which calls `{name}` here")));
+                    spec = genv.inferred_no_panic_key(callee);
+                    transitive = true;
+                }
+                PanicReason::UnresolvedCall { def_id, call_site } => {
+                    let name = genv.tcx().def_path_debug_str(def_id);
+                    hops.push((call_site, format!("cannot resolve `{name}` to a concrete implementation")));
+                    return (hops, root_cause(transitive, format!("UnresolvedCall(`{name}`)")));
+                }
+                PanicReason::DynamicDispatch { call_site } => {
+                    hops.push((call_site, "calls a function pointer or closure".into()));
+                    return (hops, root_cause(transitive, "DynamicDispatch".into()));
+                }
+                PanicReason::SynthesizedPanic { call_site } => {
+                    hops.push((call_site, "arithmetic operation that may panic".into()));
+                    return (hops, root_cause(transitive, "SynthesizedPanic".into()));
+                }
+                PanicReason::NotInCallGraph => {
+                    return (hops, root_cause(transitive, "NotInCallGraph".into()));
+                }
+                PanicReason::NoMIRAvailable => {
+                    return (hops, root_cause(transitive, "NoMIRAvailable".into()));
+                }
+            },
+        }
+    }
+    (hops, "unknown".into())
+}
+
+fn root_cause(transitive: bool, cause: String) -> String {
+    if transitive { format!("Transitive -> {cause}") } else { cause }
 }
 
 mod errors {

--- a/crates/flux-refineck/src/lib.rs
+++ b/crates/flux-refineck/src/lib.rs
@@ -268,12 +268,13 @@ fn report_errors(
             ConstrReason::Other => {
                 emit(errors::UnknownError { span }.into_diag(dcx, rustc_errors::Level::Error))
             }
-            ConstrReason::NoPanic(callee, reason) => {
+            ConstrReason::NoPanic { callee, caller, location } => {
+                let spec = genv.inferred_no_panic_at(caller, location);
                 emit(
                     errors::PanicError {
                         span,
                         callee: genv.tcx().def_path_debug_str(callee),
-                        reason: format!("{:?}", reason),
+                        reason: format!("{spec:?}"),
                     }
                     .into_diag(dcx, rustc_errors::Level::Error),
                 )


### PR DESCRIPTION
This PR adds the infrastructure to track and report the root cause of panics.
Specifically, this PR:
1. Extends `PanicReason` with a notion of blame, i.e., what span is responsible for the panic. For most `PanicReason`s this means tracking a single span (such as the call to an unresolved function), but for `Transitive` panics, we also track `callee: NodeKey<'tcx>` which denotes "func x panics because func `callee` panics". Notably, this requires including the `tcx` lifetime in `PanicSpec`. To prevent the `tcx` lifetime from needing to be included in `ConstrReason` (which currently holds a `PanicSpec`), this PR:
2. Replaces `PanicSpec` in `ConstrReason` with callee `DefId`, caller `DefId`, and `Location`. This prevents `ConstrReason` from having the `tcx` lifetime. If it did include that lifetime, we would have to propagate it throughout basically all the fixpoint machinery, which we want to avoid. 
3. Adds a helper `inferred_no_panic_at` that takes a caller and a location, and fetches the relevant `PanicSpec`. This lets us reconstruct the `PanicSpec` from the info in the `ConstrReason`.
4. Tracks the spans of callsites computed by the callgraph.
5. Improved error messages to report the above info. The most significant change is the errors for `Transitive` panics, which now report the chain of calls that leads to the panic in the form of compiler notes.

Example: 

Old  error:
```
error[E0999]: call to core[4d41]::slice::{impl#0}::reverse may panic: MightPanic(Transitive)
   --> src/retrospective.rs:102:5
    |
102 |     recent_values.reverse();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
```

New error:
```
error[E0999]: call to core[4d41]::slice::{impl#0}::reverse may panic: Transitive -> SynthesizedPanic
    --> src/retrospective.rs:102:5
     |
 102 |     recent_values.reverse();
     |     ^^^^^^^^^^^^^^^^^^^^^^^
     |
note: which calls `core[4d41]::slice::{impl#0}::reverse::revswap` here
    --> /home/evan/.rustup/toolchains/nightly-2025-11-25-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/mod.rs:997:9
     |
 997 |         revswap(front_half, back_half, half_len);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: Rustc-synthesized panic here (likely arithmetic overflow, bounds check, div-by-zero, or assert! macro)
    --> /home/evan/.rustup/toolchains/nightly-2025-11-25-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/mod.rs:1014:32
     |
1014 |                 mem::swap(&mut a[i], &mut b[n - 1 - i]);
     |                                ^^^^

```


Note: `collect_panic_chain` and `inferred_no_panic_at` are Claude-generated. They seem reasonable, and I tweaked them to give the error messages I want, but maybe scrutinize them a little more.

Intended to close #1677 