### PR TITLE
Add specs for Ptr/NonNull casts

### DIFF
--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -139,17 +139,22 @@ macro_rules! ptr_specs {
             unsafe fn read(self) -> T
             where T: Sized;
 
+            // Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L48
+            #[spec(fn(me: *$mutable[@p] T) -> *$mutable[p.base, p.addr, p.size] U)]
+            fn cast<U>(self) -> *$mutable U;
+
             $($($extra)*)?
         }
     };
 }
 
-ptr_specs!(const);
-
 // Rustfmt likes inserting a comma in here that breaks compilation, so we disable it for this macro invocation
 #[rustfmt::skip]
 ptr_specs!(
     mut,
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/mut_ptr.rs#L134
+    #[spec(fn(me: *mut[@p] T) -> *const[p.base, p.addr, p.size] T)]
+    fn cast_const(self) -> *const T;
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/mut_ptr.rs#L1413
     #[spec(fn (me: *mut[@p] T, val: T)
         requires valid(p, T::size_of()) && aligned_to(p, T::align_of()))]
@@ -162,6 +167,14 @@ ptr_specs!(
     unsafe fn replace(self, src: T) -> T
     where
         T: Sized;
+);
+
+#[rustfmt::skip]
+ptr_specs!(
+    const,
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/const_ptr.rs#L145
+    #[spec(fn(me: *const[@p] T) -> *mut[p.base, p.addr, p.size] T)]
+    fn cast_mut(self) -> *mut T;
 );
 
 #[extern_spec(core::ptr)]

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -46,6 +46,10 @@ impl<T> NonNull<T> {
     #[spec(fn(NonNull<T>[@base, @addr, @size]) -> *mut[base, addr, size] T)]
     fn as_ptr(self) -> *mut T;
 
+    /// Core impl: https://github.com/rust-lang/rust/blob/4b7e3a76d8df78960dc7c65cad43f5da1dac8ade/library/core/src/ptr/non_null.rs#L512
+    #[spec(fn(NonNull<T>[@base, @addr, @size]) -> NonNull<U>[base, addr, size])]
+    fn cast<U>(self) -> NonNull<U>;
+
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L652
     #[spec(fn(NonNull<T>[@base, @addr, @size], count: usize)
         -> NonNull<T>[base, addr + count * T::size_of(), size - count * T::size_of()]

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr01.rs
@@ -98,3 +98,37 @@ pub fn test_offset_from_unsigned_reversed(p: *const i32, q: *const i32) {
         let _ = p.offset_from_unsigned(q); //~ ERROR refinement type error
     }
 }
