### PR TITLE
Implement wildcard literals

### DIFF
--- a/crates/flux-arc-interner/src/lib.rs
+++ b/crates/flux-arc-interner/src/lib.rs
@@ -402,4 +402,4 @@ macro_rules! _impl_slice_internable {
 }
 pub use crate::_impl_slice_internable as impl_slice_internable;
 
-impl_slice_internable!(rustc_abi::FieldIdx);
+impl_slice_internable!(bool, rustc_abi::FieldIdx);

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -877,6 +877,7 @@ impl<'genv, 'tcx> FluxItemCtxt<'genv, 'tcx> {
         fhir::Qualifier {
             def_id: self.owner,
             args: self.desugar_refine_params(&qualifier.params),
+            wildcards: self.genv().alloc_slice(&qualifier.wildcards),
             kind,
             expr: self.desugar_expr(&qualifier.expr),
         }
@@ -1058,7 +1059,6 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     span: ident.span,
                     kind,
                     sort,
-                    is_wildcard: false,
                     fhir_id: self.next_fhir_id(),
                 }
             })
@@ -1087,7 +1087,6 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
             span: param.ident.span,
             kind,
             sort: self.desugar_sort(&param.sort, None),
-            is_wildcard: param.is_wildcard,
             fhir_id: self.next_fhir_id(),
         }
     }
@@ -1258,7 +1257,6 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     span: bind.span,
                     sort: fhir::Sort::Infer,
                     kind,
-                    is_wildcard: false,
                     fhir_id: self.next_fhir_id(),
                 };
                 let path = fhir::PathExpr {

--- a/crates/flux-desugar/src/desugar.rs
+++ b/crates/flux-desugar/src/desugar.rs
@@ -1058,6 +1058,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     span: ident.span,
                     kind,
                     sort,
+                    is_wildcard: false,
                     fhir_id: self.next_fhir_id(),
                 }
             })
@@ -1086,6 +1087,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
             span: param.ident.span,
             kind,
             sort: self.desugar_sort(&param.sort, None),
+            is_wildcard: param.is_wildcard,
             fhir_id: self.next_fhir_id(),
         }
     }
@@ -1256,6 +1258,7 @@ trait DesugarCtxt<'genv, 'tcx: 'genv>: ErrorEmitter + ErrorCollector<ErrorGuaran
                     span: bind.span,
                     sort: fhir::Sort::Infer,
                     kind,
+                    is_wildcard: false,
                     fhir_id: self.next_fhir_id(),
                 };
                 let path = fhir::PathExpr {

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -254,7 +254,6 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
                         ident: *bind,
                         mode: None,
                         sort: surface::Sort::Infer,
-                        is_wildcard: false,
                         node_id,
                         span: bind.span,
                     };

--- a/crates/flux-desugar/src/resolver/refinement_resolver.rs
+++ b/crates/flux-desugar/src/resolver/refinement_resolver.rs
@@ -254,6 +254,7 @@ impl<V: ScopedVisitor> surface::visit::Visitor for ScopedVisitorWrapper<V> {
                         ident: *bind,
                         mode: None,
                         sort: surface::Sort::Infer,
+                        is_wildcard: false,
                         node_id,
                         span: bind.span,
                     };

--- a/crates/flux-fhir-analysis/locales/en-US.ftl
+++ b/crates/flux-fhir-analysis/locales/en-US.ftl
@@ -36,6 +36,11 @@ fhir_analysis_expected_fun =
 fhir_analysis_unsupported_primop =
     properties for `{$op}` are not yet supported
 
+fhir_analysis_invalid_wildcard_sort =
+    wildcard parameter cannot have sort `{$found}`
+    .label = this parameter is marked as a wildcard with `#`
+    .note = a wildcard parameter is instantiated with literal constants, so its sort must be one that has literals: `int`, `real`, `str`, or a bit vector
+
 fhir_analysis_invalid_param_in_func_pos =
     illegal use of refinement parameter
     .label = {$is_pred ->

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -473,7 +473,13 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         env.push_layer(Layer::list(self.results(), 0, qualifier.args));
         let body = self.conv_expr(&mut env, &qualifier.expr)?;
         let body = rty::Binder::bind_with_vars(body, env.pop_layer().into_bound_vars(self.genv())?);
-        Ok(rty::Qualifier { def_id: qualifier.def_id, body, kind: qualifier.kind })
+        let wildcards: rty::List<bool> = qualifier
+            .args
+            .iter()
+            .map(|param| param.is_wildcard)
+            .collect();
+        debug_assert_eq!(wildcards.len(), body.vars().len());
+        Ok(rty::Qualifier { def_id: qualifier.def_id, body, wildcards, kind: qualifier.kind })
     }
 
     pub(crate) fn conv_defn(

--- a/crates/flux-fhir-analysis/src/conv/mod.rs
+++ b/crates/flux-fhir-analysis/src/conv/mod.rs
@@ -473,11 +473,7 @@ impl<'genv, 'tcx: 'genv, P: ConvPhase<'genv, 'tcx>> ConvCtxt<P> {
         env.push_layer(Layer::list(self.results(), 0, qualifier.args));
         let body = self.conv_expr(&mut env, &qualifier.expr)?;
         let body = rty::Binder::bind_with_vars(body, env.pop_layer().into_bound_vars(self.genv())?);
-        let wildcards: rty::List<bool> = qualifier
-            .args
-            .iter()
-            .map(|param| param.is_wildcard)
-            .collect();
+        let wildcards: rty::List<bool> = qualifier.wildcards.iter().copied().collect();
         debug_assert_eq!(wildcards.len(), body.vars().len());
         Ok(rty::Qualifier { def_id: qualifier.def_id, body, wildcards, kind: qualifier.kind })
     }

