### PR TITLE
Preserve exhausted slice iterator state in specs

### DIFF
--- a/lib/flux-core/src/slice/iter.rs
+++ b/lib/flux-core/src/slice/iter.rs
@@ -20,7 +20,11 @@ impl<'a, T> Iter<'a, T> {
 impl<'a, T> Iterator for Iter<'a, T> {
     #[no_panic]
     #[spec(fn(self: &mut Iter<T>[@curr_s]) -> Option<_>[curr_s.idx < curr_s.len]
-           ensures self: Iter<T>{next_s: curr_s.idx + 1 == next_s.idx && curr_s.len == next_s.len})]
+           ensures self: Iter<T>{next_s:
+               curr_s.len == next_s.len &&
+               (curr_s.idx < curr_s.len => next_s.idx == curr_s.idx + 1) &&
+               (curr_s.idx >= curr_s.len => next_s.idx == curr_s.idx)
+           })]
     fn next(&mut self) -> Option<&'a T>;
 
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/iter/traits/iterator.rs#L3049

--- a/lib/flux-core/src/slice/iter.rs
+++ b/lib/flux-core/src/slice/iter.rs
@@ -15,7 +15,10 @@ impl<'a, T> Iter<'a, T> {
 #[assoc(
     fn size(x: Iter) -> int { x.len - x.idx }
     fn done(x: Iter) -> bool { x.idx >= x.len }
-    fn step(x: Iter, y: Iter) -> bool { x.idx + 1 == y.idx && x.len == y.len}
+    fn step(x: Iter, y: Iter) -> bool {
+        x.len == y.len &&
+        (if x.idx < x.len { y.idx == x.idx + 1 } else { y.idx == x.idx })
+    }
 )]
 impl<'a, T> Iterator for Iter<'a, T> {
     #[no_panic]

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_slice00.rs
@@ -28,10 +28,25 @@ pub fn test_first_branch(xs: &[i32]) {
 
 // --- iter ---
 
+#[flux_rs::trusted]
+#[flux_rs::spec(fn(&std::slice::Iter<T>[@idx, @len]) -> usize[idx])]
+fn iter_idx<T>(_: &std::slice::Iter<T>) -> usize {
+    unimplemented!()
+}
+
 pub fn test_iter_as_slice_len(xs: &[i32]) {
     let it = xs.iter();
     let ys = it.as_slice();
     assert(xs.len() == ys.len());
+}
+
+pub fn test_exhausted_iter_next_preserves_position() {
+    let mut it = [0_i32; 0].iter();
+    let idx = iter_idx(&it);
+    let _ = it.next();
+    assert(iter_idx(&it) == idx);
+    let _ = it.next();
+    assert(iter_idx(&it) == idx);
 }
 
 // --- first_mut / last_mut ---

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_slice00.rs
@@ -34,6 +34,14 @@ fn iter_idx<T>(_: &std::slice::Iter<T>) -> usize {
     unimplemented!()
 }
 
+#[flux_rs::spec(
+    fn(it: &mut I[@curr_s])
+    ensures it: I{next_s: <I as Iterator>::step(curr_s, next_s)}
+)]
+fn advance<I: Iterator>(it: &mut I) {
+    let _ = it.next();
+}
+
 pub fn test_iter_as_slice_len(xs: &[i32]) {
     let it = xs.iter();
     let ys = it.as_slice();
@@ -46,6 +54,13 @@ pub fn test_exhausted_iter_next_preserves_position() {
     let _ = it.next();
     assert(iter_idx(&it) == idx);
     let _ = it.next();
+    assert(iter_idx(&it) == idx);
+}
+
+pub fn test_generic_next_preserves_exhausted_iter_position() {
+    let mut it = [0_i32; 0].iter();
+    let idx = iter_idx(&it);
+    advance(&mut it);
     assert(iter_idx(&it) == idx);
 }
 


### PR DESCRIPTION
## Summary

- preserve `slice::Iter` position when `next` is called after exhaustion
- align the associated `Iterator::step` relation with the concrete method spec
- cover direct, repeated, and generic exhausted calls

Rust leaves an exhausted slice iterator at the same position, but the current extern spec advances `idx` unconditionally. This creates impossible states with `idx > len` and makes concrete and generic iterator reasoning disagree.

The regression fails on `main` and passes with these changes.

## Context

- An earlier unmerged commit identified the conditional transition: https://github.com/flux-rs/flux/commit/5b200c968c42098aeec4afde25fa9d8f71005c7c
- The analogous exhausted-range fix is in #1739.
- The broader discussion about checking iterator specs against core implementations: https://github.com/flux-rs/flux/pull/1170#discussion_r2193188584

## Test

`PATH="$HOME/.cargo/bin:$PATH" cargo xtask test flux_core_slice00 --suite with-deps`