+
+// --- cast ---
+
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] u8 | addr >= base && addr > 0 && size == 1 && addr % 8 == 0}))]
+pub fn test_cast_method_does_not_create_extent(ptr: *mut u8) {
+    let wide = ptr.cast::<u64>();
+    unsafe {
+        std::ptr::write(wide, 0); //~ ERROR refinement type error
+    }
+}
+
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] u8 | addr >= base && addr > 0 && size >= 8 && addr % 8 != 0}))]
+pub fn test_cast_method_does_not_create_alignment(ptr: *mut u8) {
+    let wide = ptr.cast::<u64>();
+    unsafe {
+        std::ptr::write(wide, 0); //~ ERROR refinement type error
+    }
+}
+
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size < 4 && addr % 4 == 0}))]
+pub fn test_cast_const_method_preserves_extent(ptr: *mut i32) {
+    let const_ptr = ptr.cast_const();
+    unsafe {
+        let _value = std::ptr::read(const_ptr); //~ ERROR refinement type error
+    }
+}
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size < 4 && addr % 4 == 0}))]
+pub fn test_cast_mut_method_preserves_extent(ptr: *const i32) {
+    let mut_ptr = ptr.cast_mut();
+    unsafe {
+        std::ptr::write(mut_ptr, 0); //~ ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null05.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null05.rs
@@ -1,0 +1,23 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// --- cast ---
+
+#[flux::spec(fn(nn: NonNull<u8>[@base, @addr, @size])
+    requires addr >= base && addr > 0 && size == 1 && addr % 8 == 0)]
+pub fn test_cast_does_not_create_extent(nn: NonNull<u8>) {
+    let wide = nn.cast::<u64>();
+    unsafe {
+        wide.write(0); //~ ERROR refinement type error
+    }
+}
+
+#[flux::spec(fn(nn: NonNull<u8>[@base, @addr, @size])
+    requires addr >= base && addr > 0 && size >= 8 && addr % 8 != 0)]
+pub fn test_cast_does_not_create_alignment(nn: NonNull<u8>) {
+    let wide = nn.cast::<u64>();
+    unsafe {
+        wide.write(0); //~ ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr01.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr01.rs
@@ -227,6 +227,67 @@ pub fn test_cast_slice_bytes(buf: &[i32; 4]) {
     }
 }
 
+// --- cast ---
+//
+// These mirror the ptr-to-ptr `as` casts above.
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}))]
+pub fn test_cast_method_narrow_read(ptr: *const i32) {
+    let byte_ptr = ptr.cast::<u8>();
+    unsafe {
+        let _b = std::ptr::read(byte_ptr);
+    }
+}
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 8 && addr % 8 == 0}))]
+pub fn test_cast_method_widen_read(ptr: *const i32) {
+    let wide_ptr = ptr.cast::<i64>();
+    unsafe {
+        let _v = std::ptr::read(wide_ptr);
+    }
+}
+
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}))]
+pub fn test_cast_method_byte_add_write(ptr: *mut i32) {
+    let byte_ptr = ptr.cast::<u8>();
+    unsafe {
+        std::ptr::write(byte_ptr.byte_add(3), 255);
+    }
+}
+
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}))]
+pub fn test_cast_method_round_trip(ptr: *mut i32) {
+    let byte_ptr = ptr.cast::<u8>();
+    let int_ptr = byte_ptr.cast::<i32>();
+    unsafe {
+        std::ptr::write(int_ptr, 10);
+    }
+}
+
+pub fn test_cast_method_slice_bytes(buf: &[i32; 4]) {
+    let ptr = buf.as_ptr();
+    let byte_ptr = ptr.cast::<u8>();
+    unsafe {
+        let _b = std::ptr::read(byte_ptr.byte_add(15));
+    }
+}
+
+#[flux::spec(fn (ptr: {*mut[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}))]
+pub fn test_cast_const_method(ptr: *mut i32) {
+    let const_ptr = ptr.cast_const();
+    unsafe {
+        let _value = std::ptr::read(const_ptr);
+    }
+}
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size >= 4 && addr % 4 == 0}))]
+pub fn test_cast_mut_method(ptr: *const i32) {
+    let mut_ptr = ptr.cast_mut();
+    unsafe {
+        std::ptr::write(mut_ptr, 10);
+    }
+}
+
 pub fn ref_to_ptr_read(z: i32) -> i32 {
     unsafe { std::ptr::read(&z) }
 }

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null05.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null05.rs
@@ -1,0 +1,55 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+
+// --- cast ---
+
+#[flux::spec(fn(nn: NonNull<T>[@base, @addr, @size]) -> NonNull<U>[base, addr, size])]
+pub fn test_cast_preserves_indices<T, U>(nn: NonNull<T>) -> NonNull<U> {
+    nn.cast::<U>()
+}
+
+#[flux::spec(fn(nn: NonNull<i32>[@base, @addr, @size])
+    requires addr >= base && addr > 0 && size >= 4 && addr % 4 == 0)]
+pub fn test_cast_narrow_read(nn: NonNull<i32>) {
+    let bytes = nn.cast::<u8>();
+    unsafe {
+        let _value = bytes.read();
+    }
+}
+
+#[flux::spec(fn(nn: NonNull<i32>[@base, @addr, @size])
+    requires addr >= base && addr > 0 && size >= 8 && addr % 8 == 0)]
+pub fn test_cast_widen_read(nn: NonNull<i32>) {
+    let wide = nn.cast::<i64>();
+    unsafe {
+        let _value = wide.read();
+    }
+}
+
+#[flux::spec(fn(nn: NonNull<i32>[@base, @addr, @size])
+    requires addr >= base && addr > 0 && size >= 4 && addr % 4 == 0)]
+pub fn test_cast_byte_add_write(nn: NonNull<i32>) {
+    let bytes = nn.cast::<u8>();
+    unsafe {
+        bytes.byte_add(3).write(255);
+    }
+}
+
+#[flux::spec(fn(nn: NonNull<i32>[@base, @addr, @size])
+    requires addr >= base && addr > 0 && size >= 4 && addr % 4 == 0)]
+pub fn test_cast_round_trip(nn: NonNull<i32>) {
+    let bytes = nn.cast::<u8>();
+    let ints = bytes.cast::<i32>();
+    unsafe {
+        ints.write(10);
+    }
+}
+
+pub fn test_cast_slice_bytes(buf: &mut [i32; 4]) {
+    let nn = unsafe { NonNull::new_unchecked(buf.as_mut_ptr()) };
+    let bytes = nn.cast::<u8>();
+    unsafe {
+        let _last = bytes.byte_add(15).read();
+    }
+}


### PR DESCRIPTION
This pr adds specs that preserve pointer/NonNull indices through their `cast*` methods. This is already how we handle `as` casts (see https://github.com/flux-rs/flux/pull/1710).