### PR TITLE
Implement auto strong returned references

### DIFF
--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -473,6 +473,20 @@ fn fold_local_ptrs(infcx: &mut InferCtxt, env: &mut TypeEnv, span: Span) -> Infe
     env.fold_local_ptrs(&mut at)
 }
 
+/// Auto-strong a `&mut T` returned by a call: instead of the invariant `&mut T`, which loses
+/// track of the value behind the reference, we hand back a pointer to a fresh local location
+/// holding `T`. Reads through the returned reference are then precise and writes are strong
+/// updates, which get checked against `T` when the pointer is folded back into a `&mut T` by
+/// [`fold_local_ptrs`] at the end of the block.
+fn unfold_returned_ref(infcx: &mut InferCtxt, env: &mut TypeEnv, ret: &Ty) -> InferResult<Ty> {
+    if let TyKind::Indexed(BaseTy::Ref(re, bound, Mutability::Mut), _) = ret.kind() {
+        let loc = env.unfold_local_ptr(infcx, bound)?;
+        Ok(Ty::ptr(PtrKind::Mut(*re), Path::from(loc)))
+    } else {
+        Ok(ret.clone())
+    }
+}
+
 fn promoted_fn_sig(ty: &Ty) -> PolyFnSig {
     let safety = rustc_hir::Safety::Safe;
     let abi = rustc_abi::ExternAbi::Rust;
@@ -758,6 +772,9 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
     ) -> Result<Vec<(BasicBlock, Guard)>> {
         let source_info = terminator.source_info;
         let terminator_span = source_info.span;
+        // A pointer to a returned reference (see [`unfold_returned_ref`]) is only kept strong
+        // within the block that created it, so that it never escapes into a join point.
+        fold_local_ptrs(infcx, env, terminator_span).with_span(terminator_span)?;
         match &terminator.kind {
             TerminatorKind::Return => {
                 self.check_ret(infcx, env, last_stmt_span.unwrap_or(terminator_span))?;
@@ -1021,7 +1038,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         fold_local_ptrs(infcx, env, span).with_span(span)?;
 
         Ok(ResolvedCall {
-            output: output.ret,
+            output: unfold_returned_ref(infcx, env, &output.ret).with_span(span)?,
             _early_args: early_refine_args
                 .into_iter()
                 .map(|arg| infcx.fully_resolve_evars(arg))

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -953,7 +953,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         let obligations = infcx
             .at(span)
             .ensure_resolved_evars(|infcx| {
-                let ret_place_ty = env.lookup_place(infcx, Place::RETURN)?;
+                let ret_place_ty = env.fold_if_unfolded(infcx, Place::RETURN)?;
                 let output = self
                     .fn_sig
                     .output

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -20,9 +20,9 @@ use flux_middle::{
     query_bug,
     rty::{
         self, AdtDef, AliasReft, BaseTy, BinOp, Binder, Bool, Clause, Constant,
-        CoroutineObligPredicate, EarlyBinder, Expr, FnOutput, FnSig, FnTraitPredicate, GenericArg,
-        GenericArgsExt as _, Int, IntTy, Mutability, Path, PolyFnSig, PtrKind, RefineArgs,
-        RefineArgsExt,
+        CoroutineObligPredicate, EarlyBinder, Expr, FIRST_VARIANT, FnOutput, FnSig,
+        FnTraitPredicate, GenericArg, GenericArgsExt as _, Int, IntTy, Mutability, Path, PolyFnSig,
+        PtrKind, RefineArgs, RefineArgsExt,
         Region::ReErased,
         Sort, SubsetTyCtor, Ty, TyKind, Uint, UintTy, VariantIdx,
         fold::{TypeFoldable, TypeFolder, TypeSuperFoldable},
@@ -66,7 +66,9 @@ use crate::{
     primops,
     queue::WorkQueue,
     rty::Char,
-    type_env::{BasicBlockEnv, BasicBlockEnvShape, PtrToRefBound, TypeEnv, TypeEnvTrace},
+    type_env::{
+        BasicBlockEnv, BasicBlockEnvShape, PtrToRefBound, TypeEnv, TypeEnvTrace, downcast_struct,
+    },
 };
 
 type Result<T = ()> = std::result::Result<T, CheckerError>;
@@ -473,18 +475,74 @@ fn fold_local_ptrs(infcx: &mut InferCtxt, env: &mut TypeEnv, span: Span) -> Infe
     env.fold_local_ptrs(&mut at)
 }
 
-/// Auto-strong a `&mut T` returned by a call: instead of the invariant `&mut T`, which loses
-/// track of the value behind the reference, we hand back a pointer to a fresh local location
-/// holding `T`. Reads through the returned reference are then precise and writes are strong
-/// updates, which get checked against `T` when the pointer is folded back into a `&mut T` by
-/// [`fold_local_ptrs`] at the end of the block.
-fn unfold_returned_ref(infcx: &mut InferCtxt, env: &mut TypeEnv, ret: &Ty) -> InferResult<Ty> {
-    if let TyKind::Indexed(BaseTy::Ref(re, bound, Mutability::Mut), _) = ret.kind() {
-        let loc = env.unfold_local_ptr(infcx, bound)?;
-        Ok(Ty::ptr(PtrKind::Mut(*re), Path::from(loc)))
-    } else {
-        Ok(ret.clone())
+/// Auto-strong the `&mut T`s in a value returned by a call: instead of the invariant `&mut T`,
+/// which loses track of the value behind the reference, we hand back a pointer to a fresh local
+/// location holding `T`. Reads through the returned reference are then precise and writes are
+/// strong updates, which get checked against `T` when the pointer is folded back into a `&mut T`
+/// by [`fold_local_ptrs`] at the end of the block.
+///
+/// References nested inside a returned tuple or struct get the same treatment, which for a struct
+/// means handing back the struct *unfolded*, i.e. a [`TyKind::Downcast`]. A struct with no nested
+/// `&mut` is handed back as is, so this doesn't force an unfold on every call returning a struct.
+fn unfold_returned_refs(
+    infcx: &mut InferCtxt,
+    env: &mut TypeEnv,
+    ret: &Ty,
+    span: Span,
+) -> InferResult<Ty> {
+    match ret.kind() {
+        TyKind::Indexed(BaseTy::Ref(re, bound, Mutability::Mut), _) => {
+            let loc = env.unfold_local_ptr(infcx, bound)?;
+            Ok(Ty::ptr(PtrKind::Mut(*re), Path::from(loc)))
+        }
+        TyKind::Indexed(BaseTy::Tuple(fields), idx) => {
+            match unfold_returned_refs_in_fields(infcx, env, fields, span)? {
+                Some(fields) => Ok(Ty::indexed(BaseTy::Tuple(fields), idx.clone())),
+                None => Ok(ret.clone()),
+            }
+        }
+        // Boxes are excluded because they have their own unfolding into a [`PtrKind::Box`], and
+        // the fields of an opaque struct cannot be accessed at all.
+        TyKind::Indexed(BaseTy::Adt(adt, args), idx)
+            if adt.is_struct() && !adt.is_opaque() && !adt.is_box() =>
+        {
+            // The unfold is speculative, so a struct whose fields we cannot compute is left alone
+            // instead of reporting the error here; accessing such a field reports it anyway.
+            let Ok(fields) = downcast_struct(infcx, adt, args, idx, span) else {
+                return Ok(ret.clone());
+            };
+            match unfold_returned_refs_in_fields(infcx, env, &fields, span)? {
+                Some(fields) => {
+                    Ok(Ty::downcast(
+                        adt.clone(),
+                        args.with_holes(),
+                        ret.clone(),
+                        FIRST_VARIANT,
+                        fields,
+                    ))
+                }
+                None => Ok(ret.clone()),
+            }
+        }
+        _ => Ok(ret.clone()),
     }
+}
+
+/// Unfolds the `&mut`s in each field, returning `None` if there was nothing to unfold.
+fn unfold_returned_refs_in_fields(
+    infcx: &mut InferCtxt,
+    env: &mut TypeEnv,
+    fields: &[Ty],
+    span: Span,
+) -> InferResult<Option<rty::List<Ty>>> {
+    let mut unfolded = Vec::with_capacity(fields.len());
+    let mut changed = false;
+    for field in fields {
+        let unfolded_field = unfold_returned_refs(infcx, env, field, span)?;
+        changed |= &unfolded_field != field;
+        unfolded.push(unfolded_field);
+    }
+    Ok(changed.then(|| unfolded.into()))
 }
 
 fn promoted_fn_sig(ty: &Ty) -> PolyFnSig {
@@ -772,7 +830,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
     ) -> Result<Vec<(BasicBlock, Guard)>> {
         let source_info = terminator.source_info;
         let terminator_span = source_info.span;
-        // A pointer to a returned reference (see [`unfold_returned_ref`]) is kept strong until
+        // A pointer to a returned reference (see [`unfold_returned_refs`]) is kept strong until
         // the end of the block that uses it; here is where it is folded back. Note that this
         // doesn't cover the edge out of the call that created it, see [`Checker::check_goto`].
         fold_local_ptrs(infcx, env, terminator_span).with_span(terminator_span)?;
@@ -855,6 +913,8 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 let name = destination.name(&self.body.local_names);
                 let ret = infcx.unpack_at_name(name, &ret);
                 infcx.assume_invariants(&ret);
+                let ret = unfold_returned_refs(infcx, env, &ret, terminator_span)
+                    .with_span(terminator_span)?;
 
                 env.assign(&mut infcx.at(terminator_span), destination, ret)
                     .with_span(terminator_span)?;
@@ -1039,7 +1099,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         fold_local_ptrs(infcx, env, span).with_span(span)?;
 
         Ok(ResolvedCall {
-            output: unfold_returned_ref(infcx, env, &output.ret).with_span(span)?,
+            output: output.ret,
             _early_args: early_refine_args
                 .into_iter()
                 .map(|arg| infcx.fully_resolve_evars(arg))
@@ -1310,7 +1370,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
     ) -> Result {
         let is_exit_block = self.is_exit_block(target);
         // A local pointer may cross the edge from a call into its successor block (see
-        // [`unfold_returned_ref`]), but it must not reach a join point or a return, where the
+        // [`unfold_returned_refs`]), but it must not reach a join point or a return, where the
         // location it points to would escape the block it was created in.
         if is_exit_block || self.body.is_join_point(target) {
             fold_local_ptrs(&mut infcx, &mut env, span).with_span(span)?;

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -772,8 +772,9 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
     ) -> Result<Vec<(BasicBlock, Guard)>> {
         let source_info = terminator.source_info;
         let terminator_span = source_info.span;
-        // A pointer to a returned reference (see [`unfold_returned_ref`]) is only kept strong
-        // within the block that created it, so that it never escapes into a join point.
+        // A pointer to a returned reference (see [`unfold_returned_ref`]) is kept strong until
+        // the end of the block that uses it; here is where it is folded back. Note that this
+        // doesn't cover the edge out of the call that created it, see [`Checker::check_goto`].
         fold_local_ptrs(infcx, env, terminator_span).with_span(terminator_span)?;
         match &terminator.kind {
             TerminatorKind::Return => {
@@ -1307,7 +1308,14 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         span: Span,
         target: BasicBlock,
     ) -> Result {
-        if self.is_exit_block(target) {
+        let is_exit_block = self.is_exit_block(target);
+        // A local pointer may cross the edge from a call into its successor block (see
+        // [`unfold_returned_ref`]), but it must not reach a join point or a return, where the
+        // location it points to would escape the block it was created in.
+        if is_exit_block || self.body.is_join_point(target) {
+            fold_local_ptrs(&mut infcx, &mut env, span).with_span(span)?;
+        }
+        if is_exit_block {
             // We inline *exit basic blocks* (i.e., that just return) because this typically
             // gives us better a better error span.
             let mut location = Location { block: target, statement_index: 0 };

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -231,14 +231,11 @@ impl<'a> TypeEnv<'a> {
     }
 
     pub(crate) fn fold_local_ptrs(&mut self, infcx: &mut InferCtxtAt) -> InferResult {
-        for (loc, bound) in self.bindings.local_ptrs() {
-            self.bindings.ptrs_to_refs(&loc, &bound);
-            let ty = self
-                .bindings
-                .lookup(&Path::from(loc), infcx.span)
-                .fold(infcx)?;
-            infcx.subtyping(&ty, &bound, ConstrReason::FoldLocal)?;
-            self.bindings.remove_local(&loc);
+        for loc in self.bindings.local_ptrs() {
+            // Folding a location may fold a pointer stored in it, so one we collected may be gone
+            // by the time we get to it.
+            let Some(bound) = self.bindings.local_ptr_bound(&loc) else { continue };
+            self.bindings.fold_local_ptr(infcx, &loc, &bound)?;
         }
         Ok(())
     }

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -230,7 +230,12 @@ impl<'a> TypeEnv<'a> {
     }
 
     pub(crate) fn fold_local_ptrs(&mut self, infcx: &mut InferCtxtAt) -> InferResult {
-        for (loc, bound, ty) in self.bindings.local_ptrs() {
+        for (loc, bound) in self.bindings.local_ptrs() {
+            self.bindings.ptrs_to_refs(&loc, &bound);
+            let ty = self
+                .bindings
+                .lookup(&Path::from(loc), infcx.span)
+                .fold(infcx)?;
             infcx.subtyping(&ty, &bound, ConstrReason::FoldLocal)?;
             self.bindings.remove_local(&loc);
         }

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -218,6 +218,17 @@ impl<'a> TypeEnv<'a> {
         // ℓ: t1
         let t1 = self.bindings.lookup(path, infcx.span).fold(infcx)?;
 
+        // The reference takes over from the pointer, so for a local pointer location this is where
+        // the strong window closes: the bound recorded for it is checked here, and the location is
+        // no longer one [`TypeEnv::fold_local_ptrs`] folds back. Without this, folding it back at
+        // the end of the block would find it blocked.
+        if path.projection().is_empty()
+            && let Some(local_bound) = self.bindings.local_ptr_bound(&path.loc)
+        {
+            infcx.subtyping(&t1, &local_bound, ConstrReason::FoldLocal)?;
+            self.bindings.demote_local_ptr(&path.loc);
+        }
+
         // t1 <: t2
         let t2 = match bound {
             PtrToRefBound::Ty(t2) => {

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -120,6 +120,20 @@ impl<'a> TypeEnv<'a> {
         Ok(result.ty)
     }
 
+    /// Folds `place` if it holds a struct left unfolded by `unfold_returned_refs`. Reading such a
+    /// struct as a whole has to fold it, because the fold/unfold analysis runs on the mir and so
+    /// doesn't know it was unfolded, i.e. it never inserts a ghost statement to fold it back.
+    pub(crate) fn fold_if_unfolded(
+        &mut self,
+        infcx: &mut InferCtxtAt,
+        place: &Place,
+    ) -> InferResult<Ty> {
+        let span = infcx.span;
+        self.bindings
+            .lookup_unfolding(infcx, place, span)?
+            .fold_if_unfolded(infcx)
+    }
+
     pub(crate) fn get(&self, path: &Path) -> Ty {
         self.bindings.get(path)
     }
@@ -271,6 +285,7 @@ impl<'a> TypeEnv<'a> {
 
     pub(crate) fn move_place(&mut self, infcx: &mut InferCtxtAt, place: &Place) -> InferResult<Ty> {
         let span = infcx.span;
+        self.fold_if_unfolded(infcx, place)?;
         let result = self.bindings.lookup_unfolding(infcx, place, span)?;
         if result.is_strg {
             let uninit = Ty::uninit();

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -40,6 +40,7 @@ use rustc_span::{Span, Symbol};
 use rustc_type_ir::BoundVar;
 use serde::Serialize;
 
+pub(crate) use self::place_ty::downcast_struct;
 use self::place_ty::{LocKind, PlacesTree};
 use super::rty::Sort;
 

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -7,7 +7,6 @@ use flux_infer::{
 };
 use flux_middle::{
     global_env::GlobalEnv,
-    queries::QueryResult,
     rty::{
         AdtDef, BaseTy, Binder, EarlyBinder, Expr, FIRST_VARIANT, GenericArg, GenericArgsExt, List,
         Loc, Mutability, Path, PtrKind, Ref, Sort, Ty, TyKind, VariantIdx, VariantSig,
@@ -314,18 +313,38 @@ impl PlacesTree {
         }
     }
 
-    /// The local pointer locations, together with the type each is bounded by.
-    pub(crate) fn local_ptrs(&self) -> Vec<(Loc, Ty)> {
+    /// The local pointer locations.
+    pub(crate) fn local_ptrs(&self) -> Vec<Loc> {
         self.map
             .iter()
             .filter_map(|(loc, binding)| {
-                if let LocKind::LocalPtr(bound) = &binding.kind {
-                    Some((*loc, bound.clone()))
-                } else {
-                    None
-                }
+                matches!(binding.kind, LocKind::LocalPtr(_)).then_some(*loc)
             })
             .collect()
+    }
+
+    /// The type `loc` is bounded by, if it is a local pointer location that is still around.
+    pub(crate) fn local_ptr_bound(&self, loc: &Loc) -> Option<Ty> {
+        match &self.map.get(loc)?.kind {
+            LocKind::LocalPtr(bound) => Some(bound.clone()),
+            _ => None,
+        }
+    }
+
+    /// Reverts the unfolding of a local pointer location: every live pointer into `loc` becomes
+    /// the mutable reference it stands for, the type currently at `loc` is checked against the
+    /// `bound` recorded for it, and the location is removed.
+    pub(crate) fn fold_local_ptr(
+        &mut self,
+        infcx: &mut InferCtxtAt,
+        loc: &Loc,
+        bound: &Ty,
+    ) -> InferResult {
+        self.ptrs_to_refs(loc, bound);
+        let ty = self.lookup(&Path::from(*loc), infcx.span).fold(infcx)?;
+        infcx.subtyping(&ty, bound, ConstrReason::FoldLocal)?;
+        self.remove_local(loc);
+        Ok(())
     }
 
     fn remove(&mut self, loc: &Loc) -> Binding {
@@ -415,7 +434,7 @@ impl LookupResult<'_> {
         self.update(Ty::blocked(new_ty))
     }
 
-    pub(crate) fn fold(self, infcx: &mut InferCtxtAt) -> QueryResult<Ty> {
+    pub(crate) fn fold(self, infcx: &mut InferCtxtAt) -> InferResult<Ty> {
         let ty = fold(self.bindings, infcx, &self.ty, self.is_strg)?;
         self.update(ty.clone());
         Ok(ty)
@@ -911,8 +930,24 @@ fn fold(
     infcx: &mut InferCtxtAt,
     ty: &Ty,
     is_strg: bool,
-) -> QueryResult<Ty> {
+) -> InferResult<Ty> {
     match ty.kind() {
+        // A pointer to a local pointer location is folded back into the reference it stands for.
+        // `TypeEnv::fold_local_ptrs` does this at the end of a block, but a pointer nested inside
+        // a struct or tuple can be reached before that, by a fold of the value holding it, and a
+        // folded type must not mention the location.
+        TyKind::Ptr(PtrKind::Mut(re), path) => {
+            let Some(bound) = bindings.local_ptr_bound(&path.loc) else {
+                return Ok(ty.clone());
+            };
+            // Same type [`PlacesTree::ptrs_to_refs`] gives the other pointers into the location:
+            // the bound for a pointer to the location itself, the current type of the field for a
+            // pointer into one.
+            let pointee =
+                if path.projection().is_empty() { bound.clone() } else { bindings.get(path) };
+            bindings.fold_local_ptr(infcx, &path.loc, &bound)?;
+            Ok(Ty::mk_ref(*re, pointee, Mutability::Mut))
+        }
         TyKind::Ptr(PtrKind::Box, path) => {
             let loc = path.to_loc().unwrap_or_else(|| tracked_span_bug!());
             let binding = bindings.remove(&loc);

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -331,6 +331,12 @@ impl PlacesTree {
         }
     }
 
+    /// Stops treating `loc` as a local pointer location, i.e. as one [`PlacesTree::fold_local_ptr`]
+    /// still has to fold back.
+    pub(crate) fn demote_local_ptr(&mut self, loc: &Loc) {
+        self.get_loc_mut(loc).kind = LocKind::Local;
+    }
+
     /// Reverts the unfolding of a local pointer location: every live pointer into `loc` becomes
     /// the mutable reference it stands for, the type currently at `loc` is checked against the
     /// `bound` recorded for it, and the location is removed.
@@ -341,6 +347,12 @@ impl PlacesTree {
         bound: &Ty,
     ) -> InferResult {
         self.ptrs_to_refs(loc, bound);
+        // A reference handed out into the location, e.g. by an unsize coercion of a pointer to one
+        // of its fields, blocks the place it points to. Folding the location back ends the strong
+        // window, and with it any such borrow.
+        let unblocked = self.get_loc(loc).ty.fold_with(&mut Unblock);
+        self.get_loc_mut(loc).ty = unblocked;
+
         let ty = self.lookup(&Path::from(*loc), infcx.span).fold(infcx)?;
         infcx.subtyping(&ty, bound, ConstrReason::FoldLocal)?;
         self.remove_local(loc);
@@ -398,6 +410,18 @@ impl PlacesTree {
 
     fn cursor_for(&self, key: &impl LookupKey) -> Cursor {
         Cursor::new(key)
+    }
+}
+
+/// Unblocks every blocked type inside. See [`PlacesTree::fold_local_ptr`].
+struct Unblock;
+
+impl TypeFolder for Unblock {
+    fn fold_ty(&mut self, ty: &Ty) -> Ty {
+        match ty.kind() {
+            TyKind::Blocked(ty) => ty.fold_with(self),
+            _ => ty.super_fold_with(self),
+        }
     }
 }
 

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -844,7 +844,7 @@ fn downcast(
 /// the `downcast` returns a vector of `ty` for each `fld` of `x` where
 ///     * `x.fld : T[A := t ..][i := e...]`
 /// i.e. by substituting the type and value indices using the types and values from `x`.
-fn downcast_struct(
+pub(crate) fn downcast_struct(
     infcx: &mut InferCtxt,
     adt: &AdtDef,
     args: &[GenericArg],

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -11,12 +11,15 @@ use flux_middle::{
     rty::{
         AdtDef, BaseTy, Binder, EarlyBinder, Expr, FIRST_VARIANT, GenericArg, GenericArgsExt, List,
         Loc, Mutability, Path, PtrKind, Ref, Sort, Ty, TyKind, VariantIdx, VariantSig,
-        fold::{FallibleTypeFolder, TypeFoldable, TypeVisitable, TypeVisitor},
+        fold::{
+            FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitable,
+            TypeVisitor,
+        },
     },
 };
 use flux_rustc_bridge::mir::{FieldIdx, Place, PlaceElem};
 use itertools::Itertools;
-use rustc_data_structures::fx::FxIndexMap;
+use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
 use rustc_hir::def_id::DefId;
 use rustc_span::Span;
 #[derive(Clone, Default)]
@@ -292,12 +295,32 @@ impl PlacesTree {
         self.map.shift_remove(loc);
     }
 
-    pub(crate) fn local_ptrs(&self) -> Vec<(Loc, Ty, Ty)> {
+    /// Reverts every pointer into `loc` that is still live back into the mutable reference it
+    /// stands for. A pointer to the root of the location gets `bound`, the type the location is
+    /// about to be folded against; a pointer into a field keeps the field's current type.
+    pub(crate) fn ptrs_to_refs(&mut self, loc: &Loc, bound: &Ty) {
+        let mut pointees = FxHashMap::default();
+        self.iter_flatten(|_, _, ty| {
+            if let TyKind::Ptr(PtrKind::Mut(_), path) = ty.kind()
+                && path.loc == *loc
+            {
+                let pointee =
+                    if path.projection().is_empty() { bound.clone() } else { self.get(path) };
+                pointees.insert(path.clone(), pointee);
+            }
+        });
+        if !pointees.is_empty() {
+            self.fmap_mut(|_, ty| ty.fold_with(&mut PtrsToRefs(&pointees)));
+        }
+    }
+
+    /// The local pointer locations, together with the type each is bounded by.
+    pub(crate) fn local_ptrs(&self) -> Vec<(Loc, Ty)> {
         self.map
             .iter()
             .filter_map(|(loc, binding)| {
                 if let LocKind::LocalPtr(bound) = &binding.kind {
-                    Some((*loc, bound.clone(), binding.ty.clone()))
+                    Some((*loc, bound.clone()))
                 } else {
                     None
                 }
@@ -356,6 +379,22 @@ impl PlacesTree {
 
     fn cursor_for(&self, key: &impl LookupKey) -> Cursor {
         Cursor::new(key)
+    }
+}
+
+/// Replaces each pointer to a path in the given map by a mutable reference to the type the path
+/// is mapped to. See [`PlacesTree::ptrs_to_refs`].
+struct PtrsToRefs<'a>(&'a FxHashMap<Path, Ty>);
+
+impl TypeFolder for PtrsToRefs<'_> {
+    fn fold_ty(&mut self, ty: &Ty) -> Ty {
+        if let TyKind::Ptr(PtrKind::Mut(re), path) = ty.kind()
+            && let Some(pointee) = self.0.get(path)
+        {
+            Ty::mk_ref(*re, pointee.clone(), Mutability::Mut)
+        } else {
+            ty.super_fold_with(self)
+        }
     }
 }
 

--- a/crates/flux-refineck/src/type_env/place_ty.rs
+++ b/crates/flux-refineck/src/type_env/place_ty.rs
@@ -440,6 +440,18 @@ impl LookupResult<'_> {
         Ok(ty)
     }
 
+    /// Folds the value if it is currently unfolded. The fold/unfold analysis inserts a ghost
+    /// statement to fold a place before it is used as a whole, but it runs on the mir, so it
+    /// knows nothing about a struct unfolded by `unfold_returned_refs`; reading one has to fold
+    /// it here.
+    pub(crate) fn fold_if_unfolded(self, infcx: &mut InferCtxtAt) -> InferResult<Ty> {
+        if self.is_strg && matches!(self.ty.kind(), TyKind::Downcast(..)) {
+            self.fold(infcx)
+        } else {
+            Ok(self.ty)
+        }
+    }
+
     pub(crate) fn path(&self) -> Path {
         self.cursor.to_path()
     }

--- a/tests/tests/neg/surface/auto_strong_ret00.rs
+++ b/tests/tests/neg/surface/auto_strong_ret00.rs
@@ -1,0 +1,15 @@
+/// Test that writes through a `&mut` returned by a call are still checked against the type of
+/// the reference when the auto-strong pointer is folded back,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> &mut usize{v: v >= 10})]
+pub fn returns_a_mut(x: &mut usize) -> &mut usize {
+    x
+}
+
+#[flux::sig(fn () -> usize{v: v >= 10})]
+pub fn client() -> usize {
+    let mut blah = 10;
+    let tmp = returns_a_mut(&mut blah);
+    *tmp = 5;
+    blah
+} //~ ERROR type invariant may not hold

--- a/tests/tests/neg/surface/auto_strong_ret01.rs
+++ b/tests/tests/neg/surface/auto_strong_ret01.rs
@@ -1,0 +1,23 @@
+/// Test that a write through a `&mut` into a *field* of a `&mut` returned by a call is still
+/// checked when the auto-strong pointer is folded back,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+
+#[flux::refined_by(fst: int, snd: int)]
+pub struct Pair {
+    #[flux::field(usize[fst])]
+    pub fst: usize,
+    #[flux::field(usize[snd])]
+    pub snd: usize,
+}
+
+#[flux::sig(fn (p: &mut Pair{v: v.fst >= 10}) -> &mut Pair{v: v.fst >= 10})]
+pub fn returns_a_mut(p: &mut Pair) -> &mut Pair {
+    p
+}
+
+pub fn client() {
+    let mut pair = Pair { fst: 10, snd: 0 };
+    let p = returns_a_mut(&mut pair);
+    let fst = &mut p.fst;
+    *fst = 5;
+} //~ ERROR type invariant may not hold

--- a/tests/tests/neg/surface/auto_strong_ret02.rs
+++ b/tests/tests/neg/surface/auto_strong_ret02.rs
@@ -1,0 +1,30 @@
+/// Test that writes through a `&mut` nested inside a struct or tuple returned by a call are still
+/// checked when the auto-strong pointer is folded back,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+
+pub struct Wrapper<'a> {
+    #[flux::field(&mut usize{v: v >= 10})]
+    pub inner: &'a mut usize,
+}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> Wrapper)]
+pub fn wrap(x: &mut usize) -> Wrapper<'_> {
+    Wrapper { inner: x }
+}
+
+pub fn struct_client() {
+    let mut blah = 10;
+    let w = wrap(&mut blah);
+    *w.inner = 5;
+} //~ ERROR type invariant may not hold
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> (&mut usize{v: v >= 10}, usize[0]))]
+pub fn tag(x: &mut usize) -> (&mut usize, usize) {
+    (x, 0)
+}
+
+pub fn tuple_client() {
+    let mut blah = 10;
+    let (r, _n) = tag(&mut blah);
+    *r = 5;
+} //~ ERROR type invariant may not hold

--- a/tests/tests/neg/surface/auto_strong_ret03.rs
+++ b/tests/tests/neg/surface/auto_strong_ret03.rs
@@ -1,0 +1,32 @@
+/// Test that a write through a `&mut` nested inside a struct returned by a call is checked when
+/// the struct is folded before the end of the block,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+
+pub struct Wrapper<'a> {
+    #[flux::field(&mut usize{v: v >= 10})]
+    pub inner: &'a mut usize,
+}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> Wrapper)]
+pub fn wrap(x: &mut usize) -> Wrapper<'_> {
+    Wrapper { inner: x }
+}
+
+pub trait Sink {
+    fn put(&mut self);
+}
+
+impl Sink for Wrapper<'_> {
+    fn put(&mut self) {
+        *self.inner = 20;
+    }
+}
+
+pub fn erase(_s: &mut dyn Sink) {}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}))]
+pub fn borrowed_and_coerced(x: &mut usize) {
+    let mut w = wrap(x);
+    *w.inner = 5;
+    erase(&mut w); //~ ERROR type invariant may not hold
+}

--- a/tests/tests/neg/surface/auto_strong_ret04.rs
+++ b/tests/tests/neg/surface/auto_strong_ret04.rs
@@ -1,0 +1,28 @@
+/// Test that folding an auto-stronged struct back to use it as a whole checks the writes made
+/// through its fields, see issue https://github.com/flux-rs/flux/issues/1714
+
+pub struct Wrapper<'a> {
+    #[flux::field(&mut usize{v: v >= 10})]
+    pub inner: &'a mut usize,
+}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> Wrapper)]
+pub fn wrap(x: &mut usize) -> Wrapper<'_> {
+    Wrapper { inner: x }
+}
+
+pub fn take(_w: Wrapper) {}
+
+pub fn passed_by_value() {
+    let mut blah = 10;
+    let w = wrap(&mut blah);
+    *w.inner = 5;
+    take(w); //~ ERROR type invariant may not hold
+}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> Wrapper)]
+pub fn returned(x: &mut usize) -> Wrapper<'_> {
+    let w = wrap(x);
+    *w.inner = 5;
+    w //~ ERROR type invariant may not hold
+}

--- a/tests/tests/neg/surface/auto_strong_ret05.rs
+++ b/tests/tests/neg/surface/auto_strong_ret05.rs
@@ -1,0 +1,49 @@
+/// Test that a write through a `&mut` returned by a call is checked against the returned type
+/// when the pointer is turned into a reference by an unsize coercion,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+
+pub trait Sink {
+    fn put(&mut self);
+}
+
+#[flux::refined_by(n: int)]
+pub struct W {
+    #[flux::field(usize[n])]
+    pub n: usize,
+}
+
+impl Sink for W {
+    fn put(&mut self) {}
+}
+
+#[flux::trusted]
+#[flux::sig(fn () -> &mut W{v: v.n >= 10})]
+pub fn get() -> &'static mut W {
+    unimplemented!()
+}
+
+pub fn erase(_s: &mut dyn Sink) {}
+
+pub fn written_then_coerced() {
+    let w = get();
+    w.n = 0;
+    erase(w); //~ ERROR type invariant may not hold
+}
+
+#[flux::refined_by(fst: int)]
+pub struct Pair {
+    #[flux::field(W[fst])]
+    pub fst: W,
+}
+
+#[flux::trusted]
+#[flux::sig(fn () -> &mut Pair{v: v.fst >= 10})]
+pub fn get_pair() -> &'static mut Pair {
+    unimplemented!()
+}
+
+pub fn field_written_then_coerced() {
+    let p = get_pair();
+    p.fst.n = 0;
+    erase(&mut p.fst); //~ ERROR type invariant may not hold
+}

--- a/tests/tests/pos/surface/auto_strong_ret00.rs
+++ b/tests/tests/pos/surface/auto_strong_ret00.rs
@@ -1,0 +1,41 @@
+/// Test that a `&mut` returned by a call is automatically treated as a strong reference,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+
+#[flux::sig(fn(x: bool[true]))]
+pub fn assert(_x: bool) {}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> &mut usize{v: v >= 10})]
+pub fn returns_a_mut(x: &mut usize) -> &mut usize {
+    x
+}
+
+pub fn reads_are_equal() {
+    let mut blah = 10;
+    let tmp = returns_a_mut(&mut blah);
+    let a = *tmp;
+    let b = *tmp;
+    assert(a == b)
+}
+
+pub fn read_after_write() {
+    let mut blah = 10;
+    let tmp = returns_a_mut(&mut blah);
+    *tmp = 20;
+    assert(*tmp == 20)
+}
+
+pub fn write_in_branch(b: bool) {
+    let mut blah = 10;
+    let tmp = returns_a_mut(&mut blah);
+    if b {
+        *tmp = 20;
+    }
+    assert(*tmp >= 10)
+}
+
+/// The pointer is folded back before it reaches the join point where both calls meet.
+pub fn call_in_branch(b: bool) {
+    let mut blah = 10;
+    let tmp = if b { returns_a_mut(&mut blah) } else { returns_a_mut(&mut blah) };
+    assert(*tmp >= 10)
+}

--- a/tests/tests/pos/surface/auto_strong_ret01.rs
+++ b/tests/tests/pos/surface/auto_strong_ret01.rs
@@ -1,0 +1,36 @@
+/// Test that a `&mut` into a *field* of a `&mut` returned by a call is strong too, i.e. that
+/// pointers with a non-empty projection into the auto-strong location are precise,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+
+#[flux::sig(fn(x: bool[true]))]
+pub fn assert(_x: bool) {}
+
+#[flux::refined_by(fst: int, snd: int)]
+pub struct Pair {
+    #[flux::field(usize[fst])]
+    pub fst: usize,
+    #[flux::field(usize[snd])]
+    pub snd: usize,
+}
+
+#[flux::sig(fn (p: &mut Pair{v: v.fst >= 10}) -> &mut Pair{v: v.fst >= 10})]
+pub fn returns_a_mut(p: &mut Pair) -> &mut Pair {
+    p
+}
+
+pub fn field_reads_are_equal() {
+    let mut pair = Pair { fst: 10, snd: 0 };
+    let p = returns_a_mut(&mut pair);
+    let fst = &mut p.fst;
+    let a = *fst;
+    let b = *fst;
+    assert(a == b)
+}
+
+pub fn field_read_after_write() {
+    let mut pair = Pair { fst: 10, snd: 0 };
+    let p = returns_a_mut(&mut pair);
+    let fst = &mut p.fst;
+    *fst = 20;
+    assert(*fst == 20)
+}

--- a/tests/tests/pos/surface/auto_strong_ret02.rs
+++ b/tests/tests/pos/surface/auto_strong_ret02.rs
@@ -1,0 +1,42 @@
+/// Test that a `&mut` nested inside a struct or tuple returned by a call is auto-stronged too,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+
+#[flux::sig(fn(x: bool[true]))]
+pub fn assert(_x: bool) {}
+
+pub struct Wrapper<'a> {
+    #[flux::field(&mut usize{v: v >= 10})]
+    pub inner: &'a mut usize,
+}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> Wrapper)]
+pub fn wrap(x: &mut usize) -> Wrapper<'_> {
+    Wrapper { inner: x }
+}
+
+pub fn struct_field_reads_are_equal() {
+    let mut blah = 10;
+    let w = wrap(&mut blah);
+    let a = *w.inner;
+    let b = *w.inner;
+    assert(a == b)
+}
+
+pub fn struct_field_read_after_write() {
+    let mut blah = 10;
+    let w = wrap(&mut blah);
+    *w.inner = 20;
+    assert(*w.inner == 20)
+}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> (&mut usize{v: v >= 10}, usize[0]))]
+pub fn tag(x: &mut usize) -> (&mut usize, usize) {
+    (x, 0)
+}
+
+pub fn tuple_field_read_after_write() {
+    let mut blah = 10;
+    let (r, _n) = tag(&mut blah);
+    *r = 20;
+    assert(*r == 20)
+}

--- a/tests/tests/pos/surface/auto_strong_ret03.rs
+++ b/tests/tests/pos/surface/auto_strong_ret03.rs
@@ -1,0 +1,32 @@
+/// Test that a `&mut` nested inside a struct returned by a call is folded back when the struct
+/// itself is folded, before the end of the block,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+
+pub struct Wrapper<'a> {
+    #[flux::field(&mut usize{v: v >= 10})]
+    pub inner: &'a mut usize,
+}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> Wrapper)]
+pub fn wrap(x: &mut usize) -> Wrapper<'_> {
+    Wrapper { inner: x }
+}
+
+pub trait Sink {
+    fn put(&mut self);
+}
+
+impl Sink for Wrapper<'_> {
+    fn put(&mut self) {
+        *self.inner = 20;
+    }
+}
+
+pub fn erase(_s: &mut dyn Sink) {}
+
+/// The unsize coercion is a statement, so it folds the struct while the pointer to the nested
+/// `&mut` is still around.
+#[flux::sig(fn (x: &mut usize{v: v >= 10}))]
+pub fn borrowed_and_coerced(x: &mut usize) {
+    erase(&mut wrap(x));
+}

--- a/tests/tests/pos/surface/auto_strong_ret04.rs
+++ b/tests/tests/pos/surface/auto_strong_ret04.rs
@@ -1,0 +1,33 @@
+/// Test that a struct auto-stronged by a call (see auto_strong_ret02.rs) can still be used as a
+/// whole, i.e. that it is folded back before it is moved or returned,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+
+pub struct Wrapper<'a> {
+    #[flux::field(&mut usize{v: v >= 10})]
+    pub inner: &'a mut usize,
+}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> Wrapper)]
+pub fn wrap(x: &mut usize) -> Wrapper<'_> {
+    Wrapper { inner: x }
+}
+
+pub fn take(_w: Wrapper) {}
+
+pub fn passed_by_value() {
+    let mut blah = 10;
+    let w = wrap(&mut blah);
+    take(w);
+}
+
+pub fn moved_then_passed_by_value() {
+    let mut blah = 10;
+    let w = wrap(&mut blah);
+    let v = w;
+    take(v);
+}
+
+#[flux::sig(fn (x: &mut usize{v: v >= 10}) -> Wrapper)]
+pub fn returned(x: &mut usize) -> Wrapper<'_> {
+    wrap(x)
+}

