### PR TITLE
Don't block when materializing under shared borrow

### DIFF
--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -740,6 +740,19 @@ impl fmt::Debug for TypeTrace {
     }
 }
 
+/// Whether converting a `ptr(mut, ℓ)` into a `&mut` should block `ℓ`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Blocking {
+    /// Block `ℓ` for the duration of the borrow. This is the normal case: the resulting `&mut`
+    /// can be used to mutate the pointee, so `ℓ` must not be used until the borrow expires.
+    Block,
+    /// Leave `ℓ` alone. Used when the resulting `&mut` sits *underneath* a shared reference: a
+    /// `&&mut T` cannot be reborrowed mutably, so the pointee cannot change and there is nothing
+    /// to block. Blocking here would be unreleasable anyway, because no mutable borrow expires to
+    /// trigger the matching `Unblock` ghost statement.
+    NoBlock,
+}
+
 pub trait LocEnv {
     fn ptr_to_ref(
         &mut self,
@@ -748,6 +761,7 @@ pub trait LocEnv {
         re: Region,
         path: &Path,
         bound: Ty,
+        blocking: Blocking,
     ) -> InferResult<Ty>;
 
     fn unfold_strg_ref(&mut self, infcx: &mut InferCtxt, path: &Path, ty: &Ty) -> InferResult<Loc>;
@@ -765,6 +779,7 @@ impl LocEnv for DummyEnv {
         _: Region,
         _: &Path,
         _: Ty,
+        _: Blocking,
     ) -> InferResult<Ty> {
         tracked_span_bug!("call to `ptr_to_ref` on `DummyEnv`")
     }
@@ -788,11 +803,14 @@ struct Sub<'a, E> {
     /// relating an opaque type. Other obligations related to relating opaque types are resolved
     /// directly here. The implementation is really messy and we may be missing some obligations.
     obligations: Vec<Binder<rty::CoroutineObligPredicate>>,
+    /// Whether we are currently relating types underneath a shared reference. A `ptr` reached
+    /// from here must not block its location. See [`Blocking::NoBlock`].
+    under_shared_ref: bool,
 }
 
 impl<'a, E: LocEnv> Sub<'a, E> {
     fn new(env: &'a mut E, reason: ConstrReason, span: Span) -> Self {
-        Self { env, reason, span, obligations: vec![] }
+        Self { env, reason, span, obligations: vec![], under_shared_ref: false }
     }
 
     fn tag(&self) -> Tag {
@@ -857,12 +875,15 @@ impl<'a, E: LocEnv> Sub<'a, E> {
                 // we solve them.
                 self.idxs_eq(infcx, &Expr::unit(), idx);
 
+                let blocking =
+                    if self.under_shared_ref { Blocking::NoBlock } else { Blocking::Block };
                 self.env.ptr_to_ref(
                     &mut infcx.at(self.span),
                     self.reason,
                     *re,
                     path,
                     bound.clone(),
+                    blocking,
                 )?;
                 Ok(())
             }
@@ -973,7 +994,12 @@ impl<'a, E: LocEnv> Sub<'a, E> {
                 }
             }
             (BaseTy::Ref(_, ty_a, Mutability::Not), BaseTy::Ref(_, ty_b, Mutability::Not)) => {
-                self.tys(infcx, ty_a, ty_b)
+                // Nothing below a shared reference can be mutated, so the flag is monotone: once
+                // set it stays set even if we descend through a `&mut` further down.
+                let prev = std::mem::replace(&mut self.under_shared_ref, true);
+                let r = self.tys(infcx, ty_a, ty_b);
+                self.under_shared_ref = prev;
+                r
             }
             (BaseTy::Tuple(tys_a), BaseTy::Tuple(tys_b)) => {
                 debug_assert_eq!(tys_a.len(), tys_b.len());

--- a/crates/flux-infer/src/infer.rs
+++ b/crates/flux-infer/src/infer.rs
@@ -400,19 +400,24 @@ impl<'infcx, 'genv, 'tcx> InferCtxt<'infcx, 'genv, 'tcx> {
         }
     }
 
+    /// Instantiate the binder with fresh inference variables and run `f` in a scope that requires
+    /// every evar generated for it to be solved by the time `f` returns.
+    ///
+    /// Note `f` returns an [`InferResult`] which is propagated as is. It'd be wrong to wrap it in
+    /// `Ok` and unwrap the outer result: if `f` fails early it may leave evars unsolved, and the
+    /// `UnsolvedEvar` from [`InferCtxt::pop_evar_scope`] would then mask the real error.
     fn enter_exists<T, U>(
         &mut self,
         t: &Binder<T>,
-        f: impl FnOnce(&mut InferCtxt<'_, 'genv, 'tcx>, T) -> U,
-    ) -> U
+        f: impl FnOnce(&mut InferCtxt<'_, 'genv, 'tcx>, T) -> InferResult<U>,
+    ) -> InferResult<U>
     where
         T: TypeFoldable,
     {
         self.ensure_resolved_evars(|infcx| {
             let t = t.replace_bound_refts_with(|sort, mode, _| infcx.fresh_infer_var(sort, mode));
-            Ok(f(infcx, t))
+            f(infcx, t)
         })
-        .unwrap()
     }
 
     /// Used in conjunction with [`InferCtxt::pop_evar_scope`] to ensure evars are solved at the end

--- a/crates/flux-refineck/src/checker.rs
+++ b/crates/flux-refineck/src/checker.rs
@@ -7,7 +7,8 @@ use flux_common::{
 use flux_config::{self as config, InferOpts};
 use flux_infer::{
     infer::{
-        ConstrReason, GlobalEnvExt as _, InferCtxt, InferCtxtRoot, InferResult, SubtypeReason,
+        Blocking, ConstrReason, GlobalEnvExt as _, InferCtxt, InferCtxtRoot, InferResult,
+        SubtypeReason,
     },
     projections::NormalizeExt as _,
     refine_tree::{Marker, RefineCtxtTrace},
@@ -1400,6 +1401,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                         *re,
                         path,
                         PtrToRefBound::Infer,
+                        Blocking::Block,
                     )
                 } else {
                     Ok(ty.clone())
@@ -1836,6 +1838,7 @@ impl<'ck, 'genv, 'tcx, M: Mode> Checker<'ck, 'genv, 'tcx, M> {
                 *re,
                 path,
                 PtrToRefBound::Identity,
+                Blocking::Block,
             )?
         } else {
             src.clone()

--- a/crates/flux-refineck/src/type_env.rs
+++ b/crates/flux-refineck/src/type_env.rs
@@ -9,7 +9,7 @@ use flux_common::{
 };
 use flux_infer::{
     fixpoint_encoding::KVarEncoding,
-    infer::{ConstrReason, InferCtxt, InferCtxtAt, InferCtxtRoot, InferResult},
+    infer::{Blocking, ConstrReason, InferCtxt, InferCtxtAt, InferCtxtRoot, InferResult},
     refine_tree::Scope,
 };
 use flux_macros::DebugAsJson;
@@ -161,8 +161,14 @@ impl<'a> TypeEnv<'a> {
             tracked_span_bug!("ptr_to_borrow called on non mutable pointer type")
         };
 
-        let ref_ty =
-            self.ptr_to_ref(infcx, ConstrReason::Other, *re, path, PtrToRefBound::Infer)?;
+        let ref_ty = self.ptr_to_ref(
+            infcx,
+            ConstrReason::Other,
+            *re,
+            path,
+            PtrToRefBound::Infer,
+            Blocking::Block,
+        )?;
 
         self.bindings.lookup(place, infcx.span).update(ref_ty);
 
@@ -199,6 +205,7 @@ impl<'a> TypeEnv<'a> {
         re: Region,
         path: &Path,
         bound: PtrToRefBound,
+        blocking: Blocking,
     ) -> InferResult<Ty> {
         // ℓ: t1
         let t1 = self.bindings.lookup(path, infcx.span).fold(infcx)?;
@@ -207,7 +214,7 @@ impl<'a> TypeEnv<'a> {
         let t2 = match bound {
             PtrToRefBound::Ty(t2) => {
                 let t2 = rty_match_regions(&t2, &t1);
-                infcx.subtyping(&t1, &t2, reason)?;
+                infcx.subtyping_with_env(self, &t1, &t2, reason)?;
                 t2
             }
             PtrToRefBound::Infer => {
@@ -215,16 +222,19 @@ impl<'a> TypeEnv<'a> {
                     debug_assert_eq!(kind, HoleKind::Pred);
                     infcx.fresh_kvar(sorts, KVarEncoding::Conj)
                 });
-                infcx.subtyping(&t1, &t2, reason)?;
+                infcx.subtyping_with_env(self, &t1, &t2, reason)?;
                 t2
             }
             PtrToRefBound::Identity => t1.clone(),
         };
 
-        // ℓ: †t2
-        self.bindings
-            .lookup(path, infcx.span)
-            .block_with(t2.clone());
+        // ℓ: †t2, unless the `&mut` is going underneath a shared reference, in which case `ℓ`
+        // keeps its current (more precise) type. See [`Blocking::NoBlock`].
+        if blocking == Blocking::Block {
+            self.bindings
+                .lookup(path, infcx.span)
+                .block_with(t2.clone());
+        }
 
         Ok(Ty::mk_ref(re, t2, Mutability::Mut))
     }
@@ -434,8 +444,9 @@ impl flux_infer::infer::LocEnv for TypeEnv<'_> {
         re: Region,
         path: &Path,
         bound: Ty,
+        blocking: Blocking,
     ) -> InferResult<Ty> {
-        self.ptr_to_ref(infcx, reason, re, path, PtrToRefBound::Ty(bound))
+        self.ptr_to_ref(infcx, reason, re, path, PtrToRefBound::Ty(bound), blocking)
     }
 
     fn get(&self, path: &Path) -> Ty {

--- a/tests/tests/pos/surface/issue-1754.rs
+++ b/tests/tests/pos/surface/issue-1754.rs
@@ -1,0 +1,52 @@
+//! Regression test for https://github.com/flux-rs/flux/issues/1754
+//!
+//! `Self` is implicitly `?Sized` in a trait definition, so with `impl<T: Buf + ?Sized> Buf for
+//! &mut T` the type `&mut Self` itself implements `Buf`. Method resolution on `self.remaining()`
+//! therefore picks `<&mut Self as Buf>::remaining`, which takes `&&mut Self` and so autorefs the
+//! *local* holding `ptr(mut, l)` rather than `*self`.
+//!
+//! Relating `&ptr(mut, l)` against `&(&mut Self)` used to convert the pointer to a `&mut` and
+//! block `l`, and nothing ever unblocked it: the borrow responsible is shared, so no `Unblock`
+//! ghost statement is emitted for it. The later `self.advance(1)` then saw a blocked type.
+//! A `&mut` underneath a shared reference cannot be used to mutate, so we no longer block.
+
+pub trait Buf {
+    fn remaining(&self) -> usize;
+    fn advance(&mut self, cnt: usize);
+
+    fn get_u8(&mut self) -> usize {
+        let n = self.remaining(); // shared reborrow of `self`
+        self.advance(1); // mutable reborrow of `self`
+        n
+    }
+}
+
+impl<T: Buf + ?Sized> Buf for &mut T {
+    fn remaining(&self) -> usize {
+        (**self).remaining()
+    }
+    fn advance(&mut self, cnt: usize) {
+        (**self).advance(cnt)
+    }
+}
+
+// A `ptr` nested under a *shared* reference: the location must keep its precise type, because
+// it is not blocked.
+fn read_shared_nested(_x: &&mut i32) {}
+
+#[flux::sig(fn(x: &mut i32[@n]) ensures x: i32[n])]
+fn keeps_index(x: &mut i32) {
+    read_shared_nested(&x);
+}
+
+// A `ptr` nested under a `&mut`: this used to ICE with "call to `ptr_to_ref` on `DummyEnv`",
+// because `TypeEnv::ptr_to_ref` related the location's type against the bound using a `DummyEnv`.
+fn read_mut_nested(x: &mut &mut i32) -> i32 {
+    **x
+}
+
+fn call_mut_nested(mut x: &mut i32) -> i32 {
+    let b = read_mut_nested(&mut x);
+    *x = 4;
+    b
+}


### PR DESCRIPTION
Fixes #1754

maybe? (This is CC's doing, but the cause and fix sound plausible to me?)

## Cause

The real error was **`incompatible types: †Self - Self[?1e]`** — a blocked type reaching subtyping.
Because `Self` is `?Sized` in a trait, `&mut Self` itself implemented `Buf`, so `self.remaining()` passed `&_1` — a shared reference wrapping the `ptr(mut, ℓ)` — which forced `flux` to materialize a real `&mut` inside it, and materializing a `&mut` always blocks its location. The block was then never released, because unblocks are only emitted when a _mutable_ borrow expires and the borrow responsible here was a shared one.

## Fix

Flux now tracks whether subtyping is descending underneath a shared reference, and when it is, 
materializing a `&mut` no longer blocks its location. That's safe because **you can never mutate through a `&&mut T`**, 
so the location can't change and there was nothing to block in the first place — which is also why no unblock 
was ever coming.