### PR TITLE
Add specs for Ordering + more raw pointer comparisons

### DIFF
--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -36,6 +36,27 @@ trait Ord {
         Self: Sized;
 }
 
+#[extern_spec]
+#[assoc(
+    fn is_lt(x: Self, y: Rhs, res: bool) -> bool { true }
+    fn is_le(x: Self, y: Rhs, res: bool) -> bool { true }
+    fn is_gt(x: Self, y: Rhs, res: bool) -> bool { true }
+    fn is_ge(x: Self, y: Rhs, res: bool) -> bool { true }
+)]
+trait PartialOrd<Rhs: PointeeSized = Self>: PointeeSized {
+    #[spec(fn(&Self[@x], &Rhs[@y]) -> bool{v: <Self as PartialOrd<Rhs>>::is_lt(x, y, v)})]
+    fn lt(&self, other: &Rhs) -> bool;
+
+    #[spec(fn(&Self[@x], &Rhs[@y]) -> bool{v: <Self as PartialOrd<Rhs>>::is_le(x, y, v)})]
+    fn le(&self, other: &Rhs) -> bool;
+
+    #[spec(fn(&Self[@x], &Rhs[@y]) -> bool{v: <Self as PartialOrd<Rhs>>::is_gt(x, y, v)})]
+    fn gt(&self, other: &Rhs) -> bool;
+
+    #[spec(fn(&Self[@x], &Rhs[@y]) -> bool{v: <Self as PartialOrd<Rhs>>::is_ge(x, y, v)})]
+    fn ge(&self, other: &Rhs) -> bool;
+}
+
 #[extern_spec(core::cmp)]
 #[assoc(
     fn min_res(a: int, b: int, res: int) -> bool { res == min(a, b) }

--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -51,7 +51,7 @@ enum Ordering {
     #[variant(Ordering[0])]
     Equal,
     #[variant(Ordering[1])]
-    Greater
+    Greater,
 }
 
 #[extern_spec(core::cmp)]

--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -53,3 +53,13 @@ enum Ordering {
     #[variant(Ordering[1])]
     Greater
 }
+
+#[extern_spec(core::cmp)]
+#[assoc(
+    fn is_eq(m: Ordering, o: Ordering, res: bool) -> bool { res <=> (m.res == o.res) }
+    fn is_ne(m: Ordering, o: Ordering, res: bool) -> bool { res <=> (m.res != o.res) }
+)]
+impl PartialEq for Ordering {
+    #[spec(fn(me: &Ordering[@m], other: &Ordering[@o]) -> bool[m == o])]
+    fn eq(self: &Ordering, other: &Ordering) -> bool;
+}

--- a/lib/flux-core/src/cmp.rs
+++ b/lib/flux-core/src/cmp.rs
@@ -42,3 +42,14 @@ trait Ord {
     fn max_res(a: int, b: int, res: int) -> bool { res == max(a, b) }
 )]
 impl Ord for usize {}
+
+#[extern_spec(core::cmp)]
+#[refined_by(res: int)]
+enum Ordering {
+    #[variant(Ordering[-1])]
+    Less,
+    #[variant(Ordering[0])]
+    Equal,
+    #[variant(Ordering[1])]
+    Greater
+}

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -57,6 +57,7 @@
 mod non_null;
 
 use flux_attrs::*;
