### PR TITLE
Add specs for raw pointer comparisons

### DIFF
--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -613,7 +613,7 @@ impl Expr {
         }
     }
 
-    /// Reduce a pointer to it's address, for comparisons
+    /// Reduce a pointer to its address, for relational operators
     pub fn reduce_ptr_addr(&self) -> Expr {
         self.proj_and_reduce(FieldProj::RawPtr { field: RawPtrField::Addr })
     }

--- a/crates/flux-middle/src/rty/expr.rs
+++ b/crates/flux-middle/src/rty/expr.rs
@@ -613,6 +613,11 @@ impl Expr {
         }
     }
 
+    /// Reduce a pointer to it's address, for comparisons
+    pub fn reduce_ptr_addr(&self) -> Expr {
+        self.proj_and_reduce(FieldProj::RawPtr { field: RawPtrField::Addr })
+    }
+
     pub fn visit_conj<'a>(&'a self, mut f: impl FnMut(&'a Expr)) {
         fn go<'a>(e: &'a Expr, f: &mut impl FnMut(&'a Expr)) {
             if let ExprKind::BinaryOp(BinOp::And, e1, e2) = e.kind() {

--- a/crates/flux-middle/src/rty/mod.rs
+++ b/crates/flux-middle/src/rty/mod.rs
@@ -1720,6 +1720,12 @@ impl Ty {
             .unwrap_or_default()
     }
 
+    pub fn is_raw_ptr(&self) -> bool {
+        self.as_bty_skipping_existentials()
+            .map(BaseTy::is_raw_ptr)
+            .unwrap_or_default()
+    }
+
     pub fn is_array(&self) -> bool {
         self.as_bty_skipping_existentials()
             .map(BaseTy::is_array)
@@ -1991,6 +1997,10 @@ impl BaseTy {
 
     pub fn is_str(&self) -> bool {
         matches!(self, BaseTy::Str)
+    }
+
+    pub fn is_raw_ptr(&self) -> bool {
+        matches!(self, BaseTy::RawPtr(..))
     }
 
     pub fn invariants(

--- a/crates/flux-refineck/src/primops.rs
+++ b/crates/flux-refineck/src/primops.rs
@@ -464,12 +464,17 @@ fn mk_bit_xor_rules() -> RuleMatcher<2> {
 }
 
 // the (a: T, b: S) case ensures the last case is "unreachable", hence the "allow"
+// raw pointers may have slightly different types, but we still want to compare their addresses
 #[allow(unreachable_code)]
 /// `a == b`
 fn mk_eq_rules() -> RuleMatcher<2> {
     primop_rules! {
-        fn(a: T, b: T) -> bool[E::eq(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
-        if T.is_integral() || T.is_bool() || T.is_char() || T.is_str() || T.is_raw_ptr()
+        fn(a: T, b: T) -> bool[E::eq(a, b)]
+        if T.is_integral() || T.is_bool() || T.is_char() || T.is_str()
+
+        fn(a: T, b: S) -> bool[E::eq(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
+        if T.is_raw_ptr() && S.is_raw_ptr()
+
         fn(a: T, b: S) -> bool
     }
 }
@@ -478,8 +483,11 @@ fn mk_eq_rules() -> RuleMatcher<2> {
 /// `a != b`
 fn mk_ne_rules() -> RuleMatcher<2> {
     primop_rules! {
-        fn(a: T, b: T) -> bool[E::ne(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
+        fn(a: T, b: T) -> bool[E::ne(a, b)]
         if T.is_integral() || T.is_bool() || T.is_raw_ptr()
+
+        fn(a: T, b: S) -> bool[E::ne(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
+        if T.is_raw_ptr() && S.is_raw_ptr()
 
         fn(a: T, b: S) -> bool
     }
@@ -491,6 +499,9 @@ fn mk_le_rules() -> RuleMatcher<2> {
     primop_rules! {
         fn(a: T, b: T) -> bool[E::le(a, b)]
         if T.is_integral()
+
+        fn(a: T, b: S) -> bool[E::le(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
+        if T.is_raw_ptr() && S.is_raw_ptr()
 
         fn(a: bool, b: bool) -> bool[E::implies(a, b)]
 
@@ -505,6 +516,9 @@ fn mk_ge_rules() -> RuleMatcher<2> {
         fn(a: T, b: T) -> bool[E::ge(a, b)]
         if T.is_integral()
 
+        fn(a: T, b: S) -> bool[E::ge(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
+        if T.is_raw_ptr() && S.is_raw_ptr()
+
         fn(a: bool, b: bool) -> bool[E::implies(b, a)]
 
         fn(a: T, b: S) -> bool
@@ -518,6 +532,9 @@ fn mk_lt_rules() -> RuleMatcher<2> {
         fn(a: T, b: T) -> bool[E::lt(a, b)]
         if T.is_integral()
 
+        fn(a: T, b: S) -> bool[E::lt(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
+        if T.is_raw_ptr() && S.is_raw_ptr()
+
         fn(a: bool, b: bool) -> bool[E::and(a.not(), b)]
 
         fn(a: T, b: S) -> bool
@@ -530,6 +547,9 @@ fn mk_gt_rules() -> RuleMatcher<2> {
     primop_rules! {
         fn(a: T, b: T) -> bool[E::gt(a, b)]
         if T.is_integral()
+
+        fn(a: T, b: S) -> bool[E::gt(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
+        if T.is_raw_ptr() && S.is_raw_ptr()
 
         fn(a: bool, b: bool) -> bool[E::and(a, b.not())]
 

--- a/crates/flux-refineck/src/primops.rs
+++ b/crates/flux-refineck/src/primops.rs
@@ -468,8 +468,8 @@ fn mk_bit_xor_rules() -> RuleMatcher<2> {
 /// `a == b`
 fn mk_eq_rules() -> RuleMatcher<2> {
     primop_rules! {
-        fn(a: T, b: T) -> bool[E::eq(a, b)]
-        if T.is_integral() || T.is_bool() || T.is_char() || T.is_str()
+        fn(a: T, b: T) -> bool[E::eq(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
+        if T.is_integral() || T.is_bool() || T.is_char() || T.is_str() || T.is_raw_ptr()
         fn(a: T, b: S) -> bool
     }
 }
@@ -478,8 +478,8 @@ fn mk_eq_rules() -> RuleMatcher<2> {
 /// `a != b`
 fn mk_ne_rules() -> RuleMatcher<2> {
     primop_rules! {
-        fn(a: T, b: T) -> bool[E::ne(a, b)]
-        if T.is_integral() || T.is_bool()
+        fn(a: T, b: T) -> bool[E::ne(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
+        if T.is_integral() || T.is_bool() || T.is_raw_ptr()
 
         fn(a: T, b: S) -> bool
     }

--- a/crates/flux-refineck/src/primops.rs
+++ b/crates/flux-refineck/src/primops.rs
@@ -484,7 +484,7 @@ fn mk_eq_rules() -> RuleMatcher<2> {
 fn mk_ne_rules() -> RuleMatcher<2> {
     primop_rules! {
         fn(a: T, b: T) -> bool[E::ne(a, b)]
-        if T.is_integral() || T.is_bool() || T.is_raw_ptr()
+        if T.is_integral() || T.is_bool()
 
         fn(a: T, b: S) -> bool[E::ne(a.reduce_ptr_addr(), b.reduce_ptr_addr())]
         if T.is_raw_ptr() && S.is_raw_ptr()

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -139,11 +139,18 @@ macro_rules! ptr_specs {
             unsafe fn read(self) -> T
             where T: Sized;
 
-            // Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L48
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L48
             #[spec(fn(me: *$mutable[@p] T) -> *$mutable[p.base, p.addr, p.size] U)]
             fn cast<U>(self) -> *$mutable U;
 
             $($($extra)*)?
+        }
+
+        #[extern_spec(core::ptr)]
+        impl<T> PartialEq for *$mutable T {
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1614
+            #[spec(fn (me: &*$mutable[@m] T, other: &*$mutable[@o] T) -> bool[m.addr == o.addr])]
+            fn eq(&self, other: &*$mutable T) -> bool;
         }
     };
 }

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -140,3 +140,10 @@ impl<T> NonNull<[T]> {
         requires nn_valid(base, addr, size, len * T::size_of()) && nn_aligned_to(addr, T::align_of()))]
     fn slice_from_raw_parts(data: NonNull<T>, len: usize) -> Self;
 }
+
+#[extern_spec(core::ptr)]
+impl<T> PartialEq for NonNull<T> {
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1691
+    #[spec(fn (me: &NonNull<T>[@m], other: &NonNull<T>[@o]) -> bool[m.addr == o.addr])]
+    fn eq(&self, other: &NonNull<T>) -> bool;
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr10.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr10.rs
@@ -1,0 +1,10 @@
+extern crate flux_core;
+
+use flux_rs::assert;
+
+// --- eq ---
+
+pub fn test_ptr_neq(p: *mut i32) {
+    let p1 = p;
+    assert(!(p1.eq(&p))) //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr10.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr10.rs
@@ -8,3 +8,65 @@ pub fn test_ptr_neq(p: *mut i32) {
     let p1 = p;
     assert(!(p1.eq(&p))) //~ ERROR refinement type error
 }
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32, p2: *const[base, 0, size] i32))]
+pub fn test_ptr_id(p1: *const i32, p2: *const i32) {
+    assert(p1.eq(&p2)) //~ ERROR refinement type error
+}
+
+// --- ne ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
+pub fn test_ptr_neq_sym(p: *const i32) {
+    unsafe {
+        let p1 = p.add(1);
+        let p0 = p1.sub(1);
+        assert(p != p0) //~ ERROR refinement type error
+    }
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32, p2: *const[base, addr, size] i32))]
+pub fn test_ptr_id_sym(p1: *const i32, p2: *const i32) {
+    assert(p1 != p2) //~ ERROR refinement type error
+}
+
+// --- lt ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
+pub fn test_ptr_lt(p: *const i32) {
+    unsafe {
+        let p1 = p.add(1);
+        assert(p1 < p) //~ ERROR refinement type error
+    }
+}
+
+// --- le ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
+pub fn test_ptr_le(p: *const i32) {
+    unsafe {
+        let p1 = p.add(1);
+        assert(p1 <= p) //~ ERROR refinement type error
+    }
+}
+
+// --- gt ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 40}))]
+pub fn test_ptr_gt(p: *const i32) {
+    unsafe {
+        let p1 = p.add(4);
+        assert(p > p1) //~ ERROR refinement type error
+    }
+}
+
+// --- ge ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 16}))]
+pub fn test_ptr_ge(p: *const i32) {
+    unsafe {
+        let p1 = p.add(2);
+        let p2 = p1.sub(1);
+        assert(p2 >= p1) //~ ERROR refinement type error
+    }
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null07.rs
@@ -1,0 +1,32 @@
+extern crate flux_core;
+
+use flux_rs::assert;
+use std::ptr::NonNull;
+
+// --- eq ---
+
+pub fn test_ptr_neq(p: NonNull<i32>) {
+    let p1 = p;
+    assert(!(p1.eq(&p))) //~ ERROR refinement type error
+}
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size], p2: NonNull<i32>[base, 0, size]))]
+pub fn test_ptr_id(p1: NonNull<i32>, p2: NonNull<i32>) {
+    assert(p1.eq(&p2)) //~ ERROR refinement type error
+}
+
+// --- ne ---
+
+#[flux::spec(fn (ptr: {NonNull<i32>[@base, @addr, @size] | addr >= base && size == 8}))]
+pub fn test_ptr_neq_sym(p: NonNull<i32>) {
+    unsafe {
+        let p1 = p.add(1);
+        let p0 = p1.sub(1);
+        assert(p != p0) //~ ERROR refinement type error
+    }
+}
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size], p2: NonNull<i32>[base, addr, size]))]
+pub fn test_ptr_id_sym(p1: NonNull<i32>, p2: NonNull<i32>) {
+    assert(p1 != p2) //~ ERROR refinement type error
+}

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null07.rs
@@ -10,15 +10,15 @@ pub fn test_ptr_neq(p: NonNull<i32>) {
     assert(!(p1.eq(&p))) //~ ERROR refinement type error
 }
 
-#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size], p2: NonNull<i32>[base, 0, size]))]
-pub fn test_ptr_id(p1: NonNull<i32>, p2: NonNull<i32>) {
+#[flux::spec(fn(p1: NonNull<f64>[@base, @addr, @size], p2: NonNull<f64>[base, 8, size]))]
+pub fn test_ptr_id(p1: NonNull<f64>, p2: NonNull<f64>) {
     assert(p1.eq(&p2)) //~ ERROR refinement type error
 }
 
 // --- ne ---
 
-#[flux::spec(fn (ptr: {NonNull<i32>[@base, @addr, @size] | addr >= base && size == 8}))]
-pub fn test_ptr_neq_sym(p: NonNull<i32>) {
+#[flux::spec(fn (ptr: {NonNull<u32>[@base, @addr, @size] | addr >= base && size == 8}))]
+pub fn test_ptr_neq_sym(p: NonNull<u32>) {
     unsafe {
         let p1 = p.add(1);
         let p0 = p1.sub(1);

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
@@ -4,7 +4,7 @@ use flux_rs::assert;
 
 // --- eq ---
 
-#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size == 8 && addr % 4 == 0}))]
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
 pub fn test_ptr_eq(p: *const i32) {
     unsafe {
         let p1 = p.add(1);
@@ -13,7 +13,7 @@ pub fn test_ptr_eq(p: *const i32) {
     }
 }
 
-#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size == 8 && addr % 4 == 0}))]
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
 pub fn test_ptr_eq_sym(p: *const i32) {
     unsafe {
         let p1 = p.add(1);
@@ -30,4 +30,44 @@ pub fn test_ptr_id_sym(p1: *const i32, p2: *const i32) {
 #[flux::spec(fn(p1: *const[@base, @addr, @size] i32, p2: *const[base, addr, size] i32))]
 pub fn test_ptr_id(p1: *const i32, p2: *const i32) {
     assert(p1.eq(&p2))
+}
+
+// --- lt ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
+pub fn test_ptr_lt(p: *const i32) {
+    unsafe {
+        let p1 = p.add(1);
+        assert(p < p1)
+    }
+}
+
+// --- le ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
+pub fn test_ptr_le(p: *const i32) {
+    unsafe {
+        let p1 = p.add(1);
+        assert(p <= p1)
+    }
+}
+
+// --- gt ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 40}))]
+pub fn test_ptr_gt(p: *const i32) {
+    unsafe {
+        let p1 = p.add(4);
+        assert(p1 > p)
+    }
+}
+
+// --- ge ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
+pub fn test_ptr_ge(p: *const i32) {
+    unsafe {
+        let p1 = p.add(0);
+        assert(p1 >= p)
+    }
 }

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
@@ -22,10 +22,7 @@ pub fn test_ptr_eq_sym(p: *const i32) {
     }
 }
 
-#[flux::spec(fn(
-    p1: *const[@base, @addr, @size] i32,
-    p2: { *const[@b, @a, @s] i32 | b == base && a == addr && s == size }
-))]
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32, p2: *const[base, addr, size] i32))]
 pub fn test_ptr_id(p1: *const i32, p2: *const i32) {
     assert(p1 == p2)
 }

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
@@ -23,6 +23,11 @@ pub fn test_ptr_eq_sym(p: *const i32) {
 }
 
 #[flux::spec(fn(p1: *const[@base, @addr, @size] i32, p2: *const[base, addr, size] i32))]
-pub fn test_ptr_id(p1: *const i32, p2: *const i32) {
+pub fn test_ptr_id_sym(p1: *const i32, p2: *const i32) {
     assert(p1 == p2)
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32, p2: *const[base, addr, size] i32))]
+pub fn test_ptr_id(p1: *const i32, p2: *const i32) {
+    assert(p1.eq(&p2))
 }

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
@@ -1,0 +1,31 @@
+extern crate flux_core;
+
+use flux_rs::assert;
+
+// --- eq ---
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size == 8 && addr % 4 == 0}))]
+pub fn test_ptr_eq(p: *const i32) {
+    unsafe {
+        let p1 = p.add(1);
+        let p0 = p1.sub(1);
+        assert(p.eq(&p0))
+    }
+}
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && addr > 0 && size == 8 && addr % 4 == 0}))]
+pub fn test_ptr_eq_sym(p: *const i32) {
+    unsafe {
+        let p1 = p.add(1);
+        let p0 = p1.sub(1);
+        assert(p == p0)
+    }
+}
+
+#[flux::spec(fn(
+    p1: *const[@base, @addr, @size] i32,
+    p2: { *const[@b, @a, @s] i32 | b == base && a == addr && s == size }
+))]
+pub fn test_ptr_id(p1: *const i32, p2: *const i32) {
+    assert(p1 == p2)
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
@@ -22,6 +22,18 @@ pub fn test_ptr_eq_sym(p: *const i32) {
     }
 }
 
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, addr, @size1] i32 | base != base1 && size != size1}))]
+pub fn test_ptr_id_sym_addr_only(p1: *const i32, p2: *const i32) {
+    assert(p1 == p2)
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, addr, @size1] i32 | base != base1 && size != size1}))]
+pub fn test_ptr_id_addr_only(p1: *const i32, p2: *const i32) {
+    assert(p1.eq(&p2))
+}
+
 #[flux::spec(fn(p1: *const[@base, @addr, @size] i32, p2: *const[base, addr, size] i32))]
 pub fn test_ptr_id_sym(p1: *const i32, p2: *const i32) {
     assert(p1 == p2)
@@ -42,6 +54,13 @@ pub fn test_ptr_lt(p: *const i32) {
     }
 }
 
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr < addr1}))]
+pub fn test_ptr_lt_addr_only(p1: *const i32, p2: *const i32) {
+    assert(p1 < p2)
+}
+
 // --- le ---
 
 #[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
@@ -50,6 +69,13 @@ pub fn test_ptr_le(p: *const i32) {
         let p1 = p.add(1);
         assert(p <= p1)
     }
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr <= addr1}))]
+pub fn test_ptr_le_addr_only(p1: *const i32, p2: *const i32) {
+    assert(p1 <= p2)
 }
 
 // --- gt ---
