### PR TITLE
spec for windows and position

### DIFF
--- a/lib/flux-core/src/iter/traits/iterator.rs
+++ b/lib/flux-core/src/iter/traits/iterator.rs
@@ -50,4 +50,12 @@ trait Iterator {
     fn collect<B: FromIterator<Self::Item>>(self) -> B
     where
         Self: Sized;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/iter/traits/iterator.rs#L3049
+    #[spec(fn(self: &mut Self[@s], P) -> Option<usize{n: n < <Self as Iterator>::size(s)}>
+           where P: FnMut(Self::Item) -> bool)]
+    fn position<P>(&mut self, predicate: P) -> Option<usize>
+    where
+        Self: Sized,
+        P: FnMut(Self::Item) -> bool;
 }

--- a/lib/flux-core/src/slice/iter.rs
+++ b/lib/flux-core/src/slice/iter.rs
@@ -22,6 +22,13 @@ impl<'a, T> Iterator for Iter<'a, T> {
     #[spec(fn(self: &mut Iter<T>[@curr_s]) -> Option<_>[curr_s.idx < curr_s.len]
            ensures self: Iter<T>{next_s: curr_s.idx + 1 == next_s.idx && curr_s.len == next_s.len})]
     fn next(&mut self) -> Option<&'a T>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/iter/traits/iterator.rs#L3049
+    #[spec(fn(self: &mut Iter<T>[@s], P) -> Option<usize{n: n < s.len - s.idx}>)]
+    fn position<P>(&mut self, predicate: P) -> Option<usize>
+    where
+        Self: Sized,
+        P: FnMut(&'a T) -> bool;
 }
 
 #[extern_spec(core::slice)]
@@ -29,4 +36,22 @@ impl<'a, T> IntoIterator for &'a [T] {
     #[no_panic]
     #[spec(fn(&[T][@n]) -> Iter<T>[0, n])]
     fn into_iter(v: &'a [T]) -> Iter<'a, T>;
+}
+
+#[extern_spec(core::slice)]
+#[refined_by(remaining: int, window_size: int)]
+struct Windows<'a, T>;
+
+#[extern_spec(core::slice)]
+#[assoc(
+    fn size(x: Windows) -> int { if x.window_size > x.remaining { 0 } else { x.remaining - x.window_size + 1 } }
+    fn done(x: Windows) -> bool { x.remaining < x.window_size }
+    fn step(x: Windows, y: Windows) -> bool { y.remaining == x.remaining - 1 && y.window_size == x.window_size }
+)]
+impl<'a, T> Iterator for Windows<'a, T> {
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/iter.rs#L1356
+    #[no_panic]
+    #[spec(fn(self: &mut Windows<T>[@curr_s]) -> Option<&[T][curr_s.window_size]>[curr_s.remaining >= curr_s.window_size]
+           ensures self: Windows<T>{next_s: next_s.remaining == curr_s.remaining - 1 && next_s.window_size == curr_s.window_size})]
+    fn next(&mut self) -> Option<&'a [T]>;
 }

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -81,6 +81,11 @@ impl<T> [T] {
     #[spec(fn(&Self[@n]) -> Iter<T>[0, n])]
     fn iter(&self) -> Iter<'_, T>;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/mod.rs#L1114
+    #[no_panic]
+    #[spec(fn(&Self[@n], {usize[@size] | size > 0}) -> Windows<T>[n, size])]
+    fn windows(&self, size: usize) -> Windows<'_, T>;
+
     #[no_panic]
     #[spec(fn(&Self[@n], mid: usize{mid <= n}) -> (&[T][mid], &[T][n - mid]))]
     fn split_at(&self, mid: usize) -> (&[T], &[T]);

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_slice03.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_slice03.rs
@@ -1,0 +1,15 @@
+extern crate flux_core;
+
+// windows() yields slices of length window_size, so indexing out of that
+// range is a statically detectable error.
+
+pub fn test_windows_oob(xs: &[i32]) {
+    let mut it = xs.windows(2);
+    if let Some(w) = it.next() {
+        let _ = w[2]; //~ ERROR possible out-of-bounds access
+    }
+}
+
+pub fn test_windows_unwrap_unchecked(xs: &[i32]) {
+    let _ = xs.windows(2).next().unwrap(); //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_iter00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_iter00.rs
@@ -1,0 +1,18 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- position ---
+
+// If position returns Some(i), i is strictly less than the iterator's size.
+pub fn test_position_in_bounds(xs: &[i32]) {
+    if let Some(i) = xs.iter().position(|&x| x > 0) {
+        assert(i < xs.len());
+    }
+}
+
+// The bound is tight enough to use the result as a direct index.
+pub fn test_position_safe_index(xs: &[i32]) {
+    if let Some(i) = xs.iter().position(|&x| x > 0) {
+        let _ = xs[i];
+    }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_slice04.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_slice04.rs
@@ -1,0 +1,49 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+// --- windows ---
+
+pub fn test_windows_some_concrete() {
+    let v = [1, 2, 3, 4, 5];
+    let mut it = v.windows(3);
+    assert(it.next().is_some());
+}
+
+pub fn test_windows_none_when_too_short() {
+    let v: [i32; 2] = [1, 2];
+    let mut it = v.windows(3);
+    assert(it.next().is_none());
+}
+
+pub fn test_windows_some_branch(xs: &[i32]) {
+    if xs.len() >= 4 {
+        let mut it = xs.windows(4);
+        assert(it.next().is_some());
+    }
+}
+
+pub fn test_windows_none_branch(xs: &[i32]) {
+    if xs.len() < 4 {
+        let mut it = xs.windows(4);
+        assert(it.next().is_none());
+    }
+}
+
+// The key property: window_size is tracked in the item type.
+// Flux knows w has length 2, so w[0] and w[1] are provably safe without a runtime check.
+pub fn test_windows_index_safe(xs: &[i32]) {
+    let mut it = xs.windows(2);
+    if let Some(w) = it.next() {
+        let _diff = w[1] - w[0];
+    }
+}
+
+// Same with window_size=3: w[0], w[1], w[2] are all provably safe.
+pub fn test_windows_index_safe_3(xs: &[i32]) {
+    let mut it = xs.windows(3);
+    if let Some(w) = it.next() {
+        let _ = w[0];
+        let _ = w[1];
+        let _ = w[2];
+    }
+}


### PR DESCRIPTION
This PR adds specs for `position` and `slice::windows`.
The spec for position specifies that the output (if it is `Some`) returns an idx < `iter.size`.
The spec for `windows` propagates size constraints across the iter. The lets us verify code like
```rust
pub fn test_windows_index_safe(xs: &[i32]) {
    let mut it = xs.windows(2);
    if let Some(w) = it.next() {
        let _diff = w[1] - w[0];
    }
```

These were both added in service of verifying the insulin pump.