+use core::cmp::Ordering;
 
 macro_rules! ptr_specs {
     ($mutable:tt $(, $($extra:tt)*)?) => {
@@ -151,6 +152,38 @@ macro_rules! ptr_specs {
             /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1614
             #[spec(fn (me: &*$mutable[@m] T, other: &*$mutable[@o] T) -> bool[m.addr == o.addr])]
             fn eq(&self, other: &*$mutable T) -> bool;
+        }
+
+        #[extern_spec(core::ptr)]
+        impl<T> Ord for *$mutable T {
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1633
+            #[spec(fn (me: &*$mutable[@m] T, other: &*$mutable[@o] T) ->
+                Ordering[if m == o {0} else if m < o {-1} else {1}])]
+            fn cmp(&self, other: &*$mutable T) -> Ordering;
+        }
+
+        #[extern_spec(core::ptr)]
+        impl<T> PartialOrd for *$mutable T {
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1653
+            #[spec(fn (me: &*$mutable[@m] T, other: &*$mutable[@o] T) ->
+                Option<Ordering[if m == o {0} else if m < o {-1} else {1}]>[true])]
+            fn partial_cmp(&self, other: &*$mutable T) -> Option<Ordering>;
+
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1662
+            #[spec(fn (me: &*$mutable[@m] T, other: &*$mutable[@o] T) -> bool[m.addr < o.addr])]
+            fn lt(&self, other: &*$mutable T) -> bool;
+
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1668
+            #[spec(fn (me: &*$mutable[@m] T, other: &*$mutable[@o] T) -> bool[m.addr <= o.addr])]
+            fn le(&self, other: &*$mutable T) -> bool;
+
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1674
+            #[spec(fn (me: &*$mutable[@m] T, other: &*$mutable[@o] T) -> bool[m.addr > o.addr])]
+            fn gt(&self, other: &*$mutable T) -> bool;
+
+            /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1680
+            #[spec(fn (me: &*$mutable[@m] T, other: &*$mutable[@o] T) -> bool[m.addr >= o.addr])]
+            fn ge(&self, other: &*$mutable T) -> bool;
         }
     };
 }

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -158,7 +158,7 @@ macro_rules! ptr_specs {
         impl<T> Ord for *$mutable T {
             /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1633
             #[spec(fn (me: &*$mutable[@m] T, other: &*$mutable[@o] T) ->
-                Ordering[if m == o {0} else if m < o {-1} else {1}])]
+                Ordering[if m.addr == o.addr {0} else if m.addr < o.addr {-1} else {1}])]
             fn cmp(&self, other: &*$mutable T) -> Ordering;
         }
 
@@ -166,7 +166,7 @@ macro_rules! ptr_specs {
         impl<T> PartialOrd for *$mutable T {
             /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1653
             #[spec(fn (me: &*$mutable[@m] T, other: &*$mutable[@o] T) ->
-                Option<Ordering[if m == o {0} else if m < o {-1} else {1}]>[true])]
+                Option<Ordering[if m.addr == o.addr {0} else if m.addr < o.addr {-1} else {1}]>[true])]
             fn partial_cmp(&self, other: &*$mutable T) -> Option<Ordering>;
 
             /// Core impl: https://github.com/rust-lang/rust/blob/7517636f510adf0a797e10cf655c21c0eb0723fb/library/core/src/ptr/const_ptr.rs#L1662

--- a/lib/flux-core/src/ptr/mod.rs
+++ b/lib/flux-core/src/ptr/mod.rs
@@ -56,8 +56,9 @@
 /// which is currently out of scope.
 mod non_null;
 
-use flux_attrs::*;
 use core::cmp::Ordering;
+
+use flux_attrs::*;
 
 macro_rules! ptr_specs {
     ($mutable:tt $(, $($extra:tt)*)?) => {

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -143,6 +143,10 @@ impl<T> NonNull<[T]> {
 }
 
 #[extern_spec(core::ptr)]
+#[assoc(
+    fn is_eq(m: NonNull, o: NonNull, res: bool) -> bool { res <=> (m.addr == o.addr) }
+    fn is_ne(m: NonNull, o: NonNull, res: bool) -> bool { res <=> (m.addr != o.addr) }
+)]
 impl<T> PartialEq for NonNull<T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1691
     #[spec(fn (me: &NonNull<T>[@m], other: &NonNull<T>[@o]) -> bool[m.addr == o.addr])]

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -24,8 +24,9 @@
     }
 })]
 
-use flux_attrs::*;
 use core::cmp::Ordering;
+
+use flux_attrs::*;
 
 #[extern_spec(core::ptr)]
 #[refined_by(base: int, addr: int, size: int)]

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -163,6 +163,12 @@ impl<T> Ord for NonNull<T> {
 }
 
 #[extern_spec(core::ptr)]