@@ -62,6 +88,13 @@ pub fn test_ptr_gt(p: *const i32) {
     }
 }
 
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr > addr1}))]
+pub fn test_ptr_gt_addr_only(p1: *const i32, p2: *const i32) {
+    assert(p1 > p2)
+}
+
 // --- ge ---
 
 #[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
@@ -71,3 +104,11 @@ pub fn test_ptr_ge(p: *const i32) {
         assert(p1 >= p)
     }
 }
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr >= addr1}))]
+pub fn test_ptr_ge_addr_only(p1: *const i32, p2: *const i32) {
+    assert(p1 >= p2)
+}
+

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
@@ -1,0 +1,34 @@
+extern crate flux_core;
+
+use flux_rs::assert;
+use std::ptr::NonNull;
+
+// --- eq ---
+
+#[flux::spec(fn (ptr: {NonNull<i32>[@base, @addr, @size] | addr >= base && size == 8}))]
+pub fn test_ptr_eq(p: NonNull<i32>) {
+    unsafe {
+        let p1 = p.add(1);
+        let p0 = p1.sub(1);
+        assert(p.eq(&p0))
+    }
+}
+
+#[flux::spec(fn (ptr: {NonNull<i32>[@base, @addr, @size] | addr >= base && size == 8}))]
+pub fn test_ptr_eq_sym(p: NonNull<i32>) {
+    unsafe {
+        let p1 = p.add(1);
+        let p0 = p1.sub(1);
+        assert(p == p0)
+    }
+}
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size], p2: NonNull<i32>[base, addr, size]))]
+pub fn test_ptr_id_sym(p1: NonNull<i32>, p2: NonNull<i32>) {
+    assert(p1 == p2)
+}
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size], p2: NonNull<i32>[base, addr, size]))]
+pub fn test_ptr_id(p1: NonNull<i32>, p2: NonNull<i32>) {
+    assert(p1.eq(&p2))
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
@@ -14,8 +14,8 @@ pub fn test_ptr_eq(p: NonNull<i32>) {
     }
 }
 
