### PR TITLE
Preserve exhausted slice windows state in specs

### DIFF
--- a/lib/flux-core/src/slice/iter.rs
+++ b/lib/flux-core/src/slice/iter.rs
@@ -53,12 +53,17 @@ struct Windows<'a, T>;
 #[assoc(
     fn size(x: Windows) -> int { if x.window_size > x.remaining { 0 } else { x.remaining - x.window_size + 1 } }
     fn done(x: Windows) -> bool { x.remaining < x.window_size }
-    fn step(x: Windows, y: Windows) -> bool { y.remaining == x.remaining - 1 && y.window_size == x.window_size }
+    fn step(x: Windows, y: Windows) -> bool {
+        y.remaining == if x.remaining >= x.window_size { x.remaining - 1 } else { x.remaining }
+        && y.window_size == x.window_size
+    }
 )]
 impl<'a, T> Iterator for Windows<'a, T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/slice/iter.rs#L1356
     #[no_panic]
     #[spec(fn(self: &mut Windows<T>[@curr_s]) -> Option<&[T][curr_s.window_size]>[curr_s.remaining >= curr_s.window_size]
-           ensures self: Windows<T>{next_s: next_s.remaining == curr_s.remaining - 1 && next_s.window_size == curr_s.window_size})]
+           ensures self: Windows<T>{next_s:
+               next_s.remaining == if curr_s.remaining >= curr_s.window_size { curr_s.remaining - 1 } else { curr_s.remaining }
+               && next_s.window_size == curr_s.window_size})]
     fn next(&mut self) -> Option<&'a [T]>;
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_slice03.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_slice03.rs
@@ -1,6 +1,8 @@
 extern crate flux_core;
 
 #[flux_rs::trusted]
+// Exposes the ghost state for transition tests. This is consistent for Windows
+// values reachable through `slice::windows`, whose remaining length is nonnegative.
 #[flux_rs::spec(fn(&std::slice::Windows<T>[@remaining, @size]) -> usize[remaining])]
 fn windows_remaining<T>(_: &std::slice::Windows<T>) -> usize {
     unimplemented!()

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_slice03.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_slice03.rs
@@ -1,5 +1,11 @@
 extern crate flux_core;
 
+#[flux_rs::trusted]
+#[flux_rs::spec(fn(&std::slice::Windows<T>[@remaining, @size]) -> usize[remaining])]
+fn windows_remaining<T>(_: &std::slice::Windows<T>) -> usize {
+    unimplemented!()
+}
+
 // windows() yields slices of length window_size, so indexing out of that
 // range is a statically detectable error.
 
@@ -12,4 +18,12 @@ pub fn test_windows_oob(xs: &[i32]) {
 
 pub fn test_windows_unwrap_unchecked(xs: &[i32]) {
     let _ = xs.windows(2).next().unwrap(); //~ ERROR refinement type error
+}
+
+pub fn test_exhausted_windows_does_not_create_false_context() {
+    let xs: [i32; 0] = [];
+    let mut it = xs.windows(1);
+    let _ = it.next();
+    let _ = windows_remaining(&it);
+    let _ = xs[0]; //~ ERROR possible out-of-bounds access
 }

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_slice04.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_slice04.rs
@@ -3,6 +3,12 @@ use flux_rs::assert;
 
 // --- windows ---
 
+#[flux_rs::trusted]
+#[flux_rs::spec(fn(&std::slice::Windows<T>[@remaining, @size]) -> usize[remaining])]
+fn windows_remaining<T>(_: &std::slice::Windows<T>) -> usize {
+    unimplemented!()
+}
+
 pub fn test_windows_some_concrete() {
     let v = [1, 2, 3, 4, 5];
     let mut it = v.windows(3);
@@ -13,6 +19,16 @@ pub fn test_windows_none_when_too_short() {
     let v: [i32; 2] = [1, 2];
     let mut it = v.windows(3);
     assert(it.next().is_none());
+}
+
+pub fn test_exhausted_windows_next_preserves_remaining() {
+    let v: [i32; 0] = [];
+    let mut it = v.windows(1);
+    let remaining = windows_remaining(&it);
+    let _ = it.next();
+    assert(windows_remaining(&it) == remaining);
+    let _ = it.next();
+    assert(windows_remaining(&it) == remaining);
 }
 
 pub fn test_windows_some_branch(xs: &[i32]) {

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_slice04.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_slice04.rs
@@ -4,6 +4,8 @@ use flux_rs::assert;
 // --- windows ---
 
 #[flux_rs::trusted]
+// Exposes the ghost state for transition tests. This is consistent for Windows
+// values reachable through `slice::windows`, whose remaining length is nonnegative.
 #[flux_rs::spec(fn(&std::slice::Windows<T>[@remaining, @size]) -> usize[remaining])]
 fn windows_remaining<T>(_: &std::slice::Windows<T>) -> usize {
     unimplemented!()
@@ -28,6 +30,16 @@ pub fn test_exhausted_windows_next_preserves_remaining() {
     let _ = it.next();
     assert(windows_remaining(&it) == remaining);
     let _ = it.next();
+    assert(windows_remaining(&it) == remaining);
+}
+
+pub fn test_windows_final_item_then_exhaustion_preserves_remaining() {
+    let v = [1];
+    let mut it = v.windows(1);
+    assert(it.next().is_some());
+    let remaining = windows_remaining(&it);
+    assert(remaining == 0);
+    assert(it.next().is_none());
     assert(windows_remaining(&it) == remaining);
 }
 


### PR DESCRIPTION
## Summary

- preserve `slice::Windows` remaining state after the iterator is exhausted
- align the associated `Iterator::step` relation with the `next` postcondition
- cover initially exhausted, final-item, and repeated-exhaustion transitions
- add a negative regression preventing inconsistent exhausted state from creating false proof context

The current specification decrements `remaining` on every call to `next`, including calls after exhaustion. Rust leaves an exhausted `Windows` iterator unchanged. Once the ghost state becomes negative, it can introduce inconsistent assumptions and make invalid programs verify.

## Test

- `PATH="$HOME/.cargo/bin:$PATH" cargo xtask test flux_core_slice03`
- `PATH="$HOME/.cargo/bin:$PATH" cargo xtask test flux_core_slice04`