--- a/tests/tests/pos/surface/auto_strong_ret05.rs
+++ b/tests/tests/pos/surface/auto_strong_ret05.rs
@@ -1,0 +1,61 @@
+/// Test that a `&mut` returned by a call can be turned into a reference before the end of the
+/// block, e.g. by an unsize coercion, and still be used afterwards,
+/// see issue https://github.com/flux-rs/flux/issues/1714
+
+pub trait Sink {
+    fn put(&mut self);
+}
+
+#[flux::refined_by(n: int)]
+pub struct W {
+    #[flux::field(usize[n])]
+    pub n: usize,
+}
+
+impl Sink for W {
+    fn put(&mut self) {}
+}
+
+#[flux::trusted]
+#[flux::sig(fn () -> &mut W{v: v.n >= 10})]
+pub fn get() -> &'static mut W {
+    unimplemented!()
+}
+
+pub fn erase(_s: &mut dyn Sink) {}
+
+pub fn coerced() {
+    let w = get();
+    erase(w);
+}
+
+pub fn coerced_then_used() {
+    let w = get();
+    erase(w);
+    w.n += 1;
+}
+
+pub fn written_then_coerced() {
+    let w = get();
+    w.n = 20;
+    erase(w);
+}
+
+#[flux::refined_by(fst: int)]
+pub struct Pair {
+    #[flux::field(W[fst])]
+    pub fst: W,
+}
+
+#[flux::trusted]
+#[flux::sig(fn () -> &mut Pair{v: v.fst >= 10})]
+pub fn get_pair() -> &'static mut Pair {
+    unimplemented!()
+}
+
+/// A pointer into a *field* of the returned `&mut`, coerced. Only the field is blocked, so the
+/// location is still folded back at the end of the block.
+pub fn field_coerced() {
+    let p = get_pair();
+    erase(&mut p.fst);
+}


