### PR TITLE
Fix slice iterator as_slice remaining-length spec

### DIFF
--- a/lib/flux-core/src/slice/iter.rs
+++ b/lib/flux-core/src/slice/iter.rs
@@ -7,7 +7,7 @@ struct Iter<'a, T>;
 #[extern_spec(core::slice)]
 impl<'a, T> Iter<'a, T> {
     #[no_panic]
-    #[spec(fn(&Self[@it]) -> &[T][it.len])]
+    #[spec(fn(&Self[@it]) -> &[T][it.len - it.idx])]
     fn as_slice(&self) -> &'a [T];
 }
 

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_slice00.rs
@@ -29,6 +29,16 @@ pub fn test_get_unchecked_index(xs: &[i32], i: usize) {
     assert(xs.get(i).is_some()); //~ ERROR refinement type error
 }
 
+// --- iter ---
+
+#[flux_rs::spec(fn(xs: &[i32][1]))]
+pub fn test_iter_as_slice_after_next(xs: &[i32]) {
+    let mut it = xs.iter();
+    let _ = it.next();
+    let remaining = it.as_slice();
+    let _ = remaining[0]; //~ ERROR possible out-of-bounds access
+}
+
 // --- first_mut / last_mut ---
 
 pub fn test_first_mut(xs: &mut [i32]) {

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_slice00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_slice00.rs
@@ -64,6 +64,14 @@ pub fn test_generic_next_preserves_exhausted_iter_position() {
     assert(iter_idx(&it) == idx);
 }
 
+#[flux_rs::spec(fn(xs: &[i32][1]))]
+pub fn test_iter_as_slice_len_after_next(xs: &[i32]) {
+    let mut it = xs.iter();
+    let _ = it.next();
+    let ys = it.as_slice();
+    assert(ys.len() == 0);
+}
+
 // --- first_mut / last_mut ---
 
 pub fn test_first_mut_empty() {


### PR DESCRIPTION
## Summary

- specify `slice::Iter::as_slice` with the remaining length, `len - idx`
- add a positive regression for the length after consuming an element
- add a negative regression rejecting an index into an exhausted remainder

The current spec gives `as_slice` the iterator original length. After consuming the only element, Flux therefore accepts an access that Rust panics on:

```rust
let mut it = &[42][..].iter();
it.next();
let remaining = it.as_slice();
remaining[0];
```

The regression fails on `main` because the expected bounds error is missing, and passes on this branch.

## Context

- `slice::Iter` received adjacent iterator specifications in #1680.
- Exhausted iterator state is handled by #1740.

## Test

`PATH="$HOME/.cargo/bin:$PATH" cargo xtask test flux_core_slice00`