### PR TITLE
Strengthen exhausted Range::next postcondition

### DIFF
--- a/lib/flux-core/src/iter/range.rs
+++ b/lib/flux-core/src/iter/range.rs
@@ -50,7 +50,11 @@ impl Step for i32 {}
 impl<A: Step> Iterator for ops::Range<A> {
     #[spec(
         fn(self: &mut Range<A>[@old]) -> Option<A[old.start]>[old.start < old.end]
-        ensures self: Range<A>{r: (old.start < old.end => r.start == <A as Step>::step_forward(old.start, 1)) && r.end == old.end }
+        ensures self: Range<A>{r:
+            (old.start < old.end => r.start == <A as Step>::step_forward(old.start, 1)) &&
+            (!(old.start < old.end) => r.start == old.start) &&
+            r.end == old.end
+        }
     )]
     fn next(&mut self) -> Option<A>;
 }

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_iter00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_iter00.rs
@@ -75,3 +75,12 @@ pub fn test_take_beyond_end(xs: &[i32]) {
         assert(i < xs.len());
     }
 }
+
+// --- Range::next ---
+
+pub fn test_exhausted_range_is_unchanged() {
+    let mut range = 0..0;
+    let start = range.start;
+    assert(range.next().is_none());
+    assert(range.start == start);
+}


### PR DESCRIPTION
## Summary

- preserve the Range start refinement when next returns None
- add a regression test showing an exhausted range remains unchanged

Rust leaves an exhausted Range unchanged, but the extern spec only constrained start on the non-empty branch. This caused Flux to forget the start value after a failed next call.

This follows the original discussion about validating the iterator specs against their core implementations: https://github.com/flux-rs/flux/pull/1170#discussion_r2193188584

## Test

- PATH=/Users/junekim/.cargo/bin:$PATH cargo +nightly-2026-02-05 xtask test flux_core_iter00