### PR TITLE
Implement `qualifier!` macro

### DIFF
--- a/book/src/guide/specifications.md
+++ b/book/src/guide/specifications.md
@@ -1043,3 +1043,14 @@ that assertion.
 ```rust,noplayground
 {{#include ../../../tests/tests/with_deps/pos/surface/invariant_macro00.rs}}
 ```
+
+## Qualifier Macro
+
+The `qualifier!` macro specifies just the qualifier, leaving the assertion to you. Use
+`invariant!` when the invariant is valid Rust as well as a valid refinement, and `qualifier!`
+plus `assert` when it isn't: its body is never re-emitted as Rust, so it can use
+refinement-only syntax. Sorts are inferred, or annotated as in `invariant!`.
+
+```rust,noplayground
+{{#include ../../../tests/tests/with_deps/pos/surface/qualifier_macro00.rs}}
+```

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -529,8 +529,18 @@ fn parse_qualifier(cx: &mut ParseCtxt) -> ParseResult<Qualifier> {
             }
         }));
 
+        // Uniquify the name so hints don't collide with each other (qualifier names are
+        // crate-global). The span alone is not enough: every expansion of a macro like
+        // `qualifier!` transcribes the same `name` token, so all of them share a span. The
+        // node id is a session-global counter, so it distinguishes them.
         let span = name.span;
