### PR TITLE
Core ptr specs part 4: `NonNull<T>`

### DIFF
--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -52,6 +52,8 @@
 /// These specs do NOT prove temporal safety.
 /// To prove temporal safety, Flux would need to tie the lifetimes of allocations to the pointers derived from them,
 /// which is currently out of scope.
+mod non_null;
+
 use flux_attrs::*;
 
 macro_rules! ptr_specs {

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -1,3 +1,29 @@
+#![flux::defs {
+    // The pointer lies within its allocation: addr >= base (not before the start)
+    // and size >= 0. One-past-the-end pointers (size == 0) satisfy this — they
+    // are valid starting points for arithmetic but cannot be dereferenced.
+    fn nn_in_bounds(base: int, addr: int, size: int) -> bool {
+        addr >= base && size >= 0
+    }
+
+    // The range [addr, addr + num_bytes) fits inside the allocation.
+    fn nn_dereferenceable(base: int, addr: int, size: int, num_bytes: int) -> bool {
+        addr >= base && num_bytes <= size && size >= 0
+    }
+
+    // Validity for read/write. Allows null only for ZST accesses (num_bytes == 0);
+    // for NonNull the addr != 0 invariant is already guaranteed by the type, so
+    // this reduces to the dereferenceable check.
+    fn nn_valid(base: int, addr: int, size: int, num_bytes: int) -> bool {
+        num_bytes == 0 || nn_dereferenceable(base, addr, size, num_bytes)
+    }
+
+    // The address is a multiple of `alignment`.
+    fn nn_aligned_to(addr: int, alignment: int) -> bool {
+        addr % alignment == 0
+    }
+}]
+
 use flux_attrs::*;
 
 #[extern_spec(core::ptr)]
@@ -7,6 +33,7 @@ struct NonNull<T>;
 
 #[extern_spec(core::ptr)]
 impl<T> NonNull<T> {
+    /// Need to enforce that the pointer value is non-null, because as the name suggests, this function does not check.
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L234
     #[spec(fn(*mut[@p] T) -> NonNull<T>[p.base, p.addr, p.size] requires p.addr != 0)]
     unsafe fn new_unchecked(ptr: *mut T) -> Self;
@@ -22,44 +49,44 @@ impl<T> NonNull<T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L652
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
         -> NonNull<T>[base, addr + count * T::size_of(), size - count * T::size_of()]
-            requires addr >= base && size >= 0 && count * T::size_of() <= size)]
+            requires nn_in_bounds(base, addr, size) && count * T::size_of() <= size)]
     unsafe fn add(self, count: usize) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L729
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
         -> NonNull<T>[base, addr - count * T::size_of(), size + count * T::size_of()]
-            requires addr >= base && size >= 0 && count * T::size_of() <= addr - base)]
+            requires nn_in_bounds(base, addr, size) && count * T::size_of() <= addr - base)]
     unsafe fn sub(self, count: usize) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L576
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: isize)
         -> NonNull<T>[base, addr + count * T::size_of(), size - count * T::size_of()]
-            requires addr >= base && size >= 0 && count * T::size_of() <= size && addr + count * T::size_of() >= base)]
+            requires nn_in_bounds(base, addr, size) && count * T::size_of() <= size && addr + count * T::size_of() >= base)]
     unsafe fn offset(self, count: isize) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L678
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
         -> NonNull<T>[base, addr + count, size - count]
-            requires addr >= base && size >= 0 && count <= size)]
+            requires nn_in_bounds(base, addr, size) && count <= size)]
     unsafe fn byte_add(self, count: usize) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L760
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
         -> NonNull<T>[base, addr - count, size + count]
-            requires addr >= base && size >= 0 && count <= addr - base)]
+            requires nn_in_bounds(base, addr, size) && count <= addr - base)]
     unsafe fn byte_sub(self, count: usize) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L602
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: isize)
         -> NonNull<T>[base, addr + count, size - count]
-            requires addr >= base && size >= 0 && count <= size && addr + count >= base)]
+            requires nn_in_bounds(base, addr, size) && count <= size && addr + count >= base)]
     unsafe fn byte_offset(self, count: isize) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L858
     #[spec(fn(NonNull<T>[@sbase, @saddr, @ssize], origin: NonNull<T>[@obase, @oaddr, @osize]) -> isize[(saddr - oaddr) / T::size_of()]
         requires sbase == obase &&
-                 saddr >= sbase && ssize >= 0 &&
-                 oaddr >= obase && osize >= 0 &&
+                 nn_in_bounds(sbase, saddr, ssize) &&
+                 nn_in_bounds(obase, oaddr, osize) &&
                  (saddr - oaddr) % T::size_of() == 0 &&
                  T::size_of() > 0)]
     unsafe fn offset_from(self, origin: NonNull<T>) -> isize
@@ -69,8 +96,8 @@ impl<T> NonNull<T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L949
     #[spec(fn(NonNull<T>[@sbase, @saddr, @ssize], subtracted: NonNull<T>[@obase, @oaddr, @osize]) -> usize[(saddr - oaddr) / T::size_of()]
         requires sbase == obase &&
-                 saddr >= sbase && ssize >= 0 &&
-                 oaddr >= obase && osize >= 0 &&
+                 nn_in_bounds(sbase, saddr, ssize) &&
+                 nn_in_bounds(obase, oaddr, osize) &&
                  saddr >= oaddr &&
                  (saddr - oaddr) % T::size_of() == 0 &&
                  T::size_of() > 0)]
