### PR TITLE
Preserve exhausted skip iterator size

### DIFF
--- a/lib/flux-core/src/iter/adapters/skip.rs
+++ b/lib/flux-core/src/iter/adapters/skip.rs
@@ -13,7 +13,9 @@ struct Skip<I>;
 #[extern_spec(core::iter)]
 #[assoc(
     fn size(r: Skip) -> int { r.size }
-    fn step(self: Skip, other: Skip) -> bool { other.size == self.size - 1 }
+    fn step(self: Skip, other: Skip) -> bool {
+        other.size == if self.size > 0 { self.size - 1 } else { self.size }
+    }
 )]
 impl<I: Iterator> Iterator for Skip<I> {
     #[spec(

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_iter01.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_iter01.rs
@@ -1,0 +1,16 @@
+extern crate flux_core;
+
+#[flux_rs::trusted]
+#[flux_rs::spec(fn(&std::iter::Skip<I>[@size]) -> usize[size])]
+fn skip_size<I>(_: &std::iter::Skip<I>) -> usize {
+    unimplemented!()
+}
+
+// Calling `next` on an exhausted `Skip` must not make its logical size negative.
+// A negative size is inconsistent with `usize` and would let Flux prove `false`.
+pub fn test_exhausted_skip_does_not_create_false_context() {
+    let mut it = [0_i32; 0].iter().skip(0);
+    let _ = it.next();
+    let _ = skip_size(&it);
+    flux_rs::assert(false); //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_iter01.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_iter01.rs
@@ -1,0 +1,17 @@
+extern crate flux_core;
+
+use flux_rs::assert;
+
+#[flux_rs::trusted]
+#[flux_rs::spec(fn(&std::iter::Skip<I>[@size]) -> usize[size])]
+fn skip_size<I>(_: &std::iter::Skip<I>) -> usize {
+    unimplemented!()
+}
+
+pub fn test_exhausted_skip_preserves_size() {
+    let mut it = [0_i32; 0].iter().skip(0);
+    let _ = it.next();
+    assert(skip_size(&it) == 0);
+    let _ = it.next();
+    assert(skip_size(&it) == 0);
+}


### PR DESCRIPTION
## Summary

- preserve `Skip`’s abstract remaining size when `next` is called after exhaustion
- add repeated-exhaustion coverage
- add a negative regression showing that a negative ghost size creates false proof context

The current Flux transition decrements the abstract remaining-output size unconditionally. At size zero, this produces `-1`; because the size is exposed as a `usize`, that inconsistent state can make invalid assertions verify.

This keeps the existing simplified `Skip` abstraction and only corrects its exhausted-size transition. It does not attempt to model the adapter’s private skip count or arbitrary non-fused inner iterators.

## Test

`PATH="$HOME/.cargo/bin:$PATH" cargo xtask test flux_core_iter01`