-        let str = format!("{}_{}_{}", name.name.to_ident_string(), span.lo().0, span.hi().0);
+        let str = format!(
+            "{}_{}_{}_{}",
+            name.name.to_ident_string(),
+            span.lo().0,
+            span.hi().0,
+            cx.next_node_id().as_usize()
+        );
         name = Ident { name: Symbol::intern(&str), ..name };
     }
 

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -933,14 +933,12 @@ impl Expr {
                         if let [segment] = path.segments.as_slice() {
                             self.vars.insert(segment.ident);
                         }
-                        visit::walk_expr(self, expr);
                     }
                     ExprKind::Call(callee, args) => {
                         // The callee of a call is a refinement function, not a variable, so
-                        // don't collect it. Anything more complex than a single-segment path
-                        // may contain free variables, so visit it normally.
-                        if !matches!(&callee.kind, ExprKind::Path(path) if path.segments.len() == 1)
-                        {
+                        // don't collect it. Anything that's not a path may contain free
+                        // variables, so visit it normally.
+                        if !matches!(&callee.kind, ExprKind::Path(_)) {
                             self.visit_expr(callee);
                         }
                         for arg in args {

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -927,14 +927,29 @@ impl Expr {
 
         impl visit::Visitor for FreeVarsVisitor {
             fn visit_expr(&mut self, expr: &Expr) {
-                if let ExprKind::Path(path) = &expr.kind {
-                    // Only collect paths with a single segment
-                    if let [segment] = path.segments.as_slice() {
-                        self.vars.insert(segment.ident);
+                match &expr.kind {
+                    ExprKind::Path(path) => {
+                        // Only collect paths with a single segment
+                        if let [segment] = path.segments.as_slice() {
+                            self.vars.insert(segment.ident);
+                        }
+                        visit::walk_expr(self, expr);
                     }
+                    ExprKind::Call(callee, args) => {
+                        // The callee of a call is a refinement function, not a variable, so
+                        // don't collect it. Anything more complex than a single-segment path
+                        // may contain free variables, so visit it normally.
+                        if !matches!(&callee.kind, ExprKind::Path(path) if path.segments.len() == 1)
+                        {
+                            self.visit_expr(callee);
+                        }
+                        for arg in args {
+                            self.visit_expr(arg);
+                        }
+                    }
+                    // Continue visiting child expressions
+                    _ => visit::walk_expr(self, expr),
                 }
-                // Continue visiting child expressions
-                visit::walk_expr(self, expr);
             }
         }
 

--- a/lib/flux-rs/src/lib.rs
+++ b/lib/flux-rs/src/lib.rs
@@ -28,7 +28,7 @@ pub fn unreachable() -> ! {
 #[doc(hidden)]
 macro_rules! __private_detached_spec {
     ($($e:tt)*) => {
-        #[flux_rs::specs {
+        #[$crate::specs {
             $($e)*
         }]
         const _: () = ();
@@ -44,11 +44,10 @@ macro_rules! __private_detached_spec {
 #[doc(hidden)]
 macro_rules! __private_invariant {
     ($($param:ident : $ty:ty),* ; $expr:expr) => {
-        #[flux::defs{
+        $crate::defs! {
             invariant qualifier Auto($($param: $ty),*) { $expr }
-        }]
-        const _: () = ();
-        flux_rs::assert($expr);
+        }
+        $crate::assert($expr);
     };
 }
 
@@ -67,16 +66,14 @@ macro_rules! __private_invariant {
 #[doc(hidden)]
 macro_rules! __private_qualifier {
     ($($param:ident : $ty:ty),+ ; $($body:tt)*) => {
-        #[flux::defs{
+        $crate::defs! {
             invariant qualifier Auto($($param: $ty),+) { $($body)* }
-        }]
-        const _: () = ();
+        }
     };
     ($($body:tt)*) => {
-        #[flux::defs{
+        $crate::defs! {
             invariant qualifier Auto() { $($body)* }
-        }]
-        const _: () = ();
+        }
     };
 }
 

--- a/lib/flux-rs/src/lib.rs
+++ b/lib/flux-rs/src/lib.rs
@@ -52,6 +52,34 @@ macro_rules! __private_invariant {
     };
 }
 
+/// Macro for creating `invariant qualifier`s without an assertion.
+///
+/// Unlike [`invariant`](crate::macros::invariant), the body is never re-emitted as Rust, so it
+/// may use refinement-only syntax. Sorts are inferred; annotate the ones that can't be, using
+/// the same `params ; body` syntax as [`invariant`](crate::macros::invariant).
+///
+/// # Example
+/// ```
+/// flux_rs::macros::qualifier!(my_plus(res, i) == n);
+/// flux_rs::macros::qualifier!(res: int, i: int ; res + i == n);
+/// ```
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __private_qualifier {
+    ($($param:ident : $ty:ty),+ ; $($body:tt)*) => {
+        #[flux::defs{
+            invariant qualifier Auto($($param: $ty),+) { $($body)* }
+        }]
+        const _: () = ();
+    };
+    ($($body:tt)*) => {
+        #[flux::defs{
+            invariant qualifier Auto() { $($body)* }
+        }]
+        const _: () = ();
+    };
+}
+
 pub mod macros {
     /// Macro for creating detached specifications.
     ///
@@ -69,4 +97,11 @@ pub mod macros {
     /// flux_rs::macros::invariant!(res: int, i: int, n: int ; res + i == n);
     /// ```
     pub use crate::__private_invariant as invariant;
+    /// Macro for creating a local `invariant qualifier` hint.
+    /// # Example
+    /// ```
+    /// flux_rs::macros::qualifier!(my_plus(res, i) == n);
+    /// flux_rs::macros::qualifier!(res: int, i: int ; res + i == n);
+    /// ```
+    pub use crate::__private_qualifier as qualifier;
 }

--- a/tests/tests/with_deps/pos/surface/qualifier_macro00.rs
+++ b/tests/tests/with_deps/pos/surface/qualifier_macro00.rs
@@ -1,0 +1,82 @@
+use flux_rs::{assert, attrs::*, macros::qualifier};
+
+defs! {
+    fn my_plus(x: int, y: int) -> int { x + y }
+}
+
+#[spec(fn (n: usize) -> usize[n])]
+pub fn test_with_hand_written_qualifier(n: usize) -> usize {
+    let mut i = n;
+    let mut res = 0;
+    while i > 0 {
+        #[flux::defs{
+            invariant qualifier Auto(res: int) { res + i == n }
+         }]
+        const _: () = ();
+        assert(res + i == n);
+        i -= 1;
+        res += 1;
+    }
+    res
+}
+
+/// Same as above, with the sort of `res` annotated. This should expand to exactly the
+/// hand-written form.
+#[spec(fn (n: usize) -> usize[n])]
+pub fn test(n: usize) -> usize {
+    let mut i = n;
+    let mut res = 0;
+    while i > 0 {
+        qualifier!(res: int ; res + i == n);
+        assert(res + i == n);
+        i -= 1;
+        res += 1;
+    }
+    res
+}
+
+/// Sorts are inferred when the body constrains them; here the `n >= 0` conjunct does it.
+#[spec(fn (n: usize) -> usize[n])]
+pub fn test_inferred_sorts(n: usize) -> usize {
+    let mut i = n;
+    let mut res = 0;
+    while i > 0 {
+        qualifier!(res + i == n && n >= 0);
+        assert(res + i == n);
+        i -= 1;
+        res += 1;
+    }
+    res
+}
+
+/// Two `qualifier!`s in the same function, plus one more in a different function, to check
+/// the generated qualifier names don't collide.
+#[spec(fn (n: usize) -> usize[n])]
+pub fn test_multiple_qualifiers(n: usize) -> usize {
+    let mut i = n;
+    let mut res = 0;
+    while i > 0 {
+        qualifier!(res: int, i: int, n: int ; res + i == n);
+        qualifier!(res >= 0 && i >= 0);
+        assert(res + i == n);
+        i -= 1;
+        res += 1;
+    }
+    res
+}
+
+/// The body of `qualifier!` is never re-emitted as Rust, so it can use refinement-only
+/// syntax: a call to a refinement function, and `=>`, which is not a Rust operator.
+#[spec(fn (n: usize) -> usize[n])]
+pub fn test_refinement_syntax(n: usize) -> usize {
+    let mut i = n;
+    let mut res = 0;
+    while i > 0 {
+        qualifier!(my_plus(res, i) == n);
+        qualifier!(i >= 0 => res + i == n);
+        assert(res + i == n);
+        i -= 1;
+        res += 1;
+    }
+    res
+}


### PR DESCRIPTION
Resolves #1389, follow-up to #1386.

Code example:

```rust
defs! {
    fn my_plus(x: int, y: int) -> int { x + y }
}

#[spec(fn (n: usize) -> usize[n])]
pub fn test(n: usize) -> usize {
    let mut i = n;
    let mut res = 0;
    while i > 0 {
        qualifier!(my_plus(res, i) == n);
        assert(res + i == n);
        i -= 1;
        res += 1;
    }
    res
}
```

## Changes
- `lib/flux-rs/src/lib.rs` — the `qualifier!` macro (`tt`-captured body, plus an optional `params ; body` arm for sorts) and its re-export in `flux_rs::macros`
- `crates/flux-syntax/src/parser/mod.rs` — uniquify hint qualifier names with `next_node_id()`
- `crates/flux-syntax/src/surface.rs` — `free_vars` no longer collects call callees
- `tests/tests/with_deps/pos/surface/qualifier_macro00.rs` — new test
- `book/src/guide/specifications.md` — new "Qualifier Macro" section, `{{#include}}`ing the test