### PR TITLE
Add alignment to add/sub

### DIFF
--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -24,11 +24,13 @@
         num_bytes == 0 || valid_no_zst(p, num_bytes)
     }
 
+    fn addr_aligned(addr: int, alignment: int) -> bool { addr % alignment == 0 }
+
     // The pointer's address is a multiple of `alignment`. Most read/write
     // functions require proper alignment (align_of::<T>()); the notable
     // exceptions are read_unaligned and write_unaligned.
     // See: https://doc.rust-lang.org/std/ptr/index.html#alignment
-    fn aligned_to(p: ptr, alignment: int) -> bool { p.addr % alignment == 0 }
+    fn aligned_to(p: ptr, alignment: int) -> bool { addr_aligned(p.addr, alignment) }
 
     // The byte ranges [p.addr, p.addr + num_bytes) and [q.addr, q.addr + num_bytes)
     // do not overlap.
@@ -62,12 +64,16 @@ macro_rules! ptr_specs {
         impl<T> *$mutable T {
             #[spec(fn (me: *$mutable[@p] T, count: usize)
                 -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T
-                    requires in_bounds(p) && count * T::size_of() <= p.size)]
+                    requires in_bounds(p) && count * T::size_of() <= p.size
+                    ensures addr_aligned(p.addr, T::align_of()) => addr_aligned(p.addr + count * T::size_of(), T::align_of())
+            )]
             unsafe fn add(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
                 -> *$mutable[p.base, p.addr - count * T::size_of(), p.size + count * T::size_of()] T
-                    requires in_bounds(p) && count * T::size_of() <= p.addr - p.base)]
+                    requires in_bounds(p) && count * T::size_of() <= p.addr - p.base
+                    ensures addr_aligned(p.addr, T::align_of()) => addr_aligned(p.addr - count * T::size_of(), T::align_of())
+            )]
             unsafe fn sub(self, count: usize) -> Self;
 
             #[spec(fn (me: *$mutable[@p] T, count: usize)
@@ -88,7 +94,9 @@ macro_rules! ptr_specs {
             /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L349
             #[spec(fn (me: *$mutable[@p] T, count: isize)
                 -> *$mutable[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T
-                    requires in_bounds(p) && count * T::size_of() <= p.size && p.addr + count * T::size_of() >= p.base)]
+                    requires in_bounds(p) && count * T::size_of() <= p.size && p.addr + count * T::size_of() >= p.base
+                    ensures addr_aligned(p.addr, T::align_of()) => addr_aligned(p.addr + count * T::size_of(), T::align_of())
+            )]
             unsafe fn offset(self, count: isize) -> Self;
 
             /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L471

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr09.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr09.rs
@@ -1,9 +1,21 @@
+// This test shows why the interaction of *pointer arithmetic* and *alignment* can get tricky due to *modular arithmetic*.
+// See https://github.com/flux-rs/flux/pull/1686
+//
+// - Without `align > 0` in the `size_align_inv`, Z3 & CVC5 cannot prove the fact (perhaps it just doesn't hold?),
+// - With    `align > 0` in the `size_align_inv`, and without the ensures in `fn new_add`, Z3 hangs,    CVC5 hang,
+// - With    `align > 0` in the `size_align_inv`, and with    the ensures in `fn new_add`, Z3 succeeds, CVC5 hangs.
 use std::ptr::{self, NonNull};
 
 extern crate flux_core;
 
 flux_rs::defs! {
-    fn addr_aligned(addr: int, alignment: int) -> bool { addr % alignment == 0 }
+    fn addr_aligned(addr: int, alignment: int) -> bool {
+        addr % alignment == 0
+    }
+
+    fn size_align_inv(size: int, align: int) -> bool {
+       addr_aligned(size, align) && align > 0
+    }
 }
 
 #[flux_rs::refined_by(base:int, addr:int, size:int, cap:int)]
