### PR TITLE
Add specs for dangling pointer functions

### DIFF
--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -190,6 +190,18 @@ fn null<T>() -> *const T;
 fn null_mut<T>() -> *mut T;
 
 #[extern_spec(core::ptr)]
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L917
+#[no_panic]
+#[spec(fn() -> *const{p: p.size == 0 && p.addr != 0 && aligned_to(p, T::align_of())} T)]
+fn dangling<T>() -> *const T;
+
+#[extern_spec(core::ptr)]
+// See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L962
+#[no_panic]
+#[spec(fn() -> *mut{p: p.size == 0 && p.addr != 0 && aligned_to(p, T::align_of())} T)]
+fn dangling_mut<T>() -> *mut T;
+
+#[extern_spec(core::ptr)]
 // - `src` must be valid for reads or `T` must be a ZST.
 // - `src` must be properly aligned. Use `read_unaligned` if this is not the case.
 // See: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/mod.rs#L1591-L1596

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -32,6 +32,13 @@ use flux_attrs::*;
 struct NonNull<T>;
 
 #[extern_spec(core::ptr)]
+impl<T: Sized> NonNull<T> {
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L131
+    #[spec(fn() -> NonNull<T>{p: p.size == 0 && p.addr != 0 && nn_aligned_to(p.addr, T::align_of())})]
+    fn dangling() -> Self;
+}
+
+#[extern_spec(core::ptr)]
 impl<T> NonNull<T> {
     /// Need to enforce that the pointer value is non-null, because as the name suggests, this function does not check.
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L234

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr09.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr09.rs
@@ -1,0 +1,47 @@
+extern crate flux_core;
+
+use std::ptr;
+use flux_rs::assert;
+
+// --- dangling ---
+
+pub fn test_dangling_deref_non_zst() {
+    let p: *const i32 = ptr::dangling();
+    unsafe {
+        let _val = p.read(); //~ ERROR refinement type error
+    }
+}
+
+// this and the NonNull version of dangling() never return null
+pub fn test_dangling_null() {
+    let p: *const i64 = ptr::dangling();
+    assert(p.is_null()) //~ ERROR refinement type error
+}
+
+// in reality, dangling() always returns the alignment of the underlying
+// type; however, it is only specified to return an aligned pointer, so
+// comparisons may be unequal
+pub fn test_dangling_same() {
+    let p1: *const u64 = ptr::dangling();
+    let p2: *const u64 = ptr::dangling();
+    assert(p1 == p2) //~ ERROR refinement type error
+}
+
+// --- dangling_mut ---
+
+pub fn test_dangling_write() {
+    let p: *mut f32 = ptr::dangling_mut();
+    unsafe {
+        p.write(12.3); //~ ERROR refinement type error
+    }
+}
+
+pub fn test_dangling_cmp(p: *mut i32) {
+    let p_dangle: *mut i32 = ptr::dangling_mut();
+    assert(!(p == p_dangle)) //~ ERROR refinement type error
+}
+
+pub fn test_dangling_aligned() {
+    let p: *mut u64 = ptr::dangling_mut();
+    assert(!p.is_aligned()) //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null06.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null06.rs
@@ -1,0 +1,31 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+use flux_rs::assert;
+
+// --- dangling ---
+
+pub fn test_dangling_deref_non_zst() {
+    let nn = NonNull::dangling();
+    unsafe {
+        let _val: i32 = nn.read(); //~ ERROR refinement type error
+    }
+}
+
+pub fn test_dangling_null() {
+    let nn: NonNull<u32> = NonNull::dangling();
+    let raw = nn.as_ptr();
+    assert(raw.is_null()) //~ ERROR refinement type error
+}
+
+pub fn test_dangling_write() {
+    let nn: NonNull<f32> = NonNull::dangling();
+    unsafe {
+        nn.write(4.2); //~ ERROR refinement type error
+    }
+}
+
+pub fn test_dangling_cmp(nn: NonNull<i32>) {
+    let nn_dangle = NonNull::dangling();
+    assert(!(nn == nn_dangle)) //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr10.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr10.rs
@@ -1,0 +1,20 @@
+extern crate flux_core;
+
+use std::ptr;
+use flux_rs::assert;
+
+// --- dangling ---
+
+pub fn test_dangling_deref_zst() {
+    let p: *const () = ptr::dangling();
+    unsafe {
+        let _val: () = p.read();
+    }
+}
+
+// --- dangling_mut ---
+
+pub fn test_dangling_not_null() {
+    let p: *mut i32 = ptr::dangling_mut();
+    assert(!p.is_null())
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null06.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null06.rs
@@ -1,0 +1,21 @@
+extern crate flux_core;
+
+use std::ptr::NonNull;
+use flux_rs::assert;
+
+// --- dangling ---
+
+// dereferencing a dangling pointer to a zero sized type is fine
+// note that dangling pointers must be aligned
+pub fn test_dangling_deref_zst() {
+    let nn = NonNull::dangling();
+    unsafe {
+        let _val: () = nn.read();
+    }
+}
+
+pub fn test_dangling_not_null() {
+    let nn: NonNull<u32> = NonNull::dangling();
+    let raw = nn.as_ptr();
+    assert(!raw.is_null())
+}


### PR DESCRIPTION
- PR adds specs for std::ptr::dangling / dangling_mut / NonNull::dangling, which create a dangling pointer