### PR TITLE
Fix function pointer subtyping

### DIFF
--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -1031,10 +1031,7 @@ impl<'a, E: LocEnv> Sub<'a, E> {
                 }
                 Ok(())
             }
-            (BaseTy::FnPtr(sig_a), BaseTy::FnPtr(sig_b)) => {
-                tracked_span_assert_eq!(sig_a.erase_regions(), sig_b.erase_regions());
-                Ok(())
-            }
+            (BaseTy::FnPtr(sig_a), BaseTy::FnPtr(sig_b)) => self.fn_sigs(infcx, sig_a, sig_b),
             (BaseTy::Never, BaseTy::Never) => Ok(()),
             (
                 BaseTy::Coroutine(did1, resume_ty_a, tys_a, _),
@@ -1053,6 +1050,74 @@ impl<'a, E: LocEnv> Sub<'a, E> {
             (BaseTy::Foreign(did_a), BaseTy::Foreign(did_b)) if did_a == did_b => Ok(()),
             _ => Err(query_bug!("incompatible base types: `{a:#?}` - `{b:#?}`"))?,
         }
+    }
+
+    fn fn_sigs(
+        &mut self,
+        infcx: &mut InferCtxt,
+        sub_sig: &rty::PolyFnSig,
+        super_sig: &rty::PolyFnSig,
+    ) -> InferResult {
+        // Mirror `check_fn_subtyping`: universally instantiate the super signature and
+        // existentially instantiate the sub signature, then relate inputs contravariantly and
+        // the output covariantly.
+        let mut infcx = infcx.branch();
+
+        let super_sig = super_sig
+            .replace_bound_vars(
+                |_| rty::ReErased,
+                |sort, _, kind| Expr::fvar(infcx.define_bound_reft_var(sort, kind)),
+            )
+            .deeply_normalize(&mut infcx.at(self.span))?;
+
+        let output = infcx.ensure_resolved_evars(|infcx| {
+            let sub_sig = sub_sig
+                .replace_bound_vars(
+                    |_| rty::ReErased,
+                    |sort, mode, _| infcx.fresh_infer_var(sort, mode),
+                )
+                .deeply_normalize(&mut infcx.at(self.span))?;
+
+            tracked_span_dbg_assert_eq!(sub_sig.safety, super_sig.safety);
+            tracked_span_dbg_assert_eq!(sub_sig.abi, super_sig.abi);
+            tracked_span_dbg_assert_eq!(sub_sig.inputs().len(), super_sig.inputs().len());
+
+            for pred in super_sig.requires() {
+                infcx.assume_pred(pred);
+            }
+            infcx.check_pred(Expr::implies(super_sig.no_panic(), sub_sig.no_panic()), self.tag());
+            for (actual, formal) in iter::zip(super_sig.inputs(), sub_sig.inputs()) {
+                self.tys(infcx, actual, formal)?;
+            }
+            for pred in sub_sig.requires() {
+                infcx.check_pred(pred, self.tag());
+            }
+
+            Ok(sub_sig.output())
+        })?;
+
+        let output =
+            infcx
+                .fully_resolve_evars(&output)
+                .replace_bound_refts_with(|sort, _, kind| {
+                    Expr::fvar(infcx.define_bound_reft_var(sort, kind))
+                });
+        infcx.ensure_resolved_evars(|infcx| {
+            let super_output = super_sig
+                .output()
+                .replace_bound_refts_with(|sort, mode, _| infcx.fresh_infer_var(sort, mode));
+
+            // Function pointer signatures are currently lifted from rustc without refinements.
+            // Keep this guard explicit so future support for refined function pointers cannot
+            // silently drop their stateful postconditions. Named functions handle those in
+            // `check_fn_subtyping` in refineck.
+            if !output.ensures.is_empty() || !super_output.ensures.is_empty() {
+                return Err(
+                    query_bug!("function pointer subtyping with ensures is unsupported").into()
+                );
+            }
+            self.tys(infcx, &output.ret, &super_output.ret)
+        })
     }
 
     fn generic_args(

--- a/tests/tests/pos/fn_ptrs/fnptr03.rs
+++ b/tests/tests/pos/fn_ptrs/fnptr03.rs
@@ -1,0 +1,9 @@
+use std::marker::PhantomData;
+
+pub struct Input<T>(PhantomData<fn(T)>);
+
+impl<T> Input<T> {
+    pub fn new() -> Self {
+        Input::<T>(PhantomData)
+    }
+}

--- a/tests/tests/pos/fn_ptrs/fnptr04.rs
+++ b/tests/tests/pos/fn_ptrs/fnptr04.rs
@@ -1,0 +1,9 @@
+use std::marker::PhantomData;
+
+pub struct InputOutput<T>(PhantomData<fn(T) -> T>);
+
+impl<T> InputOutput<T> {
+    pub fn new() -> Self {
+        InputOutput::<T>(PhantomData)
+    }
+}

--- a/tests/tests/pos/fn_ptrs/fnptr05.rs
+++ b/tests/tests/pos/fn_ptrs/fnptr05.rs
@@ -1,0 +1,11 @@
+pub struct Packet<'a>(&'a [u8]);
+
+pub struct Nested {
+    callback: fn(fn(Packet) -> Packet) -> fn(Packet) -> Packet,
+}
+
+impl Nested {
+    pub fn new(callback: fn(fn(Packet) -> Packet) -> fn(Packet) -> Packet) -> Self {
+        Self { callback }
+    }
+}