+#[assoc(
+    fn is_lt(m: NonNull, o: NonNull, res: bool) -> bool { res <=> (m.addr < o.addr) }
+    fn is_le(m: NonNull, o: NonNull, res: bool) -> bool { res <=> (m.addr <= o.addr) }
+    fn is_gt(m: NonNull, o: NonNull, res: bool) -> bool { res <=> (m.addr > o.addr) }
+    fn is_ge(m: NonNull, o: NonNull, res: bool) -> bool { res <=> (m.addr >= o.addr) }
+)]
 impl<T> PartialOrd for NonNull<T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1709
     #[spec(fn (me: &NonNull<T>[@m], other: &NonNull<T>[@o]) ->

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -153,7 +153,7 @@ impl<T> PartialEq for NonNull<T> {
 impl<T> Ord for NonNull<T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1700
     #[spec(fn (me: &NonNull<T>[@m], other: &NonNull<T>[@o]) ->
-        Ordering[if m == o {0} else if m < o {-1} else {1}])]
+        Ordering[if m.addr == o.addr {0} else if m.addr < o.addr {-1} else {1}])]
     fn cmp(&self, other: &NonNull<T>) -> Ordering;
 }
 
@@ -161,6 +161,6 @@ impl<T> Ord for NonNull<T> {
 impl<T> PartialOrd for NonNull<T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1709
     #[spec(fn (me: &NonNull<T>[@m], other: &NonNull<T>[@o]) ->
-        Option<Ordering[if m == o {0} else if m < o {-1} else {1}]>[true])]
+        Option<Ordering[if m.addr == o.addr {0} else if m.addr < o.addr {-1} else {1}]>[true])]
     fn partial_cmp(&self, other: &NonNull<T>) -> Option<Ordering>;
 }

--- a/lib/flux-core/src/ptr/non_null.rs
+++ b/lib/flux-core/src/ptr/non_null.rs
@@ -25,6 +25,7 @@
 })]
 
 use flux_attrs::*;
+use core::cmp::Ordering;
 
 #[extern_spec(core::ptr)]
 #[refined_by(base: int, addr: int, size: int)]
@@ -146,4 +147,20 @@ impl<T> PartialEq for NonNull<T> {
     /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1691
     #[spec(fn (me: &NonNull<T>[@m], other: &NonNull<T>[@o]) -> bool[m.addr == o.addr])]
     fn eq(&self, other: &NonNull<T>) -> bool;
+}
+
+#[extern_spec(core::ptr)]
+impl<T> Ord for NonNull<T> {
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1700
+    #[spec(fn (me: &NonNull<T>[@m], other: &NonNull<T>[@o]) ->
+        Ordering[if m == o {0} else if m < o {-1} else {1}])]
+    fn cmp(&self, other: &NonNull<T>) -> Ordering;
+}
+
+#[extern_spec(core::ptr)]
+impl<T> PartialOrd for NonNull<T> {
+    /// Core impl: https://github.com/rust-lang/rust/blob/c871d09d1cc32a649f4c5177bb819646260ed120/library/core/src/ptr/non_null.rs#L1709
+    #[spec(fn (me: &NonNull<T>[@m], other: &NonNull<T>[@o]) ->
+        Option<Ordering[if m == o {0} else if m < o {-1} else {1}]>[true])]
+    fn partial_cmp(&self, other: &NonNull<T>) -> Option<Ordering>;
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr10.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr10.rs
@@ -122,8 +122,8 @@ pub fn test_ptr_partial_cmp_opt(p1: *const i32, p2: *const i32) -> Option<Orderi
 }
 
 #[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
-    p2: {*const[@base1, @addr1, @size1] i32
-            | base != base1 && size != size1 && addr < addr1}) -> Option<Ordering[1]>[true])]
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr < addr1}) -> Option<Ordering[1]>[true])]
 pub fn test_ptr_partial_cmp_lt(p1: *const i32, p2: *const i32) -> Option<Ordering> {
     p1.partial_cmp(&p2) //~ ERROR refinement type error
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr10.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr10.rs
@@ -1,6 +1,7 @@
 extern crate flux_core;
 
 use flux_rs::assert;
+use std::cmp::Ordering;
 
 // --- eq ---
 
@@ -40,6 +41,14 @@ pub fn test_ptr_lt(p: *const i32) {
     }
 }
 
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
+pub fn test_ptr_lt_fn(p: *const i32) {
+    unsafe {
+        let p1 = p.add(1);
+        assert(p1.lt(&p)) //~ ERROR refinement type error
+    }
+}
+
 // --- le ---
 
 #[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
