### PR TITLE
Render extern specs in rustdoc

### DIFF
--- a/lib/flux-alloc/src/lib.rs
+++ b/lib/flux-alloc/src/lib.rs
@@ -2,20 +2,20 @@
 #![cfg_attr(flux, feature(allocator_api))]
 #![cfg_attr(flux, flux::no_suggestions)]
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod slice;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod vec;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod string;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod rc;
 
 // TODO(RJ): I get an "unused extern crate" warning here,
 // but without it, `in_bounds` is not in scope in `lib/vec/mod.rs`.
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 #[allow(unused_extern_crates)]
 extern crate flux_core;

--- a/lib/flux-alloc/src/lib.rs
+++ b/lib/flux-alloc/src/lib.rs
@@ -1,4 +1,5 @@
 // #![no_std]
+#![cfg_attr(doc, deny(rustdoc::broken_intra_doc_links))]
 #![cfg_attr(flux, feature(allocator_api))]
 #![cfg_attr(flux, flux::no_suggestions)]
 

--- a/lib/flux-attrs-impl/src/extern_spec.rs
+++ b/lib/flux-attrs-impl/src/extern_spec.rs
@@ -124,7 +124,9 @@ fn doc_target(mod_path: &Option<syn::Path>, ident: &Ident) -> String {
 }
 
 fn doc_source(summary: &str, source: &str) -> String {
-    format!("{summary}\n\n```rust,ignore\n{source}\n```")
+    format!(
+        "{summary}\n\nThis is not a real Rust item; it exists only to document the external specification.\n\n```rust,ignore\n{source}\n```"
+    )
 }
 
 fn stable_doc_hash(source: &str) -> u64 {
@@ -833,6 +835,7 @@ mod tests {
         assert!(tokens.contains("pub struct size_of_valSpec_"));
         assert!(tokens.contains("sig (fn (usize) -> usize)"));
         assert!(tokens.contains("core::mem::size_of_val"));
+        assert!(tokens.contains("not a real Rust item"));
     }
 
     #[test]

--- a/lib/flux-attrs-impl/src/extern_spec.rs
+++ b/lib/flux-attrs-impl/src/extern_spec.rs
@@ -140,7 +140,7 @@ fn stable_doc_hash(source: &str) -> u64 {
     source
         .bytes()
         .fold(14_695_981_039_346_656_037, |hash, byte| {
-            hash.wrapping_mul(1_099_511_628_211) ^ u64::from(byte)
+            (hash ^ u64::from(byte)).wrapping_mul(1_099_511_628_211)
         })
 }
 
@@ -884,6 +884,6 @@ mod tests {
 
     #[test]
     fn documentation_hash_is_stable() {
-        assert_eq!(stable_doc_hash("flux"), 0x0382_677e_e2f5_8e78);
+        assert_eq!(stable_doc_hash("flux"), 0xd61b_dd79_08af_2642);
     }
 }

--- a/lib/flux-attrs-impl/src/extern_spec.rs
+++ b/lib/flux-attrs-impl/src/extern_spec.rs
@@ -150,9 +150,13 @@ fn doc_source_text(span: Span, canonical_source: &str) -> String {
 
 fn select_doc_source(source: Option<String>, canonical_source: &str) -> String {
     source
-        // A span originating in a macro definition contains metavariables rather than the
-        // concrete expansion users searched for in rustdoc.
-        .filter(|source| !source.contains('$'))
+        // Macro-generated spans can point back to template source instead of the concrete
+        // expansion. Preserve source formatting only when it represents the same tokens.
+        .filter(|source| {
+            source
+                .parse::<TokenStream>()
+                .is_ok_and(|tokens| tokens.to_string() == canonical_source)
+        })
         .unwrap_or_else(|| canonical_source.to_owned())
 }
 
@@ -914,6 +918,15 @@ mod tests {
         assert_eq!(
             select_doc_source(Some("impl $T {}".into()), "impl usize {}"),
             "impl usize {}"
+        );
+    }
+
+    #[test]
+    fn equivalent_source_preserves_authored_formatting() {
+        let source = "fn get(\n    value: usize,\n) -> usize;";
+        assert_eq!(
+            select_doc_source(Some(source.into()), "fn get (value : usize ,) -> usize ;"),
+            source
         );
     }
 }

--- a/lib/flux-attrs-impl/src/extern_spec.rs
+++ b/lib/flux-attrs-impl/src/extern_spec.rs
@@ -33,6 +33,105 @@ pub(crate) fn transform_extern_spec(
     }
 }
 