--- a/crates/flux-fhir-analysis/src/wf/errors.rs
+++ b/crates/flux-fhir-analysis/src/wf/errors.rs
@@ -78,6 +78,22 @@ impl UnsupportedPrimOp {
 }
 
 #[derive(Diagnostic)]
+#[diag(fhir_analysis_invalid_wildcard_sort, code = E0999)]
+#[note]
+pub(super) struct InvalidWildcardSort {
+    #[primary_span]
+    #[label]
+    span: Span,
+    found: rty::Sort,
+}
+
+impl InvalidWildcardSort {
+    pub(super) fn new(span: Span, found: rty::Sort) -> Self {
+        Self { span, found }
+    }
+}
+
+#[derive(Diagnostic)]
 #[diag(fhir_analysis_expected_fun, code = E0999)]
 pub(super) struct ExpectedFun<'a> {
     #[primary_span]

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -365,7 +365,9 @@ impl<'genv> fhir::visit::Visitor<'genv> for Wf<'_, 'genv, '_> {
         self.check_expr(&qual.expr, &rty::Sort::Bool);
 
         // A sort with no literals to scrape would silently make the qualifier inert.
-        for param in qual.args.iter().filter(|param| param.is_wildcard) {
+        let wildcards = std::iter::zip(qual.args, qual.wildcards)
+            .filter_map(|(param, &is_wildcard)| is_wildcard.then_some(param));
+        for param in wildcards {
             let sort = self.infcx.param_sort(param.id);
             if !matches!(
                 sort,

--- a/crates/flux-fhir-analysis/src/wf/mod.rs
+++ b/crates/flux-fhir-analysis/src/wf/mod.rs
@@ -363,6 +363,18 @@ impl<'a, 'genv, 'tcx> Wf<'a, 'genv, 'tcx> {
 impl<'genv> fhir::visit::Visitor<'genv> for Wf<'_, 'genv, '_> {
     fn visit_qualifier(&mut self, qual: &fhir::Qualifier<'genv>) {
         self.check_expr(&qual.expr, &rty::Sort::Bool);
+
+        // A sort with no literals to scrape would silently make the qualifier inert.
+        for param in qual.args.iter().filter(|param| param.is_wildcard) {
+            let sort = self.infcx.param_sort(param.id);
+            if !matches!(
+                sort,
+                rty::Sort::Int | rty::Sort::Real | rty::Sort::Str | rty::Sort::BitVec(_)
+            ) {
+                self.errors
+                    .emit(errors::InvalidWildcardSort::new(param.span, sort));
+            }
+        }
     }
 
     fn visit_primop_prop(&mut self, primop_prop: &fhir::PrimOpProp<'genv>) {

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -2559,9 +2559,10 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
     ) -> QueryResult<fixpoint::Qualifier> {
         let (args, body) = self.body_to_fixpoint(&qualifier.body, scx)?;
         let name = qualifier.def_id.name().to_string();
-        let args = args
-            .into_iter()
-            .map(|(name, sort)| fixpoint::QualParam::new(name, sort))
+        // `body_to_fixpoint` returns args in `body.vars()` order, which is how `wildcards` is indexed.
+        debug_assert_eq!(args.len(), qualifier.wildcards.len());
+        let args = iter::zip(args, &qualifier.wildcards)
+            .map(|((name, sort), &is_wildcard)| fixpoint::QualParam { name, sort, is_wildcard })
             .collect();
         Ok(fixpoint::Qualifier { name, args, body })
     }

--- a/crates/flux-infer/src/fixpoint_encoding.rs
+++ b/crates/flux-infer/src/fixpoint_encoding.rs
@@ -2559,6 +2559,10 @@ impl<'genv, 'tcx> ExprEncodingCtxt<'genv, 'tcx> {
     ) -> QueryResult<fixpoint::Qualifier> {
         let (args, body) = self.body_to_fixpoint(&qualifier.body, scx)?;
         let name = qualifier.def_id.name().to_string();
+        let args = args
+            .into_iter()
+            .map(|(name, sort)| fixpoint::QualParam::new(name, sort))
+            .collect();
         Ok(fixpoint::Qualifier { name, args, body })
     }
 }

--- a/crates/flux-infer/src/fixpoint_qualifiers.rs
+++ b/crates/flux-infer/src/fixpoint_qualifiers.rs
@@ -4,23 +4,23 @@ use liquid_fixpoint::{BinOp, BinRel, Sort};
 
 use crate::fixpoint_encoding::fixpoint::{
     LocalVar, Var,
-    fixpoint_generated::{Expr, Qualifier},
+    fixpoint_generated::{Expr, QualParam, Qualifier},
 };
 pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new(|| {
     // UNARY
     let eqtrue = Qualifier {
         name: String::from("EqTrue"),
-        args: vec![(Var::Local(LocalVar::from(0u32)), Sort::Bool)],
+        args: vec![QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Bool)],
         body: Expr::Var(Var::Local(LocalVar::from(0u32))),
     };
     let eqfalse = Qualifier {
         name: String::from("EqFalse"),
-        args: vec![(Var::Local(LocalVar::from(0u32)), Sort::Bool)],
+        args: vec![QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Bool)],
         body: Expr::Not(Box::new(Expr::Var(Var::Local(LocalVar::from(0u32))))),
     };
     let eqzero = Qualifier {
         name: String::from("EqZero"),
-        args: vec![(Var::Local(LocalVar::from(0u32)), Sort::Int)],
+        args: vec![QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int)],
         body: Expr::Atom(
             BinRel::Eq,
             Box::new([Expr::Var(Var::Local(LocalVar::from(0u32))), Expr::int(0)]),
@@ -28,7 +28,7 @@ pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new
     };
     let gtzero = Qualifier {
         name: String::from("GtZero"),
-        args: vec![(Var::Local(LocalVar::from(0u32)), Sort::Int)],
+        args: vec![QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int)],
         body: Expr::Atom(
             BinRel::Gt,
             Box::new([Expr::Var(Var::Local(LocalVar::from(0u32))), Expr::int(0)]),
@@ -36,7 +36,7 @@ pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new
     };
     let gezero = Qualifier {
         name: String::from("GeZero"),
-        args: vec![(Var::Local(LocalVar::from(0u32)), Sort::Int)],
+        args: vec![QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int)],
         body: Expr::Atom(
             BinRel::Ge,
             Box::new([Expr::Var(Var::Local(LocalVar::from(0u32))), Expr::int(0)]),
@@ -44,7 +44,7 @@ pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new
     };
     let ltzero = Qualifier {
         name: String::from("LtZero"),
-        args: vec![(Var::Local(LocalVar::from(0u32)), Sort::Int)],
+        args: vec![QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int)],
         body: Expr::Atom(
             BinRel::Lt,
             Box::new([Expr::Var(Var::Local(LocalVar::from(0u32))), Expr::int(0)]),
@@ -52,7 +52,7 @@ pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new
     };
     let lezero = Qualifier {
         name: String::from("LeZero"),
-        args: vec![(Var::Local(LocalVar::from(0u32)), Sort::Int)],
+        args: vec![QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int)],
         body: Expr::Atom(
             BinRel::Le,
             Box::new([Expr::Var(Var::Local(LocalVar::from(0u32))), Expr::int(0)]),
@@ -63,8 +63,8 @@ pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new
     let eq = Qualifier {
         name: String::from("Eq"),
         args: vec![
-            (Var::Local(LocalVar::from(0u32)), Sort::Int),
-            (Var::Local(LocalVar::from(1u32)), Sort::Int),
+            QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int),
+            QualParam::new(Var::Local(LocalVar::from(1u32)), Sort::Int),
         ],
         body: Expr::Atom(
             BinRel::Eq,
@@ -77,8 +77,8 @@ pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new
     let gt = Qualifier {
         name: String::from("Gt"),
         args: vec![
-            (Var::Local(LocalVar::from(0u32)), Sort::Int),
-            (Var::Local(LocalVar::from(1u32)), Sort::Int),
+            QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int),
+            QualParam::new(Var::Local(LocalVar::from(1u32)), Sort::Int),
         ],
         body: Expr::Atom(
             BinRel::Gt,
@@ -92,8 +92,8 @@ pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new
         Qualifier {
             name: String::from("Ge"),
             args: vec![
-                (Var::Local(LocalVar::from(0u32)), Sort::Int),
-                (Var::Local(LocalVar::from(1u32)), Sort::Int),
+                QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int),
+                QualParam::new(Var::Local(LocalVar::from(1u32)), Sort::Int),
             ],
             body: Expr::Atom(
                 BinRel::Ge,
@@ -106,8 +106,8 @@ pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new
     let lt = Qualifier {
         name: String::from("Lt"),
         args: vec![
-            (Var::Local(LocalVar::from(0u32)), Sort::Int),
-            (Var::Local(LocalVar::from(1u32)), Sort::Int),
+            QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int),
+            QualParam::new(Var::Local(LocalVar::from(1u32)), Sort::Int),
         ],
         body: Expr::Atom(
             BinRel::Lt,
@@ -120,8 +120,8 @@ pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new
     let le = Qualifier {
         name: String::from("Le"),
         args: vec![
-            (Var::Local(LocalVar::from(0u32)), Sort::Int),
-            (Var::Local(LocalVar::from(1u32)), Sort::Int),
+            QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int),
+            QualParam::new(Var::Local(LocalVar::from(1u32)), Sort::Int),
         ],
         body: Expr::Atom(
             BinRel::Le,
@@ -134,8 +134,8 @@ pub(crate) static FIXPOINT_QUALIFIERS: LazyLock<[Qualifier; 13]> = LazyLock::new
     let le1 = Qualifier {
         name: String::from("Le1"),
         args: vec![
-            (Var::Local(LocalVar::from(0u32)), Sort::Int),
-            (Var::Local(LocalVar::from(1u32)), Sort::Int),
+            QualParam::new(Var::Local(LocalVar::from(0u32)), Sort::Int),
+            QualParam::new(Var::Local(LocalVar::from(1u32)), Sort::Int),
         ],
         body: Expr::Atom(
             BinRel::Le,

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -149,6 +149,7 @@ pub enum GenericParamKind<'fhir> {
 pub struct Qualifier<'fhir> {
     pub def_id: FluxLocalDefId,
     pub args: &'fhir [RefineParam<'fhir>],
+    pub wildcards: &'fhir [bool],
     pub expr: Expr<'fhir>,
     pub kind: QualifierKind,
 }
@@ -924,7 +925,6 @@ pub struct RefineParam<'fhir> {
     pub span: Span,
     pub sort: Sort<'fhir>,
     pub kind: ParamKind,
-    pub is_wildcard: bool,
     pub fhir_id: FhirId,
 }
 

--- a/crates/flux-middle/src/fhir.rs
+++ b/crates/flux-middle/src/fhir.rs
@@ -924,6 +924,7 @@ pub struct RefineParam<'fhir> {
     pub span: Span,
     pub sort: Sort<'fhir>,
     pub kind: ParamKind,
+    pub is_wildcard: bool,
     pub fhir_id: FhirId,
 }
 

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1447,6 +1447,7 @@ pub enum Ensures {
 pub struct Qualifier {
     pub def_id: FluxLocalDefId,
     pub body: Binder<Expr>,
+    pub wildcards: List<bool>,
     pub kind: QualifierKind,
 }
 

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -1385,7 +1385,7 @@ fn parse_refine_param(cx: &mut ParseCtxt, require_sort: RequireSort) -> ParseRes
 }
 
 /// ```text
-/// ⟨qualifier_param⟩ := ⟨mode⟩? ⟨ident⟩ #? : ⟨sort⟩
+/// ⟨qualifier_param⟩ := #? ⟨mode⟩? ⟨ident⟩ : ⟨sort⟩
 /// ```
 fn parse_qualifier_param(cx: &mut ParseCtxt) -> ParseResult<RefineParam> {
     parse_refine_param_inner(cx, RequireSort::Yes, AllowWildcard::Yes)
@@ -1397,14 +1397,11 @@ fn parse_refine_param_inner(
     allow_wildcard: AllowWildcard,
 ) -> ParseResult<RefineParam> {
     let lo = cx.lo();
+    // `#a: int` rather than fixpoint's `a#: int` because rustc lexes the attribute first and
+    // rejects `a#` as a reserved prefix.
+    let is_wildcard = matches!(allow_wildcard, AllowWildcard::Yes) && cx.advance_if(token::Pound);
     let mode = parse_opt_param_mode(cx);
     let ident = parse_ident(cx)?;
-    // `a #: int` rather than fixpoint's `a#: int` because rustc lexes the attribute first and
-    // rejects `a#` as a reserved prefix.
-    let is_wildcard = matches!(allow_wildcard, AllowWildcard::Yes) && cx.peek(token::Pound);
-    if is_wildcard {
-        cx.advance();
-    }
     let sort = parse_sort_if_required(cx, require_sort)?;
     let hi = cx.hi();
     Ok(RefineParam {

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -502,7 +502,7 @@ fn parse_qualifier_kind(cx: &mut ParseCtxt) -> ParseResult<QualifierKind> {
 
 /// ```text
 /// ⟨qualifier⟩ :=  ⟨ qualifier_kind ⟩?
-///                 qualifier ⟨ident⟩ ( ⟨refine_param⟩,* )
+///                 qualifier ⟨ident⟩ ( ⟨qualifier_param⟩,* )
 ///                 ⟨block⟩
 /// ```
 fn parse_qualifier(cx: &mut ParseCtxt) -> ParseResult<Qualifier> {
@@ -510,7 +510,7 @@ fn parse_qualifier(cx: &mut ParseCtxt) -> ParseResult<Qualifier> {
     let kind = parse_qualifier_kind(cx)?;
     cx.expect(kw::Qualifier)?;
     let mut name = parse_ident(cx)?;
-    let mut params = parens(cx, Comma, |cx| parse_refine_param(cx, RequireSort::Yes))?;
+    let mut params = parens(cx, Comma, parse_qualifier_param)?;
     let expr = parse_block(cx)?;
     let hi = cx.hi();
 
@@ -519,11 +519,14 @@ fn parse_qualifier(cx: &mut ParseCtxt) -> ParseResult<Qualifier> {
         for param in &params {
             fvars.remove(&param.ident);
         }
+        // Params synthesized from the body's free variables are bound to values in the enclosing
+        // function, so they are never wildcards.
         params.extend(fvars.into_iter().map(|ident| {
             RefineParam {
                 ident,
                 sort: Sort::Infer,
                 mode: None,
+                is_wildcard: false,
                 span: ident.span,
                 node_id: cx.next_node_id(),
             }
@@ -1367,18 +1370,51 @@ fn parse_sort_if_required(cx: &mut ParseCtxt, require_sort: RequireSort) -> Pars
     }
 }
 
+enum AllowWildcard {
+    Yes,
+    No,
+}
+
 /// ```text
 /// ⟨refine_param⟩ := ⟨mode⟩? ⟨ident⟩ ⟨ : ⟨sort⟩ ⟩?    if require_sort is Maybe
 ///                 | ⟨mode⟩? ⟨ident⟩ : ⟨sort⟩         if require_sort is Yes
 ///                 | ⟨mode⟩? ⟨ident⟩                  if require_sort is No
 /// ```
 fn parse_refine_param(cx: &mut ParseCtxt, require_sort: RequireSort) -> ParseResult<RefineParam> {
+    parse_refine_param_inner(cx, require_sort, AllowWildcard::No)
+}
+
+/// ```text
+/// ⟨qualifier_param⟩ := ⟨mode⟩? ⟨ident⟩ #? : ⟨sort⟩
+/// ```
+fn parse_qualifier_param(cx: &mut ParseCtxt) -> ParseResult<RefineParam> {
+    parse_refine_param_inner(cx, RequireSort::Yes, AllowWildcard::Yes)
+}
+
+fn parse_refine_param_inner(
+    cx: &mut ParseCtxt,
+    require_sort: RequireSort,
+    allow_wildcard: AllowWildcard,
+) -> ParseResult<RefineParam> {
     let lo = cx.lo();
     let mode = parse_opt_param_mode(cx);
     let ident = parse_ident(cx)?;
+    // `a #: int` rather than fixpoint's `a#: int` because rustc lexes the attribute first and
+    // rejects `a#` as a reserved prefix.
+    let is_wildcard = matches!(allow_wildcard, AllowWildcard::Yes) && cx.peek(token::Pound);
+    if is_wildcard {
+        cx.advance();
+    }
     let sort = parse_sort_if_required(cx, require_sort)?;
     let hi = cx.hi();
-    Ok(RefineParam { mode, ident, sort, span: cx.mk_span(lo, hi), node_id: cx.next_node_id() })
+    Ok(RefineParam {
+        mode,
+        ident,
+        sort,
+        is_wildcard,
+        span: cx.mk_span(lo, hi),
+        node_id: cx.next_node_id(),
+    })
 }
 
 /// ```text

--- a/crates/flux-syntax/src/parser/mod.rs
+++ b/crates/flux-syntax/src/parser/mod.rs
@@ -510,7 +510,10 @@ fn parse_qualifier(cx: &mut ParseCtxt) -> ParseResult<Qualifier> {
     let kind = parse_qualifier_kind(cx)?;
     cx.expect(kw::Qualifier)?;
     let mut name = parse_ident(cx)?;
-    let mut params = parens(cx, Comma, parse_qualifier_param)?;
+    let (mut params, mut wildcards): (RefineParams, Vec<bool>) =
+        parens(cx, Comma, parse_qualifier_param)?
+            .into_iter()
+            .unzip();
     let expr = parse_block(cx)?;
     let hi = cx.hi();
 
@@ -519,18 +522,18 @@ fn parse_qualifier(cx: &mut ParseCtxt) -> ParseResult<Qualifier> {
         for param in &params {
             fvars.remove(&param.ident);
         }
-        // Params synthesized from the body's free variables are bound to values in the enclosing
-        // function, so they are never wildcards.
         params.extend(fvars.into_iter().map(|ident| {
             RefineParam {
                 ident,
                 sort: Sort::Infer,
                 mode: None,
-                is_wildcard: false,
                 span: ident.span,
                 node_id: cx.next_node_id(),
             }
         }));
+        // Params synthesized from the body's free variables are bound to values in the enclosing
+        // function, so they are never wildcards.
+        wildcards.resize(params.len(), false);
 
         // Uniquify the name so hints don't collide with each other (qualifier names are
         // crate-global). The span alone is not enough: every expansion of a macro like
@@ -547,7 +550,8 @@ fn parse_qualifier(cx: &mut ParseCtxt) -> ParseResult<Qualifier> {
         name = Ident { name: Symbol::intern(&str), ..name };
     }
 
-    Ok(Qualifier { name, params, expr, span: cx.mk_span(lo, hi), kind })
+    debug_assert_eq!(params.len(), wildcards.len());
+    Ok(Qualifier { name, params, wildcards, expr, span: cx.mk_span(lo, hi), kind })
 }
 
 /// ```text
@@ -1370,48 +1374,30 @@ fn parse_sort_if_required(cx: &mut ParseCtxt, require_sort: RequireSort) -> Pars
     }
 }
 
-enum AllowWildcard {
-    Yes,
-    No,
-}
-
 /// ```text
 /// ⟨refine_param⟩ := ⟨mode⟩? ⟨ident⟩ ⟨ : ⟨sort⟩ ⟩?    if require_sort is Maybe
 ///                 | ⟨mode⟩? ⟨ident⟩ : ⟨sort⟩         if require_sort is Yes
 ///                 | ⟨mode⟩? ⟨ident⟩                  if require_sort is No
 /// ```
 fn parse_refine_param(cx: &mut ParseCtxt, require_sort: RequireSort) -> ParseResult<RefineParam> {
-    parse_refine_param_inner(cx, require_sort, AllowWildcard::No)
-}
-
-/// ```text
-/// ⟨qualifier_param⟩ := #? ⟨mode⟩? ⟨ident⟩ : ⟨sort⟩
-/// ```
-fn parse_qualifier_param(cx: &mut ParseCtxt) -> ParseResult<RefineParam> {
-    parse_refine_param_inner(cx, RequireSort::Yes, AllowWildcard::Yes)
-}
-
-fn parse_refine_param_inner(
-    cx: &mut ParseCtxt,
-    require_sort: RequireSort,
-    allow_wildcard: AllowWildcard,
-) -> ParseResult<RefineParam> {
     let lo = cx.lo();
-    // `#a: int` rather than fixpoint's `a#: int` because rustc lexes the attribute first and
-    // rejects `a#` as a reserved prefix.
-    let is_wildcard = matches!(allow_wildcard, AllowWildcard::Yes) && cx.advance_if(token::Pound);
     let mode = parse_opt_param_mode(cx);
     let ident = parse_ident(cx)?;
     let sort = parse_sort_if_required(cx, require_sort)?;
     let hi = cx.hi();
-    Ok(RefineParam {
-        mode,
-        ident,
-        sort,
-        is_wildcard,
-        span: cx.mk_span(lo, hi),
-        node_id: cx.next_node_id(),
-    })
+    Ok(RefineParam { mode, ident, sort, span: cx.mk_span(lo, hi), node_id: cx.next_node_id() })
+}
+
+/// ```text
+/// ⟨qualifier_param⟩ := #? ⟨refine_param⟩
+/// ```
+///
+/// `#a: int` rather than fixpoint's `a#: int` because rustc lexes the enclosing attribute first and
+/// rejects `a#` as a reserved prefix.
+fn parse_qualifier_param(cx: &mut ParseCtxt) -> ParseResult<(RefineParam, bool)> {
+    let is_wildcard = cx.advance_if(token::Pound);
+    let param = parse_refine_param(cx, RequireSort::Yes)?;
+    Ok((param, is_wildcard))
 }
 
 /// ```text

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -69,6 +69,7 @@ pub enum UseTreeKind {
 pub struct Qualifier {
     pub name: Ident,
     pub params: RefineParams,
+    pub wildcards: Vec<bool>,
     pub expr: Expr,
     pub span: Span,
     pub kind: QualifierKind,
@@ -292,7 +293,6 @@ pub struct RefineParam {
     pub ident: Ident,
     pub sort: Sort,
     pub mode: Option<ParamMode>,
-    pub is_wildcard: bool,
     pub span: Span,
     pub node_id: NodeId,
 }

--- a/crates/flux-syntax/src/surface.rs
+++ b/crates/flux-syntax/src/surface.rs
@@ -292,6 +292,7 @@ pub struct RefineParam {
     pub ident: Ident,
     pub sort: Sort,
     pub mode: Option<ParamMode>,
+    pub is_wildcard: bool,
     pub span: Span,
     pub node_id: NodeId,
 }

--- a/lib/liquid-fixpoint/src/constraint.rs
+++ b/lib/liquid-fixpoint/src/constraint.rs
@@ -955,8 +955,21 @@ pub enum Constant<T: Types> {
 #[derive_where(Debug, Clone, Hash)]
 pub struct Qualifier<T: Types> {
     pub name: String,
-    pub args: Vec<(T::Var, Sort<T>)>,
+    pub args: Vec<QualParam<T>>,
     pub body: Expr<T>,
+}
+
+#[derive_where(Debug, Clone, Hash)]
+pub struct QualParam<T: Types> {
+    pub name: T::Var,
+    pub sort: Sort<T>,
+    pub is_wildcard: bool,
+}
+
+impl<T: Types> QualParam<T> {
+    pub fn new(name: T::Var, sort: Sort<T>) -> Self {
+        Self { name, sort, is_wildcard: false }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]

--- a/lib/liquid-fixpoint/src/constraint_solving.rs
+++ b/lib/liquid-fixpoint/src/constraint_solving.rs
@@ -325,7 +325,7 @@ impl<T: Types> Pred<T> {
                                 .0
                                 .args
                                 .iter()
-                                .map(|arg| &arg.0)
+                                .map(|param| &param.name)
                                 .zip(qualifier.1.iter().map(|arg_idx| &args[*arg_idx]))
                                 .fold(qualifier.0.body.clone(), |acc, e| {
                                     acc.substitute_var(e.0, e.1)
@@ -347,7 +347,7 @@ impl<T: Types> Pred<T> {
                         .0
                         .args
                         .iter()
-                        .map(|arg| &arg.0)
+                        .map(|param| &param.name)
                         .zip(assignment.1.iter().map(|arg_idx| &args[*arg_idx]))
                         .fold(assignment.0.body.clone(), |acc, e| acc.substitute_var(e.0, e.1)),
                 )

--- a/lib/liquid-fixpoint/src/constraint_with_env.rs
+++ b/lib/liquid-fixpoint/src/constraint_with_env.rs
@@ -65,6 +65,11 @@ impl<T: Types> ConstraintWithEnv<T> {
             let kvar_arg_count = decl.sorts.len();
             assignments.insert(decl.kvid.clone(), vec![]);
             for qualifier in &self.qualifiers {
+                // TODO: assignments index into the kvar's arguments, so there's no way to name a
+                // literal here. Skip wildcards rather than silently treat them as ordinary params.
+                if qualifier.args.iter().any(|param| param.is_wildcard) {
+                    continue;
+                }
                 let qualifier_arg_count = qualifier.args.len();
                 for argument_combination in (0..kvar_arg_count).combinations(qualifier_arg_count) {
                     assignments.get_mut(&decl.kvid).unwrap().extend(
@@ -200,7 +205,7 @@ fn type_signature_matches<T: Types>(
         return false;
     }
 
-    for (qs, ks) in qualifier.args.iter().map(|arg| arg.1.clone()).zip(
+    for (qs, ks) in qualifier.args.iter().map(|param| param.sort.clone()).zip(
         argument_permutation
             .iter()
             .map(|arg_idx| kvar_decl.sorts[*arg_idx].clone()),

--- a/lib/liquid-fixpoint/src/format.rs
+++ b/lib/liquid-fixpoint/src/format.rs
@@ -403,8 +403,10 @@ impl<T: Types> fmt::Display for Qualifier<T> {
             f,
             "(qualif {} ({}) ({}))",
             self.name,
-            self.args.iter().format_with(" ", |(name, sort), f| {
-                f(&format_args!("({} {sort})", name.display()))
+            self.args.iter().format_with(" ", |param, f| {
+                // The `#` is signature syntax, not part of the variable's name.
+                let wildcard = if param.is_wildcard { "#" } else { "" };
+                f(&format_args!("({}{wildcard} {})", param.name.display(), param.sort))
             }),
             self.body
         )

--- a/lib/liquid-fixpoint/src/lib.rs
+++ b/lib/liquid-fixpoint/src/lib.rs
@@ -43,7 +43,7 @@ use std::{
 
 pub use constraint::{
     BinOp, BinRel, Bind, Constant, Constraint, DataCtor, DataDecl, DataField, Expr, FlatConstraint,
-    FunSort, Pred, Qualifier, Quantifier, Sort, SortCtor, SortDecl, WKVar,
+    FunSort, Pred, QualParam, Qualifier, Quantifier, Sort, SortCtor, SortDecl, WKVar,
 };
 use derive_where::derive_where;
 #[cfg(feature = "nightly")]
@@ -136,6 +136,7 @@ macro_rules! declare_types {
             pub type FunBody = $crate::FunBody<FixpointTypes>;
             pub type Task = $crate::Task<FixpointTypes>;
             pub type Qualifier = $crate::Qualifier<FixpointTypes>;
+            pub type QualParam = $crate::QualParam<FixpointTypes>;
             pub type Sort = $crate::Sort<FixpointTypes>;
             pub type SortCtor = $crate::SortCtor<FixpointTypes>;
             pub type SortDecl = $crate::SortDecl<FixpointTypes>;

--- a/tests/tests/neg/error_messages/desugar/wildcard_position00.rs
+++ b/tests/tests/neg/error_messages/desugar/wildcard_position00.rs
@@ -1,0 +1,6 @@
+// The `#` wildcard marker is only meaningful on a qualifier parameter, so it is a syntax error
+// anywhere else a refinement parameter can appear.
+
+#![flux::defs {
+    fn dbl(x #: int) -> int { x + x } //~ ERROR syntax error
+}]

--- a/tests/tests/neg/error_messages/desugar/wildcard_position00.rs
+++ b/tests/tests/neg/error_messages/desugar/wildcard_position00.rs
@@ -2,5 +2,5 @@
 // anywhere else a refinement parameter can appear.
 
 #![flux::defs {
-    fn dbl(x #: int) -> int { x + x } //~ ERROR syntax error
+    fn dbl(#x: int) -> int { x + x } //~ ERROR syntax error
 }]

--- a/tests/tests/neg/error_messages/wf/wildcard_sort00.rs
+++ b/tests/tests/neg/error_messages/wf/wildcard_sort00.rs
@@ -1,6 +1,6 @@
 #![flux::defs {
     // A wildcard is instantiated with literal constants, so it needs a sort that has them.
-    qualifier BadWild(x: int, a #: bool) { a => x > 0 } //~ ERROR wildcard parameter cannot have sort
+    qualifier BadWild(x: int, #a: bool) { a => x > 0 } //~ ERROR wildcard parameter cannot have sort
 }]
 
 #[flux::sig(fn(i32[@n]) -> i32[n])]

--- a/tests/tests/neg/error_messages/wf/wildcard_sort00.rs
+++ b/tests/tests/neg/error_messages/wf/wildcard_sort00.rs
@@ -1,0 +1,9 @@
+#![flux::defs {
+    // A wildcard is instantiated with literal constants, so it needs a sort that has them.
+    qualifier BadWild(x: int, a #: bool) { a => x > 0 } //~ ERROR wildcard parameter cannot have sort
+}]
+
+#[flux::sig(fn(i32[@n]) -> i32[n])]
+pub fn dummy(x: i32) -> i32 {
+    x
+}

--- a/tests/tests/pos/user_qualifiers/wildcard00.rs
+++ b/tests/tests/pos/user_qualifiers/wildcard00.rs
@@ -4,7 +4,7 @@
 // instantiated with it.
 
 #![flux::defs {
-    qualifier LeLit(x: int, a #: int) { x <= a }
+    qualifier LeLit(x: int, #a: int) { x <= a }
 }]
 
 #[flux::sig(fn() -> usize[10])]

--- a/tests/tests/pos/user_qualifiers/wildcard00.rs
+++ b/tests/tests/pos/user_qualifiers/wildcard00.rs
@@ -1,0 +1,17 @@
+// Test that a qualifier parameter marked as a wildcard with `#` is instantiated with the literal
+// constants appearing in the constraint. Proving the loop below exits with `i == 10` needs the
+// invariant `i <= 10`, which is specific to the literal `10`, so `LeLit` can only work if `a` is
+// instantiated with it.
+
+#![flux::defs {
+    qualifier LeLit(x: int, a #: int) { x <= a }
+}]
+
+#[flux::sig(fn() -> usize[10])]
+pub fn count_to_ten() -> usize {
+    let mut i = 0;
+    while i < 10 {
+        i += 1;
+    }
+    i
+}

--- a/tests/tests/with_deps/pos/surface/issue-1583.rs
+++ b/tests/tests/with_deps/pos/surface/issue-1583.rs
@@ -1,0 +1,17 @@
+// Proving `arr[i]` in bounds requires the invariant `end <= 10` on the range's `end` field, and
+// `10` appears only as a literal, so the qualifier must have its parameter `a` instantiated with
+// it. This does not verify without the `#` marker.
+#![allow(unused)]
+#![flux::defs {
+    qualifier LeLit(x: int, a #: int) { x <= a }
+}]
+
+extern crate flux_core;
+
+pub fn blah(arr: &[i32; 10]) -> i32 {
+    let mut tot = 0;
+    for i in 0..10 {
+        tot += arr[i];
+    }
+    tot
+}

--- a/tests/tests/with_deps/pos/surface/issue-1583.rs
+++ b/tests/tests/with_deps/pos/surface/issue-1583.rs
@@ -3,7 +3,7 @@
 // it. This does not verify without the `#` marker.
 #![allow(unused)]
 #![flux::defs {
-    qualifier LeLit(x: int, a #: int) { x <= a }
+    qualifier LeLit(x: int, #a: int) { x <= a }
 }]
 
 extern crate flux_core;


### PR DESCRIPTION
Resolves https://github.com/flux-rs/flux/issues/1583, using the wildcard-literals feature from ucsd-progsys/liquid-fixpoint#834.

Code example:
```rs
#![flux::defs {
    qualifier LeLit(x: int, a #: int) { x <= a }
}]

extern crate flux_core;

pub fn blah(arr: &[i32; 10]) -> i32 {
    let mut tot = 0;
    for i in 0..10 {
        tot += arr[i];
    }
    tot
}
```

## Summary
- A `is_wildcard` flag is propagated through the representation of every qualifier
- The flag rides `RefineParam` through surface and fhir, becomes a `List<bool>` mask alongside the Binder in `rty::Qualifier`
- Parser accepts `#` marker only in qualifier parameter position, the flag is eventually put back into a new `QualParam` struct in liquid-fixpoint