@@ -80,16 +107,14 @@ impl<T> NonNull<T> {
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L986
     #[spec(fn(NonNull<T>[@base, @addr, @size]) -> T
-        requires (T::size_of() == 0 || (addr >= base && T::size_of() <= size && size >= 0))
-                 && addr % T::align_of() == 0)]
+        requires nn_valid(base, addr, size, T::size_of()) && nn_aligned_to(addr, T::align_of()))]
     unsafe fn read(self) -> T
     where
         T: Sized;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1141
     #[spec(fn(NonNull<T>[@base, @addr, @size], val: T)
-        requires (T::size_of() == 0 || (addr >= base && T::size_of() <= size && size >= 0))
-                 && addr % T::align_of() == 0)]
+        requires nn_valid(base, addr, size, T::size_of()) && nn_aligned_to(addr, T::align_of()))]
     unsafe fn write(self, val: T)
     where
         T: Sized;

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -123,13 +123,9 @@ impl<T> NonNull<T> {
 #[extern_spec(core::ptr)]
 impl<T> NonNull<[T]> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1420
+    /// Safety: https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety
     #[no_panic]
-    #[spec(fn(data: NonNull<T>[@base, @addr, @size], len: usize) -> NonNull<[T]>[base, addr, len * T::size_of()])]
+    #[spec(fn(data: NonNull<T>[@base, @addr, @size], len: usize) -> NonNull<[T]>[base, addr, size]
+        requires nn_valid(base, addr, size, len * T::size_of()) && nn_aligned_to(addr, T::align_of()))]
     fn slice_from_raw_parts(data: NonNull<T>, len: usize) -> Self;
-
-    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1444
-    #[no_panic]
-    #[spec(fn(NonNull<[T]>[@base, @addr, @size]) -> usize[size / T::size_of()]
-        requires T::size_of() > 0)]
-    fn len(self) -> usize;
 }

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -11,9 +11,9 @@
         addr >= base && num_bytes <= size && size >= 0
     }
 
-    // Validity for read/write. Allows null only for ZST accesses (num_bytes == 0);
-    // for NonNull the addr != 0 invariant is already guaranteed by the type, so
-    // this reduces to the dereferenceable check.
+    // Validity for read/write. Like ptr::valid, but drops the `addr != 0` guard —
+    // NonNull's invariant covers that. The num_bytes == 0 ZST shortcut is retained:
+    // a zero-byte access is valid even when the pointer is outside the allocation.
     fn nn_valid(base: int, addr: int, size: int, num_bytes: int) -> bool {
         num_bytes == 0 || nn_dereferenceable(base, addr, size, num_bytes)
     }
@@ -55,13 +55,13 @@ impl<T> NonNull<T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L729
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
         -> NonNull<T>[base, addr - count * T::size_of(), size + count * T::size_of()]
-            requires nn_in_bounds(base, addr, size) && count * T::size_of() <= addr - base)]
+            requires nn_in_bounds(base, addr, size) && count * T::size_of() <= addr - base && addr - count * T::size_of() != 0)]
     unsafe fn sub(self, count: usize) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L576
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: isize)
         -> NonNull<T>[base, addr + count * T::size_of(), size - count * T::size_of()]
-            requires nn_in_bounds(base, addr, size) && count * T::size_of() <= size && addr + count * T::size_of() >= base)]
+            requires nn_in_bounds(base, addr, size) && count * T::size_of() <= size && addr + count * T::size_of() >= base && addr + count * T::size_of() != 0)]
     unsafe fn offset(self, count: isize) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L678
@@ -73,13 +73,13 @@ impl<T> NonNull<T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L760
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
         -> NonNull<T>[base, addr - count, size + count]
-            requires nn_in_bounds(base, addr, size) && count <= addr - base)]
+            requires nn_in_bounds(base, addr, size) && count <= addr - base && addr - count != 0)]
     unsafe fn byte_sub(self, count: usize) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L602
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: isize)
         -> NonNull<T>[base, addr + count, size - count]
-            requires nn_in_bounds(base, addr, size) && count <= size && addr + count >= base)]
+            requires nn_in_bounds(base, addr, size) && count <= size && addr + count >= base && addr + count != 0)]
     unsafe fn byte_offset(self, count: isize) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L858

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -1,0 +1,21 @@
+use flux_attrs::*;
+
+#[extern_spec(core::ptr)]
+#[refined_by(p: ptr)]
+#[invariant(p.addr != 0)]
+struct NonNull<T>;
+
+#[extern_spec(core::ptr)]
+impl<T> NonNull<T> {
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L234
+    #[spec(fn(*mut[@p] T) -> NonNull<T>[p] requires p.addr != 0)]
+    unsafe fn new_unchecked(ptr: *mut T) -> Self;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L270
+    #[spec(fn(*mut[@p] T) -> Option<NonNull<T>[p]>)]
+    fn new(ptr: *mut T) -> Option<NonNull<T>>;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L402
+    #[spec(fn(NonNull<T>[@nn]) -> *mut[nn] T)]
+    fn as_ptr(self) -> *mut T;
+}

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -54,4 +54,29 @@ impl<T> NonNull<T> {
         -> NonNull<T>[base, addr + count, size - count]
             requires addr >= base && size >= 0 && count <= size && addr + count >= base)]
     unsafe fn byte_offset(self, count: isize) -> Self;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L986