@@ -13,7 +25,7 @@ flux_rs::defs! {
                      T::size_of() > 0 &&
                      addr > 0 &&
                      addr_aligned(addr, T::align_of()) &&
-                     addr_aligned(T::size_of(), T::align_of())
+                     size_align_inv(T::size_of(), T::align_of())
                      )]
 struct RawVec<T> {
     #[flux_rs::field(NonNull<T>[base, addr, size])]
@@ -23,7 +35,7 @@ struct RawVec<T> {
 }
 
 #[flux_rs::refined_by(raw:RawVec, len: int)]
-#[flux_rs::invariant(len <= raw.cap && addr_aligned(T::size_of(), T::align_of()))]
+#[flux_rs::invariant(len <= raw.cap && size_align_inv(T::size_of(), T::align_of()))]
 pub struct Vec<T> {
     #[flux_rs::field(RawVec<T>[raw])]
     buf: RawVec<T>,
@@ -31,7 +43,28 @@ pub struct Vec<T> {
     len: usize,
 }
 
+#[flux_rs::trusted]
+#[flux_rs::spec(fn (me: *mut[@p] T, count: usize)
+                -> *mut[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T
+                    requires  count * T::size_of() <= p.size
+                    ensures addr_aligned(p.addr, T::align_of()) => addr_aligned(p.addr + count * T::size_of(), T::align_of())
+            )]
+unsafe fn new_add<T: Sized>(me: *mut T, count: usize) -> *mut T {
+    unsafe { me.add(count) }
+}
+
 impl<T> Vec<T> {
+    #[flux_rs::spec(fn (self: &mut Vec<T>[@me], elem: T) ensures self: Vec<T>)]
+    pub fn push_new(&mut self, elem: T) {
+        if self.len != self.buf.cap {
+            unsafe {
+                let ptr0 = self.buf.ptr.as_ptr();
+                let ptr1 = new_add(ptr0, self.len);
+                ptr::write(ptr1, elem);
+            }
+        }
+    }
+
     #[flux_rs::spec(fn (self: &mut Vec<T>[@me], elem: T) ensures self: Vec<T>)]
     pub fn push(&mut self, elem: T) {
         if self.len != self.buf.cap {

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr09.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr09.rs
@@ -31,16 +31,6 @@ pub struct Vec<T> {
     len: usize,
 }
 
-// #[flux_rs::trusted]
-// #[flux_rs::spec(fn (me: *mut[@p] T, count: usize)
-//                 -> *mut[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T
-//                     requires  count * T::size_of() <= p.size
-//                     ensures addr_aligned(p.addr, T::align_of()) => addr_aligned(p.addr + count * T::size_of(), T::align_of())
-//                )]
-// unsafe fn new_add<T: Sized>(me: *mut T, count: usize) -> *mut T {
-//     unsafe { me.add(count) }
-// }
-
 impl<T> Vec<T> {
     #[flux_rs::spec(fn (self: &mut Vec<T>[@me], elem: T) ensures self: Vec<T>)]
     pub fn push(&mut self, elem: T) {

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr09.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr09.rs
@@ -1,0 +1,55 @@
+use std::ptr::{self, NonNull};
+
+extern crate flux_core;
+
+flux_rs::defs! {
+    fn addr_aligned(addr: int, alignment: int) -> bool { addr % alignment == 0 }
+}
+
+#[flux_rs::refined_by(base:int, addr:int, size:int, cap:int)]
+#[flux_rs::invariant(size == cap * T::size_of() &&
+                     cap <= isize::MAX &&
+                     addr == base &&
+                     T::size_of() > 0 &&
+                     addr > 0 &&
+                     addr_aligned(addr, T::align_of()) &&
+                     addr_aligned(T::size_of(), T::align_of())
+                     )]
+struct RawVec<T> {
+    #[flux_rs::field(NonNull<T>[base, addr, size])]
+    ptr: NonNull<T>,
+    #[flux_rs::field(usize[cap])]
+    cap: usize,
+}
+
+#[flux_rs::refined_by(raw:RawVec, len: int)]
+#[flux_rs::invariant(len <= raw.cap && addr_aligned(T::size_of(), T::align_of()))]
+pub struct Vec<T> {
+    #[flux_rs::field(RawVec<T>[raw])]
+    buf: RawVec<T>,
+    #[flux_rs::field(usize[len])]
+    len: usize,
+}
+
+// #[flux_rs::trusted]
+// #[flux_rs::spec(fn (me: *mut[@p] T, count: usize)
+//                 -> *mut[p.base, p.addr + count * T::size_of(), p.size - count * T::size_of()] T
+//                     requires  count * T::size_of() <= p.size
+//                     ensures addr_aligned(p.addr, T::align_of()) => addr_aligned(p.addr + count * T::size_of(), T::align_of())
+//                )]
+// unsafe fn new_add<T: Sized>(me: *mut T, count: usize) -> *mut T {
+//     unsafe { me.add(count) }
+// }
+
+impl<T> Vec<T> {
+    #[flux_rs::spec(fn (self: &mut Vec<T>[@me], elem: T) ensures self: Vec<T>)]
+    pub fn push(&mut self, elem: T) {
+        if self.len != self.buf.cap {
+            unsafe {
+                let ptr0 = self.buf.ptr.as_ptr();
+                let ptr1 = ptr0.add(self.len);
+                ptr::write(ptr1, elem);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds an` ensures` clause to the `ptr::add/ptr::sub` specs that shows alignment is preserved 
by arithmetic `ensures addr_aligned(in) => addr_aligned(out)` instead of making clients 
re-derive alignment via modular arithmetic.

Why?

1. Provability — For generic `T`, the invariant `T::size_of() % T::align_of() == 0` is needed but has no place to be materialized (size/align are just uninterpreted functions),

2. Performance — Modular arithmetic `(%)` makes Z3/CVC5 hang, once we add the additional `align > 0` needed to prove the relevant fact. 