### PR DESCRIPTION
Closes https://github.com/flux-rs/flux/issues/1714
```rs
#[flux::sig(fn(x: bool[true]))]
fn assert(_x: bool) {}

#[flux::sig(fn(x: &mut usize{v: v >= 10}) -> &mut usize{v: v >= 10})]
fn returns_a_mut(x: &mut usize) -> &mut usize {
    x
}

fn reads_agree() {
    let mut blah = 10;
    let tmp = returns_a_mut(&mut blah);
    let a = *tmp;
    let b = *tmp;
    assert(a == b) // now succeeds: before, `a` and `b` were unrelated values,
                   // each only known to satisfy `{v: v >= 10}`
}

fn read_after_write() {
    let mut blah = 10;
    let tmp = returns_a_mut(&mut blah);
    *tmp = 20; // a strong update, not a weak one
    assert(*tmp == 20)
}

#[flux::sig(fn(x: &mut usize{v: v >= 10}) -> (&mut usize{v: v >= 10}, usize[0]))]
fn tag(x: &mut usize) -> (&mut usize, usize) {
    (x, 0)
}

fn through_a_tuple() {
    let mut blah = 10;
    let (r, _n) = tag(&mut blah);
    *r = 20;
    assert(*r == 20) // references nested in a returned tuple or struct too
}
```