--- a/tests/tests/pos/fn_ptrs/fnptr06.rs
+++ b/tests/tests/pos/fn_ptrs/fnptr06.rs
@@ -1,0 +1,9 @@
+use std::marker::PhantomData;
+
+pub struct HigherRanked<T>(PhantomData<for<'a> fn(&'a T) -> &'a T>);
+
+impl<T> HigherRanked<T> {
+    pub fn new() -> Self {
+        HigherRanked::<T>(PhantomData)
+    }
+}

--- a/tests/tests/pos/fn_ptrs/fnptr07.rs
+++ b/tests/tests/pos/fn_ptrs/fnptr07.rs
@@ -1,0 +1,11 @@
+use std::marker::PhantomData;
+
+pub struct MultipleBinders<T>(
+    PhantomData<for<'a, 'b> fn(&'a T, &'b T) -> (&'b T, &'a T)>,
+);
+
+impl<T> MultipleBinders<T> {
+    pub fn new() -> Self {
+        MultipleBinders::<T>(PhantomData)
+    }
+}

--- a/tests/tests/pos/fn_ptrs/fnptr08.rs
+++ b/tests/tests/pos/fn_ptrs/fnptr08.rs
@@ -1,0 +1,9 @@
+use std::marker::PhantomData;
+
+pub struct MutableInput<T>(PhantomData<for<'a> fn(&'a mut T)>);
+
+impl<T> MutableInput<T> {
+    pub fn new() -> Self {
+        MutableInput::<T>(PhantomData)
+    }
+}

--- a/tests/tests/pos/fn_ptrs/fnptr09.rs
+++ b/tests/tests/pos/fn_ptrs/fnptr09.rs
@@ -1,0 +1,9 @@
+use std::marker::PhantomData;
+
+pub struct Unsafe<T>(PhantomData<unsafe fn(T) -> T>);
+
+impl<T> Unsafe<T> {
+    pub fn new() -> Self {
+        Unsafe::<T>(PhantomData)
+    }
+}

--- a/tests/tests/pos/fn_ptrs/issue-1185.rs
+++ b/tests/tests/pos/fn_ptrs/issue-1185.rs
@@ -1,0 +1,7 @@
+pub struct BuildHasherDefault<H>(std::marker::PhantomData<fn() -> H>);
+
+impl<H> BuildHasherDefault<H> {
+    pub fn new() -> Self {
+        BuildHasherDefault::<H>(std::marker::PhantomData)
+    }
+}

--- a/tests/tests/pos/fn_ptrs/issue-1718.rs
+++ b/tests/tests/pos/fn_ptrs/issue-1718.rs
@@ -1,0 +1,13 @@
+pub struct TracerPacket<'a> {
+    pub buffer: &'a [u8],
+}
+
+pub struct Tracer {
+    writer: fn(TracerPacket),
+}
+
+impl Tracer {
+    pub fn new(writer: fn(TracerPacket)) -> Tracer {
+        Tracer { writer }
+    }
+}


### PR DESCRIPTION
Relates function pointer signatures using function subtyping instead of asserting structural equality. This handles alpha-renamed bound regions in #1718 and default refinement differences in #1185.

This follows the approach discussed in [the Zulip thread on moving function subtyping into `flux-infer`](https://flux-rs.zulipchat.com/#narrow/channel/486099-dev/topic/.E2.9C.94.20fn.20subtyping.20split.20across.20.60checker.2Ers.60.20and.20.60infer.2Ers.60/near/528932148).

Adds regression coverage for generic inputs and outputs, nested function pointers, higher-ranked lifetimes, multiple binders, mutable references, and unsafe function pointers. All new cases ICE on `main` and pass with this change.

Fixes #1718.
Fixes #1185.