-#[flux::spec(fn (ptr: {NonNull<i32>[@base, @addr, @size] | addr >= base && size == 8}))]
-pub fn test_ptr_eq_sym(p: NonNull<i32>) {
+#[flux::spec(fn (ptr: {NonNull<u64>[@base, @addr, @size] | addr >= base && size == 16}))]
+pub fn test_ptr_eq_sym(p: NonNull<u64>) {
     unsafe {
         let p1 = p.add(1);
         let p0 = p1.sub(1);
@@ -23,8 +23,8 @@ pub fn test_ptr_eq_sym(p: NonNull<i32>) {
     }
 }
 
-#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size], p2: NonNull<i32>[base, addr, size]))]
-pub fn test_ptr_id_sym(p1: NonNull<i32>, p2: NonNull<i32>) {
+#[flux::spec(fn(p1: NonNull<f32>[@base, @addr, @size], p2: NonNull<f32>[base, addr, size]))]
+pub fn test_ptr_id_sym(p1: NonNull<f32>, p2: NonNull<f32>) {
     assert(p1 == p2)
 }
 

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
@@ -32,3 +32,15 @@ pub fn test_ptr_id_sym(p1: NonNull<f32>, p2: NonNull<f32>) {
 pub fn test_ptr_id(p1: NonNull<i32>, p2: NonNull<i32>) {
     assert(p1.eq(&p2))
 }
+
+#[flux::spec(fn(p1: NonNull<f32>[@base, @addr, @size],
+                p2: {NonNull<f32>[@base1, addr, @size1] | base != base1 && size != size1}))]
+pub fn test_ptr_id_sym_addr_only(p1: NonNull<f32>, p2: NonNull<f32>) {
+    assert(p1 == p2)
+}
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size],
+                p2: {NonNull<i32>[@base1, addr, @size1] | base != base1 && size != size1}))]
+pub fn test_ptr_id_addr_only(p1: NonNull<i32>, p2: NonNull<i32>) {
+    assert(p1.eq(&p2))
+}


### PR DESCRIPTION
- This PR adds specs for PartialEq pointer equality functions (for *mut T, *const T, and NonNull<T>), and adds logic to reduce comparisons of raw pointers to comparisons of their addresses
- Note that comparing raw pointers across allocations should be well defined, since they implement Ord
- Implementing PartialOrd comparisons is left to a future PR, since they return an Ordering