@@ -47,6 +56,14 @@ pub fn test_ptr_le(p: *const i32) {
     unsafe {
         let p1 = p.add(1);
         assert(p1 <= p) //~ ERROR refinement type error
+    }
+}
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
+pub fn test_ptr_le_fn(p: *const i32) {
+    unsafe {
+        let p1 = p.add(1);
+        assert(p1.le(&p)) //~ ERROR refinement type error
     }
 }
 
@@ -60,6 +77,14 @@ pub fn test_ptr_gt(p: *const i32) {
     }
 }
 
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 40}))]
+pub fn test_ptr_gt_fn(p: *const i32) {
+    unsafe {
+        let p1 = p.add(4);
+        assert(p.gt(&p1)) //~ ERROR refinement type error
+    }
+}
+
 // --- ge ---
 
 #[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 16}))]
@@ -69,4 +94,36 @@ pub fn test_ptr_ge(p: *const i32) {
         let p2 = p1.sub(1);
         assert(p2 >= p1) //~ ERROR refinement type error
     }
+}
+
+#[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 16}))]
+pub fn test_ptr_ge_fn(p: *const i32) {
+    unsafe {
+        let p1 = p.add(2);
+        let p2 = p1.sub(1);
+        assert(p2.ge(&p1)) //~ ERROR refinement type error
+    }
+}
+
+// -- cmp --
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr == addr1}) -> bool[true])]
+pub fn test_ptr_cmp_eq_bool(p1: *const i32, p2: *const i32) -> bool {
+    p1.cmp(&p2) != Ordering::Equal //~ ERROR refinement type error
+}
+
+// -- partial_cmp
+
+#[flux::spec(fn(p1: *const i32, p2: *const i32) -> Option<Ordering>[false])]
+pub fn test_ptr_partial_cmp_opt(p1: *const i32, p2: *const i32) -> Option<Ordering> {
+    p1.partial_cmp(&p2) //~ ERROR refinement type error
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+    p2: {*const[@base1, @addr1, @size1] i32
+            | base != base1 && size != size1 && addr < addr1}) -> Option<Ordering[1]>[true])]
+pub fn test_ptr_partial_cmp_lt(p1: *const i32, p2: *const i32) -> Option<Ordering> {
+    p1.partial_cmp(&p2) //~ ERROR refinement type error
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null07.rs
@@ -2,6 +2,7 @@ extern crate flux_core;
 
 use flux_rs::assert;
 use std::ptr::NonNull;
+use core::cmp::Ordering;
 
 // --- eq ---
 
@@ -29,4 +30,27 @@ pub fn test_ptr_neq_sym(p: NonNull<u32>) {
 #[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size], p2: NonNull<i32>[base, addr, size]))]
 pub fn test_ptr_id_sym(p1: NonNull<i32>, p2: NonNull<i32>) {
     assert(p1 != p2) //~ ERROR refinement type error
+}
+
+// -- cmp --
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr == addr1}) -> bool[true])]
+pub fn test_ptr_cmp_eq_bool<T>(p1: NonNull<T>, p2: NonNull<T>) -> bool {
+    p1.cmp(&p2) != Ordering::Equal //~ ERROR refinement type error
+}
+
+// -- partial_cmp
+
+#[flux::spec(fn(p1: NonNull<T>, p2: NonNull<T>) -> Option<Ordering>[false])]
+pub fn test_ptr_partial_cmp_opt<T>(p1: NonNull<T>, p2: NonNull<T>) -> Option<Ordering> {
+    p1.partial_cmp(&p2) //~ ERROR refinement type error
+}
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr < addr1}) -> Option<Ordering[1]>[true])]
+pub fn test_ptr_partial_cmp_lt<T>(p1: NonNull<T>, p2: NonNull<T>) -> Option<Ordering> {
+    p1.partial_cmp(&p2) //~ ERROR refinement type error
 }

