### PR TITLE
Use ribs to resolve names inside refinements

### DIFF
--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -55,7 +55,7 @@ fn collect_generics_in_params(
         fn visit_base_sort(&mut self, bsort: &surface::BaseSort) {
             if let surface::BaseSort::Path(path) = bsort {
                 let res = self.resolver_output.sort_path_res_map[&path.node_id];
-                if let fhir::SortRes::TyParam(def_id) = res {
+                if let fhir::Res::Def(DefKind::TyParam, def_id) = res.base_res() {
                     self.found.insert(def_id);
                 }
             }
@@ -1113,11 +1113,11 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                 let res = self.resolver_output().sort_path_res_map[node_id];
 
                 // In a `RefinedBy` we resolve type parameters to a sort var
-                let res = if let fhir::SortRes::TyParam(def_id) = res
+                let res = if let fhir::Res::Def(DefKind::TyParam, def_id) = res.base_res()
                     && let Some(generic_id_to_var_idx) = generic_id_to_var_idx
                 {
                     let idx = generic_id_to_var_idx.get_index_of(&def_id).unwrap();
-                    fhir::SortRes::SortParam(idx)
+                    fhir::PartialRes::new(fhir::Res::SortParam(idx))
                 } else {
                     res
                 };

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -14,7 +14,7 @@ use flux_errors::{Errors, FluxSession};
 use flux_middle::{
     ResolverOutput,
     def_id::{FluxLocalDefId, MaybeExternId},
-    fhir::{self, FhirId, FluxOwnerId, Namespace, ParamId, QPathExpr, Res},
+    fhir::{self, FhirId, FluxOwnerId, Namespace, PartialRes, QPathExpr, Res},
     global_env::GlobalEnv,
     query_bug,
     rty::QualifierKind,
@@ -947,10 +947,8 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
     }
 
     fn desugar_epath(&self, path: &surface::ExprPath) -> fhir::QPathExpr<'genv> {
-        let partial_res = *self
-            .resolver_output()
-            .path_res_map
-            .get(&path.node_id)
+        let partial_res = self
+            .opt_resolve_path(path.node_id)
             .unwrap_or_else(|| span_bug!(path.span, "unresolved expr path"));
 
         let unresolved_segments = partial_res.unresolved_segments();
@@ -1003,14 +1001,27 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
     }
 
     #[track_caller]
-    fn desugar_loc(&self, ident: surface::Ident, node_id: NodeId) -> Result<Res<ParamId>> {
-        let partial_res = self.resolver_output().path_res_map[&node_id];
+    fn desugar_loc(&self, ident: surface::Ident, node_id: NodeId) -> Result<Res> {
+        let partial_res = self.resolve_path(node_id);
         if let Some(res @ Res::Param(fhir::ParamKind::Loc, _)) = partial_res.full_res() {
             Ok(res)
         } else {
             let span = ident.span;
             Err(self.emit(errors::InvalidLoc { span }))
         }
+    }
+
+    fn opt_resolve_path(&self, node_id: NodeId) -> Option<PartialRes> {
+        Some(
+            self.resolver_output()
+                .path_res_map
+                .get(&node_id)?
+                .map_param_id(|param_id| self.resolve_param(param_id).0),
+        )
+    }
+
+    fn resolve_path(&self, node_id: NodeId) -> PartialRes {
+        self.opt_resolve_path(node_id).unwrap()
     }
 
     #[track_caller]
@@ -1108,7 +1119,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
         match sort {
             surface::BaseSort::BitVec(width) => fhir::Sort::BitVec(*width),
             surface::BaseSort::Path(surface::SortPath { segments, args, node_id }) => {
-                let res = self.resolver_output().path_res_map[node_id];
+                let res = self.resolve_path(*node_id);
 
                 // In a `RefinedBy` we resolve type parameters to a sort var
                 let res = if let fhir::Res::Def(DefKind::TyParam, def_id) = res.base_res()
@@ -1171,8 +1182,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     // If the path was resolved in the value namespace then we must create a const
                     // generic argument
                     if let Some(path) = ty.is_potential_const_arg()
-                        && let Some(res) =
-                            self.resolver_output().path_res_map[&path.node_id].full_res()
+                        && let Some(res) = self.resolve_path(path.node_id).full_res()
                         && res.matches_ns(Namespace::ValueNS)
                     {
                         fhir_args.push(self.desugar_const_path_to_const_arg(path, res));
@@ -1307,7 +1317,8 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
         let kind = match &const_arg.kind {
             surface::ConstArgKind::Lit(val) => fhir::ConstArgKind::Lit(*val),
             surface::ConstArgKind::Path(path) => {
-                let res = self.resolver_output().path_res_map[&path.node_id]
+                let res = self
+                    .resolve_path(path.node_id)
                     .full_res()
                     .unwrap_or(Res::Err);
                 self.desugar_const_path_to_const_arg_kind(path, res)
@@ -1356,7 +1367,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
         } else {
             None
         };
-        let partial_res = self.resolver_output().path_res_map[&path.node_id];
+        let partial_res = self.resolve_path(path.node_id);
 
         let unresolved_segments = partial_res.unresolved_segments();
 
@@ -1415,9 +1426,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
 
     fn desugar_path_segment(&mut self, segment: &surface::PathSegment) -> fhir::PathSegment<'genv> {
         let res = self
-            .resolver_output()
-            .path_res_map
-            .get(&segment.node_id)
+            .opt_resolve_path(segment.node_id)
             .map_or(Res::Err, |r| r.expect_full_res());
         let (args, constraints) = self.desugar_generic_args(res, &segment.args);
         fhir::PathSegment { ident: segment.ident, res, args, constraints }
@@ -1428,9 +1437,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
         segment: &surface::ExprPathSegment,
     ) -> fhir::PathSegment<'genv> {
         let res = self
-            .resolver_output()
-            .path_res_map
-            .get(&segment.node_id)
+            .opt_resolve_path(segment.node_id)
             .map_or(Res::Err, |r| r.expect_full_res());
         fhir::PathSegment { ident: segment.ident, res, args: &[], constraints: &[] }
     }
@@ -1621,7 +1628,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
     ) -> fhir::ExprKind<'genv> {
         let path = if let Some(path) = path {
             let Some(res @ Res::Def(DefKind::Struct | DefKind::Enum, _)) =
-                self.resolver_output().path_res_map[&path.node_id].full_res()
+                self.resolve_path(path.node_id).full_res()
             else {
                 return fhir::ExprKind::Err(
                     self.emit(errors::InvalidConstructorPath { span: path.span }),

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -14,7 +14,7 @@ use flux_errors::{Errors, FluxSession};
 use flux_middle::{
     ResolverOutput,
     def_id::{FluxLocalDefId, MaybeExternId},
-    fhir::{self, FhirId, FluxOwnerId, ParamId, QPathExpr, Res},
+    fhir::{self, FhirId, FluxOwnerId, Namespace, ParamId, QPathExpr, Res},
     global_env::GlobalEnv,
     query_bug,
     rty::QualifierKind,
@@ -54,7 +54,7 @@ fn collect_generics_in_params(
     impl surface::visit::Visitor for ParamCollector<'_> {
         fn visit_base_sort(&mut self, bsort: &surface::BaseSort) {
             if let surface::BaseSort::Path(path) = bsort {
-                let res = self.resolver_output.sort_path_res_map[&path.node_id];
+                let res = self.resolver_output.path_res_map[&path.node_id];
                 if let fhir::Res::Def(DefKind::TyParam, def_id) = res.base_res() {
                     self.found.insert(def_id);
                 }
@@ -949,7 +949,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
     fn desugar_epath(&self, path: &surface::ExprPath) -> fhir::QPathExpr<'genv> {
         let partial_res = *self
             .resolver_output()
-            .expr_path_res_map
+            .path_res_map
             .get(&path.node_id)
             .unwrap_or_else(|| span_bug!(path.span, "unresolved expr path"));
 
@@ -1004,7 +1004,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
 
     #[track_caller]
     fn desugar_loc(&self, ident: surface::Ident, node_id: NodeId) -> Result<Res<ParamId>> {
-        let partial_res = self.resolver_output().expr_path_res_map[&node_id];
+        let partial_res = self.resolver_output().path_res_map[&node_id];
         if let Some(res @ Res::Param(fhir::ParamKind::Loc, _)) = partial_res.full_res() {
             Ok(res)
         } else {
@@ -1108,7 +1108,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
         match sort {
             surface::BaseSort::BitVec(width) => fhir::Sort::BitVec(*width),
             surface::BaseSort::Path(surface::SortPath { segments, args, node_id }) => {
-                let res = self.resolver_output().sort_path_res_map[node_id];
+                let res = self.resolver_output().path_res_map[node_id];
 
                 // In a `RefinedBy` we resolve type parameters to a sort var
                 let res = if let fhir::Res::Def(DefKind::TyParam, def_id) = res.base_res()
@@ -1173,7 +1173,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     if let Some(path) = ty.is_potential_const_arg()
                         && let Some(res) =
                             self.resolver_output().path_res_map[&path.node_id].full_res()
-                        && res.matches_ns(fhir::Namespace::ValueNS)
+                        && res.matches_ns(Namespace::ValueNS)
                     {
                         fhir_args.push(self.desugar_const_path_to_const_arg(path, res));
                         continue;
@@ -1429,7 +1429,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
     ) -> fhir::PathSegment<'genv> {
         let res = self
             .resolver_output()
-            .expr_path_res_map
+            .path_res_map
             .get(&segment.node_id)
             .map_or(Res::Err, |r| r.expect_full_res());
         fhir::PathSegment { ident: segment.ident, res, args: &[], constraints: &[] }
@@ -1621,7 +1621,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
     ) -> fhir::ExprKind<'genv> {
         let path = if let Some(path) = path {
             let Some(res @ Res::Def(DefKind::Struct | DefKind::Enum, _)) =
-                self.resolver_output().expr_path_res_map[&path.node_id].full_res()
+                self.resolver_output().path_res_map[&path.node_id].full_res()
             else {
                 return fhir::ExprKind::Err(
                     self.emit(errors::InvalidConstructorPath { span: path.span }),

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -29,7 +29,7 @@ use hir::{ItemKind, def::DefKind};
 use itertools::{Either, Itertools};
 use rustc_data_structures::{fx::FxIndexSet, unord::UnordSet};
 use rustc_errors::{Diagnostic, ErrorGuaranteed};
-use rustc_hir::{self as hir, OwnerId, def::Namespace};
+use rustc_hir::{self as hir, OwnerId};
 use rustc_span::{
     DUMMY_SP, Span,
     def_id::{DefId, LocalDefId},
@@ -1175,7 +1175,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     if let Some(path) = ty.is_potential_const_arg()
                         && let Some(res) =
                             self.resolver_output().path_res_map[&path.node_id].full_res()
-                        && res.matches_ns(Namespace::ValueNS)
+                        && res.matches_ns(fhir::Namespace::ValueNS)
                     {
                         fhir_args.push(self.desugar_const_path_to_const_arg(path, res));
                         continue;

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -969,9 +969,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
 
         let proj_start = path.segments.len() - unresolved_segments;
         let ty_path = fhir::Path {
-            res: partial_res
-                .base_res()
-                .map_param_id(|_| span_bug!(path.span, "path resolved to refinement parameter")),
+            res: partial_res.base_res(),
             fhir_id: self.next_fhir_id(),
             segments: self.genv().alloc_slice_fill_iter(
                 path.segments[..proj_start]
@@ -1197,7 +1195,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
     fn desugar_const_path_to_const_arg(
         &mut self,
         path: &surface::Path,
-        res: fhir::Res<!>,
+        res: fhir::Res,
     ) -> fhir::GenericArg<'genv> {
         let kind = self.desugar_const_path_to_const_arg_kind(path, res);
         fhir::GenericArg::Const(fhir::ConstArg { kind, span: path.span })
@@ -1206,7 +1204,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
     fn desugar_const_path_to_const_arg_kind(
         &mut self,
         path: &surface::Path,
-        res: fhir::Res<!>,
+        res: fhir::Res,
     ) -> fhir::ConstArgKind {
         if let Res::Def(DefKind::ConstParam, def_id) = res {
             fhir::ConstArgKind::Param(def_id)
@@ -1433,8 +1431,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
             .resolver_output()
             .expr_path_res_map
             .get(&segment.node_id)
-            .map_or(Res::Err, |r| r.expect_full_res())
-            .map_param_id(|_| bug!("segment resolved to refinement parameter"));
+            .map_or(Res::Err, |r| r.expect_full_res());
         fhir::PathSegment { ident: segment.ident, res, args: &[], constraints: &[] }
     }
 

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -22,6 +22,7 @@ use flux_syntax::{
     symbols::sym,
 };
 use hir::{ItemId, ItemKind, OwnerId, def::DefKind};
+use itertools::Itertools;
 use rustc_data_structures::unord::{ExtendUnord, UnordMap};
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::{
@@ -362,15 +363,25 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
         ident: Ident,
         ns: Namespace,
     ) -> Option<fhir::Res<surface::NodeId>> {
-        for rib in self.ribs[ns].iter().rev() {
+        let mut ribs = self.ribs[ns].iter().rev();
+        while let Some(rib) = ribs.next() {
             if let Some(res) = rib.bindings.get(&ident.name) {
                 return Some(*res);
             }
-            // A module boundary stops item resolution. A param barrier hides params in enclosing
-            // scopes; since refinement params live only in `FluxFnNS` (which has no item ribs), we
-            // can stop here and fall through to the flux-func prelude / the next namespace.
-            if matches!(rib.kind, RibKind::Module | RibKind::ParamBarrier) {
-                break;
+            match rib.kind {
+                // A module boundary stops item resolution.
+                RibKind::Module => break,
+                // A param barrier hides refinement params bound in *enclosing* scopes, but not
+                // non-param bindings in outer scopes (e.g. flux funcs, in the prelude or eventually
+                // in module-level ribs). So skip the enclosing param ribs; the walk resumes at the
+                // next non-param rib.
+                RibKind::ParamBarrier => {
+                    ribs.take_while_ref(|rib| {
+                        matches!(rib.kind, RibKind::Param | RibKind::ParamBarrier)
+                    })
+                    .for_each(drop);
+                }
+                RibKind::Normal | RibKind::Param => {}
             }
         }
         if ns == TypeNS {

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -17,13 +17,13 @@ use flux_syntax::{
 use hir::{ItemId, ItemKind, OwnerId, def::DefKind};
 use rustc_data_structures::unord::{ExtendUnord, UnordMap};
 use rustc_errors::ErrorGuaranteed;
+use flux_middle::fhir::{
+    Namespace::{self, *},
+    PerNS,
+};
 use rustc_hir::{
     self as hir, CRATE_HIR_ID, CRATE_OWNER_ID, ParamName, PrimTy,
-    def::{
-        CtorOf,
-        Namespace::{self, *},
-        PerNS,
-    },
+    def::CtorOf,
     def_id::CRATE_DEF_ID,
 };
 use rustc_middle::{metadata::ModChild, ty::TyCtxt};
@@ -56,10 +56,11 @@ pub(crate) struct CrateResolver<'genv, 'tcx> {
     ribs: PerNS<Vec<Rib>>,
     /// A mapping from the names of all imported crates to their [`DefId`]
     crates: UnordMap<Symbol, DefId>,
+    /// Names available everywhere: Rust builtin types plus flux's global funcs (theory funcs,
+    /// `cast`, and user-defined refinement functions) and sorts (primitive sorts and user-defined
+    /// sorts). Flux funcs live in [`Namespace::FluxFnNS`] and sorts in [`Namespace::SortNS`].
     prelude: PerNS<Rib>,
     qualifiers: UnordMap<Symbol, FluxLocalDefId>,
-    func_decls: UnordMap<Symbol, fhir::SpecFuncKind>,
-    sort_decls: UnordMap<Symbol, FluxDefId>,
     primop_props: UnordMap<Symbol, FluxDefId>,
     err: Option<ErrorGuaranteed>,
     /// The most recent module we have visited. Used to check for visibility of other items from
@@ -97,18 +98,24 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
             genv,
             output: ResolverOutput::default(),
             specs,
-            ribs: PerNS { type_ns: vec![], value_ns: vec![], macro_ns: vec![] },
+            ribs: PerNS {
+                type_ns: vec![],
+                value_ns: vec![],
+                macro_ns: vec![],
+                sort_ns: vec![],
+                flux_fn_ns: vec![],
+            },
             crates: mk_crate_mapping(genv.tcx()),
             prelude: PerNS {
                 type_ns: builtin_types_rib(),
                 value_ns: Rib::new(RibKind::Normal),
                 macro_ns: Rib::new(RibKind::Normal),
+                sort_ns: prim_sorts_rib(),
+                flux_fn_ns: theory_funcs_rib(),
             },
             err: None,
             qualifiers: Default::default(),
-            func_decls: Default::default(),
             primop_props: Default::default(),
-            sort_decls: Default::default(),
             current_module: CRATE_OWNER_ID,
         }
     }
@@ -136,7 +143,7 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
                         let name = defn.name.name;
                         let def_id = FluxDefId::new(parent, name);
                         let kind = fhir::SpecFuncKind::Def(def_id);
-                        self.func_decls.insert(defn.name.name, kind);
+                        self.define_in_prelude(name, fhir::Res::GlobalFunc(kind), FluxFnNS);
                     }
                     surface::FluxItem::PrimOpProp(primop_prop) => {
                         let name = primop_prop.name.name;
@@ -146,19 +153,15 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
                     }
                     surface::FluxItem::SortDecl(sort_decl) => {
                         let def_id = FluxDefId::new(parent.def_id.to_def_id(), sort_decl.name.name);
-                        self.sort_decls.insert(sort_decl.name.name, def_id);
+                        self.define_in_prelude(
+                            sort_decl.name.name,
+                            fhir::Res::UserSort(def_id),
+                            SortNS,
+                        );
                     }
                 }
             }
         }
-
-        self.func_decls.extend_unord(
-            flux_middle::THEORY_FUNCS
-                .items()
-                .map(|(_, itf)| (itf.name, fhir::SpecFuncKind::Thy(itf.itf))),
-        );
-        self.func_decls
-            .insert(Symbol::intern("cast"), fhir::SpecFuncKind::Cast);
     }
 
     fn define_items(&mut self, item_ids: impl IntoIterator<Item = &'tcx ItemId>) {
@@ -212,7 +215,7 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
                 }
                 _ => continue,
             };
-            if let Some(ns) = def_kind.ns()
+            if let Some(ns) = def_kind.ns().map(Namespace::from)
                 && let Some(ident) = item.kind.ident()
             {
                 self.define_res_in(
@@ -265,7 +268,7 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
         for param in generics.params {
             let def_kind = self.genv.tcx().def_kind(param.def_id);
             if let ParamName::Plain(name) = param.name
-                && let Some(ns) = def_kind.ns()
+                && let Some(ns) = def_kind.ns().map(Namespace::from)
             {
                 debug_assert!(matches!(def_kind, DefKind::TyParam | DefKind::ConstParam));
                 let param_id = self.genv.maybe_extern_id(param.def_id).resolved_id();
@@ -408,18 +411,23 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
         let tcx = self.genv.tcx();
         match module.kind {
             ModuleKind::Mod => {
+                // Module children are Rust items, so we only ever resolve them in a Rust namespace.
+                let rustc_ns = ns.to_rustc()?;
                 let module_id = module.def_id;
                 let current_mod = self.current_module.to_def_id();
                 visible_module_children(tcx, module_id, current_mod)
                     .find(|child| {
-                        child.res.matches_ns(ns) && tcx.hygienic_eq(ident, child.ident, current_mod)
+                        child.res.matches_ns(rustc_ns)
+                            && tcx.hygienic_eq(ident, child.ident, current_mod)
                     })
                     .and_then(|child| fhir::Res::try_from(child.res).ok())
             }
             ModuleKind::Trait => {
+                // Associated items are Rust items, so we only ever resolve them in a Rust namespace.
+                let rustc_ns = ns.to_rustc()?;
                 let trait_id = module.def_id;
                 tcx.associated_items(trait_id)
-                    .find_by_ident_and_namespace(tcx, ident, ns, trait_id)
+                    .find_by_ident_and_namespace(tcx, ident, rustc_ns, trait_id)
                     .map(|assoc| fhir::Res::Def(assoc.kind.as_def_kind(), assoc.def_id))
             }
             ModuleKind::Enum => {
@@ -799,8 +807,9 @@ impl<'a, 'genv, 'tcx> ItemResolver<'a, 'genv, 'tcx> {
     fn resolve_reveals(&mut self, item_id: surface::NodeId, reveal_names: &[Ident]) {
         let mut reveals = Vec::with_capacity(reveal_names.len());
         for reveal in reveal_names {
-            if let Some(spec) = self.resolver.func_decls.get(&reveal.name)
-                && let Some(def_id) = spec.def_id()
+            if let Some(fhir::Res::GlobalFunc(kind)) =
+                self.resolver.resolve_ident_with_ribs(*reveal, FluxFnNS)
+                && let Some(def_id) = kind.def_id()
             {
                 reveals.push(def_id);
             } else {
@@ -889,6 +898,45 @@ fn builtin_types_rib() -> Rib {
     }
 }
 
+/// The [`Namespace::FluxFnNS`] prelude: theory functions and `cast`. User-defined refinement
+/// functions are added on top in [`CrateResolver::define_flux_global_items`].
+fn theory_funcs_rib() -> Rib {
+    let mut rib = Rib::new(RibKind::Normal);
+    rib.bindings.extend_unord(
+        flux_middle::THEORY_FUNCS
+            .items()
+            .map(|(_, itf)| (itf.name, fhir::Res::GlobalFunc(fhir::SpecFuncKind::Thy(itf.itf)))),
+    );
+    rib.bindings.insert(
+        Symbol::intern("cast"),
+        fhir::Res::GlobalFunc(fhir::SpecFuncKind::Cast),
+    );
+    rib
+}
+
+/// The [`Namespace::SortNS`] prelude: primitive sorts (`int`, `bool`, `Set`, `Map`, ...). User-defined
+/// sorts are added on top in [`CrateResolver::define_flux_global_items`].
+fn prim_sorts_rib() -> Rib {
+    use flux_middle::fhir::PrimSort;
+    let bindings = [
+        (sym::int, PrimSort::Int),
+        (sym::bool, PrimSort::Bool),
+        (sym::char, PrimSort::Char),
+        (sym::real, PrimSort::Real),
+        (sym::Set, PrimSort::Set),
+        (sym::Map, PrimSort::Map),
+        (sym::str, PrimSort::Str),
+        (sym::ptr, PrimSort::RawPtr),
+    ];
+    Rib {
+        kind: RibKind::Normal,
+        bindings: bindings
+            .into_iter()
+            .map(|(name, prim)| (name, fhir::Res::PrimSort(prim)))
+            .collect(),
+    }
+}
+
 fn mk_crate_mapping(tcx: TyCtxt) -> UnordMap<Symbol, DefId> {
     let mut map = UnordMap::default();
     for cnum in tcx.crates(()) {
@@ -920,7 +968,7 @@ mod errors {
     }
 
     impl UnresolvedPath {
-        pub fn new(path: &surface::Path, ns: rustc_hir::def::Namespace) -> Self {
+        pub fn new(path: &surface::Path, ns: flux_middle::fhir::Namespace) -> Self {
             Self {
                 span: path.span,
                 path: path.segments.iter().map(|segment| segment.ident).join("::"),

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -2,10 +2,7 @@ pub(crate) mod refinement_resolver;
 
 use std::collections::hash_map;
 
-use flux_common::{
-    bug,
-    result::{ErrorCollector, ResultExt},
-};
+use flux_common::result::{ErrorCollector, ResultExt};
 use flux_errors::Errors;
 use flux_middle::{
     ResolverOutput, Specs,
@@ -806,10 +803,6 @@ impl<'a, 'genv, 'tcx> ItemResolver<'a, 'genv, 'tcx> {
 
     fn resolve_path_in(&mut self, path: &surface::Path, ns: Namespace) {
         if let Some(partial_res) = self.resolver.resolve_path_with_ribs(&path.segments, ns) {
-            // Type/const paths are resolved before any refinement param is in scope, so they can
-            // never resolve to a param.
-            let partial_res =
-                partial_res.map_param_id(|_| bug!("type path resolved to a refinement parameter"));
             self.resolver
                 .output
                 .path_res_map

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -245,18 +245,25 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
         }
     }
 
-    fn define_res_in(&mut self, name: Symbol, res: fhir::Res<surface::NodeId>, ns: Namespace) {
-        self.ribs[ns].last_mut().unwrap().bindings.insert(name, res);
+    /// Define `name` in the innermost rib of `ns`. If the rib already binds `name`, keep the existing
+    /// binding and return it.
+    fn define_res_in(
+        &mut self,
+        name: Symbol,
+        res: fhir::Res<surface::NodeId>,
+        ns: Namespace,
+    ) -> Option<fhir::Res<surface::NodeId>> {
+        match self.ribs[ns].last_mut().unwrap().bindings.entry(name) {
+            hash_map::Entry::Occupied(entry) => Some(*entry.get()),
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(res);
+                None
+            }
+        }
     }
 
     fn define_in_prelude(&mut self, name: Symbol, res: fhir::Res<surface::NodeId>, ns: Namespace) {
         self.prelude[ns].bindings.insert(name, res);
-    }
-
-    /// Look up `name` in the innermost rib of `ns`. Used by the refinement resolver to detect
-    /// duplicate refinement parameters within a single scope.
-    fn lookup_in_top_rib(&self, ns: Namespace, name: Symbol) -> Option<fhir::Res<surface::NodeId>> {
-        self.ribs[ns].last().unwrap().bindings.get(&name).copied()
     }
 
     fn push_rib(&mut self, ns: Namespace, kind: RibKind) {
@@ -371,17 +378,15 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
             match rib.kind {
                 // A module boundary stops item resolution.
                 RibKind::Module => break,
-                // A param barrier hides refinement params bound in *enclosing* scopes, but not
-                // non-param bindings in outer scopes (e.g. flux funcs, in the prelude or eventually
-                // in module-level ribs). So skip the enclosing param ribs; the walk resumes at the
-                // next non-param rib.
-                RibKind::ParamBarrier => {
-                    ribs.take_while_ref(|rib| {
-                        matches!(rib.kind, RibKind::Param | RibKind::ParamBarrier)
-                    })
-                    .for_each(drop);
+                // A barrier hides refinement params bound in *enclosing* scopes, but not non-param
+                // bindings in outer scopes (e.g. flux funcs, in the prelude or eventually in
+                // module-level ribs). Params are the innermost ribs, bounded below by a module
+                // boundary / the prelude, so skip everything up to the next module boundary.
+                RibKind::FnInput | RibKind::Variant => {
+                    ribs.take_while_ref(|rib| !matches!(rib.kind, RibKind::Module))
+                        .for_each(drop);
                 }
-                RibKind::Normal | RibKind::Param => {}
+                _ => {}
             }
         }
         if ns == TypeNS {
@@ -646,17 +651,28 @@ enum ModuleKind {
     Enum,
 }
 
-#[derive(Debug)]
-enum RibKind {
-    /// Any other rib without extra rules.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum RibKind {
+    /// An ordinary rib searched with no special rules: Rust item bindings, the prelude, or a
+    /// miscellaneous refinement scope (i.e. one that is neither a barrier nor a target of
+    /// implicit-param gathering / binder-legality checks).
     Normal,
-    /// We pass through a module. Lookups of items should stop here.
+    /// A module boundary. Item resolution stops here.
     Module,
-    /// A refinement parameter scope (in [`Namespace::FluxFnNS`] only).
-    Param,
-    /// A refinement parameter scope that acts as a barrier: params in enclosing scopes are not
-    /// visible from inside it. See [`CrateResolver::resolve_ident_with_ribs`].
-    ParamBarrier,
+    // The remaining variants are the refinement scopes that get special treatment: each doubles as a
+    // surface-traversal scope kind driving implicit-param gathering and binder legality (see
+    // [`refinement_resolver`]), and `FnInput`/`Variant` additionally act as barriers that hide params
+    // bound in enclosing scopes (see [`CrateResolver::resolve_ident_with_ribs`]).
+    /// A function signature's inputs (arguments and `requires`). A barrier scope; `@` binders are
+    /// legal here.
+    FnInput,
+    /// A function signature's output (return type and `ensures`). `#` binders are legal here.
+    FnOutput,
+    /// An enum variant. A barrier scope; `@` binders are legal here.
+    Variant,
+    /// The input position of an `Fn`-trait bound (e.g. the `T` in `FnMut(T) -> S`). `@` binders are
+    /// legal here.
+    FnTraitInput,
 }
 
 #[derive(Debug)]

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -724,10 +724,6 @@ impl Segment for surface::PathSegment {
         segment: &Self,
         res: fhir::Res<surface::NodeId>,
     ) {
-        // Type paths are resolved by `ItemResolver`, which runs before any refinement param is in
-        // scope, so a type-path segment can never resolve to a refinement param.
-        let res =
-            res.map_param_id(|_| bug!("type path segment resolved to a refinement parameter"));
         resolver
             .output
             .path_res_map
@@ -745,15 +741,6 @@ impl Segment for surface::ExprPathSegment {
         segment: &Self,
         res: fhir::Res<surface::NodeId>,
     ) {
-        // A refinement param only ever appears as a single-segment path, and the per-segment record
-        // is never read for a resolved (0-unresolved-segments) path — `desugar_epath` uses the
-        // whole-path resolution instead. So we can safely skip recording a param segment. Every
-        // other (module/type) segment is provably not a param.
-        if matches!(res, fhir::Res::Param(..)) {
-            return;
-        }
-        let res =
-            res.map_param_id(|_| bug!("expr path segment resolved to a refinement parameter"));
         resolver
             .output
             .path_res_map

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -2,12 +2,19 @@ pub(crate) mod refinement_resolver;
 
 use std::collections::hash_map;
 
-use flux_common::result::{ErrorCollector, ResultExt};
+use flux_common::{
+    bug,
+    result::{ErrorCollector, ResultExt},
+};
 use flux_errors::Errors;
 use flux_middle::{
     ResolverOutput, Specs,
     def_id::{FluxDefId, FluxLocalDefId, MaybeExternId},
     fhir,
+    fhir::{
+        Namespace::{self, *},
+        PerNS,
+    },
     global_env::GlobalEnv,
 };
 use flux_syntax::{
@@ -17,14 +24,8 @@ use flux_syntax::{
 use hir::{ItemId, ItemKind, OwnerId, def::DefKind};
 use rustc_data_structures::unord::{ExtendUnord, UnordMap};
 use rustc_errors::ErrorGuaranteed;
-use flux_middle::fhir::{
-    Namespace::{self, *},
-    PerNS,
-};
 use rustc_hir::{
-    self as hir, CRATE_HIR_ID, CRATE_OWNER_ID, ParamName, PrimTy,
-    def::CtorOf,
-    def_id::CRATE_DEF_ID,
+    self as hir, CRATE_HIR_ID, CRATE_OWNER_ID, ParamName, PrimTy, def::CtorOf, def_id::CRATE_DEF_ID,
 };
 use rustc_middle::{metadata::ModChild, ty::TyCtxt};
 use rustc_span::{Span, Symbol, def_id::DefId, symbol::kw};
@@ -243,12 +244,18 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
         }
     }
 
-    fn define_res_in(&mut self, name: Symbol, res: fhir::Res, ns: Namespace) {
+    fn define_res_in(&mut self, name: Symbol, res: fhir::Res<surface::NodeId>, ns: Namespace) {
         self.ribs[ns].last_mut().unwrap().bindings.insert(name, res);
     }
 
-    fn define_in_prelude(&mut self, name: Symbol, res: fhir::Res, ns: Namespace) {
+    fn define_in_prelude(&mut self, name: Symbol, res: fhir::Res<surface::NodeId>, ns: Namespace) {
         self.prelude[ns].bindings.insert(name, res);
+    }
+
+    /// Look up `name` in the innermost rib of `ns`. Used by the refinement resolver to detect
+    /// duplicate refinement parameters within a single scope.
+    fn lookup_in_top_rib(&self, ns: Namespace, name: Symbol) -> Option<fhir::Res<surface::NodeId>> {
+        self.ribs[ns].last().unwrap().bindings.get(&name).copied()
     }
 
     fn push_rib(&mut self, ns: Namespace, kind: RibKind) {
@@ -311,7 +318,7 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
         &mut self,
         segments: &[S],
         ns: Namespace,
-    ) -> Option<fhir::PartialRes> {
+    ) -> Option<fhir::PartialRes<surface::NodeId>> {
         let mut module: Option<Module> = None;
         for (segment_idx, segment) in segments.iter().enumerate() {
             let is_last = segment_idx + 1 == segments.len();
@@ -350,12 +357,19 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
         None
     }
 
-    fn resolve_ident_with_ribs(&self, ident: Ident, ns: Namespace) -> Option<fhir::Res> {
+    fn resolve_ident_with_ribs(
+        &self,
+        ident: Ident,
+        ns: Namespace,
+    ) -> Option<fhir::Res<surface::NodeId>> {
         for rib in self.ribs[ns].iter().rev() {
             if let Some(res) = rib.bindings.get(&ident.name) {
                 return Some(*res);
             }
-            if matches!(rib.kind, RibKind::Module) {
+            // A module boundary stops item resolution. A param barrier hides params in enclosing
+            // scopes; since refinement params live only in `FluxFnNS` (which has no item ribs), we
+            // can stop here and fall through to the flux-func prelude / the next namespace.
+            if matches!(rib.kind, RibKind::Module | RibKind::ParamBarrier) {
                 break;
             }
         }
@@ -407,7 +421,7 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
         module: &Module,
         ident: Ident,
         ns: Namespace,
-    ) -> Option<fhir::Res> {
+    ) -> Option<fhir::Res<surface::NodeId>> {
         let tcx = self.genv.tcx();
         match module.kind {
             ModuleKind::Mod => {
@@ -420,7 +434,7 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
                         child.res.matches_ns(rustc_ns)
                             && tcx.hygienic_eq(ident, child.ident, current_mod)
                     })
-                    .and_then(|child| fhir::Res::try_from(child.res).ok())
+                    .and_then(|child| fhir::Res::<surface::NodeId>::try_from(child.res).ok())
             }
             ModuleKind::Trait => {
                 // Associated items are Rust items, so we only ever resolve them in a Rust namespace.
@@ -627,12 +641,17 @@ enum RibKind {
     Normal,
     /// We pass through a module. Lookups of items should stop here.
     Module,
+    /// A refinement parameter scope (in [`Namespace::FluxFnNS`] only).
+    Param,
+    /// A refinement parameter scope that acts as a barrier: params in enclosing scopes are not
+    /// visible from inside it. See [`CrateResolver::resolve_ident_with_ribs`].
+    ParamBarrier,
 }
 
 #[derive(Debug)]
 struct Rib {
     kind: RibKind,
-    bindings: UnordMap<Symbol, fhir::Res>,
+    bindings: UnordMap<Symbol, fhir::Res<surface::NodeId>>,
 }
 
 impl Rib {
@@ -671,12 +690,24 @@ fn is_prelude_import(tcx: TyCtxt, item: &hir::Item) -> bool {
 /// Abstraction over a "segment" so we can use [`CrateResolver::resolve_path_with_ribs`] with paths
 /// from different sources  (e.g., [`surface::PathSegment`], [`surface::ExprPathSegment`])
 trait Segment: std::fmt::Debug {
-    fn record_segment_res(resolver: &mut CrateResolver, segment: &Self, res: fhir::Res);
+    fn record_segment_res(
+        resolver: &mut CrateResolver,
+        segment: &Self,
+        res: fhir::Res<surface::NodeId>,
+    );
     fn ident(&self) -> Ident;
 }
 
 impl Segment for surface::PathSegment {
-    fn record_segment_res(resolver: &mut CrateResolver, segment: &Self, res: fhir::Res) {
+    fn record_segment_res(
+        resolver: &mut CrateResolver,
+        segment: &Self,
+        res: fhir::Res<surface::NodeId>,
+    ) {
+        // Type paths are resolved by `ItemResolver`, which runs before any refinement param is in
+        // scope, so a type-path segment can never resolve to a refinement param.
+        let res =
+            res.map_param_id(|_| bug!("type path segment resolved to a refinement parameter"));
         resolver
             .output
             .path_res_map
@@ -689,11 +720,24 @@ impl Segment for surface::PathSegment {
 }
 
 impl Segment for surface::ExprPathSegment {
-    fn record_segment_res(resolver: &mut CrateResolver, segment: &Self, res: fhir::Res) {
+    fn record_segment_res(
+        resolver: &mut CrateResolver,
+        segment: &Self,
+        res: fhir::Res<surface::NodeId>,
+    ) {
+        // A refinement param only ever appears as a single-segment path, and the per-segment record
+        // is never read for a resolved (0-unresolved-segments) path — `desugar_epath` uses the
+        // whole-path resolution instead. So we can safely skip recording a param segment. Every
+        // other (module/type) segment is provably not a param.
+        if matches!(res, fhir::Res::Param(..)) {
+            return;
+        }
+        let res =
+            res.map_param_id(|_| bug!("expr path segment resolved to a refinement parameter"));
         resolver
             .output
             .expr_path_res_map
-            .insert(segment.node_id, fhir::PartialRes::new(res.map_param_id(|p| p)));
+            .insert(segment.node_id, fhir::PartialRes::new(res));
     }
 
     fn ident(&self) -> Ident {
@@ -702,7 +746,12 @@ impl Segment for surface::ExprPathSegment {
 }
 
 impl Segment for Ident {
-    fn record_segment_res(_resolver: &mut CrateResolver, _segment: &Self, _res: fhir::Res) {}
+    fn record_segment_res(
+        _resolver: &mut CrateResolver,
+        _segment: &Self,
+        _res: fhir::Res<surface::NodeId>,
+    ) {
+    }
 
     fn ident(&self) -> Ident {
         *self
@@ -710,7 +759,12 @@ impl Segment for Ident {
 }
 
 impl Segment for hir::PathSegment<'_> {
-    fn record_segment_res(_resolver: &mut CrateResolver, _segment: &Self, _res: fhir::Res) {}
+    fn record_segment_res(
+        _resolver: &mut CrateResolver,
+        _segment: &Self,
+        _res: fhir::Res<surface::NodeId>,
+    ) {
+    }
 
     fn ident(&self) -> Ident {
         self.ident
@@ -745,6 +799,10 @@ impl<'a, 'genv, 'tcx> ItemResolver<'a, 'genv, 'tcx> {
 
     fn resolve_path_in(&mut self, path: &surface::Path, ns: Namespace) {
         if let Some(partial_res) = self.resolver.resolve_path_with_ribs(&path.segments, ns) {
+            // Type/const paths are resolved before any refinement param is in scope, so they can
+            // never resolve to a param.
+            let partial_res =
+                partial_res.map_param_id(|_| bug!("type path resolved to a refinement parameter"));
             self.resolver
                 .output
                 .path_res_map
@@ -907,10 +965,8 @@ fn theory_funcs_rib() -> Rib {
             .items()
             .map(|(_, itf)| (itf.name, fhir::Res::GlobalFunc(fhir::SpecFuncKind::Thy(itf.itf)))),
     );
-    rib.bindings.insert(
-        Symbol::intern("cast"),
-        fhir::Res::GlobalFunc(fhir::SpecFuncKind::Cast),
-    );
+    rib.bindings
+        .insert(Symbol::intern("cast"), fhir::Res::GlobalFunc(fhir::SpecFuncKind::Cast));
     rib
 }
 

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -58,9 +58,8 @@ pub(crate) struct CrateResolver<'genv, 'tcx> {
     ribs: PerNS<Vec<Rib>>,
     /// A mapping from the names of all imported crates to their [`DefId`]
     crates: UnordMap<Symbol, DefId>,
-    /// Names available everywhere: Rust builtin types plus flux's global funcs (theory funcs,
-    /// `cast`, and user-defined refinement functions) and sorts (primitive sorts and user-defined
-    /// sorts). Flux funcs live in [`Namespace::FluxFnNS`] and sorts in [`Namespace::SortNS`].
+    /// Names available everywhere: Rust builtin types plus flux's global funcs (theory funcs, `cast`)
+    /// and primitive sorts.
     prelude: PerNS<Rib>,
     qualifiers: UnordMap<Symbol, FluxLocalDefId>,
     primop_props: UnordMap<Symbol, FluxDefId>,
@@ -145,7 +144,7 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
                         let name = defn.name.name;
                         let def_id = FluxDefId::new(parent, name);
                         let kind = fhir::SpecFuncKind::Def(def_id);
-                        self.define_in_prelude(name, fhir::Res::GlobalFunc(kind), FluxFnNS);
+                        self.define_in_prelude(name, fhir::Res::GlobalFunc(kind), ReftNS);
                     }
                     surface::FluxItem::PrimOpProp(primop_prop) => {
                         let name = primop_prop.name.name;
@@ -757,7 +756,7 @@ impl Segment for surface::ExprPathSegment {
             res.map_param_id(|_| bug!("expr path segment resolved to a refinement parameter"));
         resolver
             .output
-            .expr_path_res_map
+            .path_res_map
             .insert(segment.node_id, fhir::PartialRes::new(res));
     }
 
@@ -887,7 +886,7 @@ impl<'a, 'genv, 'tcx> ItemResolver<'a, 'genv, 'tcx> {
         let mut reveals = Vec::with_capacity(reveal_names.len());
         for reveal in reveal_names {
             if let Some(fhir::Res::GlobalFunc(kind)) =
-                self.resolver.resolve_ident_with_ribs(*reveal, FluxFnNS)
+                self.resolver.resolve_ident_with_ribs(*reveal, ReftNS)
                 && let Some(def_id) = kind.def_id()
             {
                 reveals.push(def_id);
@@ -977,8 +976,7 @@ fn builtin_types_rib() -> Rib {
     }
 }
 
-/// The [`Namespace::FluxFnNS`] prelude: theory functions and `cast`. User-defined refinement
-/// functions are added on top in [`CrateResolver::define_flux_global_items`].
+/// The [`Namespace::ReftNS`] prelude: theory functions and `cast`.
 fn theory_funcs_rib() -> Rib {
     let mut rib = Rib::new(RibKind::Misc);
     rib.bindings.extend_unord(
@@ -987,12 +985,11 @@ fn theory_funcs_rib() -> Rib {
             .map(|(_, itf)| (itf.name, fhir::Res::GlobalFunc(fhir::SpecFuncKind::Thy(itf.itf)))),
     );
     rib.bindings
-        .insert(Symbol::intern("cast"), fhir::Res::GlobalFunc(fhir::SpecFuncKind::Cast));
+        .insert(sym::cast, fhir::Res::GlobalFunc(fhir::SpecFuncKind::Cast));
     rib
 }
 
-/// The [`Namespace::SortNS`] prelude: primitive sorts (`int`, `bool`, `Set`, `Map`, ...). User-defined
-/// sorts are added on top in [`CrateResolver::define_flux_global_items`].
+/// The [`Namespace::SortNS`] prelude: primitive sorts (`int`, `bool`, `Set`, `Map`, ...).
 fn prim_sorts_rib() -> Rib {
     use flux_middle::fhir::PrimSort;
     let bindings = [

--- a/crates/flux-desugar/src/resolver.rs
+++ b/crates/flux-desugar/src/resolver.rs
@@ -110,8 +110,8 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
             crates: mk_crate_mapping(genv.tcx()),
             prelude: PerNS {
                 type_ns: builtin_types_rib(),
-                value_ns: Rib::new(RibKind::Normal),
-                macro_ns: Rib::new(RibKind::Normal),
+                value_ns: Rib::new(RibKind::Misc),
+                macro_ns: Rib::new(RibKind::Misc),
                 sort_ns: prim_sorts_rib(),
                 flux_fn_ns: theory_funcs_rib(),
             },
@@ -378,11 +378,11 @@ impl<'genv, 'tcx> CrateResolver<'genv, 'tcx> {
             match rib.kind {
                 // A module boundary stops item resolution.
                 RibKind::Module => break,
-                // A barrier hides refinement params bound in *enclosing* scopes, but not non-param
-                // bindings in outer scopes (e.g. flux funcs, in the prelude or eventually in
-                // module-level ribs). Params are the innermost ribs, bounded below by a module
-                // boundary / the prelude, so skip everything up to the next module boundary.
-                RibKind::FnInput | RibKind::Variant => {
+                // A variant is a barrier that hides refinement params bound in the `refined_by` *enclosing*
+                // scope, but not other refinement bindings in other scopes (e.g. flux funcs in the parent module).
+                // FIXME: this is skipping potential names defined inside a `const _ = { ... }` or other similar
+                // "transparent modules".
+                RibKind::Variant => {
                     ribs.take_while_ref(|rib| !matches!(rib.kind, RibKind::Module))
                         .for_each(drop);
                 }
@@ -516,8 +516,8 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for CrateResolver<'_, 'tcx> {
     }
 
     fn visit_block(&mut self, block: &'tcx hir::Block<'tcx>) {
-        self.push_rib(TypeNS, RibKind::Normal);
-        self.push_rib(ValueNS, RibKind::Normal);
+        self.push_rib(TypeNS, RibKind::Misc);
+        self.push_rib(ValueNS, RibKind::Misc);
 
         let item_ids = block.stmts.iter().filter_map(|stmt| {
             if let hir::StmtKind::Item(item_id) = &stmt.kind { Some(item_id) } else { None }
@@ -540,8 +540,8 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for CrateResolver<'_, 'tcx> {
             .maybe_extern_id(item.owner_id.def_id)
             .map(|def_id| OwnerId { def_id });
 
-        self.push_rib(TypeNS, RibKind::Normal);
-        self.push_rib(ValueNS, RibKind::Normal);
+        self.push_rib(TypeNS, RibKind::Misc);
+        self.push_rib(ValueNS, RibKind::Misc);
 
         match item.kind {
             ItemKind::Trait(..) => {
@@ -603,7 +603,7 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for CrateResolver<'_, 'tcx> {
             .maybe_extern_id(impl_item.owner_id.def_id)
             .map(|def_id| OwnerId { def_id });
 
-        self.push_rib(TypeNS, RibKind::Normal);
+        self.push_rib(TypeNS, RibKind::Misc);
         if let Some(item) = self.specs.get_impl_item(def_id.local_id()) {
             self.define_generics(def_id);
             self.resolve_impl_item(item, def_id)
@@ -619,7 +619,7 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for CrateResolver<'_, 'tcx> {
             .maybe_extern_id(trait_item.owner_id.def_id)
             .map(|def_id| OwnerId { def_id });
 
-        self.push_rib(TypeNS, RibKind::Normal);
+        self.push_rib(TypeNS, RibKind::Misc);
         if let Some(item) = self.specs.get_trait_item(def_id.local_id()) {
             self.define_generics(def_id);
             self.resolve_trait_item(item, def_id)
@@ -653,22 +653,16 @@ enum ModuleKind {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum RibKind {
-    /// An ordinary rib searched with no special rules: Rust item bindings, the prelude, or a
-    /// miscellaneous refinement scope (i.e. one that is neither a barrier nor a target of
-    /// implicit-param gathering / binder-legality checks).
-    Normal,
-    /// A module boundary. Item resolution stops here.
+    /// An rib with no special rules.
+    Misc,
+    /// A module boundary. This is a barrier for item resolution.
     Module,
-    // The remaining variants are the refinement scopes that get special treatment: each doubles as a
-    // surface-traversal scope kind driving implicit-param gathering and binder legality (see
-    // [`refinement_resolver`]), and `FnInput`/`Variant` additionally act as barriers that hide params
-    // bound in enclosing scopes (see [`CrateResolver::resolve_ident_with_ribs`]).
-    /// A function signature's inputs (arguments and `requires`). A barrier scope; `@` binders are
-    /// legal here.
+    /// A function signature's inputs (arguments and `requires`). `@` binders are legal here.
     FnInput,
     /// A function signature's output (return type and `ensures`). `#` binders are legal here.
     FnOutput,
-    /// An enum variant. A barrier scope; `@` binders are legal here.
+    /// An enum variant. `@` binders are legal here. This is a barrier scope because variants
+    /// are nested within `refined_by` params.
     Variant,
     /// The input position of an `Fn`-trait bound (e.g. the `T` in `FnMut(T) -> S`). `@` binders are
     /// legal here.
@@ -975,7 +969,7 @@ impl surface::visit::Visitor for ItemResolver<'_, '_, '_> {
 
 fn builtin_types_rib() -> Rib {
     Rib {
-        kind: RibKind::Normal,
+        kind: RibKind::Misc,
         bindings: PrimTy::ALL
             .into_iter()
             .map(|pty| (pty.name(), fhir::Res::PrimTy(pty)))
@@ -986,7 +980,7 @@ fn builtin_types_rib() -> Rib {
 /// The [`Namespace::FluxFnNS`] prelude: theory functions and `cast`. User-defined refinement
 /// functions are added on top in [`CrateResolver::define_flux_global_items`].
 fn theory_funcs_rib() -> Rib {
-    let mut rib = Rib::new(RibKind::Normal);
+    let mut rib = Rib::new(RibKind::Misc);
     rib.bindings.extend_unord(
         flux_middle::THEORY_FUNCS
             .items()
@@ -1012,7 +1006,7 @@ fn prim_sorts_rib() -> Rib {
         (sym::ptr, PrimSort::RawPtr),
     ];
     Rib {
-        kind: RibKind::Normal,
+        kind: RibKind::Misc,
         bindings: bindings
             .into_iter()
             .map(|(name, prim)| (name, fhir::Res::PrimSort(prim)))

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -6,7 +6,7 @@ use flux_middle::{
     ResolverOutput,
     fhir::{
         self,
-        Namespace::{FluxFnNS, SortNS, TypeNS, ValueNS},
+        Namespace::{ReftNS, SortNS, TypeNS, ValueNS},
         PartialRes, Res,
     },
 };
@@ -399,9 +399,6 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
     }
 
     fn run(self, sort_vars: &[Ident], f: impl FnOnce(&mut ScopedVisitorWrapper<Self>)) -> Result {
-        // Sort parameters live in an item-level `SortNS` rib so they resolve uniformly with primitive
-        // and user-defined sorts. Being the innermost `SortNS` rib, they shadow those. Popped in
-        // `finish`.
         self.resolver.push_rib(SortNS, RibKind::Misc);
         for (idx, ident) in sort_vars.iter().enumerate() {
             self.resolver
@@ -409,7 +406,6 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         }
         let mut wrapper = self.wrap();
         f(&mut wrapper);
-        // Balances the `SortNS` rib pushed in `new` for this item's sort parameters.
         wrapper.resolver.pop_rib(SortNS);
 
         wrapper.0.finish()
@@ -427,7 +423,7 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
 
         if let Some(Res::Param(_, prev_id)) =
             self.resolver
-                .define_res_in(ident.name, Res::Param(kind, param_id), FluxFnNS)
+                .define_res_in(ident.name, Res::Param(kind, param_id), ReftNS)
         {
             let prev_ident = self.param_defs[&prev_id].ident;
             self.errors
@@ -469,7 +465,7 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         // Try the flux-fn namespace first so that refinement params (and then flux funcs) take
         // precedence over Rust value/type bindings — in particular, a param shadows a Rust const of
         // the same name.
-        for ns in [FluxFnNS, ValueNS, TypeNS] {
+        for ns in [ReftNS, ValueNS, TypeNS] {
             if let Some(partial_res) = self.resolver.resolve_path_with_ribs(segments, ns) {
                 return Some(partial_res);
             }
@@ -486,10 +482,7 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         if let Some(res) = res {
             // Sorts never resolve to a refinement param, so we can narrow away the param id.
             let res = res.map_param_id(|_| bug!("sort path resolved to a refinement parameter"));
-            self.resolver
-                .output
-                .sort_path_res_map
-                .insert(path.node_id, res);
+            self.resolver.output.path_res_map.insert(path.node_id, res);
         } else {
             self.errors.emit(errors::UnresolvedSort::new(path));
         }
@@ -525,7 +518,7 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
                     .entry(param_id)
                     .or_insert_with(|| param_id_gen.fresh())
             });
-            self.resolver.output.expr_path_res_map.insert(node_id, res);
+            self.resolver.output.path_res_map.insert(node_id, res);
         }
 
         // At this point, the `params` map contains all parameters that were used in an expression,
@@ -575,15 +568,12 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
     }
 
     fn enter_scope(&mut self, kind: RibKind) -> ControlFlow<()> {
-        // Refinement params live in the flux-fn namespace on the crate resolver's rib stack, sharing
-        // it with refinement functions (params, being inner ribs, shadow funcs). The scope's
-        // `RibKind` is the rib kind, so `resolve_ident_with_ribs` can honor barrier scopes.
-        self.resolver.push_rib(FluxFnNS, kind);
+        self.resolver.push_rib(ReftNS, kind);
         ControlFlow::Continue(())
     }
 
     fn exit_scope(&mut self) {
-        self.resolver.pop_rib(FluxFnNS);
+        self.resolver.pop_rib(ReftNS);
     }
 
     fn on_fn_trait_input(&mut self, in_arg: &surface::GenericArg, trait_node_id: NodeId) {

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -567,9 +567,10 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
     fn resolve_sort_path(&mut self, path: &surface::SortPath) {
         let res = self
             .try_resolve_sort_param(path)
+            .map(PartialRes::new)
             .or_else(|| self.try_resolve_sort_with_ribs(path))
-            .or_else(|| self.try_resolve_user_sort(path))
-            .or_else(|| self.try_resolve_prim_sort(path));
+            .or_else(|| self.try_resolve_user_sort(path).map(PartialRes::new))
+            .or_else(|| self.try_resolve_prim_sort(path).map(PartialRes::new));
 
         if let Some(res) = res {
             self.resolver
@@ -581,62 +582,55 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         }
     }
 
-    fn try_resolve_sort_param(&self, path: &surface::SortPath) -> Option<fhir::SortRes> {
+    fn try_resolve_sort_param(&self, path: &surface::SortPath) -> Option<fhir::Res> {
         let [segment] = &path.segments[..] else { return None };
         self.sort_params
             .get_index_of(&segment.name)
-            .map(fhir::SortRes::SortParam)
+            .map(fhir::Res::SortParam)
     }
 
-    fn try_resolve_sort_with_ribs(&mut self, path: &surface::SortPath) -> Option<fhir::SortRes> {
+    /// Returns `Some` only for sort-admissible shapes; this is where the "not a sort" diagnostic
+    /// stays localized (`None` here means [`resolve_sort_path`] emits `UnresolvedSort`).
+    fn try_resolve_sort_with_ribs(&mut self, path: &surface::SortPath) -> Option<PartialRes> {
         let partial_res = self
             .resolver
             .resolve_path_with_ribs(&path.segments, TypeNS)?;
         match (partial_res.base_res(), partial_res.unresolved_segments()) {
-            (fhir::Res::Def(DefKind::Struct | DefKind::Enum | DefKind::Union, def_id), 0) => {
-                Some(fhir::SortRes::Adt(def_id))
-            }
-            (fhir::Res::Def(DefKind::TyParam, def_id), 0) => Some(fhir::SortRes::TyParam(def_id)),
-            (fhir::Res::SelfTyParam { trait_ }, 0) => {
-                Some(fhir::SortRes::SelfParam { trait_id: trait_ })
-            }
-            (fhir::Res::SelfTyParam { trait_ }, 1) => {
-                let ident = *path.segments.last().unwrap();
-                Some(fhir::SortRes::SelfParamAssoc { trait_id: trait_, ident })
-            }
-            (fhir::Res::SelfTyAlias { alias_to, .. }, 0) => {
-                Some(fhir::SortRes::SelfAlias { alias_to })
-            }
+            (fhir::Res::Def(DefKind::Struct | DefKind::Enum | DefKind::Union, _), 0)
+            | (fhir::Res::Def(DefKind::TyParam, _), 0)
+            | (fhir::Res::SelfTyParam { .. }, 0)
+            | (fhir::Res::SelfTyParam { .. }, 1)
+            | (fhir::Res::SelfTyAlias { .. }, 0) => Some(partial_res),
             _ => None,
         }
     }
 
-    fn try_resolve_user_sort(&self, path: &surface::SortPath) -> Option<fhir::SortRes> {
+    fn try_resolve_user_sort(&self, path: &surface::SortPath) -> Option<fhir::Res> {
         let [segment] = &path.segments[..] else { return None };
         self.resolver
             .sort_decls
             .get(&segment.name)
-            .map(|decl| fhir::SortRes::User(*decl))
+            .map(|decl| fhir::Res::UserSort(*decl))
     }
 
-    fn try_resolve_prim_sort(&self, path: &surface::SortPath) -> Option<fhir::SortRes> {
+    fn try_resolve_prim_sort(&self, path: &surface::SortPath) -> Option<fhir::Res> {
         let [segment] = &path.segments[..] else { return None };
         if segment.name == sym::int {
-            Some(fhir::SortRes::PrimSort(fhir::PrimSort::Int))
+            Some(fhir::Res::PrimSort(fhir::PrimSort::Int))
         } else if segment.name == sym::bool {
-            Some(fhir::SortRes::PrimSort(fhir::PrimSort::Bool))
+            Some(fhir::Res::PrimSort(fhir::PrimSort::Bool))
         } else if segment.name == sym::char {
-            Some(fhir::SortRes::PrimSort(fhir::PrimSort::Char))
+            Some(fhir::Res::PrimSort(fhir::PrimSort::Char))
         } else if segment.name == sym::real {
-            Some(fhir::SortRes::PrimSort(fhir::PrimSort::Real))
+            Some(fhir::Res::PrimSort(fhir::PrimSort::Real))
         } else if segment.name == sym::Set {
-            Some(fhir::SortRes::PrimSort(fhir::PrimSort::Set))
+            Some(fhir::Res::PrimSort(fhir::PrimSort::Set))
         } else if segment.name == sym::Map {
-            Some(fhir::SortRes::PrimSort(fhir::PrimSort::Map))
+            Some(fhir::Res::PrimSort(fhir::PrimSort::Map))
         } else if segment.name == sym::str {
-            Some(fhir::SortRes::PrimSort(fhir::PrimSort::Str))
+            Some(fhir::Res::PrimSort(fhir::PrimSort::Str))
         } else if segment.name == sym::ptr {
-            Some(fhir::SortRes::PrimSort(fhir::PrimSort::RawPtr))
+            Some(fhir::Res::PrimSort(fhir::PrimSort::RawPtr))
         } else {
             None
         }

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -14,14 +14,11 @@ use flux_syntax::{
     surface::{self, FluxItem, Ident, NodeId, visit::Visitor as _},
     walk_list,
 };
-use rustc_data_structures::{
-    fx::{FxIndexMap, FxIndexSet},
-    unord::UnordMap,
-};
+use rustc_data_structures::{fx::FxIndexMap, unord::UnordMap};
 use rustc_hash::FxHashMap;
 use rustc_hir::def::DefKind;
 use rustc_middle::ty::TyCtxt;
-use rustc_span::{ErrorGuaranteed, Symbol};
+use rustc_span::ErrorGuaranteed;
 
 use super::{CrateResolver, RibKind, Segment};
 
@@ -75,31 +72,31 @@ impl<V> std::ops::DerefMut for ScopedVisitorWrapper<V> {
 
 impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     fn visit_trait_assoc_reft(&mut self, assoc_reft: &surface::TraitAssocReft) {
-        self.with_scope(RibKind::Normal, |this| {
+        self.with_scope(RibKind::Misc, |this| {
             surface::visit::walk_trait_assoc_reft(this, assoc_reft);
         });
     }
 
     fn visit_impl_assoc_reft(&mut self, assoc_reft: &surface::ImplAssocReft) {
-        self.with_scope(RibKind::Normal, |this| {
+        self.with_scope(RibKind::Misc, |this| {
             surface::visit::walk_impl_assoc_reft(this, assoc_reft);
         });
     }
 
     fn visit_qualifier(&mut self, qualifier: &surface::Qualifier) {
-        self.with_scope(RibKind::Normal, |this| {
+        self.with_scope(RibKind::Misc, |this| {
             surface::visit::walk_qualifier(this, qualifier);
         });
     }
 
     fn visit_defn(&mut self, defn: &surface::SpecFunc) {
-        self.with_scope(RibKind::Normal, |this| {
+        self.with_scope(RibKind::Misc, |this| {
             surface::visit::walk_defn(this, defn);
         });
     }
 
     fn visit_primop_prop(&mut self, prop: &surface::PrimOpProp) {
-        self.with_scope(RibKind::Normal, |this| {
+        self.with_scope(RibKind::Misc, |this| {
             surface::visit::walk_primop_prop(this, prop);
         });
     }
@@ -115,19 +112,19 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     }
 
     fn visit_ty_alias(&mut self, ty_alias: &surface::TyAlias) {
-        self.with_scope(RibKind::Normal, |this| {
+        self.with_scope(RibKind::Misc, |this| {
             surface::visit::walk_ty_alias(this, ty_alias);
         });
     }
 
     fn visit_struct_def(&mut self, struct_def: &surface::StructDef) {
-        self.with_scope(RibKind::Normal, |this| {
+        self.with_scope(RibKind::Misc, |this| {
             surface::visit::walk_struct_def(this, struct_def);
         });
     }
 
     fn visit_enum_def(&mut self, enum_def: &surface::EnumDef) {
-        self.with_scope(RibKind::Normal, |this| {
+        self.with_scope(RibKind::Misc, |this| {
             surface::visit::walk_enum_def(this, enum_def);
         });
     }
@@ -145,13 +142,13 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
                 self.with_scope(RibKind::FnTraitInput, |this| {
                     this.on_fn_trait_input(in_arg, trait_ref.node_id);
                     surface::visit::walk_generic_arg(this, in_arg);
-                    this.with_scope(RibKind::Normal, |this| {
+                    this.with_scope(RibKind::Misc, |this| {
                         surface::visit::walk_generic_arg(this, out_arg);
                     });
                 });
             }
             None => {
-                self.with_scope(RibKind::Normal, |this| {
+                self.with_scope(RibKind::Misc, |this| {
                     surface::visit::walk_trait_ref(this, trait_ref);
                 });
             }
@@ -159,13 +156,13 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     }
 
     fn visit_variant_ret(&mut self, ret: &surface::VariantRet) {
-        self.with_scope(RibKind::Normal, |this| {
+        self.with_scope(RibKind::Misc, |this| {
             surface::visit::walk_variant_ret(this, ret);
         });
     }
 
     fn visit_generics(&mut self, generics: &surface::Generics) {
-        self.with_scope(RibKind::Normal, |this| {
+        self.with_scope(RibKind::Misc, |this| {
             surface::visit::walk_generics(this, generics);
         });
     }
@@ -223,7 +220,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
                 self.on_implicit_param(*ident, kind, *node_id);
             }
             surface::RefineArg::Abs(..) => {
-                self.with_scope(RibKind::Normal, |this| {
+                self.with_scope(RibKind::Misc, |this| {
                     surface::visit::walk_refine_arg(this, arg);
                 });
             }
@@ -233,7 +230,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
 
     fn visit_path(&mut self, path: &surface::Path) {
         for arg in &path.refine {
-            self.with_scope(RibKind::Normal, |this| this.visit_refine_arg(arg));
+            self.with_scope(RibKind::Misc, |this| this.visit_refine_arg(arg));
         }
         walk_list!(self, visit_path_segment, &path.segments);
     }
@@ -244,7 +241,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
             if is_box && i == 0 {
                 self.visit_generic_arg(arg);
             } else {
-                self.with_scope(RibKind::Normal, |this| this.visit_generic_arg(arg));
+                self.with_scope(RibKind::Misc, |this| this.visit_generic_arg(arg));
             }
         }
     }
@@ -253,7 +250,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
         let node_id = ty.node_id;
         match &ty.kind {
             surface::TyKind::Exists { bind, .. } => {
-                self.with_scope(RibKind::Normal, |this| {
+                self.with_scope(RibKind::Misc, |this| {
                     let param = surface::RefineParam {
                         ident: *bind,
                         mode: None,
@@ -266,12 +263,12 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
                 });
             }
             surface::TyKind::GeneralExists { .. } => {
-                self.with_scope(RibKind::Normal, |this| {
+                self.with_scope(RibKind::Misc, |this| {
                     surface::visit::walk_ty(this, ty);
                 });
             }
             surface::TyKind::Array(..) => {
-                self.with_scope(RibKind::Normal, |this| {
+                self.with_scope(RibKind::Misc, |this| {
                     surface::visit::walk_ty(this, ty);
                 });
             }
@@ -282,7 +279,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     fn visit_bty(&mut self, bty: &surface::BaseTy) {
         match &bty.kind {
             surface::BaseTyKind::Slice(_) | surface::BaseTyKind::Ptr(..) => {
-                self.with_scope(RibKind::Normal, |this| {
+                self.with_scope(RibKind::Misc, |this| {
                     surface::visit::walk_bty(this, bty);
                 });
             }
@@ -353,7 +350,6 @@ struct ParamDef {
 }
 
 pub(crate) struct RefinementResolver<'a, 'genv, 'tcx> {
-    sort_params: FxIndexSet<Symbol>,
     param_defs: FxIndexMap<NodeId, ParamDef>,
     resolver: &'a mut CrateResolver<'genv, 'tcx>,
     path_res_map: FxHashMap<NodeId, PartialRes<NodeId>>,
@@ -361,24 +357,16 @@ pub(crate) struct RefinementResolver<'a, 'genv, 'tcx> {
 }
 
 impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
-    fn for_flux_item(resolver: &'a mut CrateResolver<'genv, 'tcx>, item: &FluxItem) -> Self {
-        let sort_params = match item {
-            FluxItem::FuncDef(defn) => &defn.sort_vars[..],
-            FluxItem::SortDecl(sort_decl) => &sort_decl.sort_vars[..],
-            FluxItem::Qualifier(_) | FluxItem::PrimOpProp(_) => &[],
-        };
-        Self::new(resolver, sort_params.iter().map(|ident| ident.name).collect())
-    }
-
-    fn for_rust_item(resolver: &'a mut CrateResolver<'genv, 'tcx>) -> Self {
-        Self::new(resolver, Default::default())
-    }
-
     pub(crate) fn resolve_flux_item(
         resolver: &'a mut CrateResolver<'genv, 'tcx>,
         item: &FluxItem,
     ) -> Result {
-        Self::for_flux_item(resolver, item).run(|r| r.visit_flux_item(item))
+        let sort_vars = match item {
+            FluxItem::FuncDef(defn) => &defn.sort_vars[..],
+            FluxItem::SortDecl(sort_decl) => &sort_decl.sort_vars[..],
+            FluxItem::Qualifier(_) | FluxItem::PrimOpProp(_) => &[],
+        };
+        Self::new(resolver).run(sort_vars, |r| r.visit_flux_item(item))
     }
 
     pub(crate) fn resolve_item(
@@ -386,7 +374,7 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         item: &surface::Item,
     ) -> Result {
         IllegalBinderVisitor::new(resolver).run(|vis| vis.visit_item(item))?;
-        Self::for_rust_item(resolver).run(|vis| vis.visit_item(item))
+        Self::new(resolver).run(&[], |vis| vis.visit_item(item))
     }
 
     pub(crate) fn resolve_trait_item(
@@ -394,7 +382,7 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         item: &surface::TraitItemFn,
     ) -> Result {
         IllegalBinderVisitor::new(resolver).run(|vis| vis.visit_trait_item(item))?;
-        Self::for_rust_item(resolver).run(|vis| vis.visit_trait_item(item))
+        Self::new(resolver).run(&[], |vis| vis.visit_trait_item(item))
     }
 
     pub(crate) fn resolve_impl_item(
@@ -402,23 +390,28 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         item: &surface::ImplItemFn,
     ) -> Result {
         IllegalBinderVisitor::new(resolver).run(|vis| vis.visit_impl_item(item))?;
-        Self::for_rust_item(resolver).run(|vis| vis.visit_impl_item(item))
+        Self::new(resolver).run(&[], |vis| vis.visit_impl_item(item))
     }
 
-    fn new(resolver: &'a mut CrateResolver<'genv, 'tcx>, sort_params: FxIndexSet<Symbol>) -> Self {
+    fn new(resolver: &'a mut CrateResolver<'genv, 'tcx>) -> Self {
         let errors = Errors::new(resolver.genv.sess());
-        Self {
-            resolver,
-            sort_params,
-            param_defs: Default::default(),
-            path_res_map: Default::default(),
-            errors,
-        }
+        Self { resolver, param_defs: Default::default(), path_res_map: Default::default(), errors }
     }
 
-    fn run(self, f: impl FnOnce(&mut ScopedVisitorWrapper<Self>)) -> Result {
+    fn run(self, sort_vars: &[Ident], f: impl FnOnce(&mut ScopedVisitorWrapper<Self>)) -> Result {
+        // Sort parameters live in an item-level `SortNS` rib so they resolve uniformly with primitive
+        // and user-defined sorts. Being the innermost `SortNS` rib, they shadow those. Popped in
+        // `finish`.
+        self.resolver.push_rib(SortNS, RibKind::Misc);
+        for (idx, ident) in sort_vars.iter().enumerate() {
+            self.resolver
+                .define_res_in(ident.name, Res::SortParam(idx), SortNS);
+        }
         let mut wrapper = self.wrap();
         f(&mut wrapper);
+        // Balances the `SortNS` rib pushed in `new` for this item's sort parameters.
+        wrapper.resolver.pop_rib(SortNS);
+
         wrapper.0.finish()
     }
 
@@ -461,8 +454,8 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         self.errors.emit(errors::UnresolvedVar::from_ident(ident));
     }
 
-    /// Emit an error if `res` resolved to a param that cannot be refined (used as an expression). The
-    /// param still resolves (shadowing any outer binding), matching the pre-rib behavior.
+    /// Emit an error if `res` resolved to a param that cannot be refined.
+    /// e.g., `fn(x: &mut i32) -> i32[x]`
     fn check_unrefined_param(&mut self, res: PartialRes<NodeId>, ident: Ident) {
         if let Some(Res::Param(fhir::ParamKind::Error, _)) = res.full_res() {
             self.errors.emit(errors::InvalidUnrefinedParam::new(ident));
@@ -486,13 +479,9 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
 
     fn resolve_sort_path(&mut self, path: &surface::SortPath) {
         let res = self
-            .try_resolve_sort_param(path)
-            .map(PartialRes::new)
-            .or_else(|| self.try_resolve_sort_with_ribs(path))
-            .or_else(|| {
-                self.try_resolve_sort_with_flux_ribs(path)
-                    .map(PartialRes::new)
-            });
+            .resolver
+            .resolve_path_with_ribs(&path.segments, SortNS)
+            .or_else(|| self.try_resolve_sort_in_type_ns(path));
 
         if let Some(res) = res {
             // Sorts never resolve to a refinement param, so we can narrow away the param id.
@@ -506,16 +495,8 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         }
     }
 
-    fn try_resolve_sort_param(&self, path: &surface::SortPath) -> Option<fhir::Res<NodeId>> {
-        let [segment] = &path.segments[..] else { return None };
-        self.sort_params
-            .get_index_of(&segment.name)
-            .map(fhir::Res::SortParam)
-    }
-
-    /// Returns `Some` only for sort-admissible shapes; this is where the "not a sort" diagnostic
-    /// stays localized (`None` here means [`resolve_sort_path`] emits `UnresolvedSort`).
-    fn try_resolve_sort_with_ribs(
+    /// Try to resolve path as a sort using the type namespace
+    fn try_resolve_sort_in_type_ns(
         &mut self,
         path: &surface::SortPath,
     ) -> Option<PartialRes<NodeId>> {
@@ -530,16 +511,6 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
             | (fhir::Res::SelfTyAlias { .. }, 0) => Some(partial_res),
             _ => None,
         }
-    }
-
-    /// Resolves a single-segment sort name against the flux sort namespace, covering both primitive
-    /// sorts (`int`, `bool`, `Set`, ...) and user-defined sorts, which live in the [`SortNS`] prelude.
-    fn try_resolve_sort_with_flux_ribs(
-        &self,
-        path: &surface::SortPath,
-    ) -> Option<fhir::Res<NodeId>> {
-        let [segment] = &path.segments[..] else { return None };
-        self.resolver.resolve_ident_with_ribs(*segment, SortNS)
     }
 
     pub(crate) fn finish(self) -> Result {

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -1,6 +1,6 @@
 use std::ops::ControlFlow;
 
-use flux_common::{bug, index::IndexGen};
+use flux_common::index::IndexGen;
 use flux_errors::Errors;
 use flux_middle::{
     ResolverOutput,
@@ -462,7 +462,7 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         &mut self,
         segments: &[S],
     ) -> Option<PartialRes<NodeId>> {
-        // Try the flux-fn namespace first so that refinement params (and then flux funcs) take
+        // Try the refinement namespace first so that refinement params (and then flux funcs) take
         // precedence over Rust value/type bindings — in particular, a param shadows a Rust const of
         // the same name.
         for ns in [ReftNS, ValueNS, TypeNS] {
@@ -480,8 +480,6 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
             .or_else(|| self.try_resolve_sort_in_type_ns(path));
 
         if let Some(res) = res {
-            // Sorts never resolve to a refinement param, so we can narrow away the param id.
-            let res = res.map_param_id(|_| bug!("sort path resolved to a refinement parameter"));
             self.resolver.output.path_res_map.insert(path.node_id, res);
         } else {
             self.errors.emit(errors::UnresolvedSort::new(path));

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -27,24 +27,9 @@ use super::{CrateResolver, RibKind, Segment};
 
 type Result<T = ()> = std::result::Result<T, ErrorGuaranteed>;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum ScopeKind {
-    FnInput,
-    FnOutput,
-    Variant,
-    Misc,
-    FnTraitInput,
-}
-
-impl ScopeKind {
-    fn is_barrier(self) -> bool {
-        matches!(self, ScopeKind::FnInput | ScopeKind::Variant)
-    }
-}
-
 pub(crate) trait ScopedVisitor: Sized {
     fn is_box(&self, segment: &surface::PathSegment) -> bool;
-    fn enter_scope(&mut self, kind: ScopeKind) -> ControlFlow<()>;
+    fn enter_scope(&mut self, kind: RibKind) -> ControlFlow<()>;
     fn exit_scope(&mut self) {}
 
     fn wrap(self) -> ScopedVisitorWrapper<Self> {
@@ -66,7 +51,7 @@ pub(crate) trait ScopedVisitor: Sized {
 pub(crate) struct ScopedVisitorWrapper<V>(V);
 
 impl<V: ScopedVisitor> ScopedVisitorWrapper<V> {
-    fn with_scope(&mut self, kind: ScopeKind, f: impl FnOnce(&mut Self)) {
+    fn with_scope(&mut self, kind: RibKind, f: impl FnOnce(&mut Self)) {
         let scope = self.0.enter_scope(kind);
         if let ControlFlow::Continue(_) = scope {
             f(self);
@@ -90,31 +75,31 @@ impl<V> std::ops::DerefMut for ScopedVisitorWrapper<V> {
 
 impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     fn visit_trait_assoc_reft(&mut self, assoc_reft: &surface::TraitAssocReft) {
-        self.with_scope(ScopeKind::Misc, |this| {
+        self.with_scope(RibKind::Normal, |this| {
             surface::visit::walk_trait_assoc_reft(this, assoc_reft);
         });
     }
 
     fn visit_impl_assoc_reft(&mut self, assoc_reft: &surface::ImplAssocReft) {
-        self.with_scope(ScopeKind::Misc, |this| {
+        self.with_scope(RibKind::Normal, |this| {
             surface::visit::walk_impl_assoc_reft(this, assoc_reft);
         });
     }
 
     fn visit_qualifier(&mut self, qualifier: &surface::Qualifier) {
-        self.with_scope(ScopeKind::Misc, |this| {
+        self.with_scope(RibKind::Normal, |this| {
             surface::visit::walk_qualifier(this, qualifier);
         });
     }
 
     fn visit_defn(&mut self, defn: &surface::SpecFunc) {
-        self.with_scope(ScopeKind::Misc, |this| {
+        self.with_scope(RibKind::Normal, |this| {
             surface::visit::walk_defn(this, defn);
         });
     }
 
     fn visit_primop_prop(&mut self, prop: &surface::PrimOpProp) {
-        self.with_scope(ScopeKind::Misc, |this| {
+        self.with_scope(RibKind::Normal, |this| {
             surface::visit::walk_primop_prop(this, prop);
         });
     }
@@ -130,25 +115,25 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     }
 
     fn visit_ty_alias(&mut self, ty_alias: &surface::TyAlias) {
-        self.with_scope(ScopeKind::Misc, |this| {
+        self.with_scope(RibKind::Normal, |this| {
             surface::visit::walk_ty_alias(this, ty_alias);
         });
     }
 
     fn visit_struct_def(&mut self, struct_def: &surface::StructDef) {
-        self.with_scope(ScopeKind::Misc, |this| {
+        self.with_scope(RibKind::Normal, |this| {
             surface::visit::walk_struct_def(this, struct_def);
         });
     }
 
     fn visit_enum_def(&mut self, enum_def: &surface::EnumDef) {
-        self.with_scope(ScopeKind::Misc, |this| {
+        self.with_scope(RibKind::Normal, |this| {
             surface::visit::walk_enum_def(this, enum_def);
         });
     }
 
     fn visit_variant(&mut self, variant: &surface::VariantDef) {
-        self.with_scope(ScopeKind::Variant, |this| {
+        self.with_scope(RibKind::Variant, |this| {
             this.on_enum_variant(variant);
             surface::visit::walk_variant(this, variant);
         });
@@ -157,16 +142,16 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     fn visit_trait_ref(&mut self, trait_ref: &surface::TraitRef) {
         match trait_ref.as_fn_trait_ref() {
             Some((in_arg, out_arg)) => {
-                self.with_scope(ScopeKind::FnTraitInput, |this| {
+                self.with_scope(RibKind::FnTraitInput, |this| {
                     this.on_fn_trait_input(in_arg, trait_ref.node_id);
                     surface::visit::walk_generic_arg(this, in_arg);
-                    this.with_scope(ScopeKind::Misc, |this| {
+                    this.with_scope(RibKind::Normal, |this| {
                         surface::visit::walk_generic_arg(this, out_arg);
                     });
                 });
             }
             None => {
-                self.with_scope(ScopeKind::Misc, |this| {
+                self.with_scope(RibKind::Normal, |this| {
                     surface::visit::walk_trait_ref(this, trait_ref);
                 });
             }
@@ -174,26 +159,26 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     }
 
     fn visit_variant_ret(&mut self, ret: &surface::VariantRet) {
-        self.with_scope(ScopeKind::Misc, |this| {
+        self.with_scope(RibKind::Normal, |this| {
             surface::visit::walk_variant_ret(this, ret);
         });
     }
 
     fn visit_generics(&mut self, generics: &surface::Generics) {
-        self.with_scope(ScopeKind::Misc, |this| {
+        self.with_scope(RibKind::Normal, |this| {
             surface::visit::walk_generics(this, generics);
         });
     }
 
     fn visit_fn_sig(&mut self, fn_sig: &surface::FnSig) {
-        self.with_scope(ScopeKind::FnInput, |this| {
+        self.with_scope(RibKind::FnInput, |this| {
             this.on_fn_sig(fn_sig);
             surface::visit::walk_fn_sig(this, fn_sig);
         });
     }
 
     fn visit_fn_output(&mut self, output: &surface::FnOutput) {
-        self.with_scope(ScopeKind::FnOutput, |this| {
+        self.with_scope(RibKind::FnOutput, |this| {
             this.on_fn_output(output);
             surface::visit::walk_fn_output(this, output);
         });
@@ -238,7 +223,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
                 self.on_implicit_param(*ident, kind, *node_id);
             }
             surface::RefineArg::Abs(..) => {
-                self.with_scope(ScopeKind::Misc, |this| {
+                self.with_scope(RibKind::Normal, |this| {
                     surface::visit::walk_refine_arg(this, arg);
                 });
             }
@@ -248,7 +233,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
 
     fn visit_path(&mut self, path: &surface::Path) {
         for arg in &path.refine {
-            self.with_scope(ScopeKind::Misc, |this| this.visit_refine_arg(arg));
+            self.with_scope(RibKind::Normal, |this| this.visit_refine_arg(arg));
         }
         walk_list!(self, visit_path_segment, &path.segments);
     }
@@ -259,7 +244,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
             if is_box && i == 0 {
                 self.visit_generic_arg(arg);
             } else {
-                self.with_scope(ScopeKind::Misc, |this| this.visit_generic_arg(arg));
+                self.with_scope(RibKind::Normal, |this| this.visit_generic_arg(arg));
             }
         }
     }
@@ -268,7 +253,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
         let node_id = ty.node_id;
         match &ty.kind {
             surface::TyKind::Exists { bind, .. } => {
-                self.with_scope(ScopeKind::Misc, |this| {
+                self.with_scope(RibKind::Normal, |this| {
                     let param = surface::RefineParam {
                         ident: *bind,
                         mode: None,
@@ -281,12 +266,12 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
                 });
             }
             surface::TyKind::GeneralExists { .. } => {
-                self.with_scope(ScopeKind::Misc, |this| {
+                self.with_scope(RibKind::Normal, |this| {
                     surface::visit::walk_ty(this, ty);
                 });
             }
             surface::TyKind::Array(..) => {
-                self.with_scope(ScopeKind::Misc, |this| {
+                self.with_scope(RibKind::Normal, |this| {
                     surface::visit::walk_ty(this, ty);
                 });
             }
@@ -297,7 +282,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
     fn visit_bty(&mut self, bty: &surface::BaseTy) {
         match &bty.kind {
             surface::BaseTyKind::Slice(_) | surface::BaseTyKind::Ptr(..) => {
-                self.with_scope(ScopeKind::Misc, |this| {
+                self.with_scope(RibKind::Normal, |this| {
                     surface::visit::walk_bty(this, bty);
                 });
             }
@@ -320,7 +305,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
 struct ImplicitParamCollector<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     path_res_map: &'a UnordMap<surface::NodeId, fhir::PartialRes>,
-    kind: ScopeKind,
+    kind: RibKind,
     params: Vec<(Ident, fhir::ParamKind, NodeId)>,
 }
 
@@ -328,7 +313,7 @@ impl<'a, 'tcx> ImplicitParamCollector<'a, 'tcx> {
     fn new(
         tcx: TyCtxt<'tcx>,
         path_res_map: &'a UnordMap<surface::NodeId, fhir::PartialRes>,
-        kind: ScopeKind,
+        kind: RibKind,
     ) -> Self {
         Self { tcx, path_res_map, kind, params: vec![] }
     }
@@ -351,7 +336,7 @@ impl ScopedVisitor for ImplicitParamCollector<'_, '_> {
             .unwrap_or(false)
     }
 
-    fn enter_scope(&mut self, kind: ScopeKind) -> ControlFlow<()> {
+    fn enter_scope(&mut self, kind: RibKind) -> ControlFlow<()> {
         if self.kind == kind { ControlFlow::Continue(()) } else { ControlFlow::Break(()) }
     }
 
@@ -447,17 +432,13 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         self.param_defs
             .insert(param_id, ParamDef { ident, kind, scope });
 
-        // Refinement params live in the innermost flux-fn-namespace rib on the crate resolver, which
-        // is always the param scope entered by the surrounding `with_scope`. Duplicate detection is
-        // per-scope, so we only check that rib.
-        if let Some(Res::Param(_, prev_id)) = self.resolver.lookup_in_top_rib(FluxFnNS, ident.name)
+        if let Some(Res::Param(_, prev_id)) =
+            self.resolver
+                .define_res_in(ident.name, Res::Param(kind, param_id), FluxFnNS)
         {
             let prev_ident = self.param_defs[&prev_id].ident;
             self.errors
                 .emit(errors::DuplicateParam::new(prev_ident, ident));
-        } else {
-            self.resolver
-                .define_res_in(ident.name, Res::Param(kind, param_id), FluxFnNS);
         }
     }
 
@@ -622,12 +603,11 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
             .unwrap_or(false)
     }
 
-    fn enter_scope(&mut self, kind: ScopeKind) -> ControlFlow<()> {
+    fn enter_scope(&mut self, kind: RibKind) -> ControlFlow<()> {
         // Refinement params live in the flux-fn namespace on the crate resolver's rib stack, sharing
-        // it with refinement functions (params, being inner ribs, shadow funcs). A barrier scope
-        // becomes a `RibKind::ParamBarrier` so params in enclosing scopes stay hidden.
-        let rib_kind = if kind.is_barrier() { RibKind::ParamBarrier } else { RibKind::Param };
-        self.resolver.push_rib(FluxFnNS, rib_kind);
+        // it with refinement functions (params, being inner ribs, shadow funcs). The scope's
+        // `RibKind` is the rib kind, so `resolve_ident_with_ribs` can honor barrier scopes.
+        self.resolver.push_rib(FluxFnNS, kind);
         ControlFlow::Continue(())
     }
 
@@ -639,7 +619,7 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
         let params = ImplicitParamCollector::new(
             self.resolver.genv.tcx(),
             &self.resolver.output.path_res_map,
-            ScopeKind::FnTraitInput,
+            RibKind::FnTraitInput,
         )
         .run(|vis| vis.visit_generic_arg(in_arg));
         for (ident, kind, node_id) in params {
@@ -651,7 +631,7 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
         let params = ImplicitParamCollector::new(
             self.resolver.genv.tcx(),
             &self.resolver.output.path_res_map,
-            ScopeKind::Variant,
+            RibKind::Variant,
         )
         .run(|vis| vis.visit_variant(variant));
         for (ident, kind, node_id) in params {
@@ -663,7 +643,7 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
         let params = ImplicitParamCollector::new(
             self.resolver.genv.tcx(),
             &self.resolver.output.path_res_map,
-            ScopeKind::FnInput,
+            RibKind::FnInput,
         )
         .run(|vis| vis.visit_fn_sig(fn_sig));
         for (ident, kind, param_id) in params {
@@ -675,7 +655,7 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
         let params = ImplicitParamCollector::new(
             self.resolver.genv.tcx(),
             &self.resolver.output.path_res_map,
-            ScopeKind::FnOutput,
+            RibKind::FnOutput,
         )
         .run(|vis| vis.visit_fn_output(output));
         for (ident, kind, param_id) in params {
@@ -712,7 +692,7 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
 }
 
 struct IllegalBinderVisitor<'a, 'genv, 'tcx> {
-    scopes: Vec<ScopeKind>,
+    scopes: Vec<RibKind>,
     resolver: &'a CrateResolver<'genv, 'tcx>,
     errors: Errors<'genv>,
 }
@@ -740,7 +720,7 @@ impl ScopedVisitor for IllegalBinderVisitor<'_, '_, '_> {
             .unwrap_or(false)
     }
 
-    fn enter_scope(&mut self, kind: ScopeKind) -> ControlFlow<()> {
+    fn enter_scope(&mut self, kind: RibKind) -> ControlFlow<()> {
         self.scopes.push(kind);
         ControlFlow::Continue(())
     }
@@ -756,13 +736,13 @@ impl ScopedVisitor for IllegalBinderVisitor<'_, '_, '_> {
                 (
                     matches!(
                         scope_kind,
-                        ScopeKind::FnInput | ScopeKind::FnTraitInput | ScopeKind::Variant
+                        RibKind::FnInput | RibKind::FnTraitInput | RibKind::Variant
                     ),
                     surface::BindKind::At,
                 )
             }
             fhir::ParamKind::Pound => {
-                (matches!(scope_kind, ScopeKind::FnOutput), surface::BindKind::Pound)
+                (matches!(scope_kind, RibKind::FnOutput), surface::BindKind::Pound)
             }
             fhir::ParamKind::Colon
             | fhir::ParamKind::Loc

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -4,11 +4,14 @@ use flux_common::index::IndexGen;
 use flux_errors::Errors;
 use flux_middle::{
     ResolverOutput,
-    fhir::{self, PartialRes, Res},
+    fhir::{
+        self,
+        Namespace::{FluxFnNS, SortNS, TypeNS, ValueNS},
+        PartialRes, Res,
+    },
 };
 use flux_syntax::{
     surface::{self, FluxItem, Ident, NodeId, visit::Visitor as _},
-    symbols::sym,
     walk_list,
 };
 use rustc_data_structures::{
@@ -16,10 +19,7 @@ use rustc_data_structures::{
     unord::UnordMap,
 };
 use rustc_hash::FxHashMap;
-use rustc_hir::def::{
-    DefKind,
-    Namespace::{TypeNS, ValueNS},
-};
+use rustc_hir::def::DefKind;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{ErrorGuaranteed, Symbol};
 
@@ -511,12 +511,6 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
             self.path_res_map.insert(path.node_id, res);
             return;
         }
-        if let [segment] = &path.segments[..]
-            && let Some(res) = self.try_resolve_global_func(segment.ident)
-        {
-            self.path_res_map.insert(path.node_id, PartialRes::new(res));
-            return;
-        }
 
         self.errors.emit(errors::UnresolvedVar::from_path(path));
     }
@@ -530,10 +524,6 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
             self.path_res_map.insert(node_id, res);
             return;
         }
-        if let Some(res) = self.try_resolve_global_func(ident) {
-            self.path_res_map.insert(node_id, PartialRes::new(res));
-            return;
-        }
         self.errors.emit(errors::UnresolvedVar::from_ident(ident));
     }
 
@@ -541,13 +531,12 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         &mut self,
         segments: &[S],
     ) -> Option<PartialRes<NodeId>> {
-        if let Some(partial_res) = self.resolver.resolve_path_with_ribs(segments, ValueNS) {
-            return Some(partial_res.map_param_id(|p| p));
+        for ns in [ValueNS, TypeNS, FluxFnNS] {
+            if let Some(partial_res) = self.resolver.resolve_path_with_ribs(segments, ns) {
+                return Some(partial_res.map_param_id(|p| p));
+            }
         }
-
-        self.resolver
-            .resolve_path_with_ribs(segments, TypeNS)
-            .map(|r| r.map_param_id(|p| p))
+        None
     }
 
     fn try_resolve_param(&mut self, ident: Ident) -> Option<Res<NodeId>> {
@@ -559,18 +548,15 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         Some(Res::Param(res.kind(), res.param_id()))
     }
 
-    fn try_resolve_global_func(&mut self, ident: Ident) -> Option<Res<NodeId>> {
-        let kind = self.resolver.func_decls.get(&ident.name)?;
-        Some(Res::GlobalFunc(*kind))
-    }
-
     fn resolve_sort_path(&mut self, path: &surface::SortPath) {
         let res = self
             .try_resolve_sort_param(path)
             .map(PartialRes::new)
             .or_else(|| self.try_resolve_sort_with_ribs(path))
-            .or_else(|| self.try_resolve_user_sort(path).map(PartialRes::new))
-            .or_else(|| self.try_resolve_prim_sort(path).map(PartialRes::new));
+            .or_else(|| {
+                self.try_resolve_sort_with_flux_ribs(path)
+                    .map(PartialRes::new)
+            });
 
         if let Some(res) = res {
             self.resolver
@@ -605,35 +591,11 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         }
     }
 
-    fn try_resolve_user_sort(&self, path: &surface::SortPath) -> Option<fhir::Res> {
+    /// Resolves a single-segment sort name against the flux sort namespace, covering both primitive
+    /// sorts (`int`, `bool`, `Set`, ...) and user-defined sorts, which live in the [`SortNS`] prelude.
+    fn try_resolve_sort_with_flux_ribs(&self, path: &surface::SortPath) -> Option<fhir::Res> {
         let [segment] = &path.segments[..] else { return None };
-        self.resolver
-            .sort_decls
-            .get(&segment.name)
-            .map(|decl| fhir::Res::UserSort(*decl))
-    }
-
-    fn try_resolve_prim_sort(&self, path: &surface::SortPath) -> Option<fhir::Res> {
-        let [segment] = &path.segments[..] else { return None };
-        if segment.name == sym::int {
-            Some(fhir::Res::PrimSort(fhir::PrimSort::Int))
-        } else if segment.name == sym::bool {
-            Some(fhir::Res::PrimSort(fhir::PrimSort::Bool))
-        } else if segment.name == sym::char {
-            Some(fhir::Res::PrimSort(fhir::PrimSort::Char))
-        } else if segment.name == sym::real {
-            Some(fhir::Res::PrimSort(fhir::PrimSort::Real))
-        } else if segment.name == sym::Set {
-            Some(fhir::Res::PrimSort(fhir::PrimSort::Set))
-        } else if segment.name == sym::Map {
-            Some(fhir::Res::PrimSort(fhir::PrimSort::Map))
-        } else if segment.name == sym::str {
-            Some(fhir::Res::PrimSort(fhir::PrimSort::Str))
-        } else if segment.name == sym::ptr {
-            Some(fhir::Res::PrimSort(fhir::PrimSort::RawPtr))
-        } else {
-            None
-        }
+        self.resolver.resolve_ident_with_ribs(*segment, SortNS)
     }
 
     pub(crate) fn finish(self) -> Result {

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -1,6 +1,6 @@
 use std::ops::ControlFlow;
 
-use flux_common::index::IndexGen;
+use flux_common::{bug, index::IndexGen};
 use flux_errors::Errors;
 use flux_middle::{
     ResolverOutput,
@@ -15,7 +15,7 @@ use flux_syntax::{
     walk_list,
 };
 use rustc_data_structures::{
-    fx::{FxIndexMap, FxIndexSet, IndexEntry},
+    fx::{FxIndexMap, FxIndexSet},
     unord::UnordMap,
 };
 use rustc_hash::FxHashMap;
@@ -23,7 +23,7 @@ use rustc_hir::def::DefKind;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{ErrorGuaranteed, Symbol};
 
-use super::{CrateResolver, Segment};
+use super::{CrateResolver, RibKind, Segment};
 
 type Result<T = ()> = std::result::Result<T, ErrorGuaranteed>;
 
@@ -39,20 +39,6 @@ pub(crate) enum ScopeKind {
 impl ScopeKind {
     fn is_barrier(self) -> bool {
         matches!(self, ScopeKind::FnInput | ScopeKind::Variant)
-    }
-}
-
-/// Parameters used during gathering.
-#[derive(Debug, Clone, Copy)]
-struct ParamRes(fhir::ParamKind, NodeId);
-
-impl ParamRes {
-    fn kind(self) -> fhir::ParamKind {
-        self.0
-    }
-
-    fn param_id(self) -> NodeId {
-        self.1
     }
 }
 
@@ -374,17 +360,6 @@ impl ScopedVisitor for ImplicitParamCollector<'_, '_> {
     }
 }
 
-struct Scope {
-    kind: ScopeKind,
-    bindings: FxIndexMap<Ident, ParamRes>,
-}
-
-impl Scope {
-    fn new(kind: ScopeKind) -> Self {
-        Self { kind, bindings: Default::default() }
-    }
-}
-
 #[derive(Clone, Copy)]
 struct ParamDef {
     ident: Ident,
@@ -393,7 +368,6 @@ struct ParamDef {
 }
 
 pub(crate) struct RefinementResolver<'a, 'genv, 'tcx> {
-    scopes: Vec<Scope>,
     sort_params: FxIndexSet<Symbol>,
     param_defs: FxIndexMap<NodeId, ParamDef>,
     resolver: &'a mut CrateResolver<'genv, 'tcx>,
@@ -452,7 +426,6 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
             resolver,
             sort_params,
             param_defs: Default::default(),
-            scopes: Default::default(),
             path_res_map: Default::default(),
             errors,
         }
@@ -474,40 +447,23 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         self.param_defs
             .insert(param_id, ParamDef { ident, kind, scope });
 
-        let scope = self.scopes.last_mut().unwrap();
-        match scope.bindings.entry(ident) {
-            IndexEntry::Occupied(entry) => {
-                let param_def = self.param_defs[&entry.get().param_id()];
-                self.errors
-                    .emit(errors::DuplicateParam::new(param_def.ident, ident));
-            }
-            IndexEntry::Vacant(entry) => {
-                entry.insert(ParamRes(kind, param_id));
-            }
+        // Refinement params live in the innermost flux-fn-namespace rib on the crate resolver, which
+        // is always the param scope entered by the surrounding `with_scope`. Duplicate detection is
+        // per-scope, so we only check that rib.
+        if let Some(Res::Param(_, prev_id)) = self.resolver.lookup_in_top_rib(FluxFnNS, ident.name)
+        {
+            let prev_ident = self.param_defs[&prev_id].ident;
+            self.errors
+                .emit(errors::DuplicateParam::new(prev_ident, ident));
+        } else {
+            self.resolver
+                .define_res_in(ident.name, Res::Param(kind, param_id), FluxFnNS);
         }
-    }
-
-    fn find(&mut self, ident: Ident) -> Option<ParamRes> {
-        for scope in self.scopes.iter().rev() {
-            if let Some(res) = scope.bindings.get(&ident) {
-                return Some(*res);
-            }
-
-            if scope.kind.is_barrier() {
-                return None;
-            }
-        }
-        None
     }
 
     fn resolve_path(&mut self, path: &surface::ExprPath) {
-        if let [segment] = &path.segments[..]
-            && let Some(res) = self.try_resolve_param(segment.ident)
-        {
-            self.path_res_map.insert(path.node_id, PartialRes::new(res));
-            return;
-        }
         if let Some(res) = self.try_resolve_expr_with_ribs(&path.segments) {
+            self.check_unrefined_param(res, path.segments.last().unwrap().ident);
             self.path_res_map.insert(path.node_id, res);
             return;
         }
@@ -516,36 +472,35 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
     }
 
     fn resolve_ident(&mut self, ident: Ident, node_id: NodeId) {
-        if let Some(res) = self.try_resolve_param(ident) {
-            self.path_res_map.insert(node_id, PartialRes::new(res));
-            return;
-        }
         if let Some(res) = self.try_resolve_expr_with_ribs(&[ident]) {
+            self.check_unrefined_param(res, ident);
             self.path_res_map.insert(node_id, res);
             return;
         }
         self.errors.emit(errors::UnresolvedVar::from_ident(ident));
     }
 
+    /// Emit an error if `res` resolved to a param that cannot be refined (used as an expression). The
+    /// param still resolves (shadowing any outer binding), matching the pre-rib behavior.
+    fn check_unrefined_param(&mut self, res: PartialRes<NodeId>, ident: Ident) {
+        if let Some(Res::Param(fhir::ParamKind::Error, _)) = res.full_res() {
+            self.errors.emit(errors::InvalidUnrefinedParam::new(ident));
+        }
+    }
+
     fn try_resolve_expr_with_ribs<S: Segment>(
         &mut self,
         segments: &[S],
     ) -> Option<PartialRes<NodeId>> {
-        for ns in [ValueNS, TypeNS, FluxFnNS] {
+        // Try the flux-fn namespace first so that refinement params (and then flux funcs) take
+        // precedence over Rust value/type bindings — in particular, a param shadows a Rust const of
+        // the same name.
+        for ns in [FluxFnNS, ValueNS, TypeNS] {
             if let Some(partial_res) = self.resolver.resolve_path_with_ribs(segments, ns) {
-                return Some(partial_res.map_param_id(|p| p));
+                return Some(partial_res);
             }
         }
         None
-    }
-
-    fn try_resolve_param(&mut self, ident: Ident) -> Option<Res<NodeId>> {
-        let res = self.find(ident)?;
-
-        if let fhir::ParamKind::Error = res.kind() {
-            self.errors.emit(errors::InvalidUnrefinedParam::new(ident));
-        }
-        Some(Res::Param(res.kind(), res.param_id()))
     }
 
     fn resolve_sort_path(&mut self, path: &surface::SortPath) {
@@ -559,6 +514,8 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
             });
 
         if let Some(res) = res {
+            // Sorts never resolve to a refinement param, so we can narrow away the param id.
+            let res = res.map_param_id(|_| bug!("sort path resolved to a refinement parameter"));
             self.resolver
                 .output
                 .sort_path_res_map
@@ -568,7 +525,7 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         }
     }
 
-    fn try_resolve_sort_param(&self, path: &surface::SortPath) -> Option<fhir::Res> {
+    fn try_resolve_sort_param(&self, path: &surface::SortPath) -> Option<fhir::Res<NodeId>> {
         let [segment] = &path.segments[..] else { return None };
         self.sort_params
             .get_index_of(&segment.name)
@@ -577,7 +534,10 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
 
     /// Returns `Some` only for sort-admissible shapes; this is where the "not a sort" diagnostic
     /// stays localized (`None` here means [`resolve_sort_path`] emits `UnresolvedSort`).
-    fn try_resolve_sort_with_ribs(&mut self, path: &surface::SortPath) -> Option<PartialRes> {
+    fn try_resolve_sort_with_ribs(
+        &mut self,
+        path: &surface::SortPath,
+    ) -> Option<PartialRes<NodeId>> {
         let partial_res = self
             .resolver
             .resolve_path_with_ribs(&path.segments, TypeNS)?;
@@ -593,7 +553,10 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
 
     /// Resolves a single-segment sort name against the flux sort namespace, covering both primitive
     /// sorts (`int`, `bool`, `Set`, ...) and user-defined sorts, which live in the [`SortNS`] prelude.
-    fn try_resolve_sort_with_flux_ribs(&self, path: &surface::SortPath) -> Option<fhir::Res> {
+    fn try_resolve_sort_with_flux_ribs(
+        &self,
+        path: &surface::SortPath,
+    ) -> Option<fhir::Res<NodeId>> {
         let [segment] = &path.segments[..] else { return None };
         self.resolver.resolve_ident_with_ribs(*segment, SortNS)
     }
@@ -660,12 +623,16 @@ impl ScopedVisitor for RefinementResolver<'_, '_, '_> {
     }
 
     fn enter_scope(&mut self, kind: ScopeKind) -> ControlFlow<()> {
-        self.scopes.push(Scope::new(kind));
+        // Refinement params live in the flux-fn namespace on the crate resolver's rib stack, sharing
+        // it with refinement functions (params, being inner ribs, shadow funcs). A barrier scope
+        // becomes a `RibKind::ParamBarrier` so params in enclosing scopes stay hidden.
+        let rib_kind = if kind.is_barrier() { RibKind::ParamBarrier } else { RibKind::Param };
+        self.resolver.push_rib(FluxFnNS, rib_kind);
         ControlFlow::Continue(())
     }
 
     fn exit_scope(&mut self) {
-        self.scopes.pop();
+        self.resolver.pop_rib(FluxFnNS);
     }
 
     fn on_fn_trait_input(&mut self, in_arg: &surface::GenericArg, trait_node_id: NodeId) {

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -301,7 +301,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
 
 struct ImplicitParamCollector<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
-    path_res_map: &'a UnordMap<surface::NodeId, fhir::PartialRes>,
+    path_res_map: &'a UnordMap<surface::NodeId, fhir::PartialRes<NodeId>>,
     kind: RibKind,
     params: Vec<(Ident, fhir::ParamKind, NodeId)>,
 }
@@ -309,7 +309,7 @@ struct ImplicitParamCollector<'a, 'tcx> {
 impl<'a, 'tcx> ImplicitParamCollector<'a, 'tcx> {
     fn new(
         tcx: TyCtxt<'tcx>,
-        path_res_map: &'a UnordMap<surface::NodeId, fhir::PartialRes>,
+        path_res_map: &'a UnordMap<surface::NodeId, fhir::PartialRes<NodeId>>,
         kind: RibKind,
     ) -> Self {
         Self { tcx, path_res_map, kind, params: vec![] }
@@ -513,26 +513,26 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
         // Create an `fhir::ParamId` for all parameters used in a path before iterating over
         // `param_defs` such that we can skip `fhir::ParamKind::Colon` if the param wasn't used
         for (node_id, res) in self.path_res_map {
-            let res = res.map_param_id(|param_id| {
-                *params
-                    .entry(param_id)
-                    .or_insert_with(|| param_id_gen.fresh())
-            });
             self.resolver.output.path_res_map.insert(node_id, res);
+            if let Res::Param(_, param_id) = res.base_res() {
+                params
+                    .entry(param_id)
+                    .or_insert_with(|| param_id_gen.fresh());
+            }
         }
 
         // At this point, the `params` map contains all parameters that were used in an expression,
         // so we can safely skip `ParamKind::Colon` if there's no entry for it.
-        for (param_id, param_def) in self.param_defs {
-            let name = match param_def.kind {
+        for (node_id, param_def) in self.param_defs {
+            let param_id = match param_def.kind {
                 fhir::ParamKind::Colon => {
-                    let Some(name) = params.get(&param_id) else { continue };
-                    *name
+                    let Some(param_id) = params.get(&node_id) else { continue };
+                    *param_id
                 }
                 fhir::ParamKind::Error => continue,
                 _ => {
                     params
-                        .get(&param_id)
+                        .get(&node_id)
                         .copied()
                         .unwrap_or_else(|| param_id_gen.fresh())
                 }
@@ -540,14 +540,14 @@ impl<'a, 'genv, 'tcx> RefinementResolver<'a, 'genv, 'tcx> {
             let output = &mut self.resolver.output;
             output
                 .param_res_map
-                .insert(param_id, (name, param_def.kind));
+                .insert(node_id, (param_id, param_def.kind));
 
             if let Some(scope) = param_def.scope {
                 output
                     .implicit_params
                     .entry(scope)
                     .or_default()
-                    .push((param_def.ident, param_id));
+                    .push((param_def.ident, node_id));
             }
         }
         self.errors.to_result()

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -854,33 +854,33 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
     }
 
     fn conv_sort_path(&mut self, path: &fhir::SortPath) -> QueryResult<rty::Sort> {
-        let ctor = match path.res {
-            fhir::SortRes::PrimSort(fhir::PrimSort::Int) => {
+        let ctor = match (path.res.base_res(), path.res.unresolved_segments()) {
+            (fhir::Res::PrimSort(fhir::PrimSort::Int), 0) => {
                 self.check_prim_sort_generics(path, fhir::PrimSort::Int)?;
                 return Ok(rty::Sort::Int);
             }
-            fhir::SortRes::PrimSort(fhir::PrimSort::Bool) => {
+            (fhir::Res::PrimSort(fhir::PrimSort::Bool), 0) => {
                 self.check_prim_sort_generics(path, fhir::PrimSort::Bool)?;
                 return Ok(rty::Sort::Bool);
             }
-            fhir::SortRes::PrimSort(fhir::PrimSort::Real) => {
+            (fhir::Res::PrimSort(fhir::PrimSort::Real), 0) => {
                 self.check_prim_sort_generics(path, fhir::PrimSort::Real)?;
                 return Ok(rty::Sort::Real);
             }
-            fhir::SortRes::PrimSort(fhir::PrimSort::Char) => {
+            (fhir::Res::PrimSort(fhir::PrimSort::Char), 0) => {
                 self.check_prim_sort_generics(path, fhir::PrimSort::Char)?;
                 return Ok(rty::Sort::Char);
             }
-            fhir::SortRes::PrimSort(fhir::PrimSort::Str) => {
+            (fhir::Res::PrimSort(fhir::PrimSort::Str), 0) => {
                 self.check_prim_sort_generics(path, fhir::PrimSort::Str)?;
                 return Ok(rty::Sort::Str);
             }
-            fhir::SortRes::PrimSort(fhir::PrimSort::RawPtr) => {
+            (fhir::Res::PrimSort(fhir::PrimSort::RawPtr), 0) => {
                 self.check_prim_sort_generics(path, fhir::PrimSort::RawPtr)?;
                 return Ok(rty::Sort::RawPtr);
             }
-            fhir::SortRes::SortParam(n) => return Ok(rty::Sort::Var(rty::ParamSort::from(n))),
-            fhir::SortRes::TyParam(def_id) => {
+            (fhir::Res::SortParam(n), 0) => return Ok(rty::Sort::Var(rty::ParamSort::from(n))),
+            (fhir::Res::Def(DefKind::TyParam, def_id), 0) => {
                 if !path.args.is_empty() {
                     let err = errors::GenericsOnSortTyParam::new(
                         path.segments.last().unwrap().span,
@@ -890,7 +890,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 }
                 return Ok(rty::Sort::Param(def_id_to_param_ty(self.genv(), def_id)));
             }
-            fhir::SortRes::SelfParam { .. } => {
+            (fhir::Res::SelfTyParam { .. }, 0) => {
                 if !path.args.is_empty() {
                     let err = errors::GenericsOnSelf::new(
                         path.segments.last().unwrap().span,
@@ -900,7 +900,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 }
                 return Ok(rty::Sort::Param(rty::SELF_PARAM_TY));
             }
-            fhir::SortRes::SelfAlias { alias_to } => {
+            (fhir::Res::SelfTyAlias { alias_to, .. }, 0) => {
                 if !path.args.is_empty() {
                     let err = errors::GenericsOnSelf::new(
                         path.segments.last().unwrap().span,
@@ -913,27 +913,27 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                     .sort_of_self_ty_alias(alias_to)?
                     .unwrap_or(rty::Sort::Err));
             }
-            fhir::SortRes::SelfParamAssoc { trait_id, ident } => {
-                let res = fhir::Res::SelfTyParam { trait_: trait_id };
+            (res @ fhir::Res::SelfTyParam { .. }, 1) => {
+                let ident = *path.segments.last().unwrap();
                 let assoc_segment =
                     fhir::PathSegment { args: &[], constraints: &[], ident, res: fhir::Res::Err };
                 let mut env = Env::empty();
                 let alias_ty = self.conv_type_relative_type_path(&mut env, res, &assoc_segment)?;
                 return Ok(rty::Sort::Alias(rty::AliasKind::Projection, alias_ty));
             }
-            fhir::SortRes::PrimSort(fhir::PrimSort::Set) => {
+            (fhir::Res::PrimSort(fhir::PrimSort::Set), 0) => {
                 self.check_prim_sort_generics(path, fhir::PrimSort::Set)?;
                 rty::SortCtor::Set
             }
-            fhir::SortRes::PrimSort(fhir::PrimSort::Map) => {
+            (fhir::Res::PrimSort(fhir::PrimSort::Map), 0) => {
                 self.check_prim_sort_generics(path, fhir::PrimSort::Map)?;
                 rty::SortCtor::Map
             }
-            fhir::SortRes::User(def_id) => {
+            (fhir::Res::UserSort(def_id), 0) => {
                 self.check_user_defined_sort_param_count(path, def_id)?;
                 rty::SortCtor::User(def_id)
             }
-            fhir::SortRes::Adt(def_id) => {
+            (fhir::Res::Def(DefKind::Struct | DefKind::Enum | DefKind::Union, def_id), 0) => {
                 let sort_def = self.genv().adt_sort_def_of(def_id)?;
                 if path.args.len() != sort_def.param_count() {
                     let err = errors::IncorrectGenericsOnSort::new(
@@ -947,6 +947,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 }
                 rty::SortCtor::Adt(sort_def)
             }
+            _ => bug!("unexpected resolution for sort path `{path:?}`"),
         };
         let args = path.args.iter().map(|t| self.conv_sort(t)).try_collect()?;
 
@@ -1760,7 +1761,12 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
                 rty::BaseTy::Foreign(def_id)
             }
             fhir::Res::Def(kind, def_id) => self.report_expected_type(path.span, kind, def_id)?,
-            fhir::Res::Param(..) | fhir::Res::GlobalFunc(..) | fhir::Res::Err => {
+            fhir::Res::Param(..)
+            | fhir::Res::GlobalFunc(..)
+            | fhir::Res::PrimSort(..)
+            | fhir::Res::SortParam(..)
+            | fhir::Res::UserSort(..)
+            | fhir::Res::Err => {
                 span_bug!(path.span, "unexpected resolution in conv_ty_ctor: {:?}", path.res)
             }
         };

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -32,7 +32,7 @@ use rustc_data_structures::{
 pub use rustc_hir::PrimTy;
 use rustc_hir::{
     FnHeader, OwnerId, ParamName, Safety,
-    def::{DefKind, Namespace},
+    def::DefKind,
     def_id::{DefId, LocalDefId},
 };
 use rustc_index::newtype_index;
@@ -738,6 +738,89 @@ pub enum ConstArgKind {
     Infer,
 }
 
+/// The namespaces flux resolves names in. This extends [`rustc_hir::def::Namespace`]'s three Rust
+/// namespaces with flux-specific ones: [`Namespace::SortNS`] for sorts and [`Namespace::FluxFnNS`]
+/// for refinement functions. Refinement functions live in their own namespace, separate from Rust's
+/// value namespace.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+pub enum Namespace {
+    TypeNS,
+    ValueNS,
+    MacroNS,
+    SortNS,
+    FluxFnNS,
+}
+
+impl Namespace {
+    /// A human-readable description, used in diagnostics.
+    pub fn descr(self) -> &'static str {
+        match self {
+            Namespace::TypeNS => "type",
+            Namespace::ValueNS => "value",
+            Namespace::MacroNS => "macro",
+            Namespace::SortNS => "sort",
+            Namespace::FluxFnNS => "function",
+        }
+    }
+
+    /// The corresponding [`rustc_hir::def::Namespace`], or `None` for the flux-only namespaces.
+    pub fn to_rustc(self) -> Option<rustc_hir::def::Namespace> {
+        match self {
+            Namespace::TypeNS => Some(rustc_hir::def::Namespace::TypeNS),
+            Namespace::ValueNS => Some(rustc_hir::def::Namespace::ValueNS),
+            Namespace::MacroNS => Some(rustc_hir::def::Namespace::MacroNS),
+            Namespace::SortNS | Namespace::FluxFnNS => None,
+        }
+    }
+}
+
+impl From<rustc_hir::def::Namespace> for Namespace {
+    fn from(ns: rustc_hir::def::Namespace) -> Self {
+        match ns {
+            rustc_hir::def::Namespace::TypeNS => Namespace::TypeNS,
+            rustc_hir::def::Namespace::ValueNS => Namespace::ValueNS,
+            rustc_hir::def::Namespace::MacroNS => Namespace::MacroNS,
+        }
+    }
+}
+
+/// Flux's analogue of [`rustc_hir::def::PerNS`], carrying one `T` per [`Namespace`] (including the
+/// flux-specific ones), indexable by [`Namespace`].
+#[derive(Debug, Clone)]
+pub struct PerNS<T> {
+    pub type_ns: T,
+    pub value_ns: T,
+    pub macro_ns: T,
+    pub sort_ns: T,
+    pub flux_fn_ns: T,
+}
+
+impl<T> std::ops::Index<Namespace> for PerNS<T> {
+    type Output = T;
+
+    fn index(&self, ns: Namespace) -> &T {
+        match ns {
+            Namespace::TypeNS => &self.type_ns,
+            Namespace::ValueNS => &self.value_ns,
+            Namespace::MacroNS => &self.macro_ns,
+            Namespace::SortNS => &self.sort_ns,
+            Namespace::FluxFnNS => &self.flux_fn_ns,
+        }
+    }
+}
+
+impl<T> std::ops::IndexMut<Namespace> for PerNS<T> {
+    fn index_mut(&mut self, ns: Namespace) -> &mut T {
+        match ns {
+            Namespace::TypeNS => &mut self.type_ns,
+            Namespace::ValueNS => &mut self.value_ns,
+            Namespace::MacroNS => &mut self.macro_ns,
+            Namespace::SortNS => &mut self.sort_ns,
+            Namespace::FluxFnNS => &mut self.flux_fn_ns,
+        }
+    }
+}
+
 /// The resolution of a path
 ///
 /// The enum contains a subset of the variants in [`rustc_hir::def::Res`] plus some extra variants
@@ -1135,18 +1218,16 @@ impl<Id> Res<Id> {
     }
 
     /// Returns `None` if this is `Res::Err`
-    ///
-    /// The sort-only variants (`PrimSort`, `SortParam`, `UserSort`) are never produced by Rust
-    /// path resolution (they only come out of the sort resolver), so they never need to flow
-    /// through the Rust module-child / `matches_ns` machinery. We return `None` for them.
     pub fn ns(&self) -> Option<Namespace> {
         match self {
-            Res::Def(kind, ..) => kind.ns(),
+            Res::Def(kind, ..) => kind.ns().map(Namespace::from),
             Res::PrimTy(..) | Res::SelfTyAlias { .. } | Res::SelfTyParam { .. } => {
                 Some(Namespace::TypeNS)
             }
-            Res::Param(..) | Res::GlobalFunc(..) => Some(Namespace::ValueNS),
-            Res::PrimSort(..) | Res::SortParam(..) | Res::UserSort(..) | Res::Err => None,
+            Res::Param(..) => Some(Namespace::ValueNS),
+            Res::GlobalFunc(..) => Some(Namespace::FluxFnNS),
+            Res::PrimSort(..) | Res::SortParam(..) | Res::UserSort(..) => Some(Namespace::SortNS),
+            Res::Err => None,
         }
     }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -1152,7 +1152,7 @@ pub enum Lit {
 #[derive(Clone, Copy)]
 pub struct PathExpr<'fhir> {
     pub segments: &'fhir [Ident],
-    pub res: Res<ParamId>,
+    pub res: Res,
     pub fhir_id: FhirId,
     pub span: Span,
 }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -738,17 +738,21 @@ pub enum ConstArgKind {
     Infer,
 }
 
-/// The namespaces flux resolves names in. This extends [`rustc_hir::def::Namespace`]'s three Rust
-/// namespaces with flux-specific ones: [`Namespace::SortNS`] for sorts and [`Namespace::FluxFnNS`]
-/// for refinement functions. Refinement functions live in their own namespace, separate from Rust's
-/// value namespace.
+/// Different kinds of symbols can coexist even if they share the same textual name.
+/// Therefore, they each have a separate universe (known as a "namespace").
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Namespace {
+    /// See [`rustc_hir::def::Namespace::TypeNS`]
     TypeNS,
+    /// See [`rustc_hir::def::Namespace::ValueNS`]
     ValueNS,
+    /// See [`rustc_hir::def::Namespace::MacroNS`]
     MacroNS,
+    /// The sort namespace includes primitive sorts, sort variables, and user defined sorts.
     SortNS,
-    FluxFnNS,
+    /// The refinement namespace includes refinement functions, theory function,
+    /// refinement parameters, ...
+    ReftNS,
 }
 
 impl Namespace {
@@ -759,7 +763,7 @@ impl Namespace {
             Namespace::ValueNS => "value",
             Namespace::MacroNS => "macro",
             Namespace::SortNS => "sort",
-            Namespace::FluxFnNS => "function",
+            Namespace::ReftNS => "value",
         }
     }
 
@@ -769,7 +773,7 @@ impl Namespace {
             Namespace::TypeNS => Some(rustc_hir::def::Namespace::TypeNS),
             Namespace::ValueNS => Some(rustc_hir::def::Namespace::ValueNS),
             Namespace::MacroNS => Some(rustc_hir::def::Namespace::MacroNS),
-            Namespace::SortNS | Namespace::FluxFnNS => None,
+            Namespace::SortNS | Namespace::ReftNS => None,
         }
     }
 }
@@ -804,7 +808,7 @@ impl<T> std::ops::Index<Namespace> for PerNS<T> {
             Namespace::ValueNS => &self.value_ns,
             Namespace::MacroNS => &self.macro_ns,
             Namespace::SortNS => &self.sort_ns,
-            Namespace::FluxFnNS => &self.flux_fn_ns,
+            Namespace::ReftNS => &self.flux_fn_ns,
         }
     }
 }
@@ -816,7 +820,7 @@ impl<T> std::ops::IndexMut<Namespace> for PerNS<T> {
             Namespace::ValueNS => &mut self.value_ns,
             Namespace::MacroNS => &mut self.macro_ns,
             Namespace::SortNS => &mut self.sort_ns,
-            Namespace::FluxFnNS => &mut self.flux_fn_ns,
+            Namespace::ReftNS => &mut self.flux_fn_ns,
         }
     }
 }
@@ -1225,7 +1229,7 @@ impl<Id> Res<Id> {
                 Some(Namespace::TypeNS)
             }
             Res::Param(..) => Some(Namespace::ValueNS),
-            Res::GlobalFunc(..) => Some(Namespace::FluxFnNS),
+            Res::GlobalFunc(..) => Some(Namespace::ReftNS),
             Res::PrimSort(..) | Res::SortParam(..) | Res::UserSort(..) => Some(Namespace::SortNS),
             Res::Err => None,
         }

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -19,7 +19,6 @@ use std::{borrow::Cow, fmt, iter};
 
 use flux_common::{bug, span_bug};
 use flux_config::PartialInferOpts;
-use flux_rustc_bridge::def_id_to_string;
 pub use flux_syntax::surface::{BinOp, UnOp};
 use flux_syntax::surface::{Ignored, ParamMode, Trusted};
 use itertools::Itertools;
@@ -762,6 +761,14 @@ pub enum Res<Id = !> {
     Param(ParamKind, Id),
     /// A refinement function defined with `flux::defs! { ... }`
     GlobalFunc(SpecFuncKind),
+    /// A primitive sort, e.g., `int`, `bool`, `Set`, `Map`. Only ever produced by the sort
+    /// resolver, never via [`TryFrom<rustc_hir::def::Res>`] or Rust path resolution.
+    PrimSort(PrimSort),
+    /// A sort parameter inside a polymorphic function or data sort. Only ever produced by the
+    /// sort resolver.
+    SortParam(usize),
+    /// A user declared sort. Only ever produced by the sort resolver.
+    UserSort(FluxDefId),
     Err,
 }
 
@@ -884,7 +891,7 @@ impl InferMode {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum PrimSort {
     Int,
     Bool,
@@ -926,39 +933,6 @@ impl PrimSort {
 }
 
 #[derive(Clone, Copy)]
-pub enum SortRes {
-    /// A primitive sort.
-    PrimSort(PrimSort),
-    /// A user declared sort.
-    User(FluxDefId),
-    /// A sort parameter inside a polymorphic function or data sort.
-    SortParam(usize),
-    /// The sort associated to a (generic) type parameter
-    TyParam(DefId),
-    /// The sort of the `Self` type, as used within a trait.
-    SelfParam {
-        /// The trait this `Self` is a generic parameter for.
-        trait_id: DefId,
-    },
-    /// The sort of a `Self` type, as used somewhere other than within a trait.
-    SelfAlias {
-        /// The item introducing the `Self` type alias, e.g., an impl block.
-        alias_to: DefId,
-    },
-    /// The sort of an associated type in a trait declaration, e.g:
-    ///
-    /// ```ignore
-    /// #[assoc(fn assoc_reft(x: Self::Assoc) -> bool)]
-    /// trait MyTrait {
-    ///     type Assoc;
-    /// }
-    /// ```
-    SelfParamAssoc { trait_id: DefId, ident: Ident },
-    /// The sort automatically generated for an adt (enum/struct) with a `flux::refined_by` annotation
-    Adt(DefId),
-}
-
-#[derive(Clone, Copy)]
 pub enum Sort<'fhir> {
     Path(SortPath<'fhir>),
     /// The sort of a location parameter introduced with the `x: &strg T` syntax.
@@ -980,7 +954,7 @@ pub enum Sort<'fhir> {
 /// See [`flux_syntax::surface::SortPath`]
 #[derive(Clone, Copy)]
 pub struct SortPath<'fhir> {
-    pub res: SortRes,
+    pub res: PartialRes,
     pub segments: &'fhir [Ident],
     pub args: &'fhir [Sort<'fhir>],
 }
@@ -1145,6 +1119,9 @@ impl<Id> Res<Id> {
             Res::SelfTyAlias { .. } | Res::SelfTyParam { .. } => "self type",
             Res::Param(..) => "refinement parameter",
             Res::GlobalFunc(..) => "refinement function",
+            Res::PrimSort(..) => "primitive sort",
+            Res::SortParam(..) => "sort parameter",
+            Res::UserSort(..) => "user-defined sort",
             Res::Err => "unresolved item",
         }
     }
@@ -1158,6 +1135,10 @@ impl<Id> Res<Id> {
     }
 
     /// Returns `None` if this is `Res::Err`
+    ///
+    /// The sort-only variants (`PrimSort`, `SortParam`, `UserSort`) are never produced by Rust
+    /// path resolution (they only come out of the sort resolver), so they never need to flow
+    /// through the Rust module-child / `matches_ns` machinery. We return `None` for them.
     pub fn ns(&self) -> Option<Namespace> {
         match self {
             Res::Def(kind, ..) => kind.ns(),
@@ -1165,7 +1146,7 @@ impl<Id> Res<Id> {
                 Some(Namespace::TypeNS)
             }
             Res::Param(..) | Res::GlobalFunc(..) => Some(Namespace::ValueNS),
-            Res::Err => None,
+            Res::PrimSort(..) | Res::SortParam(..) | Res::UserSort(..) | Res::Err => None,
         }
     }
 
@@ -1184,6 +1165,9 @@ impl<Id> Res<Id> {
             }
             Res::SelfTyParam { trait_ } => Res::SelfTyParam { trait_ },
             Res::GlobalFunc(spec_func_kind) => Res::GlobalFunc(spec_func_kind),
+            Res::PrimSort(prim_sort) => Res::PrimSort(prim_sort),
+            Res::SortParam(n) => Res::SortParam(n),
+            Res::UserSort(def_id) => Res::UserSort(def_id),
             Res::Err => Res::Err,
         }
     }
@@ -1684,34 +1668,6 @@ impl fmt::Debug for SortPath<'_> {
             write!(f, "<{:?}>", self.args.iter().format(", "))?;
         }
         Ok(())
-    }
-}
-
-impl fmt::Debug for SortRes {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SortRes::PrimSort(PrimSort::Bool) => write!(f, "bool"),
-            SortRes::PrimSort(PrimSort::Int) => write!(f, "int"),
-            SortRes::PrimSort(PrimSort::Real) => write!(f, "real"),
-            SortRes::PrimSort(PrimSort::Char) => write!(f, "char"),
-            SortRes::PrimSort(PrimSort::Str) => write!(f, "str"),
-            SortRes::PrimSort(PrimSort::Set) => write!(f, "Set"),
-            SortRes::PrimSort(PrimSort::Map) => write!(f, "Map"),
-            SortRes::PrimSort(PrimSort::RawPtr) => write!(f, "ptr"),
-            SortRes::SortParam(n) => write!(f, "@{n}"),
-            SortRes::TyParam(def_id) => write!(f, "{}::sort", def_id_to_string(*def_id)),
-            SortRes::SelfParam { trait_id } => {
-                write!(f, "{}::Self::sort", def_id_to_string(*trait_id))
-            }
-            SortRes::SelfAlias { alias_to } => {
-                write!(f, "{}::Self::sort", def_id_to_string(*alias_to))
-            }
-            SortRes::SelfParamAssoc { ident: assoc, .. } => {
-                write!(f, "Self::{assoc}")
-            }
-            SortRes::User(def_id) => write!(f, "{:?}", def_id.name()),
-            SortRes::Adt(def_id) => write!(f, "{}::sort", def_id_to_string(*def_id)),
-        }
     }
 }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -826,7 +826,7 @@ impl<T> std::ops::IndexMut<Namespace> for PerNS<T> {
 /// The enum contains a subset of the variants in [`rustc_hir::def::Res`] plus some extra variants
 /// for stuff refinements resolve to.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
-pub enum Res<Id = !> {
+pub enum Res<Id = ParamId> {
     /// See [`rustc_hir::def::Res::Def`]
     Def(DefKind, DefId),
     /// See [`rustc_hir::def::Res::PrimTy`]
@@ -857,7 +857,7 @@ pub enum Res<Id = !> {
 
 /// See [`rustc_hir::def::PartialRes`]
 #[derive(Copy, Clone, Debug)]
-pub struct PartialRes<Id = !> {
+pub struct PartialRes<Id = ParamId> {
     base_res: Res<Id>,
     unresolved_segments: usize,
 }

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -502,7 +502,7 @@ pub struct ResolverOutput {
     /// [`surface::VariantDef`]. The [`NodeId`]s in the vectors are keys in [`Self::param_res_map`].
     pub implicit_params: UnordMap<NodeId, Vec<(Ident, NodeId)>>,
     pub sort_path_res_map: UnordMap<NodeId, fhir::PartialRes>,
-    pub expr_path_res_map: UnordMap<NodeId, fhir::PartialRes<fhir::ParamId>>,
+    pub expr_path_res_map: UnordMap<NodeId, fhir::PartialRes>,
     /// The resolved list of local qualifiers per function.
     /// The [`NodeId`] corresponds to the [`surface::FnSpec`].
     pub qualifier_res_map: UnordMap<NodeId, Vec<def_id::FluxLocalDefId>>,

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -492,7 +492,7 @@ pub enum ExternSpecMappingErr {
 #[derive(Default)]
 pub struct ResolverOutput {
     /// Resolution of type, refinement, and sort paths
-    pub path_res_map: UnordMap<NodeId, fhir::PartialRes>,
+    pub path_res_map: UnordMap<NodeId, fhir::PartialRes<NodeId>>,
     /// Resolution of explicitly and implicitly scoped parameters. The [`fhir::ParamId`] is unique
     /// per item. The [`NodeId`] used as the key corresponds to the node introducing the parameter.
     /// When explicit, this is the id of the [`surface::GenericArg`] or [`surface::RefineParam`],

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -501,7 +501,7 @@ pub struct ResolverOutput {
     /// the node introducing the scope, e.g., [`surface::FnSig`], [`surface::FnOutput`], or
     /// [`surface::VariantDef`]. The [`NodeId`]s in the vectors are keys in [`Self::param_res_map`].
     pub implicit_params: UnordMap<NodeId, Vec<(Ident, NodeId)>>,
-    pub sort_path_res_map: UnordMap<NodeId, fhir::SortRes>,
+    pub sort_path_res_map: UnordMap<NodeId, fhir::PartialRes>,
     pub expr_path_res_map: UnordMap<NodeId, fhir::PartialRes<fhir::ParamId>>,
     /// The resolved list of local qualifiers per function.
     /// The [`NodeId`] corresponds to the [`surface::FnSpec`].

--- a/crates/flux-middle/src/lib.rs
+++ b/crates/flux-middle/src/lib.rs
@@ -491,6 +491,7 @@ pub enum ExternSpecMappingErr {
 
 #[derive(Default)]
 pub struct ResolverOutput {
+    /// Resolution of type, refinement, and sort paths
     pub path_res_map: UnordMap<NodeId, fhir::PartialRes>,
     /// Resolution of explicitly and implicitly scoped parameters. The [`fhir::ParamId`] is unique
     /// per item. The [`NodeId`] used as the key corresponds to the node introducing the parameter.
@@ -501,8 +502,6 @@ pub struct ResolverOutput {
     /// the node introducing the scope, e.g., [`surface::FnSig`], [`surface::FnOutput`], or
     /// [`surface::VariantDef`]. The [`NodeId`]s in the vectors are keys in [`Self::param_res_map`].
     pub implicit_params: UnordMap<NodeId, Vec<(Ident, NodeId)>>,
-    pub sort_path_res_map: UnordMap<NodeId, fhir::PartialRes>,
-    pub expr_path_res_map: UnordMap<NodeId, fhir::PartialRes>,
     /// The resolved list of local qualifiers per function.
     /// The [`NodeId`] corresponds to the [`surface::FnSpec`].
     pub qualifier_res_map: UnordMap<NodeId, Vec<def_id::FluxLocalDefId>>,

--- a/crates/flux-syntax/src/symbols.rs
+++ b/crates/flux-syntax/src/symbols.rs
@@ -25,6 +25,7 @@ symbols! {
         Set,
         addr,
         base,
+        cast,
         int,
         no_panic,
         no_panic_if,


### PR DESCRIPTION
This generalizes name resolution inside refinements to use the ribs infra. This is in preparation to make flux defs importable.