### PR TITLE
Preserve existential relationships in array elements

### DIFF
--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -20,11 +20,12 @@ use flux_middle::{
     query_bug,
     rty::{
         self, AdtDef, AliasReft, BaseTy, BinOp, Binder, Bool, Clause, Constant,
-        CoroutineObligPredicate, EarlyBinder, Expr, FnOutput, FnSig, FnTraitPredicate, GenericArg,
-        GenericArgsExt as _, Int, IntTy, Mutability, Path, PolyFnSig, PtrKind, RefineArgs,
-        RefineArgsExt,
+        CoroutineObligPredicate, EarlyBinder, Expr, ExprKind, FnOutput, FnSig, FnTraitPredicate,
+        GenericArg, GenericArgsExt as _, Int, IntTy, Mutability, Path, PolyFnSig, PtrKind,
+        RefineArgs, RefineArgsExt,
         Region::ReErased,
         Sort, SubsetTyCtor, Ty, TyKind, Uint, UintTy, VariantIdx,
+        canonicalize::{Hoister, LocalHoister},
         fold::{TypeFoldable, TypeFolder, TypeSuperFoldable},
         refining::{Refine, Refiner},
     },
@@ -1696,6 +1697,20 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
         arr_ty: Ty,
     ) -> InferResult<Ty> {
         let arr_ty = infcx.ensure_resolved_evars(|infcx| {
+            // Hoist all element indices so a single kvar can relate them.
+            let mut delegate = LocalHoister::default();
+            let arr_ty = Hoister::with_delegate(&mut delegate)
+                .transparent()
+                .hoist(&arr_ty);
+            let arr_ty = delegate
+                .bind(|_, preds| {
+                    let preds = preds
+                        .into_iter()
+                        .filter(|pred| !matches!(pred.kind(), ExprKind::Hole(rty::HoleKind::Pred)))
+                        .chain(std::iter::once(Expr::hole(rty::HoleKind::Pred)));
+                    Ty::constr(Expr::and_from_iter(preds), arr_ty)
+                })
+                .to_ty();
             let arr_ty =
                 arr_ty.replace_holes(|binders, kind| infcx.fresh_infer_var_for_hole(binders, kind));
 

--- a/tests/tests/pos/array/array05.rs
+++ b/tests/tests/pos/array/array05.rs
@@ -1,0 +1,21 @@
+use flux_attrs::*;
+
+fn assert(_: bool) {}
+
+#[flux::sig(fn() -> {a, b. (usize[a], usize[b]) | a < b})]
+fn tuple() -> (usize, usize) {
+    (10, 20)
+}
+
+#[flux::sig(fn() -> [{a, b. (usize[a], usize[b]) | a < b}; 2])]
+fn tuples() -> [(usize, usize); 2] {
+    let x0 = tuple();
+    let x1 = tuple();
+    [x0, x1]
+}
+
+fn test() {
+    let xs = tuples();
+    let (a, b) = xs[0];
+    assert(a < b);
+}


### PR DESCRIPTION
Fixes #1736.

Array construction filled refinement holes before existential indices nested inside tuple elements were hoisted. This produced independent kvars that could not express relationships between tuple fields.

Hoist the element indices first, then generate a single kvar over all of them. This allows relationships such as `a < b` to be inferred when existentially refined tuples are collected into an array.

Adds a regression test covering array construction and subsequent indexing.