--- a/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/neg/extern_specs/flux_core_ptr_non_null07.rs
@@ -2,7 +2,7 @@ extern crate flux_core;
 
 use flux_rs::assert;
 use std::ptr::NonNull;
-use core::cmp::Ordering;
+use std::cmp::Ordering;
 
 // --- eq ---
 

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
@@ -165,3 +165,29 @@ pub fn test_ptr_cmp_eq(p1: *const i32, p2: *const i32) -> Ordering {
 }
 
 // -- partial_cmp --
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr == addr1}) -> Option<Ordering[0]>[true])]
+pub fn test_ptr_partial_cmp_eq(p1: *const i32, p2: *const i32) -> Option<Ordering> {
+    p1.partial_cmp(&p2)
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr < addr1}) -> Option<Ordering[-1]>[true])]
+pub fn test_ptr_partial_cmp_lt(p1: *const i32, p2: *const i32) -> Option<Ordering> {
+    p1.partial_cmp(&p2)
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr > addr1}) -> Option<Ordering[1]>[true])]
+pub fn test_ptr_partial_cmp_gt(p1: *const i32, p2: *const i32) -> Option<Ordering> {
+    p1.partial_cmp(&p2)
+}
+
+#[flux::spec(fn(p1: *const i32, p2: *const i32) -> Option<Ordering>[true])]
+pub fn test_ptr_partial_cmp_opt(p1: *const i32, p2: *const i32) -> Option<Ordering> {
+    p1.partial_cmp(&p2)
+}

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
@@ -41,6 +41,11 @@ pub fn test_ptr_id_sym(p1: *const i32, p2: *const i32) {
 }
 
 #[flux::spec(fn(p1: *const[@base, @addr, @size] i32, p2: *const[base, addr, size] i32))]
+pub fn test_ptr_id_sym_ne(p1: *const i32, p2: *const i32) {
+    assert(!(p1 != p2))
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32, p2: *const[base, addr, size] i32))]
 pub fn test_ptr_id(p1: *const i32, p2: *const i32) {
     assert(p1.eq(&p2))
 }
@@ -162,6 +167,20 @@ pub fn test_ptr_cmp_lt(p1: *const i32, p2: *const i32) -> Ordering {
                         | base != base1 && size != size1 && addr == addr1}) -> Ordering[0])]
 pub fn test_ptr_cmp_eq(p1: *const i32, p2: *const i32) -> Ordering {
     p1.cmp(&p2)
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr == addr1}) -> bool[true])]
+pub fn test_ptr_cmp_eq_bool(p1: *const i32, p2: *const i32) -> bool {
+    p1.cmp(&p2) == Ordering::Equal
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr > addr1}) -> bool[true])]
+pub fn test_ptr_cmp_ne_bool(p1: *const i32, p2: *const i32) -> bool {
+    p1.cmp(&p2) != Ordering::Less
 }
 
 // -- partial_cmp --

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
@@ -1,7 +1,7 @@
 extern crate flux_core;
 
 use flux_rs::assert;
-use core::cmp::Ordering;
+use std::cmp::Ordering;
 
 // --- eq ---
 
@@ -176,10 +176,10 @@ pub fn test_ptr_cmp_eq_bool(p1: *const i32, p2: *const i32) -> bool {
     p1.cmp(&p2) == Ordering::Equal
 }
 
-#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
-                p2: {*const[@base1, @addr1, @size1] i32
+#[flux::spec(fn(p1: *mut[@base, @addr, @size] f64,
+                p2: {*mut[@base1, @addr1, @size1] f64
                         | base != base1 && size != size1 && addr > addr1}) -> bool[true])]
