### PR TITLE
Preserve exhausted take iterator state

### DIFF
--- a/lib/flux-core/src/iter/adapters/take.rs
+++ b/lib/flux-core/src/iter/adapters/take.rs
@@ -17,7 +17,11 @@ struct Take<I>;
     fn size(x: Take<I>) -> int { min(x.n, <I as Iterator>::size(x.inner)) }
     fn done(x: Take<I>) -> bool { x.n <= 0 || <I as Iterator>::done(x.inner) }
     fn step(x: Take<I>, y: Take<I>) -> bool {
-        y.n == x.n - 1 && <I as Iterator>::step(x.inner, y.inner)
+        if x.n > 0 {
+            y.n == x.n - 1 && <I as Iterator>::step(x.inner, y.inner)
+        } else {
+            y.n == x.n && y.inner == x.inner
+        }
     }
 )]
 impl<I: Iterator> Iterator for Take<I> {

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_iter00.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_iter00.rs
@@ -1,0 +1,17 @@
+extern crate flux_core;
+use flux_rs::assert;
+
+#[flux_rs::trusted]
+#[flux_rs::spec(fn(&std::iter::Take<I>[@n, @inner]) -> usize[n])]
+fn take_remaining<I>(_: &std::iter::Take<I>) -> usize {
+    unimplemented!()
+}
+
+// Calling `next` after `take(0)` is exhausted must not create an impossible negative count.
+pub fn test_exhausted_take_does_not_create_false_context() {
+    let xs: [i32; 0] = [];
+    let mut iter = xs.iter().take(0);
+    let _ = iter.next();
+    let _ = take_remaining(&iter);
+    assert(false); //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_iter00.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_iter00.rs
@@ -76,6 +76,22 @@ pub fn test_take_beyond_end(xs: &[i32]) {
     }
 }
 
+#[flux_rs::trusted]
+#[flux_rs::spec(fn(&std::iter::Take<I>[@n, @inner]) -> usize[n])]
+fn take_remaining<I>(_: &std::iter::Take<I>) -> usize {
+    unimplemented!()
+}
+
+pub fn test_exhausted_take_next_preserves_remaining() {
+    let xs: [i32; 0] = [];
+    let mut iter = xs.iter().take(0);
+    let remaining = take_remaining(&iter);
+    let _ = iter.next();
+    assert(take_remaining(&iter) == remaining);
+    let _ = iter.next();
+    assert(take_remaining(&iter) == remaining);
+}
+
 // --- Range::next ---
 
 pub fn test_exhausted_range_is_unchanged() {


### PR DESCRIPTION
## Summary

- preserve a `Take` iterator’s quota and inner state when `next` is called with no quota remaining
- add repeated-exhaustion coverage
- add a negative regression showing that a negative ghost quota creates false proof context

Rust returns `None` without modifying either field when `Take::next` is called with `n == 0`. The current Flux transition decrements `n` unconditionally, producing `-1`. Because the quota originates as a `usize`, that inconsistent state can make invalid assertions verify.

## Test

`PATH="$HOME/.cargo/bin:$PATH" cargo xtask test flux_core_iter00`