+    #[spec(fn(NonNull<T>[@base, @addr, @size]) -> T
+        requires (T::size_of() == 0 || (addr >= base && T::size_of() <= size && size >= 0))
+                 && addr % T::align_of() == 0)]
+    unsafe fn read(self) -> T
+    where
+        T: Sized;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1141
+    #[spec(fn(NonNull<T>[@base, @addr, @size], val: T)
+        requires (T::size_of() == 0 || (addr >= base && T::size_of() <= size && size >= 0))
+                 && addr % T::align_of() == 0)]
+    unsafe fn write(self, val: T)
+    where
+        T: Sized;
+}
+
+#[extern_spec(core::ptr)]
+impl<T> NonNull<[T]> {
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1444
+    #[no_panic]
+    #[spec(fn(NonNull<[T]>[@base, @addr, @size]) -> usize[size / T::size_of()]
+        requires T::size_of() > 0)]
+    fn len(self) -> usize;
 }

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -55,6 +55,29 @@ impl<T> NonNull<T> {
             requires addr >= base && size >= 0 && count <= size && addr + count >= base)]
     unsafe fn byte_offset(self, count: isize) -> Self;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L858
+    #[spec(fn(NonNull<T>[@sbase, @saddr, @ssize], origin: NonNull<T>[@obase, @oaddr, @osize]) -> isize[(saddr - oaddr) / T::size_of()]
+        requires sbase == obase &&
+                 saddr >= sbase && ssize >= 0 &&
+                 oaddr >= obase && osize >= 0 &&
+                 (saddr - oaddr) % T::size_of() == 0 &&
+                 T::size_of() > 0)]
+    unsafe fn offset_from(self, origin: NonNull<T>) -> isize
+    where
+        T: Sized;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L949
+    #[spec(fn(NonNull<T>[@sbase, @saddr, @ssize], subtracted: NonNull<T>[@obase, @oaddr, @osize]) -> usize[(saddr - oaddr) / T::size_of()]
+        requires sbase == obase &&
+                 saddr >= sbase && ssize >= 0 &&
+                 oaddr >= obase && osize >= 0 &&
+                 saddr >= oaddr &&
+                 (saddr - oaddr) % T::size_of() == 0 &&
+                 T::size_of() > 0)]
+    unsafe fn offset_from_unsigned(self, subtracted: NonNull<T>) -> usize
+    where
+        T: Sized;
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L986
     #[spec(fn(NonNull<T>[@base, @addr, @size]) -> T
         requires (T::size_of() == 0 || (addr >= base && T::size_of() <= size && size >= 0))
@@ -74,6 +97,11 @@ impl<T> NonNull<T> {
 
 #[extern_spec(core::ptr)]
 impl<T> NonNull<[T]> {
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1420
+    #[no_panic]
+    #[spec(fn(data: NonNull<T>[@base, @addr, @size], len: usize) -> NonNull<[T]>[base, addr, len * T::size_of()])]
+    fn slice_from_raw_parts(data: NonNull<T>, len: usize) -> Self;
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1444
     #[no_panic]
     #[spec(fn(NonNull<[T]>[@base, @addr, @size]) -> usize[size / T::size_of()]

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -36,4 +36,22 @@ impl<T> NonNull<T> {
         -> NonNull<T>[base, addr + count * T::size_of(), size - count * T::size_of()]
             requires addr >= base && size >= 0 && count * T::size_of() <= size && addr + count * T::size_of() >= base)]
     unsafe fn offset(self, count: isize) -> Self;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L678
+    #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
+        -> NonNull<T>[base, addr + count, size - count]
+            requires addr >= base && size >= 0 && count <= size)]
+    unsafe fn byte_add(self, count: usize) -> Self;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L760
+    #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
+        -> NonNull<T>[base, addr - count, size + count]
+            requires addr >= base && size >= 0 && count <= addr - base)]
+    unsafe fn byte_sub(self, count: usize) -> Self;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L602
+    #[spec(fn(NonNull<T>[@base, @addr, @size], count: isize)
+        -> NonNull<T>[base, addr + count, size - count]
+            requires addr >= base && size >= 0 && count <= size && addr + count >= base)]
+    unsafe fn byte_offset(self, count: isize) -> Self;
 }

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -1,21 +1,39 @@
 use flux_attrs::*;
 
 #[extern_spec(core::ptr)]
-#[refined_by(p: ptr)]
-#[invariant(p.addr != 0)]
+#[refined_by(base: int, addr: int, size: int)]
+#[invariant(addr != 0)]
 struct NonNull<T>;
 
 #[extern_spec(core::ptr)]
 impl<T> NonNull<T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L234
-    #[spec(fn(*mut[@p] T) -> NonNull<T>[p] requires p.addr != 0)]
+    #[spec(fn(*mut[@p] T) -> NonNull<T>[p.base, p.addr, p.size] requires p.addr != 0)]
     unsafe fn new_unchecked(ptr: *mut T) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L270
-    #[spec(fn(*mut[@p] T) -> Option<NonNull<T>[p]>)]
+    #[spec(fn(*mut[@p] T) -> Option<NonNull<T>[p.base, p.addr, p.size]>)]
     fn new(ptr: *mut T) -> Option<NonNull<T>>;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L402
-    #[spec(fn(NonNull<T>[@nn]) -> *mut[nn] T)]
+    #[spec(fn(NonNull<T>[@base, @addr, @size]) -> *mut[base, addr, size] T)]
     fn as_ptr(self) -> *mut T;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L652