-pub fn test_ptr_cmp_ne_bool(p1: *const i32, p2: *const i32) -> bool {
+pub fn test_ptr_cmp_ne_bool(p1: *mut f64, p2: *mut f64) -> bool {
     p1.cmp(&p2) != Ordering::Less
 }
 
@@ -192,17 +192,17 @@ pub fn test_ptr_partial_cmp_eq(p1: *const i32, p2: *const i32) -> Option<Orderin
     p1.partial_cmp(&p2)
 }
 
-#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
-                p2: {*const[@base1, @addr1, @size1] i32
+#[flux::spec(fn(p1: *mut[@base, @addr, @size] i32,
+                p2: {*mut[@base1, @addr1, @size1] i32
                         | base != base1 && size != size1 && addr < addr1}) -> Option<Ordering[-1]>[true])]
-pub fn test_ptr_partial_cmp_lt(p1: *const i32, p2: *const i32) -> Option<Ordering> {
+pub fn test_ptr_partial_cmp_lt(p1: *mut i32, p2: *mut i32) -> Option<Ordering> {
     p1.partial_cmp(&p2)
 }
 
-#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
-                p2: {*const[@base1, @addr1, @size1] i32
+#[flux::spec(fn(p1: *const[@base, @addr, @size] u64,
+                p2: {*const[@base1, @addr1, @size1] u64
                         | base != base1 && size != size1 && addr > addr1}) -> Option<Ordering[1]>[true])]
-pub fn test_ptr_partial_cmp_gt(p1: *const i32, p2: *const i32) -> Option<Ordering> {
+pub fn test_ptr_partial_cmp_gt(p1: *const u64, p2: *const u64) -> Option<Ordering> {
     p1.partial_cmp(&p2)
 }
 

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr11.rs
@@ -1,6 +1,7 @@
 extern crate flux_core;
 
 use flux_rs::assert;
+use core::cmp::Ordering;
 
 // --- eq ---
 
@@ -61,6 +62,13 @@ pub fn test_ptr_lt_addr_only(p1: *const i32, p2: *const i32) {
     assert(p1 < p2)
 }
 
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr < addr1}))]
+pub fn test_ptr_lt_addr_only_fn(p1: *const i32, p2: *const i32) {
+    assert(p1.lt(&p2))
+}
+
 // --- le ---
 
 #[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
@@ -76,6 +84,13 @@ pub fn test_ptr_le(p: *const i32) {
                         | base != base1 && size != size1 && addr <= addr1}))]
 pub fn test_ptr_le_addr_only(p1: *const i32, p2: *const i32) {
     assert(p1 <= p2)
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr <= addr1}))]
+pub fn test_ptr_le_addr_only_fn(p1: *const i32, p2: *const i32) {
+    assert(p1.le(&p2))
 }
 
 // --- gt ---
@@ -95,6 +110,13 @@ pub fn test_ptr_gt_addr_only(p1: *const i32, p2: *const i32) {
     assert(p1 > p2)
 }
 
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr > addr1}))]
+pub fn test_ptr_gt_addr_only_fn(p1: *const i32, p2: *const i32) {
+    assert(p1.ge(&p2))
+}
+
 // --- ge ---
 
 #[flux::spec(fn (ptr: {*const[@base, @addr, @size] i32 | addr >= base && size == 8}))]
