### PR TITLE
Guarded Mut References

### DIFF
--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -760,7 +760,13 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         let terminator_span = source_info.span;
         match &terminator.kind {
             TerminatorKind::Return => {
-                self.check_ret(infcx, env, last_stmt_span.unwrap_or(terminator_span))?;
+                self.check_ret(
+                    infcx,
+                    env,
+                    location,
+                    last_stmt_span.unwrap_or(terminator_span),
+                    terminator_span,
+                )?;
                 Ok(vec![])
             }
             TerminatorKind::Unreachable => Ok(vec![]),
@@ -866,22 +872,44 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         }
     }
 
+    /// Checks the `return` terminator at `location`. The returned value is checked against the
+    /// declared output type at `span`, while the folds needed to check the `ensures` clauses are
+    /// reported at `fold_span`, i.e., the span of the terminator itself.
     fn check_ret(
         &mut self,
         infcx: &mut InferCtxt<'_, 'genv, 'tcx>,
         env: &mut TypeEnv,
+        location: Location,
         span: Span,
+        fold_span: Span,
     ) -> Result {
+        // Folds of the arguments needed to check the `ensures` clauses. These have to run *after*
+        // the returned value is checked against the declared output type because that check is what
+        // turns a `ptr(mut, ℓ.f)` into a `&mut` and *blocks* `ℓ.f`.
+        let folds = self
+            .ghost_stmts()
+            .statements_at(Point::AtReturn(location))
+            .map(|stmt| {
+                match stmt {
+                    GhostStatement::Fold(place) => place.clone(),
+                    _ => bug!("unexpected ghost statement at return {stmt:?}"),
+                }
+            })
+            .collect_vec();
+
+        let output = self.fn_sig.output.clone();
         let obligations = infcx
             .at(span)
             .ensure_resolved_evars(|infcx| {
                 let ret_place_ty = env.lookup_place(infcx, Place::RETURN)?;
-                let output = self
-                    .fn_sig
-                    .output
+                let output = output
                     .replace_bound_refts_with(|sort, mode, _| infcx.fresh_infer_var(sort, mode));
                 let obligations =
                     infcx.subtyping_with_env(env, &ret_place_ty, &output.ret, ConstrReason::Ret)?;
+
+                for place in &folds {
+                    env.fold(&mut infcx.at(fold_span), place)?;
+                }
 
                 env.check_ensures(infcx, &output.ensures, ConstrReason::Ret)?;
 
@@ -1309,7 +1337,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 Point::BeforeLocation(location),
                 span,
             )?;
-            self.check_ret(&mut infcx, &mut env, span)
+            self.check_ret(&mut infcx, &mut env, location, span, span)
         } else if let Some(real_target) = self.is_dummy_join(target) {
             self.check_goto(infcx, env, span, real_target)
         } else if self.body.is_join_point(target) {

--- a/crates/flux-refineck/src/ghost_statements.rs
+++ b/crates/flux-refineck/src/ghost_statements.rs
@@ -81,6 +81,7 @@ impl fmt::Debug for GhostStatement {
 pub(crate) struct GhostStatements {
     at_start: Vec<GhostStatement>,
     at_location: LocationMap,
+    at_return: LocationMap,
     at_edge: EdgeMap,
 }
 
@@ -97,6 +98,7 @@ impl GhostStatements {
             let mut stmts = Self {
                 at_start: Default::default(),
                 at_location: LocationMap::default(),
+                at_return: LocationMap::default(),
                 at_edge: EdgeMap::default(),
             };
 
@@ -157,6 +159,9 @@ impl GhostStatements {
             Point::BeforeLocation(location) => {
                 self.at_location.entry(location).or_default().extend(stmts);
             }
+            Point::AtReturn(location) => {
+                self.at_return.entry(location).or_default().extend(stmts);
+            }
             Point::Edge(from, to) => {
                 self.at_edge
                     .entry(from)
@@ -178,6 +183,7 @@ impl GhostStatements {
             Point::BeforeLocation(location) => {
                 self.at_location.get(&location).into_iter().flatten()
             }
+            Point::AtReturn(location) => self.at_return.get(&location).into_iter().flatten(),
             Point::Edge(from, to) => {
                 self.at_edge
                     .get(&from)
@@ -202,6 +208,9 @@ impl GhostStatements {
                         PassWhere::BeforeLocation(location) => {
                             for stmt in self.statements_at(Point::BeforeLocation(location)) {
                                 writeln!(w, "        {stmt:?};")?;
+                            }
+                            for stmt in self.statements_at(Point::AtReturn(location)) {
+                                writeln!(w, "        at_return: {stmt:?};")?;
                             }
                         }
                         PassWhere::AfterTerminator(bb) => {
@@ -235,6 +244,11 @@ pub(crate) enum Point {
     FunEntry,
     /// The point before a location in a basic block.
     BeforeLocation(Location),
+    /// The point at a `return` terminator *after* the returned value has been checked against the
+    /// declared output type but *before* checking the `ensures` clauses. Folding arguments here
+    /// rather than at [`Point::BeforeLocation`] gives the check of the returned value a chance to
+    /// convert a `ptr(mut, ℓ.f)` into a `&mut` first, which *blocks* `ℓ.f`.
+    AtReturn(Location),
     /// An edge between two basic blocks.
     Edge(BasicBlock, BasicBlock),
 }

--- a/crates/flux-refineck/src/ghost_statements/fold_unfold.rs
+++ b/crates/flux-refineck/src/ghost_statements/fold_unfold.rs
@@ -239,7 +239,13 @@ impl Mode for Elaboration<'_> {
     }
 
     fn ret(analysis: &mut FoldUnfoldAnalysis<Self>, env: &Env) {
-        env.collect_folds_at_ret(analysis.body, &mut analysis.mode.stmts.at(analysis.point));
+        let Point::BeforeLocation(location) = analysis.point else {
+            tracked_span_bug!("unexpected point for `return` terminator {:?}", analysis.point)
+        };
+        env.collect_folds_at_ret(
+            analysis.body,
+            &mut analysis.mode.stmts.at(Point::AtReturn(location)),
+        );
     }
 }
 

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -867,6 +867,28 @@ fn downcast_enum(
     Ok(variant_sig.fields.to_vec())
 }
 
+/// A field of an aggregate can be *blocked* if there's a live mutable borrow into it, e.g., after
+/// `let r = &mut s.f`. To fold `s` back we use the *guard* of the borrow, i.e., the (upper) bound
+/// `r` is allowed to write back, as the type of the field. The aggregate itself remains blocked
+/// because the borrow is still live.
+///
+/// Returns whether any field was blocked together with the unblocked fields.
+fn unblock_fields(infcx: &mut InferCtxtAt, fields: &[Ty]) -> (bool, Vec<Ty>) {
+    let mut blocked = false;
+    let fields = fields
+        .iter()
+        .map(|ty| {
+            if let TyKind::Blocked(bound) = ty.kind() {
+                blocked = true;
+                infcx.hoister(true).hoist(bound)
+            } else {
+                ty.clone()
+            }
+        })
+        .collect_vec();
+    (blocked, fields)
+}
+
 fn fold(
     bindings: &mut PlacesTree,
     infcx: &mut InferCtxtAt,
@@ -903,9 +925,11 @@ fn fold(
                 let ty = if partially_moved {
                     Ty::uninit()
                 } else {
-                    infcx
+                    let (blocked, fields) = unblock_fields(infcx, &fields);
+                    let ty = infcx
                         .check_constructor(variant_sig, args, &fields, ConstrReason::Fold)
-                        .unwrap_or_else(|err| tracked_span_bug!("{err:?}"))
+                        .unwrap_or_else(|err| tracked_span_bug!("{err:?}"));
+                    if blocked { Ty::blocked(ty) } else { ty }
                 };
 
                 Ok(ty)
@@ -922,7 +946,13 @@ fn fold(
                 .try_collect_vec()?;
 
             let partially_moved = fields.iter().any(Ty::is_uninit);
-            let ty = if partially_moved { Ty::uninit() } else { Ty::tuple(fields) };
+            let ty = if partially_moved {
+                Ty::uninit()
+            } else {
+                let (blocked, fields) = unblock_fields(infcx, &fields);
+                let ty = Ty::tuple(fields);
+                if blocked { Ty::blocked(ty) } else { ty }
+            };
             Ok(ty)
         }
         _ => Ok(ty.clone()),

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -9,9 +9,14 @@ use flux_middle::{
     global_env::GlobalEnv,
     queries::QueryResult,
     rty::{
-        AdtDef, BaseTy, Binder, EarlyBinder, Expr, FIRST_VARIANT, GenericArg, GenericArgsExt, List,
-        Loc, Mutability, Path, PtrKind, Ref, Sort, Ty, TyKind, VariantIdx, VariantSig,
-        fold::{FallibleTypeFolder, TypeFoldable, TypeVisitable, TypeVisitor},
+        AdtDef, BaseTy, Binder, BoundReftKind, BoundVariableKinds, EarlyBinder, Expr, ExprKind,
+        FIRST_VARIANT, GenericArg, GenericArgsExt, List, Loc, Mutability, Name, Path, PtrKind, Ref,
+        Sort, Ty, TyCtor, TyKind, Var, VariantIdx, VariantSig,
+        canonicalize::{Hoister, HoisterDelegate},
+        fold::{
+            FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitable,
+            TypeVisitor,
+        },
     },
 };
 use flux_rustc_bridge::mir::{FieldIdx, Place, PlaceElem};
@@ -19,6 +24,8 @@ use itertools::Itertools;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir::def_id::DefId;
 use rustc_span::Span;
+use rustc_type_ir::{BoundVar, DebruijnIndex, INNERMOST};
+
 #[derive(Clone, Default)]
 pub(crate) struct PlacesTree {
     map: FxIndexMap<Loc, Binding>,
@@ -867,26 +874,129 @@ fn downcast_enum(
     Ok(variant_sig.fields.to_vec())
 }
 
+/// Opens the *guards* of blocked fields, recording enough information to close them back into a
+/// binder. See [`fold_guarded`].
+struct GuardOpener<'a, 'infcx, 'genv, 'tcx> {
+    infcx: &'a mut InferCtxt<'infcx, 'genv, 'tcx>,
+    /// The names the guards were opened with, in the order they were created. These become the
+    /// variables of the binder, so the order has to match `sorts`.
+    names: Vec<Name>,
+    sorts: Vec<Sort>,
+    /// The guards, in terms of `names`.
+    preds: Vec<Expr>,
+}
+
+impl HoisterDelegate for &mut GuardOpener<'_, '_, '_, '_> {
+    fn hoist_exists(&mut self, ty_ctor: &TyCtor) -> Ty {
+        let ty = ty_ctor.replace_bound_refts_with(|sort, _, kind| {
+            let name = self.infcx.define_bound_reft_var(sort, kind);
+            self.names.push(name);
+            self.sorts.push(sort.clone());
+            Expr::fvar(name)
+        });
+        self.infcx.assume_invariants(&ty);
+        ty
+    }
+
+    fn hoist_constr(&mut self, pred: Expr) {
+        // Assumed *locally* so the aggregate's invariants can be discharged against it, and
+        // recorded so it travels in the type instead of in the enclosing refinement context.
+        self.infcx.assume_pred(pred.clone());
+        self.preds.push(pred);
+    }
+}
+
+/// Abstracts `names` into the variables of a binder wrapping `t`, i.e. replaces each
+/// `Var::Free(names[i])` with `Var::Bound(<the new binder>, i)`.
+fn close_over<T: TypeFoldable>(names: &[Name], t: &T) -> T {
+    struct Closer<'a> {
+        names: &'a [Name],
+        current_index: DebruijnIndex,
+    }
+
+    impl TypeFolder for Closer<'_> {
+        fn enter_binder(&mut self, _: &BoundVariableKinds) {
+            self.current_index.shift_in(1);
+        }
+
+        fn exit_binder(&mut self) {
+            self.current_index.shift_out(1);
+        }
+
+        fn fold_expr(&mut self, expr: &Expr) -> Expr {
+            if let ExprKind::Var(Var::Free(name)) = expr.kind()
+                && let Some(idx) = self.names.iter().position(|n| n == name)
+            {
+                Expr::bvar(self.current_index, BoundVar::from_usize(idx), BoundReftKind::Anon)
+            } else {
+                expr.super_fold_with(self)
+            }
+        }
+    }
+    t.fold_with(&mut Closer { names, current_index: INNERMOST })
+}
+
 /// A field of an aggregate can be *blocked* if there's a live mutable borrow into it, e.g., after
-/// `let r = &mut s.f`. To fold `s` back we use the *guard* of the borrow, i.e., the (upper) bound
-/// `r` is allowed to write back, as the type of the field. The aggregate itself remains blocked
-/// because the borrow is still live.
+/// `let r = &mut s.f`. To fold `s` back we use the *guard* of the borrow, i.e., the bound `r` is
+/// allowed to write back, as the type of the field.
 ///
-/// Returns whether any field was blocked together with the unblocked fields.
-fn unblock_fields(infcx: &mut InferCtxtAt, fields: &[Ty]) -> (bool, Vec<Ty>) {
-    let mut blocked = false;
+/// The guards are *not* unpacked into the enclosing refinement context, which would leave both the
+/// fresh names and the guards themselves in scope for everything checked after the fold. Instead
+/// they are opened in a branch of the refinement tree, used to build the aggregate, and then closed
+/// back into a binder on the resulting type. So folding
+/// ```text
+/// Foo { foo: usize[a], bar: †usize{v: a <= v} }
+/// ```
+/// checks `Foo`'s invariants under a local `∀b. a <= b ⇒ …` and yields
+/// ```text
+/// †∃b. { Foo[a, b] | a <= b }
+/// ```
+/// The result stays blocked because the borrow is still live.
+///
+/// `mk` builds the aggregate from the opened fields; it is where field subtyping and the
+/// aggregate's invariants get checked. At least one of `fields` must be blocked, see
+/// [`has_blocked_field`].
+fn fold_guarded(
+    infcx: &mut InferCtxtAt,
+    fields: &[Ty],
+    mk: impl FnOnce(&mut InferCtxtAt, &[Ty]) -> QueryResult<Ty>,
+) -> QueryResult<Ty> {
+    let span = infcx.span;
+    let mut branch = infcx.branch();
+    let mut opener =
+        GuardOpener { infcx: &mut branch, names: vec![], sorts: vec![], preds: vec![] };
     let fields = fields
         .iter()
         .map(|ty| {
             if let TyKind::Blocked(bound) = ty.kind() {
-                blocked = true;
-                infcx.hoister(true).hoist(bound)
+                Hoister::with_delegate(&mut opener)
+                    .transparent()
+                    .hoist(bound)
             } else {
                 ty.clone()
             }
         })
         .collect_vec();
-    (blocked, fields)
+    let GuardOpener { names, sorts, preds, .. } = opener;
+
+    let ty = mk(&mut branch.at(span), &fields)?;
+
+    let pred = Expr::and_from_iter(preds);
+    let ty = if sorts.is_empty() {
+        // The guards had no existentials, so there is nothing to bind and the predicates are
+        // already in terms of variables of the enclosing scope.
+        Ty::constr(pred, ty)
+    } else {
+        let ty = Ty::constr(pred, ty).shift_in_escaping(1);
+        Ty::exists(Binder::bind_with_sorts(close_over(&names, &ty), &sorts))
+    };
+    Ok(Ty::blocked(ty))
+}
+
+fn has_blocked_field(fields: &[Ty]) -> bool {
+    fields
+        .iter()
+        .any(|ty| matches!(ty.kind(), TyKind::Blocked(_)))
 }
 
 fn fold(
@@ -921,15 +1031,19 @@ fn fold(
                     .map(|ty| fold(bindings, infcx, ty, is_strg))
                     .try_collect_vec()?;
 
+                let mk = |infcx: &mut InferCtxtAt, fields: &[Ty]| {
+                    Ok(infcx
+                        .check_constructor(variant_sig, args, fields, ConstrReason::Fold)
+                        .unwrap_or_else(|err| tracked_span_bug!("{err:?}")))
+                };
+
                 let partially_moved = fields.iter().any(Ty::is_uninit);
                 let ty = if partially_moved {
                     Ty::uninit()
+                } else if has_blocked_field(&fields) {
+                    fold_guarded(infcx, &fields, mk)?
                 } else {
-                    let (blocked, fields) = unblock_fields(infcx, &fields);
-                    let ty = infcx
-                        .check_constructor(variant_sig, args, &fields, ConstrReason::Fold)
-                        .unwrap_or_else(|err| tracked_span_bug!("{err:?}"));
-                    if blocked { Ty::blocked(ty) } else { ty }
+                    mk(infcx, &fields)?
                 };
 
                 Ok(ty)
@@ -945,13 +1059,15 @@ fn fold(
                 .map(|ty| fold(bindings, infcx, ty, is_strg))
                 .try_collect_vec()?;
 
+            let mk = |_: &mut InferCtxtAt, fields: &[Ty]| Ok(Ty::tuple(fields.to_vec()));
+
             let partially_moved = fields.iter().any(Ty::is_uninit);
             let ty = if partially_moved {
                 Ty::uninit()
+            } else if has_blocked_field(&fields) {
+                fold_guarded(infcx, &fields, mk)?
             } else {
-                let (blocked, fields) = unblock_fields(infcx, &fields);
-                let ty = Ty::tuple(fields);
-                if blocked { Ty::blocked(ty) } else { ty }
+                mk(infcx, &fields)?
             };
             Ok(ty)
         }

--- a/tests/tests/neg/surface/guarded_mut00.rs
+++ b/tests/tests/neg/surface/guarded_mut00.rs
@@ -1,0 +1,39 @@
+// The guard on the returned `&mut` is too weak to re-establish the invariant of the struct when
+// it is folded back to check the `ensures` clause.
+
+#[flux::refined_by(foo: int, bar: int)]
+#[flux::invariant(foo <= bar)] //~ NOTE this is the condition
+//~| NOTE this is the condition
+//~| NOTE this is the condition
+struct Foo {
+    #[flux::field(usize[foo])]
+    foo: usize,
+    #[flux::field(usize[bar])]
+    bar: usize,
+}
+
+#[flux::refined_by(inner: Foo, n: int)]
+struct Outer {
+    #[flux::field(Foo[inner])]
+    inner: Foo,
+    #[flux::field(usize[n])]
+    n: usize,
+}
+
+#[flux::sig(fn(s: &mut Foo[@me]) -> &mut usize ensures s: Foo)]
+fn test00(s: &mut Foo) -> &mut usize {
+    &mut s.bar
+} //~ ERROR type invariant may not hold
+
+// the guard holds of the current value of `bar` but is not strong enough: it still allows writing
+// a value below `me.foo`
+#[flux::sig(fn(s: &mut Foo[@me]) -> &mut usize{v: v + 1 >= me.foo} ensures s: Foo)]
+fn test01(s: &mut Foo) -> &mut usize {
+    &mut s.bar
+} //~ ERROR type invariant may not hold
+
+// nested field
+#[flux::sig(fn(s: &mut Outer[@me]) -> &mut usize ensures s: Outer)]
+fn test02(s: &mut Outer) -> &mut usize {
+    &mut s.inner.bar
+} //~ ERROR type invariant may not hold

--- a/tests/tests/neg/surface/guarded_mut01.rs
+++ b/tests/tests/neg/surface/guarded_mut01.rs
@@ -1,0 +1,38 @@
+// Several fields guarded at once, where the guards are not enough to re-establish the invariant.
+
+#[flux::refined_by(a: int, b: int, c: int)]
+#[flux::invariant(a <= b && a <= c)] //~ NOTE this is the condition
+struct Three {
+    #[flux::field(usize[a])]
+    a: usize,
+    #[flux::field(usize[b])]
+    b: usize,
+    #[flux::field(usize[c])]
+    c: usize,
+}
+
+#[flux::refined_by(a: int, b: int, c: int)]
+#[flux::invariant(a <= b && b <= c)] //~ NOTE this is the condition
+struct Ordered {
+    #[flux::field(usize[a])]
+    a: usize,
+    #[flux::field(usize[b])]
+    b: usize,
+    #[flux::field(usize[c])]
+    c: usize,
+}
+
+// only the first guard is strong enough
+#[flux::sig(fn(s: &mut Three[@me]) -> (&mut usize{v: me.a <= v}, &mut usize) ensures s: Three)]
+fn test00(s: &mut Three) -> (&mut usize, &mut usize) {
+    let Three { a: _, b, c } = s;
+    (b, c)
+} //~ ERROR type invariant may not hold
+
+// each guard is strong enough on its own, but they say nothing about how the two new values relate,
+// so `b <= c` cannot be recovered
+#[flux::sig(fn(s: &mut Ordered[@me]) -> (&mut usize{v: me.a <= v && v <= me.c}, &mut usize{v: me.a <= v && v <= me.c}) ensures s: Ordered)]
+fn test01(s: &mut Ordered) -> (&mut usize, &mut usize) {
+    let Ordered { a: _, b, c } = s;
+    (b, c)
+} //~ ERROR type invariant may not hold

--- a/tests/tests/pos/surface/guarded_mut00.rs
+++ b/tests/tests/pos/surface/guarded_mut00.rs
@@ -1,0 +1,56 @@
+// Returning a `&mut` into a field of a `&strg` (i.e. `&mut` + `ensures`) argument. The returned
+// reference *guards* the field: folding the struct back to check the `ensures` clause uses the
+// guard as the type of the field, so the guard has to be strong enough to re-establish the
+// struct's invariant.
+
+#[flux::refined_by(foo: int, bar: int)]
+#[flux::invariant(foo <= bar)]
+struct Foo {
+    #[flux::field(usize[foo])]
+    foo: usize,
+    #[flux::field(usize[bar])]
+    bar: usize,
+}
+
+#[flux::refined_by(inner: Foo, n: int)]
+struct Outer {
+    #[flux::field(Foo[inner])]
+    inner: Foo,
+    #[flux::field(usize[n])]
+    n: usize,
+}
+
+#[flux::sig(fn(s: &mut Foo[@me]) -> &mut usize{v: me.foo <= v} ensures s: Foo)]
+fn test00(s: &mut Foo) -> &mut usize {
+    &mut s.bar
+}
+
+#[flux::sig(fn(s: &mut Foo[@me]) -> &mut usize{v: me.foo <= v} ensures s: Foo)]
+fn test01(s: &mut Foo) -> &mut usize {
+    s.bar += 1;
+    &mut s.bar
+}
+
+// nested field
+#[flux::sig(fn(s: &mut Outer[@me]) -> &mut usize{v: me.inner.foo <= v} ensures s: Outer)]
+fn test02(s: &mut Outer) -> &mut usize {
+    &mut s.inner.bar
+}
+
+// no guard needed because no invariant mentions `n`
+#[flux::sig(fn(s: &mut Outer[@me]) -> &mut usize ensures s: Outer)]
+fn test03(s: &mut Outer) -> &mut usize {
+    &mut s.n
+}
+
+// the whole argument is borrowed, not just a field
+#[flux::sig(fn(s: &mut Foo[@me]) -> &mut Foo{v: me.foo <= v.foo} ensures s: Foo)]
+fn test04(s: &mut Foo) -> &mut Foo {
+    s
+}
+
+// tuples
+#[flux::sig(fn(s: &mut (usize[@a], usize)) -> &mut usize ensures s: (usize[a], usize))]
+fn test05(s: &mut (usize, usize)) -> &mut usize {
+    &mut s.1
+}

--- a/tests/tests/pos/surface/guarded_mut01.rs
+++ b/tests/tests/pos/surface/guarded_mut01.rs
@@ -1,0 +1,27 @@
+// Several fields guarded at once. Each guard contributes its own variable to the binder on the
+// folded type, so `fold` has to build a multi-variable binder.
+
+#[flux::refined_by(a: int, b: int, c: int)]
+#[flux::invariant(a <= b && a <= c)]
+struct Three {
+    #[flux::field(usize[a])]
+    a: usize,
+    #[flux::field(usize[b])]
+    b: usize,
+    #[flux::field(usize[c])]
+    c: usize,
+}
+
+// two live borrows, both guards strong enough
+#[flux::sig(fn(s: &mut Three[@me]) -> (&mut usize{v: me.a <= v}, &mut usize{v: me.a <= v}) ensures s: Three)]
+fn test00(s: &mut Three) -> (&mut usize, &mut usize) {
+    let Three { a: _, b, c } = s;
+    (b, c)
+}
+
+// guards that pin the values exactly, so there is nothing to bind
+#[flux::sig(fn(s: &mut Three[@me]) -> (&mut usize[me.b], &mut usize[me.c]) ensures s: Three)]
+fn test01(s: &mut Three) -> (&mut usize, &mut usize) {
+    let Three { a: _, b, c } = s;
+    (b, c)
+}

--- a/tests/tests/todo/guarded_mut00.rs
+++ b/tests/tests/todo/guarded_mut00.rs
@@ -1,0 +1,18 @@
+#[flux::refined_by(foo: int, bar: int)]
+#[flux::invariant(foo <= bar)]
+struct Foo {
+    #[flux::field(usize[foo])]
+    foo: usize,
+    #[flux::field(usize[bar])]
+    bar: usize,
+}
+
+#[flux::sig(fn(s: &mut Foo[@me]) -> &mut usize{v: me.foo <= v} ensures s: Foo)] // want callers to "block s"
+fn test_ok(s: &mut Foo) -> &mut usize {
+    &mut s.bar
+}
+
+#[flux::sig(fn(s: &mut Foo[@me]) -> &mut usize ensures s: Foo)] // want callers to "block s"
+fn test_fail(s: &mut Foo) -> &mut usize {
+    &mut s.bar
+}

--- a/tests/tests/todo/issue-1700.rs
+++ b/tests/tests/todo/issue-1700.rs
@@ -1,0 +1,23 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// --- casts ---
+
+#[flux_rs::spec(fn (ptr: *const [@p] T) -> Option<NonNull<T>{nn: nn.base == p.base && nn.addr == p.addr && nn.size == p.size}>)]
+fn new_cast_with_match<T>(ptr: *const T) -> Option<NonNull<T>> {
+    match NonNull::new(ptr as *mut T) {
+        None => None,
+        Some(nn) => Some(nn),
+    }
+}
+
+#[flux_rs::spec(fn (ptr: *const [@p] T) -> Option<NonNull<T>{nn: nn.base == p.base && nn.addr == p.addr && nn.size == p.size}>)]
+fn new_cast_with_map<T>(ptr: *const T) -> Option<NonNull<T>> {
+    NonNull::new(ptr as *mut T).map(|nn| nn)
+}
+
+#[flux_rs::spec(fn (ptr: *mut [@p] T) -> Option<NonNull<T>{nn: nn.base == p.base && nn.addr == p.addr && nn.size == p.size}>)]
+fn new_no_cast_with_map<T>(ptr: *mut T) -> Option<NonNull<T>> {
+    NonNull::new(ptr).map(|nn| nn)
+}

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "flux-checker",
   "displayName": "Flux Refinement Type Checker",
   "description": "VSCode Extension for the Flux Refinement Type Checker for Rust",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "publisher": "RanjitJhala",
   "repository": {
     "type": "git",


### PR DESCRIPTION
CC summary:

1. ghost_statements.rs — new Point::AtReturn(Location) with its own statement map, plus dump support.
2. ghost_statements/fold_unfold.rs — Mode::ret emits the argument folds at Point::AtReturn instead of Point::BeforeLocation.
3. checker.rs — check_ret collects those folds and runs them between the return-value subtyping and check_ensures, all inside the existing evar scope. A separate fold_span keeps fold errors on the closing brace (this preserved the spans in neg/error_messages/localize04.rs and neg/surface/issue-299.rs).
4. type_env/place_ty.rs — new unblock_fields: when folding a struct/tuple whose field is Blocked(t) (a live mutable borrow into it), the field is folded using the borrow's guard t, unpacked to a fresh variable with its invariants assumed. The resulting aggregate stays blocked, since the borrow is still live. This is what makes the invariant check succeed for a strong guard and fail for a weak one.

Tests

- tests/tests/pos/surface/guarded_mut00.rs — 6 cases: simple field, write-then-return, nested field (s.inner.bar), unconstrained field, whole-argument borrow, tuple.
- tests/tests/neg/surface/guarded_mut00.rs — 3 cases: no guard, a guard that holds of the current bar but is still too weak (v + 1 >= me.foo), and nested.



**Scope note:** this makes the body check sound and precise. The caller side is unchanged — after let r = test_ok(&mut foo); flux does not block foo while r is live, so writing through r won't be reflected in foo's index. Your // want callers to "block s" comment suggests you already know this; it's a separate piece of work.