+    #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
+        -> NonNull<T>[base, addr + count * T::size_of(), size - count * T::size_of()]
+            requires addr >= base && size >= 0 && count * T::size_of() <= size)]
+    unsafe fn add(self, count: usize) -> Self;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L729
+    #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
+        -> NonNull<T>[base, addr - count * T::size_of(), size + count * T::size_of()]
+            requires addr >= base && size >= 0 && count * T::size_of() <= addr - base)]
+    unsafe fn sub(self, count: usize) -> Self;
+
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L576
+    #[spec(fn(NonNull<T>[@base, @addr, @size], count: isize)
+        -> NonNull<T>[base, addr + count * T::size_of(), size - count * T::size_of()]
+            requires addr >= base && size >= 0 && count * T::size_of() <= size && addr + count * T::size_of() >= base)]
+    unsafe fn offset(self, count: isize) -> Self;
 }

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -39,7 +39,7 @@ impl<T> NonNull<T> {
     unsafe fn new_unchecked(ptr: *mut T) -> Self;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L270
-    #[spec(fn(*mut[@p] T) -> Option<NonNull<T>[p.base, p.addr, p.size]>)]
+    #[spec(fn(*mut[@p] T) -> Option<NonNull<T>[p.base, p.addr, p.size]>[p.addr != 0])]
     fn new(ptr: *mut T) -> Option<NonNull<T>>;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L402

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null00.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null00.rs
@@ -1,0 +1,14 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// new_unchecked requires a non-null pointer; passing an unconstrained pointer should fail
+pub fn test_new_unchecked_null(ptr: *mut i32) {
+    let _ = unsafe { NonNull::new_unchecked(ptr) }; //~ ERROR refinement type error
+}
+
+// new_unchecked with a known-null pointer should fail
+pub fn test_new_unchecked_known_null() {
+    let ptr: *mut i32 = std::ptr::null_mut();
+    let _ = unsafe { NonNull::new_unchecked(ptr) }; //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null00.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null00.rs
@@ -12,3 +12,11 @@ pub fn test_new_unchecked_known_null() {
     let ptr: *mut i32 = std::ptr::null_mut();
     let _ = unsafe { NonNull::new_unchecked(ptr) }; //~ ERROR refinement type error
 }
+
+// new with a null pointer yields None, not Some
+pub fn test_new_null_is_some() {
+    use flux_rs::assert;
+    let ptr: *mut i32 = std::ptr::null_mut();
+    let nn = NonNull::new(ptr);
+    assert(nn.is_some()); //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null01.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null01.rs
@@ -1,0 +1,70 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// --- add ---
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && size > 8 && addr != 0 && addr % 4 == 0)]
+pub fn test_add_ex(nn: NonNull<i32>) {
+    unsafe {
+        let _val0 = std::ptr::read(nn.add(0).as_ptr());
+        let _val1 = std::ptr::read(nn.add(1).as_ptr());
+        let _val2 = std::ptr::read(nn.add(2).as_ptr()); //~ ERROR refinement type error
+    }
+}
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && size == 8 && addr != 0 && addr % 4 == 0)]
+pub fn test_add_ix(nn: NonNull<i32>) {
+    unsafe {
+        let _val0 = std::ptr::read(nn.add(0).as_ptr());
+        let _val1 = std::ptr::read(nn.add(1).as_ptr());
+        let _val2 = std::ptr::read(nn.add(2).as_ptr()); //~ ERROR refinement type error
+    }
+}
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && size > 8 && addr != 0 && addr % 4 == 0)]
+pub fn test_add_mut_ex(nn: NonNull<i32>) {
+    unsafe {
+        std::ptr::write(nn.add(0).as_ptr(), 10);
+        std::ptr::write(nn.add(1).as_ptr(), 20);
+        std::ptr::write(nn.add(2).as_ptr(), 30); //~ ERROR refinement type error
+    }
+}
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && size == 8 && addr != 0 && addr % 4 == 0)]
+pub fn test_add_mut_ix(nn: NonNull<i32>) {
+    unsafe {
+        std::ptr::write(nn.add(0).as_ptr(), 10);
+        std::ptr::write(nn.add(1).as_ptr(), 20);
+        std::ptr::write(nn.add(2).as_ptr(), 30); //~ ERROR refinement type error
+    }
+}
+
+// --- offset (signed count) ---
+
+// forward offset past end: size == 4 holds only one i32; offset(2) needs 8 bytes
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && addr > 0 && size == 4 && addr % 4 == 0)]
+pub fn test_offset_forward_too_far(nn: NonNull<i32>) {
+    unsafe {
+        let _ = nn.offset(2); //~ ERROR refinement type error
+    }
+}
+
+// backward offset before base: addr == base means no room behind the pointer
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr == base && size >= 4 && addr % 4 == 0)]
+pub fn test_offset_backward_past_base(nn: NonNull<i32>) {
+    unsafe {
+        let _ = nn.offset(-1); //~ ERROR refinement type error
+    }
+}
+
+// --- sub ---
+
+// sub(1) moves addr before base; ptr is at the start of its allocation
+pub fn test_sub_oob(buf: &mut [i32; 2]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        std::ptr::write(nn.sub(1).as_ptr(), 10); //~ ERROR refinement type error
+                                                  //~| ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null01.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null01.rs
@@ -55,6 +55,7 @@ pub fn test_offset_forward_too_far(nn: NonNull<i32>) {
 pub fn test_offset_backward_past_base(nn: NonNull<i32>) {
     unsafe {
         let _ = nn.offset(-1); //~ ERROR refinement type error
+                               //~| ERROR refinement type error
     }
 }
 
@@ -65,6 +66,7 @@ pub fn test_sub_oob(buf: &mut [i32; 2]) {
     let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
     unsafe {
         std::ptr::write(nn.sub(1).as_ptr(), 10); //~ ERROR refinement type error
+                                                  //~| ERROR refinement type error
                                                   //~| ERROR refinement type error
     }
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null02.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null02.rs
@@ -2,6 +2,17 @@ extern crate flux_core;
 
 use std::ptr::NonNull;
 
+// --- sub ---
+
+// base == 0, addr == 1 * size_of::<i32>() == 4: all requires of sub(1) are satisfied,
+// but the result address is 0, violating the NonNull invariant addr != 0
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires base == 0 && addr == 4 && size >= 0)]
+pub fn test_sub_null_result(nn: NonNull<i32>) {
+    unsafe {
+        let _ = nn.sub(1); //~ ERROR refinement type error
+    }
+}
+
 // --- byte_add ---
 
 // byte_add(8) exhausts the 8-byte buffer, leaving size == 0
@@ -20,6 +31,7 @@ pub fn test_byte_sub_oob(buf: &mut [i32; 2]) {
     unsafe {
         let nn1 = nn.byte_add(4);
         std::ptr::write(nn1.byte_sub(8).as_ptr(), 10); //~ ERROR refinement type error
+                                                        //~| ERROR refinement type error
                                                         //~| ERROR refinement type error
     }
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null02.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null02.rs
@@ -1,0 +1,43 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// --- byte_add ---
+
+// byte_add(8) exhausts the 8-byte buffer, leaving size == 0
+pub fn test_byte_add_oob(buf: &mut [i32; 2]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        std::ptr::write(nn.byte_add(8).as_ptr(), 10); //~ ERROR refinement type error
+    }
+}
+
+// --- byte_sub ---
+
+// byte_sub(8) moves addr before base
+pub fn test_byte_sub_oob(buf: &mut [i32; 2]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let nn1 = nn.byte_add(4);
+        std::ptr::write(nn1.byte_sub(8).as_ptr(), 10); //~ ERROR refinement type error
+                                                        //~| ERROR refinement type error
+    }
+}
+
+// --- byte_offset ---
+
+// forward too far: count(9) > size(8)
+pub fn test_byte_offset_forward_oob(buf: &mut [i32; 2]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let _ = nn.byte_offset(9); //~ ERROR refinement type error
+    }
+}
+
+// backward before base: fresh ptr has addr == base, so addr + (-1) < base
+pub fn test_byte_offset_backward_oob(buf: &mut [i32; 2]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let _ = nn.byte_offset(-1); //~ ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null03.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null03.rs
@@ -1,0 +1,28 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// --- read ---
+
+// unconstrained NonNull: can't prove valid or aligned
+pub fn test_read(nn: NonNull<i32>) -> i32 {
+    unsafe { nn.read() } //~ ERROR refinement type error
+                         //~| ERROR refinement type error
+}
+
+// --- write ---
+
+// unconstrained NonNull: can't prove valid or aligned
+pub fn test_write(nn: NonNull<i32>, val: i32) {
+    unsafe { nn.write(val) } //~ ERROR refinement type error
+                              //~| ERROR refinement type error
+}
+
+// --- len ---
+
+// size == 12 → len() == 3, not 4
+#[flux::spec(fn (nn: NonNull<[i32]>[@base, @addr, @size]) requires size == 12)]
+pub fn test_len_wrong(nn: NonNull<[i32]>) {
+    use flux_rs::assert;
+    assert(nn.len() == 4); //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null03.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null03.rs
@@ -18,11 +18,3 @@ pub fn test_write(nn: NonNull<i32>, val: i32) {
                               //~| ERROR refinement type error
 }
 
-// --- len ---
-
-// size == 12 → len() == 3, not 4
-#[flux::spec(fn (nn: NonNull<[i32]>[@base, @addr, @size]) requires size == 12)]
-pub fn test_len_wrong(nn: NonNull<[i32]>) {
-    use flux_rs::assert;
-    assert(nn.len() == 4); //~ ERROR refinement type error
-}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null04.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null04.rs
@@ -1,0 +1,55 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// --- offset_from ---
+
+// different allocations: sbase != obase violates same-allocation requirement.
+// Alignment is constrained so only the base check fails.
+#[flux::spec(fn (p: NonNull<i32>[@sbase, @saddr, @ssize], q: NonNull<i32>[@obase, @oaddr, @osize])
+    requires saddr >= sbase && ssize >= 0 && oaddr >= obase && osize >= 0 && obase != sbase && (saddr - oaddr) % 4 == 0)]
+pub fn test_offset_from_diff_base(p: NonNull<i32>, q: NonNull<i32>) {
+    unsafe {
+        let _ = p.offset_from(q); //~ ERROR refinement type error
+    }
+}
+
+// non-element-aligned distance: q is 1 byte ahead of p, but T = i32 requires a multiple of 4
+#[flux::spec(fn (p: NonNull<i32>[@sbase, @saddr, @ssize], q: NonNull<i32>[@obase, @oaddr, @osize])
+    requires sbase == obase && saddr >= sbase && ssize >= 0 && oaddr == saddr + 1 && osize >= 0)]
+pub fn test_offset_from_unaligned(p: NonNull<i32>, q: NonNull<i32>) {
+    unsafe {
+        let _ = q.offset_from(p); //~ ERROR refinement type error
+    }
+}
+
+// ZST: size_of::<()>() == 0, violating T::size_of() > 0
+#[flux::spec(fn (p: NonNull<()>[@sbase, @saddr, @ssize], q: NonNull<()>[@obase, @oaddr, @osize])
+    requires sbase == obase && saddr >= sbase && ssize >= 0 && oaddr == saddr && osize == ssize)]
+pub fn test_offset_from_zst(p: NonNull<()>, q: NonNull<()>) {
+    unsafe {
+        let _ = p.offset_from(q); //~ ERROR refinement type error
+    }
+}
+
+// --- offset_from_unsigned ---
+
+// origin is ahead of self: violates saddr >= oaddr.
+// oaddr = saddr + 4 ensures (saddr - oaddr) % 4 == 0 in SMT-lib.
+#[flux::spec(fn (p: NonNull<i32>[@sbase, @saddr, @ssize], q: NonNull<i32>[@obase, @oaddr, @osize])
+    requires sbase == obase && saddr >= sbase && ssize >= 0 && oaddr == saddr + 4 && osize >= 0)]
+pub fn test_offset_from_unsigned_reversed(p: NonNull<i32>, q: NonNull<i32>) {
+    unsafe {
+        let _ = p.offset_from_unsigned(q); //~ ERROR refinement type error
+    }
+}
+
+// --- slice_from_raw_parts ---
+
+// asserts len == 4 but slice was created with len == 2
+pub fn test_slice_from_raw_parts_wrong_len(buf: &mut [i32; 4]) {
+    use flux_rs::assert;
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    let slice_nn = NonNull::slice_from_raw_parts(nn, 2);
+    assert(slice_nn.len() == 4); //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null04.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null04.rs
@@ -46,10 +46,8 @@ pub fn test_offset_from_unsigned_reversed(p: NonNull<i32>, q: NonNull<i32>) {
 
 // --- slice_from_raw_parts ---
 
-// asserts len == 4 but slice was created with len == 2
-pub fn test_slice_from_raw_parts_wrong_len(buf: &mut [i32; 4]) {
-    use flux_rs::assert;
+// 5 elements × 4 bytes = 20 bytes exceeds the 16-byte buffer; requires fails
+pub fn test_slice_from_raw_parts_oob(buf: &mut [i32; 4]) {
     let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
-    let slice_nn = NonNull::slice_from_raw_parts(nn, 2);
-    assert(slice_nn.len() == 4); //~ ERROR refinement type error
+    let _slice_nn = NonNull::slice_from_raw_parts(nn, 5); //~ ERROR refinement type error
 }

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null00.rs
@@ -1,0 +1,28 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// new_unchecked: non-null pointer in, NonNull out; as_ptr recovers the original pointer
+#[flux::spec(fn (ptr: *mut[@p] i32) requires p.addr != 0)]
+pub fn test_new_unchecked(ptr: *mut i32) {
+    let nn = unsafe { NonNull::new_unchecked(ptr) };
+    let raw = nn.as_ptr();
+    // the invariant guarantees raw is non-null
+    assert!(!raw.is_null());
+}
+
+// new: None branch — null pointer yields None
+pub fn test_new_null() {
+    let ptr: *mut i32 = std::ptr::null_mut();
+    let nn = NonNull::new(ptr);
+    assert!(nn.is_none());
+}
+
+// new + as_ptr round-trip: recovering the pointer preserves identity
+#[flux::spec(fn (ptr: *mut[@p] i32) requires p.addr != 0)]
+pub fn test_new_as_ptr_roundtrip(ptr: *mut i32) {
+    if let Some(nn) = NonNull::new(ptr) {
+        let raw = nn.as_ptr();
+        assert!(!raw.is_null());
+    }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null00.rs
@@ -11,11 +11,20 @@ pub fn test_new_unchecked(ptr: *mut i32) {
     assert!(!raw.is_null());
 }
 
-// new: None branch — null pointer yields None
+// new: None branch — null pointer statically known to yield None
 pub fn test_new_null() {
+    use flux_rs::assert;
     let ptr: *mut i32 = std::ptr::null_mut();
     let nn = NonNull::new(ptr);
-    assert!(nn.is_none());
+    assert(!nn.is_some());
+}
+
+// new: Some branch — non-null pointer statically known to yield Some
+#[flux::spec(fn (ptr: *mut[@p] i32) requires p.addr != 0)]
+pub fn test_new_nonnull(ptr: *mut i32) {
+    use flux_rs::assert;
+    let nn = NonNull::new(ptr);
+    assert(nn.is_some());
 }
 
 // new + as_ptr round-trip: recovering the pointer preserves identity

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null01.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null01.rs
@@ -1,0 +1,95 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// --- add ---
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && addr > 0 && size >= 8 && addr % 4 == 0)]
+pub fn test_add_ex(nn: NonNull<i32>) {
+    unsafe {
+        let _val0 = std::ptr::read(nn.add(0).as_ptr());
+        let _val1 = std::ptr::read(nn.add(1).as_ptr());
+    }
+}
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && addr > 0 && size == 8 && addr % 4 == 0)]
+pub fn test_add_ix(nn: NonNull<i32>) {
+    unsafe {
+        let _val0 = std::ptr::read(nn.add(0).as_ptr());
+        let _val1 = std::ptr::read(nn.add(1).as_ptr());
+    }
+}
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && addr > 0 && size >= 8 && addr % 4 == 0)]
+pub fn test_add_mut_ex(nn: NonNull<i32>) {
+    unsafe {
+        std::ptr::write(nn.add(0).as_ptr(), 10);
+        std::ptr::write(nn.add(1).as_ptr(), 20);
+    }
+}
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && addr > 0 && size == 8 && addr % 4 == 0)]
+pub fn test_add_mut_ix(nn: NonNull<i32>) {
+    unsafe {
+        std::ptr::write(nn.add(0).as_ptr(), 10);
+        std::ptr::write(nn.add(1).as_ptr(), 20);
+    }
+}
+
+// --- sub ---
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && addr > 0 && size >= 8 && addr % 4 == 0)]
+pub fn test_sub_ex(nn: NonNull<i32>) {
+    unsafe {
+        let nn1 = nn.add(1);
+        let nn0 = nn1.sub(1);
+        let _val = std::ptr::read(nn0.as_ptr());
+    }
+}
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && addr > 0 && size == 8 && addr % 4 == 0)]
+pub fn test_sub_ix(nn: NonNull<i32>) {
+    unsafe {
+        let nn1 = nn.add(1);
+        let nn0 = nn1.sub(1);
+        let _val = std::ptr::read(nn0.as_ptr());
+    }
+}
+
+// --- offset (signed count — forward and backward) ---
+
+// forward: like add(1) but with isize
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && addr > 0 && size >= 8 && addr % 4 == 0)]
+pub fn test_offset_forward(nn: NonNull<i32>) {
+    unsafe {
+        let _val0 = std::ptr::read(nn.offset(0).as_ptr());
+        let _val1 = std::ptr::read(nn.offset(1).as_ptr());
+    }
+}
+
+// backward: nn is one element into its allocation; offset(-1) steps back to base.
+// After offset(-1): new addr = addr - 4, new size = size + 4. Read requires size + 4 >= 4,
+// i.e. size >= 0. Non-null requires addr - 4 > 0, i.e. addr > 4.
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr > 4 && addr >= base + 4 && size >= 0 && addr % 4 == 0)]
+pub fn test_offset_backward(nn: NonNull<i32>) {
+    unsafe {
+        let _ = std::ptr::read(nn.offset(-1).as_ptr());
+    }
+}
+
+// *mut forward: offset + write
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr >= base && addr > 0 && size >= 8 && addr % 4 == 0)]
+pub fn test_offset_mut_forward(nn: NonNull<i32>) {
+    unsafe {
+        std::ptr::write(nn.offset(0).as_ptr(), 10);
+        std::ptr::write(nn.offset(1).as_ptr(), 20);
+    }
+}
+
+// *mut backward
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) requires addr > 4 && addr >= base + 4 && size >= 0 && addr % 4 == 0)]
+pub fn test_offset_mut_backward(nn: NonNull<i32>) {
+    unsafe {
+        std::ptr::write(nn.offset(-1).as_ptr(), 42);
+    }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null02.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null02.rs
@@ -1,0 +1,47 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// --- byte_add ---
+
+pub fn test_byte_add(buf: &mut [i32; 2]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        std::ptr::write(nn.byte_add(0).as_ptr(), 10);
+        std::ptr::write(nn.byte_add(4).as_ptr(), 20);
+    }
+}
+
+// --- byte_sub ---
+
+pub fn test_byte_sub(buf: &mut [i32; 2]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let nn1 = nn.byte_add(4);
+        let nn0 = nn1.byte_sub(4);
+        std::ptr::write(nn0.as_ptr(), 10);
+        std::ptr::write(nn1.as_ptr(), 20);
+    }
+}
+
+// --- byte_offset (signed count — forward and backward) ---
+
+// forward: byte_offset(4) advances by 4 bytes to the second element
+pub fn test_byte_offset_forward(buf: &mut [i32; 2]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        std::ptr::write(nn.byte_offset(0).as_ptr(), 10);
+        std::ptr::write(nn.byte_offset(4).as_ptr(), 20);
+    }
+}
+
+// backward: advance then step back; writes both elements
+pub fn test_byte_offset_backward(buf: &mut [i32; 2]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let nn1 = nn.byte_add(4);
+        let nn0 = nn1.byte_offset(-4);
+        std::ptr::write(nn0.as_ptr(), 10);
+        std::ptr::write(nn1.as_ptr(), 20);
+    }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null03.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null03.rs
@@ -31,16 +31,3 @@ pub fn test_write_generic<T>(nn: NonNull<T>, val: T) {
     unsafe { nn.write(val) }
 }
 