@@ -112,3 +134,34 @@ pub fn test_ptr_ge_addr_only(p1: *const i32, p2: *const i32) {
     assert(p1 >= p2)
 }
 
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr >= addr1}))]
+pub fn test_ptr_ge_addr_only_fn(p1: *const i32, p2: *const i32) {
+    assert(p1.ge(&p2))
+}
+
+// -- cmp --
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr > addr1}) -> Ordering[1])]
+pub fn test_ptr_cmp_gt(p1: *const i32, p2: *const i32) -> Ordering {
+    p1.cmp(&p2)
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr < addr1}) -> Ordering[-1])]
+pub fn test_ptr_cmp_lt(p1: *const i32, p2: *const i32) -> Ordering {
+    p1.cmp(&p2)
+}
+
+#[flux::spec(fn(p1: *const[@base, @addr, @size] i32,
+                p2: {*const[@base1, @addr1, @size1] i32
+                        | base != base1 && size != size1 && addr == addr1}) -> Ordering[0])]
+pub fn test_ptr_cmp_eq(p1: *const i32, p2: *const i32) -> Ordering {
+    p1.cmp(&p2)
+}
+
+// -- partial_cmp --

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
@@ -92,6 +92,13 @@ pub fn test_ptr_cmp_ne_bool(p1: NonNull<i32>, p2: NonNull<i32>) -> bool {
     p1.cmp(&p2) != Ordering::Less
 }
 
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr <= addr1}))]
+pub fn test_ptr_le<T>(p1: NonNull<T>, p2: NonNull<T>) {
+    assert(p1.cmp(&p2) == Ordering::Less || p1.cmp(&p2) == Ordering::Equal)
+}
+
 // -- partial_cmp --
 
 #[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size],

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
@@ -95,7 +95,7 @@ pub fn test_ptr_cmp_ne_bool(p1: NonNull<i32>, p2: NonNull<i32>) -> bool {
 #[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
                 p2: {NonNull<T>[@base1, @addr1, @size1]
                         | base != base1 && size != size1 && addr <= addr1}))]
-pub fn test_ptr_le<T>(p1: NonNull<T>, p2: NonNull<T>) {
+pub fn test_ptr_le_contrived<T>(p1: NonNull<T>, p2: NonNull<T>) {
     assert(p1.cmp(&p2) == Ordering::Less || p1.cmp(&p2) == Ordering::Equal)
 }
 
@@ -125,4 +125,68 @@ pub fn test_ptr_partial_cmp_gt(p1: NonNull<i32>, p2: NonNull<i32>) -> Option<Ord
 #[flux::spec(fn(p1: NonNull<i32>, p2: NonNull<i32>) -> Option<Ordering>[true])]
 pub fn test_ptr_partial_cmp_opt(p1: NonNull<i32>, p2: NonNull<i32>) -> Option<Ordering> {
     p1.partial_cmp(&p2)
+}
+
+// -- lt --
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr < addr1}))]
+pub fn test_ptr_lt_fn<T>(p1: NonNull<T>, p2: NonNull<T>) {
+    assert(p1.lt(&p2))
+}
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr < addr1}))]
+pub fn test_ptr_lt<T>(p1: NonNull<T>, p2: NonNull<T>) {
+    assert(p1 < p2)
+}
+
+// -- le --
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr <= addr1}))]
+pub fn test_ptr_le_fn<T>(p1: NonNull<T>, p2: NonNull<T>) {
+    assert(p1.le(&p2))
+}
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr <= addr1}))]
+pub fn test_ptr_le<T>(p1: NonNull<T>, p2: NonNull<T>) {
+    assert(p1 <= p2)
+}
+
+// -- gt --
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr > addr1}))]
+pub fn test_ptr_gt_fn<T>(p1: NonNull<T>, p2: NonNull<T>) {
+    assert(p1.gt(&p2))
+}
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr > addr1}))]
+pub fn test_ptr_gt<T>(p1: NonNull<T>, p2: NonNull<T>) {
+    assert(p1 > p2)
+}
+
+// -- ge --
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr >= addr1}))]
+pub fn test_ptr_ge_fn<T>(p1: NonNull<T>, p2: NonNull<T>) {
+    assert(p1.ge(&p2))
+}
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr >= addr1}))]
+pub fn test_ptr_ge<T>(p1: NonNull<T>, p2: NonNull<T>) {
+    assert(p1 >= p2)
 }

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
@@ -2,6 +2,7 @@ extern crate flux_core;
 
 use flux_rs::assert;
 use std::ptr::NonNull;
+use std::cmp::Ordering;
 
 // --- eq ---
 