+pub(crate) fn transform_extern_spec_doc(
+    attr: TokenStream,
+    tokens: TokenStream,
+) -> syn::Result<TokenStream> {
+    let mod_path: Option<syn::Path> =
+        if !attr.is_empty() { Some(syn::parse2(attr)?) } else { None };
+    let source = tokens.to_string();
+    let hash = stable_doc_hash(&source);
+    let item = syn::parse2::<ExternItem>(tokens)?;
+
+    let tokens = match item {
+        ExternItem::Struct(item) => doc_marker(&item.ident, hash, &source),
+        ExternItem::Enum(item) => doc_marker(&item.ident, hash, &source),
+        ExternItem::Trait(item) => doc_marker(&item.ident, hash, &source),
+        ExternItem::Fn(item) => {
+            let ident = &item.sig.ident;
+            let target = if let Some(path) = &mod_path {
+                let path = path.to_token_stream().to_string().replace(' ', "");
+                format!("External specification for [`{path}::{ident}`].")
+            } else {
+                format!("External specification for [`{ident}`].")
+            };
+            let docs = doc_source(&target, &source);
+            quote!(#[doc = #docs] pub fn #ident() {})
+        }
+        ExternItem::Impl(item) => {
+            let self_name = doc_type_name(&item.self_ty);
+            let base = if let Some((_, path, _)) = &item.trait_ {
+                let trait_name = path.segments.last().unwrap().ident.to_string();
+                format!("{trait_name}For{self_name}")
+            } else {
+                self_name
+            };
+            let ident = format_ident!("{base}Spec_{hash:08x}");
+            let self_ty = &item.self_ty;
+            let target = if let Some((_, path, _)) = &item.trait_ {
+                format!(
+                    "External specifications for `impl {} for {}`.",
+                    quote!(#path),
+                    quote!(#self_ty)
+                )
+            } else {
+                format!("External specifications for `{}`.", quote!(#self_ty))
+            };
+            let docs = doc_source(&target, &source);
+            let methods = item.items.iter().map(|method| {
+                let ident = &method.sig.ident;
+                let attrs = &method.attrs;
+                let sig = &method.sig;
+                let method_source = quote!(#(#attrs)* #sig;).to_string();
+                let method_docs = doc_source("Original declaration.", &method_source);
+                quote!(#[doc = #method_docs] fn #ident();)
+            });
+            quote!(
+                #[allow(non_camel_case_types)]
+                #[doc = #docs]
+                pub trait #ident { #(#methods)* }
+            )
+        }
+    };
+
+    Ok(quote!(#[cfg(doc)] #tokens))
+}
+
+fn doc_marker(ident: &Ident, hash: u32, source: &str) -> TokenStream {
+    let marker = format_ident!("{ident}Spec_{hash:08x}");
+    let docs = doc_source(&format!("External specification for `{ident}`."), source);
+    quote!(
+        #[allow(non_camel_case_types)]
+        #[doc = #docs]
+        pub struct #marker;
+    )
+}
+
+fn doc_source(summary: &str, source: &str) -> String {
+    format!("{summary}\n\n```rust,ignore\n{source}\n```")
+}
+
+fn stable_doc_hash(source: &str) -> u32 {
+    source
+        .bytes()
+        .fold(2_166_136_261, |hash, byte| hash.wrapping_mul(16_777_619) ^ u32::from(byte))
+}
+
+fn doc_type_name(ty: &Type) -> String {
+    match ty {
+        Type::Path(path) => path
+            .path
+            .segments
+            .last()
+            .map_or_else(|| "Type".into(), |segment| segment.ident.to_string()),
+        Type::Reference(reference) => doc_type_name(&reference.elem),
+        Type::Slice(slice) => format!("{}Slice", doc_type_name(&slice.elem)),
+        Type::Array(array) => format!("{}Array", doc_type_name(&array.elem)),
+        Type::Ptr(pointer) => format!("{}Ptr", doc_type_name(&pointer.elem)),
+        _ => "Type".into(),
+    }
+}
+
 fn extern_fn_to_tokens(
     span: Span,
     mod_use: Option<UseWildcard>,
@@ -690,5 +789,49 @@ impl ToTokens for UseWildcard {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let path = &self.0;
         tokens.extend(quote!(use #path::*;))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+
+    use super::transform_extern_spec_doc;
+
+    #[test]
+    fn documents_free_function_contract() {
+        let tokens = transform_extern_spec_doc(
+            quote!(core::mem),
+            quote!(
+                #[sig(fn(usize) -> usize)]
+                fn size_of_val(value: usize) -> usize;
+            ),
+        )
+        .unwrap()
+        .to_string();
+
+        assert!(tokens.contains("cfg (doc)"));
+        assert!(tokens.contains("pub fn size_of_val"));
+        assert!(tokens.contains("sig (fn (usize) -> usize)"));
+        assert!(tokens.contains("core::mem::size_of_val"));
+    }
+
+    #[test]
+    fn documents_impl_methods_as_a_surrogate_trait() {
+        let tokens = transform_extern_spec_doc(
+            quote!(),
+            quote!(
+                impl<T> Option<T> {
+                    #[sig(fn(&Self[@b]) -> bool[b])]
+                    const fn is_some(&self) -> bool;
+                }
+            ),
+        )
+        .unwrap()
+        .to_string();
+
+        assert!(tokens.contains("pub trait OptionSpec_"));
+        assert!(tokens.contains("fn is_some ()"));
+        assert!(tokens.contains("sig (fn (& Self [@ b]) -> bool [b])"));
     }
 }

--- a/lib/flux-attrs-impl/src/extern_spec.rs
+++ b/lib/flux-attrs-impl/src/extern_spec.rs
@@ -46,10 +46,7 @@ pub(crate) fn transform_extern_spec_doc(
     let mod_path: Option<syn::Path> =
         if !attr.is_empty() { Some(syn::parse2(attr)?) } else { None };
     let canonical_source = tokens.to_string();
-    let source = tokens
-        .span()
-        .source_text()
-        .unwrap_or_else(|| canonical_source.clone());
+    let source = doc_source_text(tokens.span(), &canonical_source);
     let hash = stable_doc_hash(&format!("{attr_source}|{canonical_source}"));
     let item = syn::parse2::<ExternItem>(tokens)?;
 
@@ -100,10 +97,10 @@ pub(crate) fn transform_extern_spec_doc(
                     .first()
                     .and_then(|attr| attr.span().join(method.sig.span()))
                     .unwrap_or_else(|| method.sig.span());
-                let method_source = method_span
-                    .source_text()
-                    .map(|source| format!("{source};"))
-                    .unwrap_or(canonical_method_source);
+                let method_source = doc_source_text(method_span, &canonical_method_source)
+                    .trim_end_matches(';')
+                    .to_string()
+                    + ";";
                 let method_docs = doc_source("Original declaration.", &method_source);
                 quote!(
                     #[allow(non_snake_case)]
@@ -145,6 +142,18 @@ fn doc_source(summary: &str, source: &str) -> String {
     format!(
         "{summary}\n\nThis is not a real Rust item; it exists only to document the external specification.\n\n```rust,ignore\n{source}\n```"
     )
+}
+
+fn doc_source_text(span: Span, canonical_source: &str) -> String {
+    select_doc_source(span.source_text(), canonical_source)
+}
+
+fn select_doc_source(source: Option<String>, canonical_source: &str) -> String {
+    source
+        // A span originating in a macro definition contains metavariables rather than the
+        // concrete expansion users searched for in rustdoc.
+        .filter(|source| !source.contains('$'))
+        .unwrap_or_else(|| canonical_source.to_owned())
 }
 
 fn stable_doc_hash(source: &str) -> u64 {
@@ -837,7 +846,7 @@ impl ToTokens for UseWildcard {
 mod tests {
     use quote::quote;
 
-    use super::{stable_doc_hash, transform_extern_spec_doc};
+    use super::{select_doc_source, stable_doc_hash, transform_extern_spec_doc};
 
     #[test]
     fn documents_free_function_contract() {
@@ -898,5 +907,13 @@ mod tests {
     #[test]
     fn documentation_hash_is_stable() {
         assert_eq!(stable_doc_hash("flux"), 0xd61b_dd79_08af_2642);
+    }
+
+    #[test]
+    fn macro_metavariables_fall_back_to_expanded_tokens() {
+        assert_eq!(
+            select_doc_source(Some("impl $T {}".into()), "impl usize {}"),
+            "impl usize {}"
+        );
     }
 }

--- a/lib/flux-attrs-impl/src/extern_spec.rs
+++ b/lib/flux-attrs-impl/src/extern_spec.rs
@@ -37,26 +37,27 @@ pub(crate) fn transform_extern_spec_doc(
     attr: TokenStream,
     tokens: TokenStream,
 ) -> syn::Result<TokenStream> {
+    let attr_source = attr.to_string();
     let mod_path: Option<syn::Path> =
         if !attr.is_empty() { Some(syn::parse2(attr)?) } else { None };
     let source = tokens.to_string();
-    let hash = stable_doc_hash(&source);
+    let hash = stable_doc_hash(&format!("{attr_source}|{source}"));
     let item = syn::parse2::<ExternItem>(tokens)?;
 
     let tokens = match item {
-        ExternItem::Struct(item) => doc_marker(&item.ident, hash, &source),
-        ExternItem::Enum(item) => doc_marker(&item.ident, hash, &source),
-        ExternItem::Trait(item) => doc_marker(&item.ident, hash, &source),
+        ExternItem::Struct(item) => doc_marker(&mod_path, &item.ident, hash, &source),
+        ExternItem::Enum(item) => doc_marker(&mod_path, &item.ident, hash, &source),
+        ExternItem::Trait(item) => doc_marker(&mod_path, &item.ident, hash, &source),
         ExternItem::Fn(item) => {
             let ident = &item.sig.ident;
-            let target = if let Some(path) = &mod_path {
-                let path = path.to_token_stream().to_string().replace(' ', "");
-                format!("External specification for [`{path}::{ident}`].")
-            } else {
-                format!("External specification for [`{ident}`].")
-            };
+            let target = doc_target(&mod_path, ident);
             let docs = doc_source(&target, &source);
-            quote!(#[doc = #docs] pub fn #ident() {})
+            let marker = format_ident!("{ident}Spec_{hash:016x}");
+            quote!(
+                #[allow(non_camel_case_types)]
+                #[doc = #docs]
+                pub struct #marker;
+            )
         }
         ExternItem::Impl(item) => {
             let self_name = doc_type_name(&item.self_ty);
@@ -66,16 +67,18 @@ pub(crate) fn transform_extern_spec_doc(
             } else {
                 self_name
             };
-            let ident = format_ident!("{base}Spec_{hash:08x}");
+            let ident = format_ident!("{base}Spec_{hash:016x}");
             let self_ty = &item.self_ty;
-            let target = if let Some((_, path, _)) = &item.trait_ {
-                format!(
-                    "External specifications for `impl {} for {}`.",
-                    quote!(#path),
-                    quote!(#self_ty)
-                )
+            let declaration = if let Some((_, path, _)) = &item.trait_ {
+                format!("`impl {} for {}`", quote!(#path), quote!(#self_ty))
             } else {
-                format!("External specifications for `{}`.", quote!(#self_ty))
+                format!("`{}`", quote!(#self_ty))
+            };
+            let target = if let Some(path) = &mod_path {
+                let path = path.to_token_stream().to_string().replace(' ', "");
+                format!("External specifications in `{path}` for {declaration}.")
+            } else {
+                format!("External specifications for {declaration}.")
             };
             let docs = doc_source(&target, &source);
             let methods = item.items.iter().map(|method| {
@@ -84,12 +87,16 @@ pub(crate) fn transform_extern_spec_doc(
                 let sig = &method.sig;
                 let method_source = quote!(#(#attrs)* #sig;).to_string();
                 let method_docs = doc_source("Original declaration.", &method_source);
-                quote!(#[doc = #method_docs] fn #ident();)
+                quote!(
+                    #[allow(non_snake_case)]
+                    #[doc = #method_docs]
+                    pub mod #ident {}
+                )
             });
             quote!(
-                #[allow(non_camel_case_types)]
+                #[allow(non_snake_case)]
                 #[doc = #docs]
-                pub trait #ident { #(#methods)* }
+                pub mod #ident { #(#methods)* }
             )
         }
     };
@@ -97,9 +104,9 @@ pub(crate) fn transform_extern_spec_doc(
     Ok(quote!(#[cfg(doc)] #tokens))
 }
 
-fn doc_marker(ident: &Ident, hash: u32, source: &str) -> TokenStream {
-    let marker = format_ident!("{ident}Spec_{hash:08x}");
-    let docs = doc_source(&format!("External specification for `{ident}`."), source);
+fn doc_marker(mod_path: &Option<syn::Path>, ident: &Ident, hash: u64, source: &str) -> TokenStream {
+    let marker = format_ident!("{ident}Spec_{hash:016x}");
+    let docs = doc_source(&doc_target(mod_path, ident), source);
     quote!(
         #[allow(non_camel_case_types)]
         #[doc = #docs]
@@ -107,23 +114,35 @@ fn doc_marker(ident: &Ident, hash: u32, source: &str) -> TokenStream {
     )
 }
 
+fn doc_target(mod_path: &Option<syn::Path>, ident: &Ident) -> String {
+    if let Some(path) = mod_path {
+        let path = path.to_token_stream().to_string().replace(' ', "");
+        format!("External specification for [`{path}::{ident}`].")
+    } else {
+        format!("External specification for `{ident}`.")
+    }
+}
+
 fn doc_source(summary: &str, source: &str) -> String {
     format!("{summary}\n\n```rust,ignore\n{source}\n```")
 }
 
-fn stable_doc_hash(source: &str) -> u32 {
+fn stable_doc_hash(source: &str) -> u64 {
     source
         .bytes()
-        .fold(2_166_136_261, |hash, byte| hash.wrapping_mul(16_777_619) ^ u32::from(byte))
+        .fold(14_695_981_039_346_656_037, |hash, byte| {
+            hash.wrapping_mul(1_099_511_628_211) ^ u64::from(byte)
+        })
 }
 
 fn doc_type_name(ty: &Type) -> String {
     match ty {
-        Type::Path(path) => path
-            .path
-            .segments
-            .last()
-            .map_or_else(|| "Type".into(), |segment| segment.ident.to_string()),
+        Type::Path(path) => {
+            path.path
+                .segments
+                .last()
+                .map_or_else(|| "Type".into(), |segment| segment.ident.to_string())
+        }
         Type::Reference(reference) => doc_type_name(&reference.elem),
         Type::Slice(slice) => format!("{}Slice", doc_type_name(&slice.elem)),
         Type::Array(array) => format!("{}Array", doc_type_name(&array.elem)),
@@ -796,7 +815,7 @@ impl ToTokens for UseWildcard {
 mod tests {
     use quote::quote;
 
-    use super::transform_extern_spec_doc;
+    use super::{stable_doc_hash, transform_extern_spec_doc};
 
     #[test]
     fn documents_free_function_contract() {
@@ -811,15 +830,15 @@ mod tests {
         .to_string();
 
         assert!(tokens.contains("cfg (doc)"));
-        assert!(tokens.contains("pub fn size_of_val"));
+        assert!(tokens.contains("pub struct size_of_valSpec_"));
         assert!(tokens.contains("sig (fn (usize) -> usize)"));
         assert!(tokens.contains("core::mem::size_of_val"));
     }
 
     #[test]
-    fn documents_impl_methods_as_a_surrogate_trait() {
+    fn documents_impl_methods_as_nested_modules() {
         let tokens = transform_extern_spec_doc(
-            quote!(),
+            quote!(core::option),
             quote!(
                 impl<T> Option<T> {
                     #[sig(fn(&Self[@b]) -> bool[b])]
@@ -830,8 +849,31 @@ mod tests {
         .unwrap()
         .to_string();
 
-        assert!(tokens.contains("pub trait OptionSpec_"));
-        assert!(tokens.contains("fn is_some ()"));
+        assert!(tokens.contains("pub mod OptionSpec_"));
+        assert!(tokens.contains("pub mod is_some"));
         assert!(tokens.contains("sig (fn (& Self [@ b]) -> bool [b])"));
+        assert!(tokens.contains("core::option"));
+    }
+
+    #[test]
+    fn target_path_affects_name_and_summary() {
+        let item = quote!(
+            struct Ordering;
+        );
+        let core = transform_extern_spec_doc(quote!(core::cmp), item.clone())
+            .unwrap()
+            .to_string();
+        let std = transform_extern_spec_doc(quote!(std::cmp), item)
+            .unwrap()
+            .to_string();
+
+        assert_ne!(core, std);
+        assert!(core.contains("core::cmp::Ordering"));
+        assert!(std.contains("std::cmp::Ordering"));
+    }
+
+    #[test]
+    fn documentation_hash_is_stable() {
+        assert_eq!(stable_doc_hash("flux"), 0x0382_677e_e2f5_8e78);
     }
 }

--- a/lib/flux-attrs-impl/src/extern_spec.rs
+++ b/lib/flux-attrs-impl/src/extern_spec.rs
@@ -915,10 +915,7 @@ mod tests {
 
     #[test]
     fn macro_metavariables_fall_back_to_expanded_tokens() {
-        assert_eq!(
-            select_doc_source(Some("impl $T {}".into()), "impl usize {}"),
-            "impl usize {}"
-        );
+        assert_eq!(select_doc_source(Some("impl $T {}".into()), "impl usize {}"), "impl usize {}");
     }
 
     #[test]

--- a/lib/flux-attrs-impl/src/extern_spec.rs
+++ b/lib/flux-attrs-impl/src/extern_spec.rs
@@ -45,8 +45,12 @@ pub(crate) fn transform_extern_spec_doc(
     let attr_source = attr.to_string();
     let mod_path: Option<syn::Path> =
         if !attr.is_empty() { Some(syn::parse2(attr)?) } else { None };
-    let source = tokens.to_string();
-    let hash = stable_doc_hash(&format!("{attr_source}|{source}"));
+    let canonical_source = tokens.to_string();
+    let source = tokens
+        .span()
+        .source_text()
+        .unwrap_or_else(|| canonical_source.clone());
+    let hash = stable_doc_hash(&format!("{attr_source}|{canonical_source}"));
     let item = syn::parse2::<ExternItem>(tokens)?;
 
     let tokens = match item {
@@ -90,7 +94,16 @@ pub(crate) fn transform_extern_spec_doc(
                 let ident = &method.sig.ident;
                 let attrs = &method.attrs;
                 let sig = &method.sig;
-                let method_source = quote!(#(#attrs)* #sig;).to_string();
+                let canonical_method_source = quote!(#(#attrs)* #sig;).to_string();
+                let method_span = method
+                    .attrs
+                    .first()
+                    .and_then(|attr| attr.span().join(method.sig.span()))
+                    .unwrap_or_else(|| method.sig.span());
+                let method_source = method_span
+                    .source_text()
+                    .map(|source| format!("{source};"))
+                    .unwrap_or(canonical_method_source);
                 let method_docs = doc_source("Original declaration.", &method_source);
                 quote!(
                     #[allow(non_snake_case)]

--- a/lib/flux-attrs-impl/src/extern_spec.rs
+++ b/lib/flux-attrs-impl/src/extern_spec.rs
@@ -37,6 +37,11 @@ pub(crate) fn transform_extern_spec_doc(
     attr: TokenStream,
     tokens: TokenStream,
 ) -> syn::Result<TokenStream> {
+    // Rustdoc cannot attach documentation to an item in another crate. Following the approach
+    // introduced by Creusot, emit searchable documentation-only items instead. Unlike Creusot,
+    // Flux cannot reuse the original signatures because refinement syntax and bodyless inherent
+    // impls do not always type-check as ordinary Rust, so marker items carry the complete
+    // declaration as a code block.
     let attr_source = attr.to_string();
     let mod_path: Option<syn::Path> =
         if !attr.is_empty() { Some(syn::parse2(attr)?) } else { None };
@@ -130,6 +135,8 @@ fn doc_source(summary: &str, source: &str) -> String {
 }
 
 fn stable_doc_hash(source: &str) -> u64 {
+    // The target path participates in `source`, so otherwise identical specs for different crates
+    // cannot collide. FNV-1a keeps names deterministic across builds and platforms.
     source
         .bytes()
         .fold(14_695_981_039_346_656_037, |hash, byte| {

--- a/lib/flux-attrs-impl/src/lib.rs
+++ b/lib/flux-attrs-impl/src/lib.rs
@@ -33,6 +33,11 @@ pub fn extern_spec(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     extern_spec::transform_extern_spec(attr, tokens).unwrap_or_else(|err| err.to_compile_error())
 }
 
+pub fn extern_spec_doc(attr: TokenStream, tokens: TokenStream) -> TokenStream {
+    extern_spec::transform_extern_spec_doc(attr, tokens)
+        .unwrap_or_else(|err| err.to_compile_error())
+}
+
 pub fn flux_tool_item_attr(name: &str, attr: TokenStream, item: TokenStream) -> TokenStream {
     let span = Span::call_site();
     let name = format_ident!("{}", name, span = span);

--- a/lib/flux-attrs/src/lib.rs
+++ b/lib/flux-attrs/src/lib.rs
@@ -210,8 +210,8 @@ mod attr_dummy {
         TokenStream::new()
     }
 
-    pub fn extern_spec(_attrs: TokenStream, _tokens: TokenStream) -> TokenStream {
-        TokenStream::new()
+    pub fn extern_spec(attrs: TokenStream, tokens: TokenStream) -> TokenStream {
+        flux_attrs_impl::extern_spec_doc(attrs.into(), tokens.into()).into()
     }
 
     macro_rules! no_op {

--- a/lib/flux-core/src/alloc/layout.rs
+++ b/lib/flux-core/src/alloc/layout.rs
@@ -1,4 +1,4 @@
-#![flux::defs(
+#![cfg_attr(flux, flux::defs(
     fn pow2(x: int) -> bool { pow2bv(bv_int_to_bv64(x)) }
     fn pow2bv(x: bitvec<64>) -> bool {
         bv_and(x, bv_sub(x, bv_int_to_bv64(1))) == bv_int_to_bv64(0)
@@ -17,7 +17,7 @@
     fn is_valid_array_layout(n: int, size: int, align: int) -> bool {
         size == 0 || size * n + align - 1 <= isize::MAX
     }
-)]
+))]
 
 use flux_attrs::*;
 

--- a/lib/flux-core/src/alloc/mod.rs
+++ b/lib/flux-core/src/alloc/mod.rs
@@ -1,2 +1,2 @@
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 mod layout;

--- a/lib/flux-core/src/array/mod.rs
+++ b/lib/flux-core/src/array/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 use core::ops::Index;
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 use core::ops::IndexMut;
 
 use flux_attrs::*;

--- a/lib/flux-core/src/iter/mod.rs
+++ b/lib/flux-core/src/iter/mod.rs
@@ -1,4 +1,4 @@
 mod adapters;
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 mod range;
 mod traits;

--- a/lib/flux-core/src/lib.rs
+++ b/lib/flux-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(doc, deny(rustdoc::broken_intra_doc_links))]
 #![cfg_attr(flux, feature(step_trait))]
 #![cfg_attr(flux, feature(sized_hierarchy))]
 #![cfg_attr(flux, feature(try_trait_v2))]

--- a/lib/flux-core/src/lib.rs
+++ b/lib/flux-core/src/lib.rs
@@ -7,37 +7,37 @@
 pub mod iter;
 pub mod ops;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod mem;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod option;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod result;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod cmp;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod clone;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod slice;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod array;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod num;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod ptr;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod convert;
 
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 pub mod alloc;
 
 // -------------------------------------------------------------------

--- a/lib/flux-core/src/num/mod.rs
+++ b/lib/flux-core/src/num/mod.rs
@@ -1,4 +1,4 @@
-#![flux::defs {
+#![cfg_attr(flux, flux::defs {
     fn clamp(v: int, lo: int, hi: int) -> int { if v < lo { lo } else if v > hi { hi } else { v } }
     fn min(a: int, b: int) -> int { if a < b { a } else { b } }
     fn max(a: int, b: int) -> int { if a > b { a } else { b } }
@@ -16,7 +16,7 @@
         else if a < 0 && b > 0 { -((-a) / b) }
         else { (-a) / (-b) }
     }
-}]
+})]
 
 use flux_attrs::*;
 

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -1,4 +1,4 @@
-#![flux::defs {
+#![cfg_attr(flux, flux::defs {
     // The memory range [addr, addr + num_bytes) is entirely contained within
     // the pointer's allocation. In our model this is: addr >= base (not before
     // the start) and num_bytes <= size (num_bytes remaining bytes fit before
@@ -43,7 +43,7 @@
     // starting points for pointer arithmetic but cannot be dereferenced.
     // Required as a precondition for all pointer arithmetic methods.
     fn in_bounds(p: ptr) -> bool { dereferenceable(p, 0) }
-}]
+})]
 /// These specs on `core::ptr` allow flux to enforce 2 safety properties:
 /// 1. Spatial safety: A pointer may only be read or written if pointer is derived from
 /// a valid allocation and the entire access would fall within the bounds of that allocation.

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -1,4 +1,4 @@
-#![flux::defs {
+#![cfg_attr(flux, flux::defs {
     // The pointer lies within its allocation: addr >= base (not before the start)
     // and size >= 0. One-past-the-end pointers (size == 0) satisfy this — they
     // are valid starting points for arithmetic but cannot be dereferenced.
@@ -22,7 +22,7 @@
     fn nn_aligned_to(addr: int, alignment: int) -> bool {
         addr % alignment == 0
     }
-}]
+})]
 
 use flux_attrs::*;
 

--- a/lib/flux-core/src/slice/index.rs
+++ b/lib/flux-core/src/slice/index.rs
@@ -1,4 +1,4 @@
-#[cfg(flux)]
+#[cfg(any(flux, doc))]
 use core::ops;
 
 use flux_attrs::*;

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! # Soundness of `SliceIndex`-based annotations
 //!
-//! Several annotations rely on `SliceIndex` being a sealed trait: it
+//! Several annotations rely on [`SliceIndex`] being a sealed trait: it
 //! requires `private_slice_index::Sealed`, which has no public path outside of
 //! `core`, so its set of implementations is fixed and exhaustive. The sealed implementations
 //! were inspected to ensure these specs are sound.

--- a/lib/flux-core/src/slice/mod.rs
+++ b/lib/flux-core/src/slice/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! # Soundness of `SliceIndex`-based annotations
 //!
-//! Several annotations rely on [`SliceIndex`] being a sealed trait: it
+//! Several annotations rely on `SliceIndex` being a sealed trait: it
 //! requires `private_slice_index::Sealed`, which has no public path outside of
 //! `core`, so its set of implementations is fixed and exhaustive. The sealed implementations
 //! were inspected to ensure these specs are sound.


### PR DESCRIPTION
Makes the `flux-core` and `flux-alloc` extern-spec libraries navigable and searchable in the generated rustdoc.

## Design

Rustdoc cannot attach documentation to items owned by another crate. Like [Creusot’s resolution of the same limitation](https://github.com/creusot-rs/creusot/issues/1104), this emits separate, searchable documentation-only items. The approach is based on [Creusot PR #1851](https://github.com/creusot-rs/creusot/pull/1851).

Flux cannot emit Creusot-style surrogate functions with their original signatures: Flux refinement syntax and bodyless inherent impls do not always type-check as ordinary Rust. Instead:

- each extern item gets a marker page containing its complete original declaration and contracts;
- impl methods become nested documentation modules, keeping method names searchable without displaying fabricated signatures;
- stable, path-sensitive 64-bit suffixes prevent collisions between specs for the same type;
- every page explicitly says that its marker is not a real Rust item.

Following the concern raised in [Creusot PR #1963](https://github.com/creusot-rs/creusot/pull/1963), broken intra-doc links are denied in `flux-core` and `flux-alloc` so generated links cannot silently regress.

Spec-only modules are included under `cfg(doc)`, while module-level Flux definitions remain restricted to `cfg(flux)`.

## Validation

Tests cover free-function and impl expansion, path-sensitive naming, target summaries, and hash stability. `cargo xtask doc`, rustfmt, and the macro tests pass.

Fixes #1669.