-// --- len ---
-
-#[flux::spec(fn (nn: NonNull<[i32]>[@base, @addr, @size]) requires size == 16)]
-pub fn test_len_concrete(nn: NonNull<[i32]>) {
-    use flux_rs::assert;
-    assert(nn.len() == 4);
-}
-
-#[flux::spec(fn (nn: NonNull<[i32]>[@base, @addr, @size]) requires size == 8)]
-pub fn test_len_exact(nn: NonNull<[i32]>) {
-    use flux_rs::assert;
-    assert(nn.len() == 2);
-}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null03.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null03.rs
@@ -1,0 +1,46 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// --- read ---
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) -> i32 requires addr >= base && addr > 0 && size >= 4 && addr % 4 == 0)]
+pub fn test_read(nn: NonNull<i32>) -> i32 {
+    unsafe { nn.read() }
+}
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size]) -> i32 requires addr >= base && addr > 0 && size == 10 && addr % 4 == 0)]
+pub fn test_read_ix(nn: NonNull<i32>) -> i32 {
+    unsafe { nn.read() }
+}
+
+// --- write ---
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size], val: i32) requires addr >= base && addr > 0 && size >= 4 && addr % 4 == 0)]
+pub fn test_write(nn: NonNull<i32>, val: i32) {
+    unsafe { nn.write(val) }
+}
+
+#[flux::spec(fn (nn: NonNull<i32>[@base, @addr, @size], val: i32) requires addr >= base && addr > 0 && size == 99 && addr % 4 == 0)]
+pub fn test_write_ix(nn: NonNull<i32>, val: i32) {
+    unsafe { nn.write(val) }
+}
+
+#[flux::spec(fn<T> (nn: NonNull<T>[@base, @addr, @size], val: T) requires addr >= base && addr > 0 && size >= T::size_of() && addr % T::align_of() == 0 && T::size_of() > 0)]
+pub fn test_write_generic<T>(nn: NonNull<T>, val: T) {
+    unsafe { nn.write(val) }
+}
+
+// --- len ---
+
+#[flux::spec(fn (nn: NonNull<[i32]>[@base, @addr, @size]) requires size == 16)]
+pub fn test_len_concrete(nn: NonNull<[i32]>) {
+    use flux_rs::assert;
+    assert(nn.len() == 4);
+}
+
+#[flux::spec(fn (nn: NonNull<[i32]>[@base, @addr, @size]) requires size == 8)]
+pub fn test_len_exact(nn: NonNull<[i32]>) {
+    use flux_rs::assert;
+    assert(nn.len() == 2);
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null04.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null04.rs
@@ -1,0 +1,86 @@
+extern crate flux_core;
+
+use flux_rs::assert;
+use std::ptr::NonNull;
+
+// --- offset_from ---
+
+// forward distance: nn.add(3) is 2 elements ahead of nn.add(1)
+pub fn test_offset_from_pos(buf: &mut [i32; 4]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let nn1 = nn.add(1);
+        let nn3 = nn.add(3);
+        let diff = nn3.offset_from(nn1);
+        assert(diff == 2);
+    }
+}
+
+// negative distance: nn1 is ahead, so nn1.offset_from(nn3) == -2
+pub fn test_offset_from_neg(buf: &mut [i32; 4]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let nn3 = nn.add(3);
+        let nn1 = nn.add(1);
+        let diff = nn1.offset_from(nn3);
+        assert(diff == -2);
+    }
+}
+
+// self offset_from self == 0
+pub fn test_offset_from_zero(buf: &mut [i32; 4]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let nn2 = nn.add(2);
+        let diff = nn2.offset_from(nn2);
+        assert(diff == 0);
+    }
+}
+
+// --- offset_from_unsigned ---
+
+// forward distance: same arithmetic as offset_from for self >= origin
+pub fn test_offset_from_unsigned_pos(buf: &mut [i32; 4]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let nn1 = nn.add(1);
+        let nn3 = nn.add(3);
+        let diff = nn3.offset_from_unsigned(nn1);
+        assert(diff == 2);
+    }
+}
+
+// self == origin: distance is zero
+pub fn test_offset_from_unsigned_zero(buf: &mut [i32; 4]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let nn2 = nn.add(2);
+        let diff = nn2.offset_from_unsigned(nn2);
+        assert(diff == 0);
+    }
+}
+
+// roundtrip: nn.add(2).offset_from_unsigned(nn) == 2
+pub fn test_offset_from_unsigned_roundtrip(buf: &mut [i32; 4]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    unsafe {
+        let nn2 = nn.add(2);
+        assert(nn2.offset_from_unsigned(nn) == 2);
+    }
+}
+
+// --- slice_from_raw_parts ---
+
+// len() recovers the count passed to slice_from_raw_parts
+pub fn test_slice_from_raw_parts_len(buf: &mut [i32; 4]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    let slice_nn = NonNull::slice_from_raw_parts(nn, 4);
+    assert(slice_nn.len() == 4);
+}
+
+// partial slice: only the first 2 elements
+pub fn test_slice_from_raw_parts_partial(buf: &mut [i32; 4]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    let slice_nn = NonNull::slice_from_raw_parts(nn, 2);
+    assert(slice_nn.len() == 2);
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null04.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null04.rs
@@ -71,16 +71,14 @@ pub fn test_offset_from_unsigned_roundtrip(buf: &mut [i32; 4]) {
 
 // --- slice_from_raw_parts ---
 
-// len() recovers the count passed to slice_from_raw_parts
-pub fn test_slice_from_raw_parts_len(buf: &mut [i32; 4]) {
+// all 4 elements: requires satisfied (4 * 4 == 16 bytes fits in buf)
+pub fn test_slice_from_raw_parts(buf: &mut [i32; 4]) {
     let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
-    let slice_nn = NonNull::slice_from_raw_parts(nn, 4);
-    assert(slice_nn.len() == 4);
+    let _slice_nn = NonNull::slice_from_raw_parts(nn, 4);
 }
 
-// partial slice: only the first 2 elements
+// partial slice: 2 elements (8 bytes) fits in the 16-byte buffer
 pub fn test_slice_from_raw_parts_partial(buf: &mut [i32; 4]) {
     let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
-    let slice_nn = NonNull::slice_from_raw_parts(nn, 2);
-    assert(slice_nn.len() == 2);
+    let _slice_nn = NonNull::slice_from_raw_parts(nn, 2);
 }


### PR DESCRIPTION
This PR adds flux-core specs for `NonNull<T>`.
Specifically it:
1. Adds specs for `new`, `new_unchecked`, `as_ptr`, `add`, `sub`, `offset`, ` byte_add`, `byte_sub`, `byte_offset`, `read`, `write`, `offset_from`, and `slice_from_raw_parts`. For those most part, these specs are syntactically identical to those in ptr. 
2. Adds a definition and invariant for `NonNull<T>` 
```rust
#[refined_by(base: int, addr: int, size: int)]
#[invariant(addr != 0)]
struct NonNull<T>;
```
3. Adds tests for the above

Technical note: I could have indexed `NonNull<T>` by a `ptr` rather than by `base, addr, size`. I chose to use the 3 indices to 1) make the specs as syntactically identical to those in ptr as possible, and 2) allow us to do direct indexing when updating a single one of those fields. If you would rather have it indexed by a ptr, I can do that.