@@ -52,4 +53,69 @@ pub fn test_ptr_id_sym_addr_only(p1: NonNull<f32>, p2: NonNull<f32>) {
                 p2: {NonNull<i32>[@base1, addr, @size1] | base != base1 && size != size1}))]
 pub fn test_ptr_id_addr_only(p1: NonNull<i32>, p2: NonNull<i32>) {
     assert(p1.eq(&p2))
+}
+
+// -- cmp --
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size],
+                p2: {NonNull<i32>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr > addr1}) -> Ordering[1])]
+pub fn test_ptr_cmp_gt(p1: NonNull<i32>, p2: NonNull<i32>) -> Ordering {
+    p1.cmp(&p2)
+}
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size],
+                p2: {NonNull<i32>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr < addr1}) -> Ordering[-1])]
+pub fn test_ptr_cmp_lt(p1: NonNull<i32>, p2: NonNull<i32>) -> Ordering {
+    p1.cmp(&p2)
+}
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size],
+                p2: {NonNull<i32>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr == addr1}) -> Ordering[0])]
+pub fn test_ptr_cmp_eq(p1: NonNull<i32>, p2: NonNull<i32>) -> Ordering {
+    p1.cmp(&p2)
+}
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size],
+                p2: {NonNull<i32>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr == addr1}) -> bool[true])]
+pub fn test_ptr_cmp_eq_bool(p1: NonNull<i32>, p2: NonNull<i32>) -> bool {
+    p1.cmp(&p2) == Ordering::Equal
+}
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size],
+                p2: {NonNull<i32>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr > addr1}) -> bool[true])]
+pub fn test_ptr_cmp_ne_bool(p1: NonNull<i32>, p2: NonNull<i32>) -> bool {
+    p1.cmp(&p2) != Ordering::Less
+}
+
+// -- partial_cmp --
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size],
+                p2: {NonNull<i32>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr == addr1}) -> Option<Ordering[0]>[true])]
+pub fn test_ptr_partial_cmp_eq(p1: NonNull<i32>, p2: NonNull<i32>) -> Option<Ordering> {
+    p1.partial_cmp(&p2)
+}
+
+#[flux::spec(fn(p1: NonNull<T>[@base, @addr, @size],
+                p2: {NonNull<T>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr < addr1}) -> Option<Ordering[-1]>[true])]
+pub fn test_ptr_partial_cmp_lt<T>(p1: NonNull<T>, p2: NonNull<T>) -> Option<Ordering> {
+    p1.partial_cmp(&p2)
+}
+
+#[flux::spec(fn(p1: NonNull<i32>[@base, @addr, @size],
+                p2: {NonNull<i32>[@base1, @addr1, @size1]
+                        | base != base1 && size != size1 && addr > addr1}) -> Option<Ordering[1]>[true])]
+pub fn test_ptr_partial_cmp_gt(p1: NonNull<i32>, p2: NonNull<i32>) -> Option<Ordering> {
+    p1.partial_cmp(&p2)
+}
+
+#[flux::spec(fn(p1: NonNull<i32>, p2: NonNull<i32>) -> Option<Ordering>[true])]
+pub fn test_ptr_partial_cmp_opt(p1: NonNull<i32>, p2: NonNull<i32>) -> Option<Ordering> {
+    p1.partial_cmp(&p2)
 }

--- a/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
+++ b/tests/tests/with_deps/pos/extern_specs/flux_core_ptr_non_null07.rs
@@ -23,6 +23,15 @@ pub fn test_ptr_eq_sym(p: NonNull<u64>) {
     }
 }
 
+#[flux::spec(fn (ptr: {NonNull<u64>[@base, @addr, @size] | addr >= base && size == 16}))]
+pub fn test_ptr_ne_sym(p: NonNull<u64>) {
+    unsafe {
+        let p1 = p.add(1);
+        let p0 = p1.sub(1);
+        assert(!(p != p0))
+    }
+}
+
 #[flux::spec(fn(p1: NonNull<f32>[@base, @addr, @size], p2: NonNull<f32>[base, addr, size]))]
 pub fn test_ptr_id_sym(p1: NonNull<f32>, p2: NonNull<f32>) {
     assert(p1 == p2)


### PR DESCRIPTION
- Followup to https://github.com/flux-rs/flux/pull/1753; gets more functions that compare raw pointers / NonNull pointers working
- Refines `Ordering` in the same way the standard library does (`-1 = Less, 0 = Equal, 1 = Greater`)